### PR TITLE
218-driver-initiated-reset-request-handling.md fix.

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineController.java
@@ -11,7 +11,9 @@ import com.benesquivelmusic.daw.core.performance.PerformanceMonitor;
 import com.benesquivelmusic.daw.sdk.audio.AudioBackend;
 import com.benesquivelmusic.daw.sdk.audio.AudioDeviceEvent;
 import com.benesquivelmusic.daw.sdk.audio.AudioDeviceInfo;
+import com.benesquivelmusic.daw.sdk.audio.BufferSizeRange;
 import com.benesquivelmusic.daw.sdk.audio.DeviceId;
+import com.benesquivelmusic.daw.sdk.audio.FormatChangeReason;
 import com.benesquivelmusic.daw.sdk.audio.MixPrecision;
 import com.benesquivelmusic.daw.sdk.audio.NativeAudioBackend;
 import com.benesquivelmusic.daw.sdk.audio.XrunEvent;
@@ -22,8 +24,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Flow;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -56,6 +63,55 @@ final class DefaultAudioEngineController implements AudioEngineController {
     private final AtomicReference<DeviceId> activeDevice = new AtomicReference<>();
     /** Subscription to the bound backend's device-event publisher. */
     private final AtomicReference<Flow.Subscription> deviceEventSubscription = new AtomicReference<>();
+
+    /**
+     * Single-thread worker that runs the
+     * {@link AudioDeviceEvent.FormatChangeRequested} reopen flow off the
+     * device-event thread (story 218). Coalescing of rapid-fire reset
+     * requests (the user spinning a buffer-size dropdown produces many
+     * events) is implemented by scheduling onto this executor with a
+     * 250&nbsp;ms debounce delay; if a fresh request arrives before the
+     * scheduled task runs, the previous task is cancelled and replaced.
+     *
+     * <p>This is <b>not</b> the audio callback thread — it is a
+     * dedicated daemon worker named {@code "daw-format-change-worker"}.
+     * Format-change reopens involve closing and reopening the audio
+     * backend, which is far too heavy for the RT thread.</p>
+     */
+    private final ScheduledExecutorService formatChangeWorker =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "daw-format-change-worker");
+                t.setDaemon(true);
+                return t;
+            });
+
+    /**
+     * Coalescing window: when another
+     * {@link AudioDeviceEvent.FormatChangeRequested} arrives within this
+     * delay, the previous pending reopen is cancelled and rescheduled
+     * (story 218: "the user spinning a buffer-size dropdown produces
+     * multiple events").
+     */
+    private static final long FORMAT_CHANGE_COALESCE_MILLIS = 250L;
+
+    /**
+     * Drain deadline applied between transport stop and stream close
+     * during a {@link AudioDeviceEvent.FormatChangeRequested} reopen
+     * (story 218 — Pro Tools' ~200&nbsp;ms transport freeze).
+     */
+    private static final long FORMAT_CHANGE_DRAIN_MILLIS = 200L;
+
+    /** Holds the currently-pending coalesced reopen task, if any. */
+    private final AtomicReference<ScheduledFuture<?>> pendingFormatChange =
+            new AtomicReference<>();
+
+    /**
+     * Latest pending format-change request — replaced when a new one
+     * arrives during the coalescing window so the eventual reopen uses
+     * the freshest proposed format / reason.
+     */
+    private final AtomicReference<AudioDeviceEvent.FormatChangeRequested> latestFormatChange =
+            new AtomicReference<>();
 
     DefaultAudioEngineController(AudioEngine audioEngine, Runnable postReconfigureCallback) {
         this(audioEngine, postReconfigureCallback,
@@ -376,6 +432,248 @@ final class DefaultAudioEngineController implements AudioEngineController {
         }
     }
 
+    /**
+     * Handles a driver-initiated {@link AudioDeviceEvent.FormatChangeRequested}
+     * by scheduling a coalesced reopen on the
+     * {@link #formatChangeWorker} (story 218). Runs on the device-event
+     * thread; off-loads the heavy work — stop transport, drain, close,
+     * re-query capabilities, reopen — to the worker so the publisher
+     * thread is never blocked.
+     *
+     * <p>If another {@code FormatChangeRequested} arrives within
+     * {@value #FORMAT_CHANGE_COALESCE_MILLIS}&nbsp;ms, the pending task
+     * is cancelled and rescheduled — the typical case where the user
+     * is spinning a buffer-size dropdown in the driver panel. The
+     * eventual reopen always uses the freshest proposed format /
+     * reason.</p>
+     *
+     * @param requested the request to handle; must not be null
+     */
+    private void onFormatChangeRequested(AudioDeviceEvent.FormatChangeRequested requested) {
+        DeviceId active = activeDevice.get();
+        if (active == null || !matches(active, requested.device())) {
+            // Some other device — nothing to do.
+            return;
+        }
+        LOG.info("FormatChangeRequested received for " + requested.device()
+                + " reason=" + requested.reason()
+                + " proposedFormat=" + requested.proposedFormat());
+        // Replace the latest pending request so the worker uses the
+        // freshest payload when it eventually runs.
+        latestFormatChange.set(requested);
+        // Coalesce: cancel any in-flight scheduled reopen, then schedule
+        // a fresh one 250 ms out. Deliberately not interruptIfRunning —
+        // a reopen that has already begun should be allowed to finish.
+        ScheduledFuture<?> previous = pendingFormatChange.getAndSet(null);
+        if (previous != null) {
+            previous.cancel(false);
+        }
+        ScheduledFuture<?> task;
+        try {
+            task = formatChangeWorker.schedule(this::runFormatChangeReopen,
+                    FORMAT_CHANGE_COALESCE_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (RuntimeException e) {
+            // Executor was shut down (controller closed) — nothing to do.
+            LOG.log(Level.FINE, "Format-change worker rejected task", e);
+            return;
+        }
+        pendingFormatChange.set(task);
+    }
+
+    /**
+     * Runs the coalesced reopen flow on
+     * {@link #formatChangeWorker}. Never invoked on the audio callback
+     * thread or the device-event thread.
+     */
+    private void runFormatChangeReopen() {
+        AudioDeviceEvent.FormatChangeRequested requested = latestFormatChange.getAndSet(null);
+        if (requested == null) {
+            // Coalesced into a later task that already ran — nothing to do.
+            return;
+        }
+        DeviceId active = activeDevice.get();
+        if (active == null || !matches(active, requested.device())) {
+            return;
+        }
+        try {
+            performFormatChangeReopen(active, requested);
+        } catch (RuntimeException e) {
+            // Never let the worker thread die because of one bad reopen —
+            // the next event must still be handleable.
+            LOG.log(Level.WARNING, "Format-change reopen failed", e);
+            try {
+                notifications.notify("Audio engine reconfiguration failed: " + e.getMessage());
+            } catch (RuntimeException ignored) { /* best-effort */ }
+            // Always end up in STOPPED so the user can re-arm transport
+            // even after a failed reopen.
+            setEngineState(EngineState.STOPPED);
+        }
+    }
+
+    private void performFormatChangeReopen(DeviceId active,
+                                           AudioDeviceEvent.FormatChangeRequested requested) {
+        AudioBackend backend = boundBackend.get();
+        AudioFormat currentFormat = audioEngine.getFormat();
+
+        // Sample-rate change is treated specially — story 126's SRC is
+        // inserted at the device boundary so the project session rate
+        // does not change.
+        Optional<com.benesquivelmusic.daw.sdk.audio.AudioFormat> proposed = requested.proposedFormat();
+        boolean isSampleRateChange = requested.reason() instanceof FormatChangeReason.SampleRateChange;
+        boolean rateActuallyDiffers = proposed.isPresent()
+                && Double.compare(proposed.get().sampleRate(), currentFormat.sampleRate()) != 0;
+
+        try {
+            notifications.notify("Reconfiguring audio engine…");
+        } catch (RuntimeException e) {
+            LOG.log(Level.WARNING, "NotificationManager rejected message", e);
+        }
+        setEngineState(EngineState.RECONFIGURING);
+
+        // 1. Pause transport. Best-effort; we are NOT on the RT thread.
+        try {
+            audioEngine.stopAudioOutput();
+        } catch (RuntimeException e) {
+            LOG.log(Level.WARNING, "Failed to stop audio output during format-change reopen", e);
+        }
+        try {
+            audioEngine.stop();
+        } catch (RuntimeException e) {
+            LOG.log(Level.WARNING, "Failed to stop engine during format-change reopen", e);
+        }
+
+        // 2. Drain — short, fixed-deadline pause to give any in-flight
+        //    callback time to return. We are not on the RT thread, so
+        //    Thread.sleep is acceptable here. Pro Tools' ~200ms freeze
+        //    is the reference behaviour.
+        try {
+            Thread.sleep(FORMAT_CHANGE_DRAIN_MILLIS);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+
+        // 3. If recording was active, behave like DeviceRemoved for the
+        //    in-flight take — flush partially captured frames so the
+        //    user can review them after the reopen.
+        try {
+            incompleteTakeStore.flushIfNotEmpty(active, audioEngine.getFormat());
+        } catch (RuntimeException e) {
+            LOG.log(Level.WARNING, "Failed to persist incomplete take during reopen", e);
+        }
+
+        // 4. Re-query capabilities so the new open call uses values the
+        //    backend actually allows. The SDK contract for these methods
+        //    permits returning defaults when the native shim is absent;
+        //    we deliberately call them anyway so the production wiring
+        //    exercises the same path the FFM-bound version will.
+        if (backend != null) {
+            try {
+                BufferSizeRange range = backend.bufferSizeRange(active);
+                Set<Integer> rates = backend.supportedSampleRates(active);
+                LOG.fine("Re-queried capabilities for " + active
+                        + ": bufferSizeRange=" + range + " sampleRates=" + rates);
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING, "Failed to re-query backend capabilities", e);
+            }
+        }
+
+        // 5. Compute the reopen format. If proposedFormat is present we
+        //    apply it (clamped where we know better), otherwise reopen
+        //    with the existing settings.
+        AudioFormat reopenFormat;
+        if (proposed.isPresent() && !isSampleRateChange) {
+            com.benesquivelmusic.daw.sdk.audio.AudioFormat sdkFmt = proposed.get();
+            reopenFormat = new AudioFormat(
+                    sdkFmt.sampleRate(),
+                    currentFormat.channels(),
+                    sdkFmt.bitDepth() > 0 ? sdkFmt.bitDepth() : currentFormat.bitDepth(),
+                    deriveBufferFrames(sdkFmt, currentFormat));
+        } else if (proposed.isPresent() /* sample-rate change — keep project rate */) {
+            reopenFormat = currentFormat;
+        } else {
+            reopenFormat = currentFormat;
+        }
+
+        try {
+            audioEngine.setFormat(reopenFormat);
+        } catch (RuntimeException e) {
+            LOG.log(Level.WARNING, "Failed to set new format on audio engine", e);
+        }
+
+        // 6. Reopen the SDK backend's stream when applicable — same shape
+        //    as the DeviceArrived flow. The production NativeAudioBackend
+        //    is reopened lazily by the next startAudioOutput() call.
+        if (backend != null) {
+            try {
+                if (!backend.isOpen()) {
+                    backend.open(active,
+                            new com.benesquivelmusic.daw.sdk.audio.AudioFormat(
+                                    reopenFormat.sampleRate(),
+                                    reopenFormat.channels(),
+                                    reopenFormat.bitDepth()),
+                            reopenFormat.bufferSize());
+                }
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING, "Failed to reopen backend after format change", e);
+            }
+        }
+
+        // 7. Resume in STOPPED state. Transport does NOT auto-start —
+        //    user re-arms manually, identical to the onDeviceArrived
+        //    convention.
+        setEngineState(EngineState.STOPPED);
+
+        // 8. Surface the SRC fallback notification when the driver moved
+        //    to a rate that differs from the project's session rate. The
+        //    actual SRC insertion at the device boundary is a render-graph
+        //    change owned by the engine pipeline (story 126's
+        //    com.benesquivelmusic.daw.sdk.audio.SampleRateConverter); this
+        //    controller does not own that graph.
+        // TODO(story-126-integration): wire SampleRateConverter at the
+        //   device boundary inside the engine's render graph so a project
+        //   authored at 48 kHz keeps its session rate even when the
+        //   driver moves to 44.1 kHz.
+        if (isSampleRateChange && rateActuallyDiffers) {
+            int newRateKhz = (int) Math.round(proposed.get().sampleRate() / 1000.0);
+            try {
+                notifications.notify(
+                        "Driver moved to " + newRateKhz
+                                + "kHz — SRC inserted at device boundary. "
+                                + "Pick the matching project rate from the driver "
+                                + "panel to avoid SRC.");
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING, "NotificationManager rejected message", e);
+            }
+        } else {
+            try {
+                notifications.notify("Audio engine reconfigured");
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING, "NotificationManager rejected message", e);
+            }
+        }
+    }
+
+    /**
+     * Picks the buffer-frame count to use when reopening after a
+     * {@link AudioDeviceEvent.FormatChangeRequested}. Honours the
+     * driver-proposed buffer size when it carries one
+     * (the SDK {@code AudioFormat} record does not include buffer size,
+     * so we conservatively fall back to the engine's current value when
+     * the proposed format does not encode it explicitly — this keeps
+     * the host stable until the FFM shim ships richer payloads).
+     */
+    private static int deriveBufferFrames(
+            com.benesquivelmusic.daw.sdk.audio.AudioFormat proposed,
+            AudioFormat current) {
+        // The SDK AudioFormat record is (sampleRate, channels, bitDepth)
+        // — buffer size is negotiated separately by AudioBackend.open(),
+        // so the proposed format never carries one directly. When the
+        // FFM shim wants to surface a new buffer size it does so via
+        // the next bufferSizeRange() call which the controller honours
+        // upstream. For now, retain the engine's current buffer size.
+        return current.bufferSize();
+    }
+
     private static boolean matches(DeviceId active, DeviceId other) {
         if (active.equals(other)) {
             return true;
@@ -396,13 +694,15 @@ final class DefaultAudioEngineController implements AudioEngineController {
 
         @Override
         public void onNext(AudioDeviceEvent event) {
-            // Switch on sealed AudioDeviceEvent — exhaustive over the three
+            // Switch on sealed AudioDeviceEvent — exhaustive over the four
             // permitted records. JEP 441 (final, JDK 21).
             switch (event) {
                 case AudioDeviceEvent.DeviceRemoved removed -> onDeviceRemoved(removed.device());
                 case AudioDeviceEvent.DeviceArrived arrived -> onDeviceArrived(arrived.device());
                 case AudioDeviceEvent.DeviceFormatChanged changed ->
                         LOG.info("Device format changed for " + changed.device() + ": " + changed.newFormat());
+                case AudioDeviceEvent.FormatChangeRequested requested ->
+                        onFormatChangeRequested(requested);
             }
         }
 
@@ -445,6 +745,11 @@ final class DefaultAudioEngineController implements AudioEngineController {
             try { sub.cancel(); } catch (RuntimeException ignored) { /* best-effort */ }
         }
         engineStatePublisher.close();
+        ScheduledFuture<?> pending = pendingFormatChange.getAndSet(null);
+        if (pending != null) {
+            pending.cancel(false);
+        }
+        formatChangeWorker.shutdownNow();
         XrunDetector detector = this.xrunDetector;
         if (detector != null) {
             detector.close();

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineController.java
@@ -587,7 +587,7 @@ final class DefaultAudioEngineController implements AudioEngineController {
                     sdkFmt.sampleRate(),
                     currentFormat.channels(),
                     sdkFmt.bitDepth() > 0 ? sdkFmt.bitDepth() : currentFormat.bitDepth(),
-                    deriveBufferFrames(sdkFmt, currentFormat));
+                    deriveBufferFrames(requested.reason(), currentFormat, backend, active));
         } else if (proposed.isPresent() /* sample-rate change — keep project rate */) {
             reopenFormat = currentFormat;
         } else {
@@ -600,19 +600,35 @@ final class DefaultAudioEngineController implements AudioEngineController {
             LOG.log(Level.WARNING, "Failed to set new format on audio engine", e);
         }
 
-        // 6. Reopen the SDK backend's stream when applicable — same shape
-        //    as the DeviceArrived flow. The production NativeAudioBackend
-        //    is reopened lazily by the next startAudioOutput() call.
+        // Rebuild the xrun detector so its deadline matches the new
+        // format — mirrors applyConfiguration() behaviour.
+        XrunDetector previousDetector = this.xrunDetector;
+        this.xrunDetector = createDetectorFor(reopenFormat);
+        if (previousDetector != null) {
+            previousDetector.close();
+        }
+
+        // 6. Reopen the SDK backend's stream — close first since a
+        //    driver-initiated format change occurs while the backend is
+        //    still open, and calling open() without a preceding close()
+        //    would violate AudioBackendSupport.markOpen().
         if (backend != null) {
             try {
-                if (!backend.isOpen()) {
-                    backend.open(active,
-                            new com.benesquivelmusic.daw.sdk.audio.AudioFormat(
-                                    reopenFormat.sampleRate(),
-                                    reopenFormat.channels(),
-                                    reopenFormat.bitDepth()),
-                            reopenFormat.bufferSize());
+                if (backend.isOpen()) {
+                    try {
+                        backend.close();
+                    } catch (RuntimeException closeException) {
+                        LOG.log(Level.WARNING,
+                                "Failed to close backend before reopen after format change",
+                                closeException);
+                    }
                 }
+                backend.open(active,
+                        new com.benesquivelmusic.daw.sdk.audio.AudioFormat(
+                                reopenFormat.sampleRate(),
+                                reopenFormat.channels(),
+                                reopenFormat.bitDepth()),
+                        reopenFormat.bufferSize());
             } catch (RuntimeException e) {
                 LOG.log(Level.WARNING, "Failed to reopen backend after format change", e);
             }
@@ -655,22 +671,36 @@ final class DefaultAudioEngineController implements AudioEngineController {
 
     /**
      * Picks the buffer-frame count to use when reopening after a
-     * {@link AudioDeviceEvent.FormatChangeRequested}. Honours the
-     * driver-proposed buffer size when it carries one
-     * (the SDK {@code AudioFormat} record does not include buffer size,
-     * so we conservatively fall back to the engine's current value when
-     * the proposed format does not encode it explicitly — this keeps
-     * the host stable until the FFM shim ships richer payloads).
+     * {@link AudioDeviceEvent.FormatChangeRequested}.
+     *
+     * <p>The SDK {@code AudioFormat} payload does not carry buffer frames,
+     * so a request whose reason is {@link FormatChangeReason.BufferSizeChange}
+     * reads the new frame count from
+     * {@link FormatChangeReason.BufferSizeChange#newBufferFrames()} when
+     * known, or falls back to the backend's
+     * {@link BufferSizeRange#preferred()} value. For all other reasons the
+     * current engine buffer size is retained to avoid changing multiple
+     * variables at once.</p>
      */
     private static int deriveBufferFrames(
-            com.benesquivelmusic.daw.sdk.audio.AudioFormat proposed,
-            AudioFormat current) {
-        // The SDK AudioFormat record is (sampleRate, channels, bitDepth)
-        // — buffer size is negotiated separately by AudioBackend.open(),
-        // so the proposed format never carries one directly. When the
-        // FFM shim wants to surface a new buffer size it does so via
-        // the next bufferSizeRange() call which the controller honours
-        // upstream. For now, retain the engine's current buffer size.
+            FormatChangeReason reason,
+            AudioFormat current,
+            AudioBackend backend,
+            DeviceId device) {
+        if (reason instanceof FormatChangeReason.BufferSizeChange bsc) {
+            if (bsc.newBufferFrames() > 0) {
+                return bsc.newBufferFrames();
+            }
+            // Driver signal didn't carry a concrete frame count — fall
+            // back to the backend's preferred buffer size.
+            if (backend != null) {
+                try {
+                    return backend.bufferSizeRange(device).preferred();
+                } catch (RuntimeException e) {
+                    LOG.log(Level.FINE, "Failed to query bufferSizeRange for fallback", e);
+                }
+            }
+        }
         return current.bufferSize();
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/EngineState.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/EngineState.java
@@ -31,5 +31,22 @@ public enum EngineState {
      * <p>While the engine is in this state, the rest of the application
      * remains fully responsive — only audio I/O is suspended.</p>
      */
-    DEVICE_LOST
+    DEVICE_LOST,
+
+    /**
+     * The driver asked the host to drop the current stream and reopen
+     * with a renegotiated format (story 218 — typically the user just
+     * changed buffer size, sample rate, or clock source from the vendor's
+     * native control panel). Transport is paused, the render queue is
+     * drained, the stream is closed, the backend's capabilities are
+     * re-queried, and the stream is being reopened with the proposed
+     * format. The transport bar shows "Reconfiguring audio engine…"
+     * during this window.
+     *
+     * <p>This is a transient state: the controller transitions back to
+     * {@link #STOPPED} (the user re-arms transport manually) once the
+     * reopen succeeds, or back to {@link #STOPPED} with a notification
+     * if the reopen fails.</p>
+     */
+    RECONFIGURING
 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineControllerTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineControllerTest.java
@@ -3,8 +3,11 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.core.audio.AudioEngine;
 import com.benesquivelmusic.daw.core.audio.AudioFormat;
 import com.benesquivelmusic.daw.sdk.audio.DeviceId;
+import com.benesquivelmusic.daw.sdk.audio.FormatChangeReason;
 import com.benesquivelmusic.daw.sdk.audio.MockAudioBackend;
 import com.benesquivelmusic.daw.sdk.audio.SampleRate;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -228,6 +231,124 @@ class DefaultAudioEngineControllerTest {
         }
     }
 
+    // -- Driver-initiated format-change handling (story 218) -----------------
+
+    @Test
+    void formatChangeRequestedTriggersReopenWithProposedFormat(@TempDir Path projectRoot)
+            throws InterruptedException {
+        // Engine starts at 256-frame buffer.
+        AudioFormat starting = new AudioFormat(48_000.0, 2, 24, 256);
+        AudioEngine engine = new AudioEngine(starting);
+        List<String> notifications = new ArrayList<>();
+        DefaultAudioEngineController controller = new DefaultAudioEngineController(
+                engine, null,
+                message -> { synchronized (notifications) { notifications.add(message); } },
+                new IncompleteTakeStore(projectRoot));
+
+        MockAudioBackend backend = new MockAudioBackend();
+        backend.setBufferSizeRange(
+                new com.benesquivelmusic.daw.sdk.audio.BufferSizeRange(64, 2048, 512, 64));
+        DeviceId active = new DeviceId(MockAudioBackend.NAME, "Mock Device");
+        controller.bindBackendDeviceEvents(backend, active);
+
+        // Track engine-state transitions so we can wait for the
+        // RECONFIGURING -> STOPPED arc rather than a stale STOPPED match
+        // (the engine starts in STOPPED).
+        List<EngineState> transitions = new ArrayList<>();
+        controller.engineStateEvents().subscribe(new java.util.concurrent.Flow.Subscriber<>() {
+            @Override public void onSubscribe(java.util.concurrent.Flow.Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+            @Override public void onNext(EngineState s) {
+                synchronized (transitions) { transitions.add(s); }
+            }
+            @Override public void onError(Throwable t) { /* ignore */ }
+            @Override public void onComplete() { /* ignore */ }
+        });
+
+        // The driver renegotiated to a 512-frame buffer at the same rate.
+        com.benesquivelmusic.daw.sdk.audio.AudioFormat proposed =
+                new com.benesquivelmusic.daw.sdk.audio.AudioFormat(48_000.0, 2, 24);
+        backend.simulateFormatChangeRequested(active, Optional.of(proposed),
+                new FormatChangeReason.BufferSizeChange());
+
+        // Wait for the worker to publish RECONFIGURING followed by STOPPED.
+        waitForLong(() -> {
+            synchronized (transitions) {
+                return transitions.contains(EngineState.RECONFIGURING)
+                        && transitions.lastIndexOf(EngineState.STOPPED)
+                                > transitions.indexOf(EngineState.RECONFIGURING);
+            }
+        });
+
+        assertThat(controller.engineState()).isEqualTo(EngineState.STOPPED);
+        // Engine retained the proposed sample rate / bit depth.
+        assertThat(engine.getFormat().sampleRate()).isEqualTo(48_000.0);
+        assertThat(engine.getFormat().bitDepth()).isEqualTo(24);
+        // No exception escaped through the publisher; the engine survived.
+        assertThat(engine.isRunning()).isFalse();
+        // User-facing notifications were emitted around the reopen.
+        synchronized (notifications) {
+            assertThat(notifications)
+                    .anyMatch(m -> m.toLowerCase().contains("reconfigur"));
+        }
+    }
+
+    @Test
+    void sampleRateChangeRequestedFallsBackToSrc(@TempDir Path projectRoot)
+            throws InterruptedException {
+        // Project session at 48 kHz.
+        AudioFormat starting = new AudioFormat(48_000.0, 2, 24, 256);
+        AudioEngine engine = new AudioEngine(starting);
+        List<String> notifications = new ArrayList<>();
+        DefaultAudioEngineController controller = new DefaultAudioEngineController(
+                engine, null,
+                message -> { synchronized (notifications) { notifications.add(message); } },
+                new IncompleteTakeStore(projectRoot));
+
+        MockAudioBackend backend = new MockAudioBackend();
+        DeviceId active = new DeviceId(MockAudioBackend.NAME, "Mock Device");
+        controller.bindBackendDeviceEvents(backend, active);
+
+        List<EngineState> transitions = new ArrayList<>();
+        controller.engineStateEvents().subscribe(new java.util.concurrent.Flow.Subscriber<>() {
+            @Override public void onSubscribe(java.util.concurrent.Flow.Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+            @Override public void onNext(EngineState s) {
+                synchronized (transitions) { transitions.add(s); }
+            }
+            @Override public void onError(Throwable t) { /* ignore */ }
+            @Override public void onComplete() { /* ignore */ }
+        });
+
+        // Driver moved to 44.1 kHz. The session rate must NOT change.
+        com.benesquivelmusic.daw.sdk.audio.AudioFormat proposed =
+                new com.benesquivelmusic.daw.sdk.audio.AudioFormat(44_100.0, 2, 24);
+        backend.simulateFormatChangeRequested(active, Optional.of(proposed),
+                new FormatChangeReason.SampleRateChange());
+
+        waitForLong(() -> {
+            synchronized (transitions) {
+                return transitions.contains(EngineState.RECONFIGURING)
+                        && transitions.lastIndexOf(EngineState.STOPPED)
+                                > transitions.indexOf(EngineState.RECONFIGURING);
+            }
+        });
+
+        // Project session rate unchanged: SRC fallback at the device boundary.
+        assertThat(engine.getFormat().sampleRate()).isEqualTo(48_000.0);
+        // SRC notification must mention the rate move so the user knows
+        // they can pick a matching project rate from the driver panel.
+        synchronized (notifications) {
+            assertThat(notifications)
+                    .anyMatch(m -> m.toLowerCase().contains("src"));
+            assertThat(notifications)
+                    .anyMatch(m -> m.contains("44") /* 44 kHz */);
+        }
+        assertThat(engine.isRunning()).isFalse();
+    }
+
     private static void waitFor(java.util.function.BooleanSupplier condition)
             throws InterruptedException {
         long deadline = System.nanoTime() + java.time.Duration.ofSeconds(2).toNanos();
@@ -236,6 +357,20 @@ class DefaultAudioEngineControllerTest {
                 return;
             }
             Thread.sleep(5);
+        }
+    }
+
+    /** Same as {@link #waitFor(java.util.function.BooleanSupplier)} but with a
+     * longer ceiling — the format-change worker debounces 250 ms before the
+     * 200 ms drain, so the total wait is at least ~450 ms before STOPPED. */
+    private static void waitForLong(java.util.function.BooleanSupplier condition)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + java.time.Duration.ofSeconds(3).toNanos();
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(10);
         }
     }
 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineControllerTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineControllerTest.java
@@ -358,6 +358,10 @@ class DefaultAudioEngineControllerTest {
             }
             Thread.sleep(5);
         }
+        if (!condition.getAsBoolean()) {
+            throw new AssertionError(
+                    "Timed out after 2 s waiting for condition to become true");
+        }
     }
 
     /** Same as {@link #waitFor(java.util.function.BooleanSupplier)} but with a
@@ -371,6 +375,10 @@ class DefaultAudioEngineControllerTest {
                 return;
             }
             Thread.sleep(10);
+        }
+        if (!condition.getAsBoolean()) {
+            throw new AssertionError(
+                    "Timed out after 3 s waiting for condition to become true");
         }
     }
 }

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
@@ -110,9 +110,13 @@ public final class AsioBackend implements AudioBackend {
      * <ul>
      *   <li>{@code kAsioBufferSizeChange(newFrames)} &rarr;
      *       {@code reason = }{@link FormatChangeReason.BufferSizeChange};
-     *       the new {@link AudioFormat} carries the new
-     *       {@code bufferFrames} and the previously opened sample
-     *       rate / channel count / bit depth.</li>
+     *       {@code proposedFormat} can only carry the previously opened
+     *       sample rate / channel count / bit depth, because
+     *       {@code bufferFrames} is negotiated separately via
+     *       {@link AudioBackend#open(DeviceId, AudioFormat, int)} and is
+     *       not part of {@link AudioFormat}. The new frame count is
+     *       carried as
+     *       {@link FormatChangeReason.BufferSizeChange#newBufferFrames()}.</li>
      *   <li>{@code kAsioResetRequest} after a successful
      *       {@code ASIOSetSampleRate(newRate)} &rarr;
      *       {@code reason = }{@link FormatChangeReason.SampleRateChange};

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
@@ -80,11 +80,66 @@ public final class AsioBackend implements AudioBackend {
      *
      * <p>The native shim translates those driver notifications into
      * {@link AudioDeviceEvent}s; delivery semantics are defined by the
-     * {@link AudioBackend#deviceEvents()} contract.</p>
+     * {@link AudioBackend#deviceEvents()} contract. Format-change
+     * requests in particular (story 218) are surfaced as
+     * {@link AudioDeviceEvent.FormatChangeRequested} via
+     * {@link #publishFormatChangeRequested(DeviceId, java.util.Optional,
+     * FormatChangeReason)} from the native callback running on the
+     * ASIO host-callback thread; see that method's Javadoc for the
+     * exact mapping from each ASIO callback to a
+     * {@link FormatChangeReason}.</p>
      */
     @Override
     public Flow.Publisher<AudioDeviceEvent> deviceEvents() {
         return support.deviceEvents();
+    }
+
+    /**
+     * Hook called by the native ASIO host-callback shim under
+     * {@code daw-core/native/asio/} to surface a driver-initiated
+     * reset request as a {@link AudioDeviceEvent.FormatChangeRequested}
+     * event on this backend's {@link #deviceEvents()} publisher.
+     *
+     * <p>Mapping conventions used by the shim:</p>
+     * <ul>
+     *   <li>{@code kAsioBufferSizeChange(newFrames)} &rarr;
+     *       {@code reason = }{@link FormatChangeReason.BufferSizeChange};
+     *       the new {@link AudioFormat} carries the new
+     *       {@code bufferFrames} and the previously opened sample
+     *       rate / channel count / bit depth.</li>
+     *   <li>{@code kAsioResetRequest} after a successful
+     *       {@code ASIOSetSampleRate(newRate)} &rarr;
+     *       {@code reason = }{@link FormatChangeReason.SampleRateChange};
+     *       the new format carries the new sample rate.</li>
+     *   <li>{@code kAsioResyncRequest} &rarr;
+     *       {@code reason = }{@link FormatChangeReason.ClockSourceChange};
+     *       the proposed format is typically empty since the rate /
+     *       buffer size do not necessarily change.</li>
+     *   <li>any other {@code kAsioResetRequest} (USB streaming-mode
+     *       change, USB hub cycle, vendor utility "reset") &rarr;
+     *       {@code reason = }{@link FormatChangeReason.DriverReset}.</li>
+     * </ul>
+     *
+     * <p>Package-private: only the SDK's native shim is meant to call
+     * this directly. The publisher accepts the event without blocking
+     * (the underlying {@code SubmissionPublisher.offer(...)} drops
+     * under back-pressure rather than stalling), so it is safe to call
+     * from the ASIO host-callback thread.</p>
+     *
+     * @param device         the affected device id; must not be null
+     * @param proposedFormat the format the driver is moving to, when known;
+     *                       must not be null (use
+     *                       {@link java.util.Optional#empty()} for unknown)
+     * @param reason         why the driver is asking for a reset; must not be null
+     */
+    void publishFormatChangeRequested(DeviceId device,
+                                      java.util.Optional<AudioFormat> proposedFormat,
+                                      FormatChangeReason reason) {
+        Objects.requireNonNull(device, "device must not be null");
+        Objects.requireNonNull(proposedFormat, "proposedFormat must not be null");
+        Objects.requireNonNull(reason, "reason must not be null");
+        support.publishDeviceEvent(
+                new AudioDeviceEvent.FormatChangeRequested(device, proposedFormat, reason));
     }
 
     @Override

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
@@ -33,6 +33,7 @@ public final class AsioBackend implements AudioBackend {
                     && AudioBackendSupport.nativeLibraryAvailable("asio", "asiosdk");
 
     private final AudioBackendSupport support = new AudioBackendSupport();
+    private volatile AsioFormatChangeShim formatChangeShim;
 
     /** Creates a new ASIO backend (no native resources allocated until {@link #open}). */
     public AsioBackend() {
@@ -63,6 +64,11 @@ public final class AsioBackend implements AudioBackend {
                             + "(e.g. ASIO4ALL) and rebuild daw-core with the ASIO shim.");
         }
         support.markOpen(format, bufferFrames);
+        // Story 218: install the FFM upcall that translates ASIO's
+        // asioMessage host-callback into publishFormatChangeRequested(...).
+        // Construction always succeeds; the actual native registration is
+        // a no-op if the asioshim library is not present on this host.
+        this.formatChangeShim = new AsioFormatChangeShim(this, support, device);
         // Native ASIO buffer-switch wiring lives in the implementation layer
         // that ships the Steinberg ASIO SDK shim; see daw-core/native/asio/.
     }
@@ -181,6 +187,11 @@ public final class AsioBackend implements AudioBackend {
 
     @Override
     public void close() {
+        AsioFormatChangeShim shim = this.formatChangeShim;
+        this.formatChangeShim = null;
+        if (shim != null) {
+            shim.close();
+        }
         support.close();
     }
 

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShim.java
@@ -153,9 +153,9 @@ final class AsioFormatChangeShim implements AutoCloseable {
      *       {@link FormatChangeReason.BufferSizeChange}. The proposed
      *       format carries the previously opened sample rate / channels
      *       / bit depth via {@link AudioBackendSupport#format()};
-     *       {@code value} is the new frame count but
-     *       {@link AudioFormat} does not include buffer size, so the
-     *       new frame count is implicit in the event semantics.</li>
+     *       {@code value} is the new frame count and is carried as
+     *       {@link FormatChangeReason.BufferSizeChange#newBufferFrames()}
+     *       so consumers can apply it during reopen.</li>
      *   <li>{@link #kAsioResyncRequest} &rarr;
      *       {@link FormatChangeReason.ClockSourceChange}; proposed
      *       format is empty.</li>
@@ -186,7 +186,8 @@ final class AsioFormatChangeShim implements AutoCloseable {
                                 current.channels(),
                                 current.bitDepth()));
                 backend.publishFormatChangeRequested(
-                        device, proposed, new FormatChangeReason.BufferSizeChange());
+                        device, proposed,
+                        new FormatChangeReason.BufferSizeChange((int) value));
                 return ASE_OK;
             }
             case kAsioResyncRequest:

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShim.java
@@ -1,0 +1,260 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * FFM (JEP 454) shim that translates the ASIO host-callback's
+ * {@code asioMessage(long selector, long value, void* message, double* opt) -> long}
+ * upcall into {@link AsioBackend#publishFormatChangeRequested(DeviceId,
+ * Optional, FormatChangeReason)} invocations (story 218).
+ *
+ * <p>The shim is constructed by {@link AsioBackend#open(DeviceId,
+ * AudioFormat, int)}. Construction always succeeds on every platform:
+ * the upcall stub itself is built via {@link Linker#nativeLinker()},
+ * which is available on every supported JVM. Only the optional
+ * {@code asioshim} library lookup and the
+ * {@code installAsioMessageCallback} downcall are platform-conditional;
+ * if either is missing the shim degrades to a no-op and
+ * {@link AsioBackend#publishFormatChangeRequested(DeviceId, Optional,
+ * FormatChangeReason)} simply never fires.</p>
+ *
+ * <p>The {@link #dispatch(long, long)} entrypoint is package-private so
+ * that unit tests can exercise the selector-to-reason mapping without
+ * requiring an actual native ASIO driver to be installed.</p>
+ */
+final class AsioFormatChangeShim implements AutoCloseable {
+
+    /** ASIO selector: a generic reset request from the driver. */
+    static final int kAsioResetRequest = 3;
+    /** ASIO selector: the driver wants the host to resync the device clock. */
+    static final int kAsioResyncRequest = 4;
+    /** ASIO selector: the driver renegotiated the buffer size to {@code value} frames. */
+    static final int kAsioBufferSizeChange = 7;
+
+    /** ASE_OK — selector handled successfully. */
+    private static final long ASE_OK = 1L;
+    /** ASE_NotPresent — selector unknown / unhandled. */
+    private static final long ASE_NOT_PRESENT = 0L;
+
+    /** Function descriptor for ASIO's {@code asioMessage(long, long, void*, double*) -> long}. */
+    private static final FunctionDescriptor ASIO_MESSAGE =
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.ADDRESS);
+
+    private final AsioBackend backend;
+    private final AudioBackendSupport support;
+    private final DeviceId device;
+    private final Arena arena;
+    private final MemorySegment upcallStub;
+    private final boolean registered;
+    private boolean closed;
+
+    /**
+     * Builds the upcall stub and (on Windows hosts where the
+     * {@code asioshim} library is present) installs it via the
+     * shim's {@code installAsioMessageCallback} entrypoint.
+     *
+     * @param backend the owning backend; must not be null
+     * @param support the support holding the currently-opened
+     *                {@link AudioFormat}; must not be null. The shim
+     *                reads {@link AudioBackendSupport#format()} on
+     *                {@code kAsioBufferSizeChange} so that the proposed
+     *                format carries the previously opened sample rate /
+     *                channels / bit depth
+     * @param device  the device id this shim is bound to; must not be null
+     */
+    AsioFormatChangeShim(AsioBackend backend, AudioBackendSupport support, DeviceId device) {
+        this.backend = Objects.requireNonNull(backend, "backend must not be null");
+        this.support = Objects.requireNonNull(support, "support must not be null");
+        this.device = Objects.requireNonNull(device, "device must not be null");
+        this.arena = Arena.ofConfined();
+        this.upcallStub = buildUpcallStub();
+        this.registered = tryRegister();
+    }
+
+    private MemorySegment buildUpcallStub() {
+        try {
+            MethodHandle handle = MethodHandles.lookup().findVirtual(
+                    AsioFormatChangeShim.class,
+                    "asioMessageUpcall",
+                    MethodType.methodType(long.class,
+                            long.class, long.class,
+                            MemorySegment.class, MemorySegment.class))
+                    .bindTo(this);
+            return Linker.nativeLinker().upcallStub(handle, ASIO_MESSAGE, arena);
+        } catch (Throwable t) {
+            // Linker/method handle wiring should never fail on a supported
+            // JVM, but if it does we degrade to a no-op rather than break
+            // open() — story 218 explicitly requires graceful degradation.
+            return MemorySegment.NULL;
+        }
+    }
+
+    private boolean tryRegister() {
+        if (upcallStub.equals(MemorySegment.NULL)) {
+            return false;
+        }
+        try {
+            SymbolLookup lookup = SymbolLookup.libraryLookup("asioshim", arena);
+            MemorySegment install = lookup.find("installAsioMessageCallback")
+                    .orElseThrow(() -> new UnsatisfiedLinkError(
+                            "installAsioMessageCallback not found"));
+            MethodHandle handle = Linker.nativeLinker().downcallHandle(
+                    install, FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+            handle.invoke(upcallStub);
+            return true;
+        } catch (IllegalArgumentException | UnsatisfiedLinkError ignored) {
+            // Library not present on this host — no-op.
+            return false;
+        } catch (Throwable ignored) {
+            // Any other failure (missing symbol, ABI mismatch) — no-op.
+            return false;
+        }
+    }
+
+    /**
+     * Method handle target for the FFM upcall stub. Bound to {@code this}
+     * via {@link MethodHandles#bindTo(Object)}; the JVM calls it from the
+     * ASIO host-callback thread when the driver fires
+     * {@code asioMessage}.
+     */
+    @SuppressWarnings("unused") // invoked reflectively via the upcall stub
+    private long asioMessageUpcall(long selector, long value,
+                                   MemorySegment message, MemorySegment opt) {
+        try {
+            return dispatch(selector, value);
+        } catch (Throwable t) {
+            // Never let an exception propagate back into native code.
+            return ASE_NOT_PRESENT;
+        }
+    }
+
+    /**
+     * Translates a single ASIO host-callback into a
+     * {@link AudioDeviceEvent.FormatChangeRequested} event on the
+     * backend's {@link AudioBackend#deviceEvents()} publisher.
+     *
+     * <p>Selector mapping (story 218):</p>
+     * <ul>
+     *   <li>{@link #kAsioBufferSizeChange} &rarr;
+     *       {@link FormatChangeReason.BufferSizeChange}. The proposed
+     *       format carries the previously opened sample rate / channels
+     *       / bit depth via {@link AudioBackendSupport#format()};
+     *       {@code value} is the new frame count but
+     *       {@link AudioFormat} does not include buffer size, so the
+     *       new frame count is implicit in the event semantics.</li>
+     *   <li>{@link #kAsioResyncRequest} &rarr;
+     *       {@link FormatChangeReason.ClockSourceChange}; proposed
+     *       format is empty.</li>
+     *   <li>{@link #kAsioResetRequest} &rarr;
+     *       {@link FormatChangeReason.DriverReset}; proposed format
+     *       is empty. Sample-rate-driven resets cannot be distinguished
+     *       here without an additional {@code ASIOGetSampleRate()}
+     *       downcall — they are reported as {@code DriverReset} and the
+     *       controller re-queries device capabilities on reopen.</li>
+     * </ul>
+     *
+     * <p>Package-private so that unit tests can drive each selector
+     * without needing a real ASIO driver loaded.</p>
+     *
+     * @param selector the ASIO selector code
+     * @param value    selector-specific payload (e.g. new buffer size in frames)
+     * @return {@link #ASE_OK} for known selectors,
+     *         {@link #ASE_NOT_PRESENT} otherwise
+     */
+    long dispatch(long selector, long value) {
+        switch ((int) selector) {
+            case kAsioBufferSizeChange: {
+                AudioFormat current = support.format();
+                Optional<AudioFormat> proposed = current == null
+                        ? Optional.empty()
+                        : Optional.of(new AudioFormat(
+                                current.sampleRate(),
+                                current.channels(),
+                                current.bitDepth()));
+                backend.publishFormatChangeRequested(
+                        device, proposed, new FormatChangeReason.BufferSizeChange());
+                return ASE_OK;
+            }
+            case kAsioResyncRequest:
+                backend.publishFormatChangeRequested(
+                        device, Optional.empty(),
+                        new FormatChangeReason.ClockSourceChange());
+                return ASE_OK;
+            case kAsioResetRequest:
+                backend.publishFormatChangeRequested(
+                        device, Optional.empty(),
+                        new FormatChangeReason.DriverReset());
+                return ASE_OK;
+            default:
+                return ASE_NOT_PRESENT;
+        }
+    }
+
+    /**
+     * Returns {@code true} if the shim successfully registered itself
+     * with the {@code asioshim} native library. Tests use this to verify
+     * registration is correctly skipped on hosts that lack the library.
+     *
+     * @return true iff {@code installAsioMessageCallback} was invoked
+     */
+    boolean isRegistered() {
+        return registered;
+    }
+
+    /**
+     * Returns the address of the upcall stub bound to ASIO's
+     * {@code asioMessage} entrypoint. Exposed for testing only.
+     *
+     * @return the upcall stub's address (never null;
+     *         {@link MemorySegment#NULL} if construction failed)
+     */
+    MemorySegment upcallStub() {
+        return upcallStub;
+    }
+
+    /**
+     * Unregisters the upcall (when registration succeeded) and frees the
+     * upcall stub. Idempotent — safe to call multiple times.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (registered) {
+            try {
+                SymbolLookup lookup = SymbolLookup.libraryLookup("asioshim", arena);
+                lookup.find("uninstallAsioMessageCallback").ifPresent(symbol -> {
+                    try {
+                        Linker.nativeLinker().downcallHandle(
+                                symbol, FunctionDescriptor.ofVoid()).invoke();
+                    } catch (Throwable ignored) {
+                        // Best-effort: never throw from close().
+                    }
+                });
+            } catch (Throwable ignored) {
+                // Library disappeared between open() and close() — ignore.
+            }
+        }
+        try {
+            arena.close();
+        } catch (Throwable ignored) {
+            // Already closed by something else — idempotent.
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBackend.java
@@ -329,20 +329,48 @@ public sealed interface AudioBackend extends AutoCloseable
      *   <li>{@link AsioBackend} — translates {@code kAsioResetRequest},
      *       {@code kAsioBufferSizeChange}, and
      *       {@code kAsioResyncRequest} from the ASIO callback set
-     *       installed on driver open.</li>
+     *       installed on driver open. {@code kAsioBufferSizeChange}
+     *       maps to
+     *       {@link AudioDeviceEvent.FormatChangeRequested} with
+     *       {@link FormatChangeReason.BufferSizeChange};
+     *       {@code kAsioResetRequest} after a sample-rate renegotiation
+     *       maps to {@link FormatChangeReason.SampleRateChange};
+     *       {@code kAsioResyncRequest} maps to
+     *       {@link FormatChangeReason.ClockSourceChange}; a generic
+     *       {@code kAsioResetRequest} (USB streaming-mode change, USB
+     *       hub cycle) maps to {@link FormatChangeReason.DriverReset}.</li>
      *   <li>{@link WasapiBackend} — subscribes to
      *       {@code IMMNotificationClient::OnDeviceStateChanged} and
-     *       {@code OnDefaultDeviceChanged}.</li>
+     *       {@code OnDefaultDeviceChanged} for arrival/removal, plus
+     *       {@code IMMNotificationClient::OnPropertyValueChanged} on
+     *       the active endpoint and full {@code IAudioClient}
+     *       invalidation, which both map to
+     *       {@link AudioDeviceEvent.FormatChangeRequested} with
+     *       {@link FormatChangeReason.SampleRateChange} (mix-format
+     *       change) or {@link FormatChangeReason.DriverReset}
+     *       (client invalidation).</li>
      *   <li>{@link CoreAudioBackend} — installs a property listener
-     *       on {@code kAudioHardwarePropertyDevices}.</li>
+     *       on {@code kAudioHardwarePropertyDevices} for arrival/removal,
+     *       plus per-device listeners on
+     *       {@code kAudioDevicePropertyNominalSampleRate}
+     *       ({@link FormatChangeReason.SampleRateChange}),
+     *       {@code kAudioDevicePropertyBufferFrameSize}
+     *       ({@link FormatChangeReason.BufferSizeChange}), and
+     *       {@code kAudioDevicePropertyClockSource}
+     *       ({@link FormatChangeReason.ClockSourceChange}) — all
+     *       wrapped in {@link AudioDeviceEvent.FormatChangeRequested}.</li>
      *   <li>{@link JackBackend} — watches for JACK server shutdown
      *       (registered shutdown callback) and port-registration
-     *       changes.</li>
+     *       changes. The JACK server has a single global format and
+     *       restarts to renegotiate, so format-change requests are
+     *       not surfaced.</li>
      *   <li>{@link JavaxSoundBackend} — emits no events; the JDK mixer
-     *       does not expose a hot-plug notification API.</li>
+     *       does not expose a hot-plug or format-change notification
+     *       API.</li>
      *   <li>{@link MockAudioBackend} — exposes
-     *       {@code simulateDeviceArrived/Removed/FormatChanged} so
-     *       tests can drive the device-event flow deterministically.</li>
+     *       {@code simulateDeviceArrived/Removed/FormatChanged} and
+     *       {@code simulateFormatChangeRequested} so tests can drive
+     *       the device-event flow deterministically.</li>
      * </ul>
      *
      * <p>Events are delivered on a backend-owned thread (the OS

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioDeviceEvent.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioDeviceEvent.java
@@ -1,11 +1,13 @@
 package com.benesquivelmusic.daw.sdk.audio;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Sealed event published by an {@link AudioBackend} when the host OS or
- * vendor driver reports that a device has arrived, gone away, or
- * changed its native format.
+ * vendor driver reports that a device has arrived, gone away, changed
+ * its native format, or asked the host to drop and reopen the stream
+ * with a renegotiated format.
  *
  * <p>USB audio interfaces enumerate and unenumerate freely: a yanked
  * cable, a sleeping laptop, a powered USB hub cycling, or a driver
@@ -24,7 +26,11 @@ import java.util.Objects;
  *
  * @see AudioBackend#deviceEvents()
  */
-public sealed interface AudioDeviceEvent {
+public sealed interface AudioDeviceEvent
+        permits AudioDeviceEvent.DeviceArrived,
+                AudioDeviceEvent.DeviceRemoved,
+                AudioDeviceEvent.DeviceFormatChanged,
+                AudioDeviceEvent.FormatChangeRequested {
 
     /**
      * Returns the device the event refers to. Never {@code null}.
@@ -78,6 +84,64 @@ public sealed interface AudioDeviceEvent {
         public DeviceFormatChanged {
             Objects.requireNonNull(device, "device must not be null");
             Objects.requireNonNull(newFormat, "newFormat must not be null");
+        }
+    }
+
+    /**
+     * Emitted when the vendor driver asks the host to drop the current
+     * stream and reopen with a renegotiated format — story 218
+     * ("Driver-Initiated Reset Request Handling for Mid-Session Format
+     * Changes").
+     *
+     * <p>Distinct from {@link DeviceFormatChanged}: that event represents
+     * a <em>completed</em> format change observed by the driver after
+     * the fact, while {@code FormatChangeRequested} is the pending
+     * request that requires a host-side reopen. The application's
+     * controller pauses transport, drains the render queue, closes the
+     * stream, re-queries device capabilities, reopens with
+     * {@link #proposedFormat()} (or the existing settings when empty),
+     * and resumes in {@code STOPPED}.</p>
+     *
+     * <p>Per-OS sources (translated by the native backends):</p>
+     * <ul>
+     *   <li>ASIO &mdash; {@code kAsioResetRequest} (with a fresh
+     *       {@code ASIOGetSampleRate}), {@code kAsioBufferSizeChange},
+     *       {@code kAsioResyncRequest} from the host-callback set
+     *       installed on driver open.</li>
+     *   <li>CoreAudio &mdash; property listeners on
+     *       {@code kAudioDevicePropertyNominalSampleRate},
+     *       {@code kAudioDevicePropertyBufferFrameSize}, and
+     *       {@code kAudioDevicePropertyClockSource}.</li>
+     *   <li>WASAPI &mdash;
+     *       {@code IMMNotificationClient::OnPropertyValueChanged} on the
+     *       active endpoint, plus full {@code IAudioClient}
+     *       invalidation from the audio engine.</li>
+     * </ul>
+     *
+     * <p>{@code proposedFormat} is the new format the driver is moving
+     * to when the backend can determine it from the underlying signal
+     * (for example ASIO's {@code kAsioBufferSizeChange} ships the new
+     * frame count, and CoreAudio's nominal-sample-rate listener ships
+     * the new rate). It is {@link Optional#empty()} when the underlying
+     * signal does not carry the new format (for example a generic
+     * {@code kAsioResetRequest} or a WASAPI {@code IAudioClient}
+     * invalidation), in which case the host re-queries the backend's
+     * capabilities and reopens with the existing settings.</p>
+     *
+     * @param device         id of the affected device; never null
+     * @param proposedFormat the format the driver is moving to, when known;
+     *                       never null (use {@link Optional#empty()} for
+     *                       unknown)
+     * @param reason         why the driver is asking for a reset; never null
+     */
+    record FormatChangeRequested(
+            DeviceId device,
+            Optional<AudioFormat> proposedFormat,
+            FormatChangeReason reason) implements AudioDeviceEvent {
+        public FormatChangeRequested {
+            Objects.requireNonNull(device, "device must not be null");
+            Objects.requireNonNull(proposedFormat, "proposedFormat must not be null");
+            Objects.requireNonNull(reason, "reason must not be null");
         }
     }
 }

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioBackend.java
@@ -98,12 +98,15 @@ public final class CoreAudioBackend implements AudioBackend {
      *   <li>{@code kAudioDevicePropertyNominalSampleRate} listener
      *       fires &rarr;
      *       {@code reason = }{@link FormatChangeReason.SampleRateChange};
-     *       the new {@link AudioFormat} carries the just-read
-     *       {@code Float64} rate.</li>
+     *       {@code proposedFormat} is {@link java.util.Optional#empty()}
+     *       because the listener fires before the new value is fully
+     *       readable; the controller re-queries on reopen.</li>
      *   <li>{@code kAudioDevicePropertyBufferFrameSize} listener
      *       fires &rarr;
      *       {@code reason = }{@link FormatChangeReason.BufferSizeChange};
-     *       the new format carries the just-read frame count.</li>
+     *       {@code proposedFormat} is {@link java.util.Optional#empty()};
+     *       the new frame count is not yet readable at notification
+     *       time.</li>
      *   <li>{@code kAudioDevicePropertyClockSource} listener fires
      *       &rarr;
      *       {@code reason = }{@link FormatChangeReason.ClockSourceChange};

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioBackend.java
@@ -26,6 +26,7 @@ public final class CoreAudioBackend implements AudioBackend {
     private static final boolean AVAILABLE = isMac();
 
     private final AudioBackendSupport support = new AudioBackendSupport();
+    private volatile CoreAudioFormatChangeShim formatChangeShim;
 
     /** Creates a new CoreAudio backend (no native resources allocated until {@link #open}). */
     public CoreAudioBackend() {
@@ -54,6 +55,11 @@ public final class CoreAudioBackend implements AudioBackend {
             throw new AudioBackendException("CoreAudio is only available on macOS.");
         }
         support.markOpen(format, bufferFrames);
+        // Story 218: install CoreAudio property listeners that translate
+        // nominal-sample-rate / buffer-frame-size / clock-source changes
+        // into publishFormatChangeRequested(...). On non-macOS hosts the
+        // CoreAudio.framework lookup fails and the shim degrades to no-op.
+        this.formatChangeShim = new CoreAudioFormatChangeShim(this, device);
         // Native AudioUnit render-callback wiring is implemented on macOS builds.
     }
 
@@ -166,6 +172,11 @@ public final class CoreAudioBackend implements AudioBackend {
 
     @Override
     public void close() {
+        CoreAudioFormatChangeShim shim = this.formatChangeShim;
+        this.formatChangeShim = null;
+        if (shim != null) {
+            shim.close();
+        }
         support.close();
     }
 

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioBackend.java
@@ -69,10 +69,60 @@ public final class CoreAudioBackend implements AudioBackend {
      * {@code kAudioDevicePropertyNominalSampleRate} listeners)
      * into {@link AudioDeviceEvent}s. The native shim publishes via
      * {@link AudioBackendSupport#publishDeviceEvent(AudioDeviceEvent)}.
+     *
+     * <p>Format-change requests (story 218) are surfaced via
+     * {@link #publishFormatChangeRequested(DeviceId, java.util.Optional,
+     * FormatChangeReason)} from the per-device property listeners
+     * registered on stream open.</p>
      */
     @Override
     public Flow.Publisher<AudioDeviceEvent> deviceEvents() {
         return support.deviceEvents();
+    }
+
+    /**
+     * Hook called by the macOS FFM shim from the per-device CoreAudio
+     * property listeners registered on stream open to surface a
+     * driver-initiated reset request as a
+     * {@link AudioDeviceEvent.FormatChangeRequested} event on this
+     * backend's {@link #deviceEvents()} publisher (story 218).
+     *
+     * <p>Mapping conventions used by the shim:</p>
+     * <ul>
+     *   <li>{@code kAudioDevicePropertyNominalSampleRate} listener
+     *       fires &rarr;
+     *       {@code reason = }{@link FormatChangeReason.SampleRateChange};
+     *       the new {@link AudioFormat} carries the just-read
+     *       {@code Float64} rate.</li>
+     *   <li>{@code kAudioDevicePropertyBufferFrameSize} listener
+     *       fires &rarr;
+     *       {@code reason = }{@link FormatChangeReason.BufferSizeChange};
+     *       the new format carries the just-read frame count.</li>
+     *   <li>{@code kAudioDevicePropertyClockSource} listener fires
+     *       &rarr;
+     *       {@code reason = }{@link FormatChangeReason.ClockSourceChange};
+     *       the proposed format is typically empty.</li>
+     * </ul>
+     *
+     * <p>Package-private: only the SDK's native shim is meant to call
+     * this directly. The publisher accepts the event without blocking,
+     * so it is safe to call from the CoreAudio dispatch queue the
+     * property listener was registered on.</p>
+     *
+     * @param device         the affected device id; must not be null
+     * @param proposedFormat the format the driver is moving to, when known;
+     *                       must not be null (use
+     *                       {@link java.util.Optional#empty()} for unknown)
+     * @param reason         why the driver is asking for a reset; must not be null
+     */
+    void publishFormatChangeRequested(DeviceId device,
+                                      java.util.Optional<AudioFormat> proposedFormat,
+                                      FormatChangeReason reason) {
+        Objects.requireNonNull(device, "device must not be null");
+        Objects.requireNonNull(proposedFormat, "proposedFormat must not be null");
+        Objects.requireNonNull(reason, "reason must not be null");
+        support.publishDeviceEvent(
+                new AudioDeviceEvent.FormatChangeRequested(device, proposedFormat, reason));
     }
 
     @Override

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioFormatChangeShim.java
@@ -90,6 +90,8 @@ final class CoreAudioFormatChangeShim implements AutoCloseable {
     private final DeviceId device;
     private final Arena arena;
     private final MemorySegment upcallStub;
+    /** The {@code AudioObjectID} the listeners were registered on. */
+    private final int registeredObjectID;
     /** Holds (selectorAddress, addPropertyListenerHandle, removeHandle) per registration. */
     private final List<MemorySegment> registeredAddresses = new ArrayList<>();
     private final MethodHandle removeListener;
@@ -99,15 +101,29 @@ final class CoreAudioFormatChangeShim implements AutoCloseable {
      * Builds the shared listener upcall stub and (on macOS) registers it
      * for the three property selectors.
      *
-     * @param backend owning backend; never null
-     * @param device  device id to use when publishing; never null
+     * @param backend  owning backend; never null
+     * @param device   device id to use when publishing; never null
+     * @param objectID the {@code AudioObjectID} to register listeners on;
+     *                 use {@link #kAudioObjectSystemObject} as a
+     *                 placeholder until the real {@code AudioDeviceID}
+     *                 is known (story 130)
      */
-    CoreAudioFormatChangeShim(CoreAudioBackend backend, DeviceId device) {
+    CoreAudioFormatChangeShim(CoreAudioBackend backend, DeviceId device, int objectID) {
         this.backend = Objects.requireNonNull(backend, "backend must not be null");
         this.device = Objects.requireNonNull(device, "device must not be null");
+        this.registeredObjectID = objectID;
         this.arena = Arena.ofConfined();
         this.upcallStub = buildUpcallStub();
         this.removeListener = tryRegister();
+    }
+
+    /**
+     * Convenience constructor that registers on
+     * {@link #kAudioObjectSystemObject} — used until story 130 surfaces
+     * the real {@code AudioDeviceID}.
+     */
+    CoreAudioFormatChangeShim(CoreAudioBackend backend, DeviceId device) {
+        this(backend, device, kAudioObjectSystemObject);
     }
 
     private MemorySegment buildUpcallStub() {
@@ -157,7 +173,7 @@ final class CoreAudioFormatChangeShim implements AutoCloseable {
                 addr.set(ValueLayout.JAVA_INT, 4L, kScopeGlobal);
                 addr.set(ValueLayout.JAVA_INT, 8L, kElementMain);
                 int status = (int) add.invoke(
-                        kAudioObjectSystemObject, addr, upcallStub, MemorySegment.NULL);
+                        registeredObjectID, addr, upcallStub, MemorySegment.NULL);
                 if (status == 0) {
                     registeredAddresses.add(addr);
                 }
@@ -201,6 +217,12 @@ final class CoreAudioFormatChangeShim implements AutoCloseable {
      *       {@link FormatChangeReason.ClockSourceChange}</li>
      * </ul>
      *
+     * <p>When {@code inObjectID} does not match the
+     * {@link #registeredObjectID} the shim was registered on, the
+     * callback is silently ignored — this prevents unrelated system-wide
+     * property changes (for other devices) from being attributed to the
+     * active device and triggering unnecessary reconfiguration.</p>
+     *
      * <p>{@code proposedFormat} is always {@link Optional#empty()}: the
      * listener fires before the new property value is fully readable on
      * the dispatch queue, so the controller re-queries it on reopen.</p>
@@ -217,6 +239,13 @@ final class CoreAudioFormatChangeShim implements AutoCloseable {
         if (inAddresses == null
                 || inAddresses.equals(MemorySegment.NULL)
                 || inNumberAddresses <= 0) {
+            return 0;
+        }
+        // Ignore callbacks from objects that don't match the registered
+        // target — prevents unrelated devices' property changes from
+        // triggering reconfiguration when registered on
+        // kAudioObjectSystemObject (story 218 review feedback).
+        if (inObjectID != registeredObjectID) {
             return 0;
         }
         MemorySegment addrs = inAddresses.reinterpret(
@@ -293,7 +322,7 @@ final class CoreAudioFormatChangeShim implements AutoCloseable {
             for (MemorySegment addr : registeredAddresses) {
                 try {
                     removeListener.invoke(
-                            kAudioObjectSystemObject, addr, upcallStub, MemorySegment.NULL);
+                            registeredObjectID, addr, upcallStub, MemorySegment.NULL);
                 } catch (Throwable ignored) {
                     // Best-effort: never throw from close().
                 }

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioFormatChangeShim.java
@@ -1,0 +1,309 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * FFM (JEP 454) shim that bridges CoreAudio's
+ * {@code AudioObjectPropertyListenerProc} callbacks into
+ * {@link CoreAudioBackend#publishFormatChangeRequested(DeviceId,
+ * Optional, FormatChangeReason)} (story 218).
+ *
+ * <p>On macOS the shim resolves
+ * {@code AudioObjectAddPropertyListener} from {@code CoreAudio.framework}
+ * and registers a single shared listener for three property selectors:
+ * {@code kAudioDevicePropertyNominalSampleRate},
+ * {@code kAudioDevicePropertyBufferFrameSize}, and
+ * {@code kAudioDevicePropertyClockSource}. On non-macOS hosts (or when
+ * the framework cannot be resolved) registration is skipped and the
+ * shim degrades to a no-op.</p>
+ *
+ * <p>The {@code AudioObjectID} target is currently a placeholder
+ * ({@code kAudioObjectSystemObject == 1}); the implementation layer
+ * that performs real device opening (story 130) must replace this with
+ * the device's actual {@code AudioDeviceID} once it is known. Until
+ * then the system-object listener still fires for system-wide property
+ * changes, which is sufficient to demonstrate the round-trip.</p>
+ */
+final class CoreAudioFormatChangeShim implements AutoCloseable {
+
+    /** {@code kAudioObjectSystemObject} — placeholder listener target. */
+    static final int kAudioObjectSystemObject = 1;
+
+    /** {@code kAudioDevicePropertyNominalSampleRate} = {@code 'nsrt'}. */
+    static final int kSelNominalSampleRate = fourCC('n', 's', 'r', 't');
+    /** {@code kAudioDevicePropertyBufferFrameSize} = {@code 'fsiz'}. */
+    static final int kSelBufferFrameSize = fourCC('f', 's', 'i', 'z');
+    /** {@code kAudioDevicePropertyClockSource} = {@code 'csrc'}. */
+    static final int kSelClockSource = fourCC('c', 's', 'r', 'c');
+
+    /** {@code kAudioObjectPropertyScopeGlobal} = {@code 'glob'}. */
+    private static final int kScopeGlobal = fourCC('g', 'l', 'o', 'b');
+    /** {@code kAudioObjectPropertyElementMain} = 0. */
+    private static final int kElementMain = 0;
+
+    /**
+     * AudioObjectPropertyAddress is {@code { UInt32 mSelector; UInt32 mScope;
+     * UInt32 mElement; }} = 12 bytes.
+     */
+    private static final long PROPERTY_ADDRESS_SIZE = 12L;
+
+    /**
+     * AudioObjectPropertyListenerProc descriptor:
+     * {@code (UInt32 inObjectID, UInt32 inNumberAddresses,
+     *         const AudioObjectPropertyAddress* inAddresses,
+     *         void* inClientData) -> OSStatus}.
+     */
+    private static final FunctionDescriptor LISTENER_PROC =
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.ADDRESS);
+
+    /**
+     * AudioObjectAddPropertyListener / AudioObjectRemovePropertyListener
+     * descriptor: {@code (UInt32 inObjectID,
+     *                     const AudioObjectPropertyAddress* inAddress,
+     *                     AudioObjectPropertyListenerProc inListener,
+     *                     void* inClientData) -> OSStatus}.
+     */
+    private static final FunctionDescriptor ADD_REMOVE_LISTENER =
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.ADDRESS);
+
+    private final CoreAudioBackend backend;
+    private final DeviceId device;
+    private final Arena arena;
+    private final MemorySegment upcallStub;
+    /** Holds (selectorAddress, addPropertyListenerHandle, removeHandle) per registration. */
+    private final List<MemorySegment> registeredAddresses = new ArrayList<>();
+    private final MethodHandle removeListener;
+    private boolean closed;
+
+    /**
+     * Builds the shared listener upcall stub and (on macOS) registers it
+     * for the three property selectors.
+     *
+     * @param backend owning backend; never null
+     * @param device  device id to use when publishing; never null
+     */
+    CoreAudioFormatChangeShim(CoreAudioBackend backend, DeviceId device) {
+        this.backend = Objects.requireNonNull(backend, "backend must not be null");
+        this.device = Objects.requireNonNull(device, "device must not be null");
+        this.arena = Arena.ofConfined();
+        this.upcallStub = buildUpcallStub();
+        this.removeListener = tryRegister();
+    }
+
+    private MemorySegment buildUpcallStub() {
+        try {
+            MethodHandle handle = MethodHandles.lookup().findVirtual(
+                    CoreAudioFormatChangeShim.class,
+                    "listenerUpcall",
+                    MethodType.methodType(int.class,
+                            int.class, int.class,
+                            MemorySegment.class, MemorySegment.class))
+                    .bindTo(this);
+            return Linker.nativeLinker().upcallStub(handle, LISTENER_PROC, arena);
+        } catch (Throwable t) {
+            return MemorySegment.NULL;
+        }
+    }
+
+    private MethodHandle tryRegister() {
+        if (upcallStub.equals(MemorySegment.NULL)) {
+            return null;
+        }
+        try {
+            SymbolLookup lookup;
+            try {
+                lookup = SymbolLookup.libraryLookup("CoreAudio", arena);
+            } catch (IllegalArgumentException firstAttempt) {
+                // Fall back to the absolute framework path the dynamic
+                // linker uses on macOS.
+                lookup = SymbolLookup.libraryLookup(
+                        "/System/Library/Frameworks/CoreAudio.framework/CoreAudio",
+                        arena);
+            }
+            MemorySegment addSym = lookup.find("AudioObjectAddPropertyListener")
+                    .orElseThrow(() -> new UnsatisfiedLinkError(
+                            "AudioObjectAddPropertyListener not found"));
+            MemorySegment removeSym = lookup.find("AudioObjectRemovePropertyListener")
+                    .orElseThrow(() -> new UnsatisfiedLinkError(
+                            "AudioObjectRemovePropertyListener not found"));
+            MethodHandle add = Linker.nativeLinker().downcallHandle(
+                    addSym, ADD_REMOVE_LISTENER);
+            MethodHandle remove = Linker.nativeLinker().downcallHandle(
+                    removeSym, ADD_REMOVE_LISTENER);
+            for (int sel : new int[]{
+                    kSelNominalSampleRate, kSelBufferFrameSize, kSelClockSource}) {
+                MemorySegment addr = arena.allocate(PROPERTY_ADDRESS_SIZE);
+                addr.set(ValueLayout.JAVA_INT, 0L, sel);
+                addr.set(ValueLayout.JAVA_INT, 4L, kScopeGlobal);
+                addr.set(ValueLayout.JAVA_INT, 8L, kElementMain);
+                int status = (int) add.invoke(
+                        kAudioObjectSystemObject, addr, upcallStub, MemorySegment.NULL);
+                if (status == 0) {
+                    registeredAddresses.add(addr);
+                }
+            }
+            return remove;
+        } catch (IllegalArgumentException | UnsatisfiedLinkError ignored) {
+            return null;
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Method handle target invoked by the FFM upcall stub when the
+     * CoreAudio dispatch queue delivers a property change.
+     */
+    @SuppressWarnings("unused") // invoked via upcall stub
+    private int listenerUpcall(int inObjectID, int inNumberAddresses,
+                               MemorySegment inAddresses,
+                               MemorySegment inClientData) {
+        try {
+            return dispatch(inObjectID, inNumberAddresses, inAddresses);
+        } catch (Throwable t) {
+            return 0;
+        }
+    }
+
+    /**
+     * Iterates {@code inNumberAddresses} {@code AudioObjectPropertyAddress}
+     * structs starting at {@code inAddresses} and publishes a
+     * {@link AudioDeviceEvent.FormatChangeRequested} for each recognised
+     * selector (story 218).
+     *
+     * <p>Selector mapping:</p>
+     * <ul>
+     *   <li>{@link #kSelNominalSampleRate} &rarr;
+     *       {@link FormatChangeReason.SampleRateChange}</li>
+     *   <li>{@link #kSelBufferFrameSize} &rarr;
+     *       {@link FormatChangeReason.BufferSizeChange}</li>
+     *   <li>{@link #kSelClockSource} &rarr;
+     *       {@link FormatChangeReason.ClockSourceChange}</li>
+     * </ul>
+     *
+     * <p>{@code proposedFormat} is always {@link Optional#empty()}: the
+     * listener fires before the new property value is fully readable on
+     * the dispatch queue, so the controller re-queries it on reopen.</p>
+     *
+     * <p>Package-private for unit-test access.</p>
+     *
+     * @param inObjectID         the {@code AudioObjectID} that fired
+     * @param inNumberAddresses  number of property addresses in the array
+     * @param inAddresses        pointer to the address array; may be
+     *                           {@link MemorySegment#NULL} (no-op)
+     * @return {@code 0} (noErr)
+     */
+    int dispatch(int inObjectID, int inNumberAddresses, MemorySegment inAddresses) {
+        if (inAddresses == null
+                || inAddresses.equals(MemorySegment.NULL)
+                || inNumberAddresses <= 0) {
+            return 0;
+        }
+        MemorySegment addrs = inAddresses.reinterpret(
+                PROPERTY_ADDRESS_SIZE * inNumberAddresses);
+        for (int i = 0; i < inNumberAddresses; i++) {
+            int selector = addrs.get(ValueLayout.JAVA_INT, i * PROPERTY_ADDRESS_SIZE);
+            FormatChangeReason reason = mapSelector(selector);
+            if (reason != null) {
+                backend.publishFormatChangeRequested(
+                        device, Optional.empty(), reason);
+            }
+        }
+        return 0;
+    }
+
+    private static FormatChangeReason mapSelector(int selector) {
+        if (selector == kSelNominalSampleRate) {
+            return new FormatChangeReason.SampleRateChange();
+        }
+        if (selector == kSelBufferFrameSize) {
+            return new FormatChangeReason.BufferSizeChange();
+        }
+        if (selector == kSelClockSource) {
+            return new FormatChangeReason.ClockSourceChange();
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if at least one property listener was
+     * successfully registered with CoreAudio.
+     *
+     * @return true if any registration succeeded
+     */
+    boolean isRegistered() {
+        return !registeredAddresses.isEmpty();
+    }
+
+    /**
+     * Returns the upcall stub address used as the
+     * {@code AudioObjectPropertyListenerProc} pointer. Exposed for testing.
+     *
+     * @return the upcall stub address
+     */
+    MemorySegment upcallStub() {
+        return upcallStub;
+    }
+
+    /**
+     * Encodes a four-character constant the same way CoreAudio's headers
+     * do: {@code (a&lt;&lt;24)|(b&lt;&lt;16)|(c&lt;&lt;8)|d}.
+     *
+     * @param a first character
+     * @param b second character
+     * @param c third character
+     * @param d fourth character
+     * @return the 4-CC integer
+     */
+    static int fourCC(char a, char b, char c, char d) {
+        return (a << 24) | (b << 16) | (c << 8) | d;
+    }
+
+    /**
+     * Removes every registered property listener and frees the upcall
+     * stub. Idempotent.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (removeListener != null) {
+            for (MemorySegment addr : registeredAddresses) {
+                try {
+                    removeListener.invoke(
+                            kAudioObjectSystemObject, addr, upcallStub, MemorySegment.NULL);
+                } catch (Throwable ignored) {
+                    // Best-effort: never throw from close().
+                }
+            }
+        }
+        registeredAddresses.clear();
+        try {
+            arena.close();
+        } catch (Throwable ignored) {
+            // Already closed — idempotent.
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/FormatChangeReason.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/FormatChangeReason.java
@@ -59,8 +59,30 @@ public sealed interface FormatChangeReason
      * a different entry from the driver panel's "Samples per buffer"
      * dropdown. ASIO source: {@code kAsioBufferSizeChange}. CoreAudio
      * source: {@code kAudioDevicePropertyBufferFrameSize}.
+     *
+     * <p>{@code newBufferFrames} is the driver's new buffer size in sample
+     * frames when the underlying signal carries it (for example ASIO's
+     * {@code kAsioBufferSizeChange} ships the new frame count in
+     * {@code value}). When the driver signal does not carry a concrete
+     * value (for example CoreAudio's
+     * {@code kAudioDevicePropertyBufferFrameSize} listener fires before
+     * the new value is fully readable), the field is {@code -1} and the
+     * controller falls back to
+     * {@link com.benesquivelmusic.daw.sdk.audio.BufferSizeRange#preferred()}.
+     * </p>
+     *
+     * @param newBufferFrames the new buffer size in sample frames, or
+     *                        {@code -1} when the signal does not carry one
      */
-    record BufferSizeChange() implements FormatChangeReason {}
+    record BufferSizeChange(int newBufferFrames) implements FormatChangeReason {
+        /** Unknown buffer size sentinel — the driver signal did not carry a concrete frame count. */
+        public static final int UNKNOWN = -1;
+
+        /** Creates a {@code BufferSizeChange} with an unknown new frame count. */
+        public BufferSizeChange() {
+            this(UNKNOWN);
+        }
+    }
 
     /**
      * The driver renegotiated the sample rate. ASIO source:

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/FormatChangeReason.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/FormatChangeReason.java
@@ -1,0 +1,89 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+/**
+ * Sealed taxonomy of the reasons a vendor driver may ask the host to drop
+ * the current stream and reopen with a renegotiated format — the
+ * {@code reason} attached to every
+ * {@link AudioDeviceEvent.FormatChangeRequested} event (story 218).
+ *
+ * <p>Each case maps onto the structured signal a specific OS / driver
+ * raises when the user changes a setting in the vendor's native control
+ * panel mid-session (the {@code openControlPanel()} flow from story 212):</p>
+ * <ul>
+ *   <li>{@link BufferSizeChange} — ASIO's
+ *       {@code kAsioBufferSizeChange} callback or CoreAudio's
+ *       {@code kAudioDevicePropertyBufferFrameSize} listener fires
+ *       after the user picks a new buffer-size entry from the driver
+ *       panel's dropdown.</li>
+ *   <li>{@link SampleRateChange} — ASIO's {@code kAsioResetRequest} with
+ *       a new {@code ASIOGetSampleRate} reading, CoreAudio's
+ *       {@code kAudioDevicePropertyNominalSampleRate} listener, or
+ *       WASAPI's mix-format-changed
+ *       {@code IMMNotificationClient::OnPropertyValueChanged} fires
+ *       after the driver renegotiates the device clock to a new rate
+ *       (typically 48&nbsp;kHz &harr; 44.1&nbsp;kHz).</li>
+ *   <li>{@link ClockSourceChange} — ASIO's {@code kAsioResyncRequest}
+ *       or CoreAudio's {@code kAudioDevicePropertyClockSource} listener
+ *       fires when the user re-targets the device to a different word-
+ *       clock / S/PDIF / ADAT lock source (see story "Hardware Clock
+ *       Source Selection").</li>
+ *   <li>{@link DriverReset} — the catch-all corresponding to ASIO's
+ *       {@code kAsioResetRequest} (USB streaming-mode change, USB hub
+ *       cycle, vendor utility "reset" button) or WASAPI's full
+ *       {@code IAudioClient} invalidation. The host must rebuild the
+ *       stream from scratch.</li>
+ * </ul>
+ *
+ * <p>The four cases are stateless tag types — they carry no fields
+ * beyond the kind itself. Records (rather than enum constants) are used
+ * so consumers can pattern-match in an exhaustive {@code switch}
+ * expression alongside record-payload events:
+ *
+ * <pre>{@code
+ * switch (reason) {
+ *     case FormatChangeReason.BufferSizeChange()  -> ...
+ *     case FormatChangeReason.SampleRateChange()  -> ...
+ *     case FormatChangeReason.ClockSourceChange() -> ...
+ *     case FormatChangeReason.DriverReset()       -> ...
+ * }
+ * }</pre>
+ */
+public sealed interface FormatChangeReason
+        permits FormatChangeReason.BufferSizeChange,
+                FormatChangeReason.SampleRateChange,
+                FormatChangeReason.ClockSourceChange,
+                FormatChangeReason.DriverReset {
+
+    /**
+     * The driver renegotiated the buffer size — typically the user picked
+     * a different entry from the driver panel's "Samples per buffer"
+     * dropdown. ASIO source: {@code kAsioBufferSizeChange}. CoreAudio
+     * source: {@code kAudioDevicePropertyBufferFrameSize}.
+     */
+    record BufferSizeChange() implements FormatChangeReason {}
+
+    /**
+     * The driver renegotiated the sample rate. ASIO source:
+     * {@code kAsioResetRequest} with a new {@code ASIOGetSampleRate}.
+     * CoreAudio source: {@code kAudioDevicePropertyNominalSampleRate}.
+     * WASAPI source: {@code IMMNotificationClient::OnPropertyValueChanged}
+     * with the device's mix-format property key.
+     */
+    record SampleRateChange() implements FormatChangeReason {}
+
+    /**
+     * The user re-targeted the device's clock to a different external
+     * source (word clock, S/PDIF, ADAT). ASIO source:
+     * {@code kAsioResyncRequest}. CoreAudio source:
+     * {@code kAudioDevicePropertyClockSource}.
+     */
+    record ClockSourceChange() implements FormatChangeReason {}
+
+    /**
+     * The driver issued a generic reset — USB streaming-mode change,
+     * vendor utility "reset" button, USB hub cycle. ASIO source:
+     * {@code kAsioResetRequest}. WASAPI source: full
+     * {@code IAudioClient} invalidation.
+     */
+    record DriverReset() implements FormatChangeReason {}
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/MockAudioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/MockAudioBackend.java
@@ -193,6 +193,33 @@ public final class MockAudioBackend implements AudioBackend {
     }
 
     /**
+     * Simulates the driver issuing a structured "drop and reopen"
+     * request mid-session — the equivalent of ASIO's
+     * {@code kAsioResetRequest} / {@code kAsioBufferSizeChange} /
+     * {@code kAsioResyncRequest}, CoreAudio's
+     * {@code kAudioDevicePropertyNominalSampleRate} listener firing,
+     * or WASAPI invalidating the active {@code IAudioClient} — so
+     * tests can drive the
+     * {@link AudioDeviceEvent.FormatChangeRequested} flow in
+     * {@code AudioEngineController} without real hardware (story 218).
+     *
+     * @param device         the affected device id; must not be null
+     * @param proposedFormat the format the driver is moving to, when known;
+     *                       must not be null
+     *                       (use {@link Optional#empty()} for unknown)
+     * @param reason         why the driver is asking for a reset; must not be null
+     */
+    public void simulateFormatChangeRequested(DeviceId device,
+                                              Optional<AudioFormat> proposedFormat,
+                                              FormatChangeReason reason) {
+        Objects.requireNonNull(device, "device must not be null");
+        Objects.requireNonNull(proposedFormat, "proposedFormat must not be null");
+        Objects.requireNonNull(reason, "reason must not be null");
+        support.publishDeviceEvent(
+                new AudioDeviceEvent.FormatChangeRequested(device, proposedFormat, reason));
+    }
+
+    /**
      * Returns a runnable that records the invocation. Tests can assert
      * the count via {@link #controlPanelInvocationCount()} and verify
      * that the dialog re-queries device capabilities after the panel

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiBackend.java
@@ -25,6 +25,7 @@ public final class WasapiBackend implements AudioBackend {
 
     private final AudioBackendSupport support = new AudioBackendSupport();
     private final boolean exclusive;
+    private volatile WasapiFormatChangeShim formatChangeShim;
 
     /** Creates a new WASAPI backend in shared mode. */
     public WasapiBackend() {
@@ -75,6 +76,11 @@ public final class WasapiBackend implements AudioBackend {
             throw new AudioBackendException("WASAPI is only available on Windows.");
         }
         support.markOpen(format, bufferFrames);
+        // Story 218: install the IMMNotificationClient FFM shim that
+        // translates OnPropertyValueChanged(PKEY_AudioEngine_DeviceFormat)
+        // into publishFormatChangeRequested(...). On non-Windows hosts
+        // the Ole32 lookup fails and the shim degrades to no-op.
+        this.formatChangeShim = new WasapiFormatChangeShim(this, device);
         // Native IAudioClient wiring implemented on Windows builds.
     }
 
@@ -189,6 +195,11 @@ public final class WasapiBackend implements AudioBackend {
 
     @Override
     public void close() {
+        WasapiFormatChangeShim shim = this.formatChangeShim;
+        this.formatChangeShim = null;
+        if (shim != null) {
+            shim.close();
+        }
         support.close();
     }
 

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiBackend.java
@@ -90,10 +90,59 @@ public final class WasapiBackend implements AudioBackend {
      * {@link AudioDeviceEvent}s. The native shim registers an
      * {@code IMMNotificationClient} on driver open and publishes via
      * {@link AudioBackendSupport#publishDeviceEvent(AudioDeviceEvent)}.
+     *
+     * <p>Format-change requests (story 218) are surfaced via
+     * {@link #publishFormatChangeRequested(DeviceId, java.util.Optional,
+     * FormatChangeReason)} from
+     * {@code IMMNotificationClient::OnPropertyValueChanged} (mix-format
+     * key on the active endpoint) and from full {@code IAudioClient}
+     * invalidation by the audio engine.</p>
      */
     @Override
     public Flow.Publisher<AudioDeviceEvent> deviceEvents() {
         return support.deviceEvents();
+    }
+
+    /**
+     * Hook called by the Windows FFM shim from
+     * {@code IMMNotificationClient::OnPropertyValueChanged} (and from
+     * the {@code AUDCLNT_E_DEVICE_INVALIDATED} path inside the audio
+     * engine) to surface a driver-initiated reset request as a
+     * {@link AudioDeviceEvent.FormatChangeRequested} event on this
+     * backend's {@link #deviceEvents()} publisher (story 218).
+     *
+     * <p>Mapping conventions used by the shim:</p>
+     * <ul>
+     *   <li>{@code OnPropertyValueChanged} for the device's mix-format
+     *       property key &rarr;
+     *       {@code reason = }{@link FormatChangeReason.SampleRateChange};
+     *       the new {@link AudioFormat} carries the renegotiated rate.</li>
+     *   <li>{@code IAudioClient} returning
+     *       {@code AUDCLNT_E_DEVICE_INVALIDATED} on the next
+     *       {@code GetBuffer} call &rarr;
+     *       {@code reason = }{@link FormatChangeReason.DriverReset};
+     *       the proposed format is empty since WASAPI does not surface
+     *       the new format until the client is re-initialised.</li>
+     * </ul>
+     *
+     * <p>Package-private: only the SDK's native shim is meant to call
+     * this directly. The publisher accepts the event without blocking,
+     * so it is safe to call from the WASAPI notification thread.</p>
+     *
+     * @param device         the affected device id; must not be null
+     * @param proposedFormat the format the driver is moving to, when known;
+     *                       must not be null (use
+     *                       {@link java.util.Optional#empty()} for unknown)
+     * @param reason         why the driver is asking for a reset; must not be null
+     */
+    void publishFormatChangeRequested(DeviceId device,
+                                      java.util.Optional<AudioFormat> proposedFormat,
+                                      FormatChangeReason reason) {
+        Objects.requireNonNull(device, "device must not be null");
+        Objects.requireNonNull(proposedFormat, "proposedFormat must not be null");
+        Objects.requireNonNull(reason, "reason must not be null");
+        support.publishDeviceEvent(
+                new AudioDeviceEvent.FormatChangeRequested(device, proposedFormat, reason));
     }
 
     @Override

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiBackend.java
@@ -122,7 +122,10 @@ public final class WasapiBackend implements AudioBackend {
      *   <li>{@code OnPropertyValueChanged} for the device's mix-format
      *       property key &rarr;
      *       {@code reason = }{@link FormatChangeReason.SampleRateChange};
-     *       the new {@link AudioFormat} carries the renegotiated rate.</li>
+     *       {@code proposedFormat} is {@link java.util.Optional#empty()}
+     *       because WASAPI does not surface the new format until the
+     *       client is re-initialised; the controller re-queries on
+     *       reopen.</li>
      *   <li>{@code IAudioClient} returning
      *       {@code AUDCLNT_E_DEVICE_INVALIDATED} on the next
      *       {@code GetBuffer} call &rarr;

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiFormatChangeShim.java
@@ -1,0 +1,392 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * FFM (JEP 454) shim that builds a Java-implemented
+ * {@code IMMNotificationClient} COM object — an in-memory pointer-to-
+ * vtable structure whose slots are FFM upcall stubs — and registers it
+ * with the Windows {@code IMMDeviceEnumerator} so that
+ * {@code OnPropertyValueChanged(PKEY_AudioEngine_DeviceFormat)}
+ * publishes a {@link AudioDeviceEvent.FormatChangeRequested} on
+ * {@link WasapiBackend#deviceEvents()} (story 218).
+ *
+ * <p>On non-Windows hosts the {@code Ole32.dll} lookup fails and the
+ * shim degrades to a no-op. Tests can still invoke the package-private
+ * {@link #dispatchPropertyChanged(MemorySegment)} helper directly to
+ * exercise the {@code PROPERTYKEY} comparison logic.</p>
+ *
+ * <p>The vtable order is fixed by the {@code IMMNotificationClient}
+ * COM contract:</p>
+ * <ol>
+ *   <li>{@code QueryInterface}</li>
+ *   <li>{@code AddRef}</li>
+ *   <li>{@code Release}</li>
+ *   <li>{@code OnDeviceStateChanged}</li>
+ *   <li>{@code OnDeviceAdded}</li>
+ *   <li>{@code OnDeviceRemoved}</li>
+ *   <li>{@code OnDefaultDeviceChanged}</li>
+ *   <li>{@code OnPropertyValueChanged}</li>
+ * </ol>
+ *
+ * <p>The {@code OnPropertyValueChanged} parameter signature uses
+ * {@link ValueLayout#ADDRESS} for the {@code PROPERTYKEY} struct rather
+ * than passing it by value — Windows x64 ABI passes structs &gt; 8
+ * bytes through a hidden pointer, which matches this descriptor in
+ * practice. The actual native registration is best-effort; the
+ * canonical exercise of the dispatch logic is via
+ * {@link #dispatchPropertyChanged(MemorySegment)}.</p>
+ */
+final class WasapiFormatChangeShim implements AutoCloseable {
+
+    /** {@code S_OK} HRESULT. */
+    static final int S_OK = 0;
+    /** {@code E_NOINTERFACE} HRESULT. */
+    static final int E_NOINTERFACE = 0x80004002;
+
+    /**
+     * {@code PKEY_AudioEngine_DeviceFormat} GUID in little-endian byte
+     * order: {@code {f19f064d-082c-4e27-bc73-6882a1bb8e4c}}, pid 0.
+     */
+    static final byte[] PKEY_AUDIO_ENGINE_DEVICE_FORMAT_GUID = new byte[]{
+            (byte) 0x4d, (byte) 0x06, (byte) 0x9f, (byte) 0xf1,
+            (byte) 0x2c, (byte) 0x08,
+            (byte) 0x27, (byte) 0x4e,
+            (byte) 0xbc, (byte) 0x73,
+            (byte) 0x68, (byte) 0x82, (byte) 0xa1, (byte) 0xbb,
+            (byte) 0x8e, (byte) 0x4c
+    };
+
+    /** Expected pid component of the matching {@code PROPERTYKEY}. */
+    static final int PKEY_AUDIO_ENGINE_DEVICE_FORMAT_PID = 0;
+
+    /** {@code IID_IUnknown} = {@code {00000000-0000-0000-C000-000000000046}}. */
+    private static final byte[] IID_IUNKNOWN = new byte[]{
+            0, 0, 0, 0,
+            0, 0,
+            0, 0,
+            (byte) 0xC0, 0,
+            0, 0, 0, 0, 0, (byte) 0x46
+    };
+
+    /** {@code IID_IMMNotificationClient} = {@code {7991EEC9-7E89-4D85-8390-6C703CEC60C0}}. */
+    private static final byte[] IID_IMMNOTIFICATION_CLIENT = new byte[]{
+            (byte) 0xC9, (byte) 0xEE, (byte) 0x91, (byte) 0x79,
+            (byte) 0x89, (byte) 0x7E,
+            (byte) 0x85, (byte) 0x4D,
+            (byte) 0x83, (byte) 0x90,
+            (byte) 0x6C, (byte) 0x70, (byte) 0x3C, (byte) 0xEC,
+            (byte) 0x60, (byte) 0xC0
+    };
+
+    /** PROPERTYKEY = 16-byte GUID + 4-byte DWORD pid = 20 bytes. */
+    static final long PROPERTYKEY_SIZE = 20L;
+    private static final long GUID_SIZE = 16L;
+
+    private final WasapiBackend backend;
+    private final DeviceId device;
+    private final Arena arena;
+    private final MemorySegment vtable;
+    private final MemorySegment instance;
+    private final boolean registered;
+    private boolean closed;
+
+    /**
+     * Builds the eight upcall stubs, lays out the COM "fat pointer"
+     * (16-byte instance whose first 8 bytes point to the vtable), and
+     * (on Windows) calls {@code RegisterEndpointNotificationCallback}
+     * on the {@code IMMDeviceEnumerator} created via
+     * {@code CoCreateInstance}.
+     *
+     * @param backend owning backend; never null
+     * @param device  device id used when publishing; never null
+     */
+    WasapiFormatChangeShim(WasapiBackend backend, DeviceId device) {
+        this.backend = Objects.requireNonNull(backend, "backend must not be null");
+        this.device = Objects.requireNonNull(device, "device must not be null");
+        this.arena = Arena.ofConfined();
+        MemorySegment vt;
+        MemorySegment inst;
+        try {
+            vt = buildVtable();
+            // 16-byte instance: first 8 bytes are the vtable pointer.
+            inst = arena.allocate(16);
+            inst.set(ValueLayout.ADDRESS, 0L, vt);
+        } catch (Throwable t) {
+            vt = MemorySegment.NULL;
+            inst = MemorySegment.NULL;
+        }
+        this.vtable = vt;
+        this.instance = inst;
+        this.registered = tryRegister();
+    }
+
+    private MemorySegment buildVtable() throws Throwable {
+        Linker linker = Linker.nativeLinker();
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+        // 1. QueryInterface(this, REFIID, void**) -> HRESULT
+        MethodHandle qiHandle = lookup.findVirtual(WasapiFormatChangeShim.class,
+                        "queryInterfaceUpcall",
+                        MethodType.methodType(int.class,
+                                MemorySegment.class, MemorySegment.class, MemorySegment.class))
+                .bindTo(this);
+        MemorySegment qi = linker.upcallStub(qiHandle,
+                FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                        ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+                arena);
+
+        // 2. AddRef(this) -> ULONG, 3. Release(this) -> ULONG
+        MethodHandle refcountHandle = lookup.findVirtual(WasapiFormatChangeShim.class,
+                        "refcountUpcall", MethodType.methodType(int.class, MemorySegment.class))
+                .bindTo(this);
+        FunctionDescriptor refcountDesc = FunctionDescriptor.of(
+                ValueLayout.JAVA_INT, ValueLayout.ADDRESS);
+        MemorySegment addRef = linker.upcallStub(refcountHandle, refcountDesc, arena);
+        MemorySegment release = linker.upcallStub(refcountHandle, refcountDesc, arena);
+
+        // 4-6. OnDeviceStateChanged / OnDeviceAdded / OnDeviceRemoved
+        MethodHandle stateChangedHandle = lookup.findVirtual(WasapiFormatChangeShim.class,
+                        "onDeviceStateChangedUpcall",
+                        MethodType.methodType(int.class,
+                                MemorySegment.class, MemorySegment.class, int.class))
+                .bindTo(this);
+        MemorySegment onStateChanged = linker.upcallStub(stateChangedHandle,
+                FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                        ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_INT),
+                arena);
+
+        MethodHandle addRemoveHandle = lookup.findVirtual(WasapiFormatChangeShim.class,
+                        "onDeviceAddedOrRemovedUpcall",
+                        MethodType.methodType(int.class,
+                                MemorySegment.class, MemorySegment.class))
+                .bindTo(this);
+        FunctionDescriptor addRemoveDesc = FunctionDescriptor.of(
+                ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS);
+        MemorySegment onAdded = linker.upcallStub(addRemoveHandle, addRemoveDesc, arena);
+        MemorySegment onRemoved = linker.upcallStub(addRemoveHandle, addRemoveDesc, arena);
+
+        // 7. OnDefaultDeviceChanged(this, EDataFlow, ERole, LPCWSTR) -> HRESULT
+        MethodHandle defaultChangedHandle = lookup.findVirtual(WasapiFormatChangeShim.class,
+                        "onDefaultDeviceChangedUpcall",
+                        MethodType.methodType(int.class,
+                                MemorySegment.class, int.class, int.class, MemorySegment.class))
+                .bindTo(this);
+        MemorySegment onDefault = linker.upcallStub(defaultChangedHandle,
+                FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                        ValueLayout.ADDRESS, ValueLayout.JAVA_INT,
+                        ValueLayout.JAVA_INT, ValueLayout.ADDRESS),
+                arena);
+
+        // 8. OnPropertyValueChanged(this, LPCWSTR, PROPERTYKEY) -> HRESULT
+        MethodHandle propValueHandle = lookup.findVirtual(WasapiFormatChangeShim.class,
+                        "onPropertyValueChangedUpcall",
+                        MethodType.methodType(int.class,
+                                MemorySegment.class, MemorySegment.class, MemorySegment.class))
+                .bindTo(this);
+        MemorySegment onProperty = linker.upcallStub(propValueHandle,
+                FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                        ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+                arena);
+
+        // Layout the vtable: 8 contiguous 8-byte function pointers.
+        MemorySegment vt = arena.allocate(8L * 8L);
+        vt.set(ValueLayout.ADDRESS, 0L * 8L, qi);
+        vt.set(ValueLayout.ADDRESS, 1L * 8L, addRef);
+        vt.set(ValueLayout.ADDRESS, 2L * 8L, release);
+        vt.set(ValueLayout.ADDRESS, 3L * 8L, onStateChanged);
+        vt.set(ValueLayout.ADDRESS, 4L * 8L, onAdded);
+        vt.set(ValueLayout.ADDRESS, 5L * 8L, onRemoved);
+        vt.set(ValueLayout.ADDRESS, 6L * 8L, onDefault);
+        vt.set(ValueLayout.ADDRESS, 7L * 8L, onProperty);
+        return vt;
+    }
+
+    private boolean tryRegister() {
+        if (instance.equals(MemorySegment.NULL)) {
+            return false;
+        }
+        try {
+            // Resolve Ole32.dll for CoInitializeEx + CoCreateInstance.
+            // On non-Windows hosts these lookups throw IllegalArgumentException
+            // and we degrade to no-op. The full IMMDeviceEnumerator-via-COM
+            // dance is wired in the implementation layer (story 130); story
+            // 218 only requires that the FFM plumbing is in place and that
+            // dispatchPropertyChanged() correctly translates the COM
+            // notification into a deviceEvents() emission.
+            SymbolLookup.libraryLookup("Ole32", arena);
+            // The actual CoCreateInstance + RegisterEndpointNotificationCallback
+            // path lives in the daw-core native shim; here we only verify the
+            // library is present so that close() can safely no-op when it
+            // is not.
+            return false;
+        } catch (IllegalArgumentException | UnsatisfiedLinkError ignored) {
+            return false;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    // -- Upcall targets ------------------------------------------------------
+
+    @SuppressWarnings("unused")
+    private int queryInterfaceUpcall(MemorySegment self, MemorySegment riid, MemorySegment ppv) {
+        try {
+            if (riid == null || riid.equals(MemorySegment.NULL)) {
+                return E_NOINTERFACE;
+            }
+            MemorySegment iid = riid.reinterpret(GUID_SIZE);
+            if (guidMatches(iid, IID_IUNKNOWN) || guidMatches(iid, IID_IMMNOTIFICATION_CLIENT)) {
+                if (ppv != null && !ppv.equals(MemorySegment.NULL)) {
+                    ppv.reinterpret(8).set(ValueLayout.ADDRESS, 0L, self);
+                }
+                return S_OK;
+            }
+            return E_NOINTERFACE;
+        } catch (Throwable t) {
+            return E_NOINTERFACE;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private int refcountUpcall(MemorySegment self) {
+        // Fixed reference count — the shim's lifetime is owned by close().
+        return 2;
+    }
+
+    @SuppressWarnings("unused")
+    private int onDeviceStateChangedUpcall(MemorySegment self,
+                                           MemorySegment pwstrDeviceId, int dwNewState) {
+        // Story 214 (device-loss) handles state changes; 218 is format-only.
+        return S_OK;
+    }
+
+    @SuppressWarnings("unused")
+    private int onDeviceAddedOrRemovedUpcall(MemorySegment self, MemorySegment pwstrDeviceId) {
+        return S_OK;
+    }
+
+    @SuppressWarnings("unused")
+    private int onDefaultDeviceChangedUpcall(MemorySegment self,
+                                             int flow, int role, MemorySegment pwstrDeviceId) {
+        return S_OK;
+    }
+
+    @SuppressWarnings("unused")
+    private int onPropertyValueChangedUpcall(MemorySegment self,
+                                             MemorySegment pwstrDeviceId,
+                                             MemorySegment key) {
+        try {
+            return dispatchPropertyChanged(key);
+        } catch (Throwable t) {
+            return S_OK;
+        }
+    }
+
+    // -- Dispatch ------------------------------------------------------------
+
+    /**
+     * Compares {@code key} (a 20-byte {@code PROPERTYKEY} = 16-byte GUID
+     * + 4-byte DWORD pid) against
+     * {@link #PKEY_AUDIO_ENGINE_DEVICE_FORMAT_GUID} / pid 0 and, on a
+     * match, publishes a
+     * {@link AudioDeviceEvent.FormatChangeRequested} with reason
+     * {@link FormatChangeReason.SampleRateChange} and an empty proposed
+     * format (story 218).
+     *
+     * <p>Package-private so that unit tests can invoke the comparison
+     * logic with a hand-built {@code MemorySegment} containing either
+     * a matching or a non-matching key.</p>
+     *
+     * @param key 20-byte {@code PROPERTYKEY} pointer (may be
+     *            {@link MemorySegment#NULL} — treated as no-op)
+     * @return {@link #S_OK}
+     */
+    int dispatchPropertyChanged(MemorySegment key) {
+        if (key == null || key.equals(MemorySegment.NULL)) {
+            return S_OK;
+        }
+        MemorySegment k = key.reinterpret(PROPERTYKEY_SIZE);
+        if (!guidMatches(k, PKEY_AUDIO_ENGINE_DEVICE_FORMAT_GUID)) {
+            return S_OK;
+        }
+        int pid = k.get(ValueLayout.JAVA_INT, GUID_SIZE);
+        if (pid != PKEY_AUDIO_ENGINE_DEVICE_FORMAT_PID) {
+            return S_OK;
+        }
+        backend.publishFormatChangeRequested(
+                device, Optional.empty(), new FormatChangeReason.SampleRateChange());
+        return S_OK;
+    }
+
+    private static boolean guidMatches(MemorySegment segment, byte[] expected) {
+        if (segment == null || segment.equals(MemorySegment.NULL)) {
+            return false;
+        }
+        for (int i = 0; i < expected.length; i++) {
+            if (segment.get(ValueLayout.JAVA_BYTE, i) != expected[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return {@code true} if {@code RegisterEndpointNotificationCallback}
+     *         was successfully invoked
+     */
+    boolean isRegistered() {
+        return registered;
+    }
+
+    /**
+     * Returns the COM "fat pointer" passed to
+     * {@code RegisterEndpointNotificationCallback}. Exposed for testing.
+     *
+     * @return the instance pointer
+     */
+    MemorySegment instance() {
+        return instance;
+    }
+
+    /**
+     * Returns the vtable pointer (eight 8-byte function pointer slots).
+     * Exposed for testing.
+     *
+     * @return the vtable pointer
+     */
+    MemorySegment vtable() {
+        return vtable;
+    }
+
+    /**
+     * Unregisters the notification callback (when registration
+     * succeeded), releases the {@code IMMDeviceEnumerator}, and frees
+     * the vtable / instance / upcall stubs. Idempotent.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        // The actual UnregisterEndpointNotificationCallback + Release
+        // call chain lives in the daw-core native shim (story 130). When
+        // registered == false there is nothing to undo.
+        try {
+            arena.close();
+        } catch (Throwable ignored) {
+            // Already closed — idempotent.
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiFormatChangeShim.java
@@ -312,7 +312,7 @@ final class WasapiFormatChangeShim implements AutoCloseable {
             }
 
             MemorySegment en = enumeratorOut.get(ValueLayout.ADDRESS, 0);
-            if (en == null || en.equals(MemorySegment.NULL)) {
+            if (en.equals(MemorySegment.NULL)) {
                 return false;
             }
 
@@ -485,8 +485,8 @@ final class WasapiFormatChangeShim implements AutoCloseable {
         closed = true;
         // Unregister and release the enumerator when registration succeeded.
         if (registered && !enumerator.equals(MemorySegment.NULL)) {
+            Linker nativeLinker = Linker.nativeLinker();
             try {
-                Linker nativeLinker = Linker.nativeLinker();
                 // UnregisterEndpointNotificationCallback(enumerator, callback)
                 MethodHandle unregister = nativeLinker.downcallHandle(
                         vtableSlot(enumerator,
@@ -499,7 +499,6 @@ final class WasapiFormatChangeShim implements AutoCloseable {
             }
             try {
                 // enumerator->Release()
-                Linker nativeLinker = Linker.nativeLinker();
                 MethodHandle release = nativeLinker.downcallHandle(
                         vtableSlot(enumerator, IUNKNOWN_RELEASE_SLOT),
                         FunctionDescriptor.of(ValueLayout.JAVA_INT,

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/WasapiFormatChangeShim.java
@@ -89,7 +89,40 @@ final class WasapiFormatChangeShim implements AutoCloseable {
             (byte) 0x60, (byte) 0xC0
     };
 
-    /** PROPERTYKEY = 16-byte GUID + 4-byte DWORD pid = 20 bytes. */
+    /** {@code S_FALSE} HRESULT. */
+    private static final int S_FALSE = 1;
+    /** {@code RPC_E_CHANGED_MODE} HRESULT — COM already initialized in a different threading model. */
+    private static final int RPC_E_CHANGED_MODE = 0x80010106;
+    /** {@code COINIT_APARTMENTTHREADED}. */
+    private static final int COINIT_APARTMENTTHREADED = 0x2;
+    /** {@code CLSCTX_ALL} = CLSCTX_INPROC_SERVER | CLSCTX_INPROC_HANDLER | CLSCTX_LOCAL_SERVER | CLSCTX_REMOTE_SERVER. */
+    private static final int CLSCTX_ALL = 0x17;
+    /** Vtable slot index for {@code IMMDeviceEnumerator::RegisterEndpointNotificationCallback}. */
+    private static final int IMMDEVICE_ENUMERATOR_REGISTER_ENDPOINT_NOTIFICATION_CALLBACK_SLOT = 6;
+    /** Vtable slot index for {@code IMMDeviceEnumerator::UnregisterEndpointNotificationCallback}. */
+    private static final int IMMDEVICE_ENUMERATOR_UNREGISTER_ENDPOINT_NOTIFICATION_CALLBACK_SLOT = 7;
+    /** Vtable slot index for {@code IUnknown::Release}. */
+    private static final int IUNKNOWN_RELEASE_SLOT = 2;
+
+    /** {@code CLSID_MMDeviceEnumerator} = {@code {BCDE0395-E52F-467C-8E3D-C4579291692E}}. */
+    private static final byte[] CLSID_MMDEVICE_ENUMERATOR = new byte[] {
+            (byte) 0x95, (byte) 0x03, (byte) 0xDE, (byte) 0xBC,
+            (byte) 0x2F, (byte) 0xE5,
+            (byte) 0x7C, (byte) 0x46,
+            (byte) 0x8E, (byte) 0x3D,
+            (byte) 0xC4, (byte) 0x57, (byte) 0x92, (byte) 0x91,
+            (byte) 0x69, (byte) 0x2E
+    };
+
+    /** {@code IID_IMMDeviceEnumerator} = {@code {A95664D2-9614-4F35-A746-DE8DB63617E6}}. */
+    private static final byte[] IID_IMMDEVICE_ENUMERATOR = new byte[] {
+            (byte) 0xD2, (byte) 0x64, (byte) 0x56, (byte) 0xA9,
+            (byte) 0x14, (byte) 0x96,
+            (byte) 0x35, (byte) 0x4F,
+            (byte) 0xA7, (byte) 0x46,
+            (byte) 0xDE, (byte) 0x8D, (byte) 0xB6, (byte) 0x36,
+            (byte) 0x17, (byte) 0xE6
+    };
     static final long PROPERTYKEY_SIZE = 20L;
     private static final long GUID_SIZE = 16L;
 
@@ -98,6 +131,8 @@ final class WasapiFormatChangeShim implements AutoCloseable {
     private final Arena arena;
     private final MemorySegment vtable;
     private final MemorySegment instance;
+    /** The {@code IMMDeviceEnumerator*} obtained via {@code CoCreateInstance}, or {@code NULL}. */
+    private MemorySegment enumerator = MemorySegment.NULL;
     private final boolean registered;
     private boolean closed;
 
@@ -212,27 +247,95 @@ final class WasapiFormatChangeShim implements AutoCloseable {
         return vt;
     }
 
+    private static boolean hresultSucceeded(int hr) {
+        return hr >= 0;
+    }
+
+    private static boolean coInitializeSucceeded(int hr) {
+        return hr == S_OK || hr == S_FALSE || hr == RPC_E_CHANGED_MODE;
+    }
+
+    private MemorySegment allocateGuid(byte[] guidBytes) {
+        MemorySegment guid = arena.allocate(guidBytes.length, 1);
+        MemorySegment.copy(MemorySegment.ofArray(guidBytes), 0, guid, 0, guidBytes.length);
+        return guid;
+    }
+
+    private static MemorySegment vtableSlot(MemorySegment comInterface, int slotIndex) {
+        MemorySegment vtablePtr = comInterface.reinterpret(ValueLayout.ADDRESS.byteSize())
+                .get(ValueLayout.ADDRESS, 0);
+        return vtablePtr.reinterpret((long) (slotIndex + 1) * ValueLayout.ADDRESS.byteSize())
+                .get(ValueLayout.ADDRESS, (long) slotIndex * ValueLayout.ADDRESS.byteSize());
+    }
+
     private boolean tryRegister() {
         if (instance.equals(MemorySegment.NULL)) {
             return false;
         }
         try {
-            // Resolve Ole32.dll for CoInitializeEx + CoCreateInstance.
-            // On non-Windows hosts these lookups throw IllegalArgumentException
-            // and we degrade to no-op. The full IMMDeviceEnumerator-via-COM
-            // dance is wired in the implementation layer (story 130); story
-            // 218 only requires that the FFM plumbing is in place and that
-            // dispatchPropertyChanged() correctly translates the COM
-            // notification into a deviceEvents() emission.
-            SymbolLookup.libraryLookup("Ole32", arena);
-            // The actual CoCreateInstance + RegisterEndpointNotificationCallback
-            // path lives in the daw-core native shim; here we only verify the
-            // library is present so that close() can safely no-op when it
-            // is not.
-            return false;
+            SymbolLookup ole32 = SymbolLookup.libraryLookup("Ole32", arena);
+            Linker nativeLinker = Linker.nativeLinker();
+
+            MethodHandle coInitializeEx = nativeLinker.downcallHandle(
+                    ole32.find("CoInitializeEx").orElseThrow(),
+                    FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                            ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+            MethodHandle coCreateInstance = nativeLinker.downcallHandle(
+                    ole32.find("CoCreateInstance").orElseThrow(),
+                    FunctionDescriptor.of(
+                            ValueLayout.JAVA_INT,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.JAVA_INT,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.ADDRESS));
+
+            int initHr = (int) coInitializeEx.invokeExact(
+                    MemorySegment.NULL, COINIT_APARTMENTTHREADED);
+            if (!coInitializeSucceeded(initHr)) {
+                return false;
+            }
+
+            MemorySegment clsid = allocateGuid(CLSID_MMDEVICE_ENUMERATOR);
+            MemorySegment iid = allocateGuid(IID_IMMDEVICE_ENUMERATOR);
+            MemorySegment enumeratorOut = arena.allocate(ValueLayout.ADDRESS);
+            enumeratorOut.set(ValueLayout.ADDRESS, 0, MemorySegment.NULL);
+
+            int createHr = (int) coCreateInstance.invokeExact(
+                    clsid,
+                    MemorySegment.NULL,
+                    CLSCTX_ALL,
+                    iid,
+                    enumeratorOut);
+            if (!hresultSucceeded(createHr)) {
+                return false;
+            }
+
+            MemorySegment en = enumeratorOut.get(ValueLayout.ADDRESS, 0);
+            if (en == null || en.equals(MemorySegment.NULL)) {
+                return false;
+            }
+
+            MethodHandle registerEndpointNotificationCallback =
+                    nativeLinker.downcallHandle(
+                            vtableSlot(en,
+                                    IMMDEVICE_ENUMERATOR_REGISTER_ENDPOINT_NOTIFICATION_CALLBACK_SLOT),
+                            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                                    ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+            int registerHr = (int) registerEndpointNotificationCallback.invokeExact(
+                    en, instance);
+            if (!hresultSucceeded(registerHr)) {
+                return false;
+            }
+
+            this.enumerator = en;
+            return true;
         } catch (IllegalArgumentException | UnsatisfiedLinkError ignored) {
+            // Library not present on this host (non-Windows) — no-op.
             return false;
         } catch (Throwable ignored) {
+            // Any other failure — no-op.
             return false;
         }
     }
@@ -380,9 +483,32 @@ final class WasapiFormatChangeShim implements AutoCloseable {
             return;
         }
         closed = true;
-        // The actual UnregisterEndpointNotificationCallback + Release
-        // call chain lives in the daw-core native shim (story 130). When
-        // registered == false there is nothing to undo.
+        // Unregister and release the enumerator when registration succeeded.
+        if (registered && !enumerator.equals(MemorySegment.NULL)) {
+            try {
+                Linker nativeLinker = Linker.nativeLinker();
+                // UnregisterEndpointNotificationCallback(enumerator, callback)
+                MethodHandle unregister = nativeLinker.downcallHandle(
+                        vtableSlot(enumerator,
+                                IMMDEVICE_ENUMERATOR_UNREGISTER_ENDPOINT_NOTIFICATION_CALLBACK_SLOT),
+                        FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                                ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+                unregister.invokeExact(enumerator, instance);
+            } catch (Throwable ignored) {
+                // Best-effort: never throw from close().
+            }
+            try {
+                // enumerator->Release()
+                Linker nativeLinker = Linker.nativeLinker();
+                MethodHandle release = nativeLinker.downcallHandle(
+                        vtableSlot(enumerator, IUNKNOWN_RELEASE_SLOT),
+                        FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                                ValueLayout.ADDRESS));
+                release.invokeExact(enumerator);
+            } catch (Throwable ignored) {
+                // Best-effort.
+            }
+        }
         try {
             arena.close();
         } catch (Throwable ignored) {

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShimTest.java
@@ -44,11 +44,10 @@ class AsioFormatChangeShimTest {
 
     @Test
     void bufferSizeChangeSelectorEmitsBufferSizeChange() throws Exception {
+        // Set up a real opened-support so the proposed format can be built
+        // from the previously opened sample rate / channels / bit depth,
+        // per the BufferSizeChange contract.
         AudioFormat opened = new AudioFormat(48_000.0, 2, 24);
-        AudioDeviceEvent event = invokeAndCapture(opened, () -> {});
-        // First, set up a real opened-support so the proposed format can
-        // be built from the previously opened sample rate / channels /
-        // bit depth, per the BufferSizeChange contract.
         AsioBackend backend = new AsioBackend();
         AudioBackendSupport support = new AudioBackendSupport();
         support.markOpen(opened, 256);
@@ -60,8 +59,6 @@ class AsioFormatChangeShimTest {
         assertThat(fc.reason()).isInstanceOf(FormatChangeReason.BufferSizeChange.class);
         assertThat(fc.proposedFormat()).contains(opened);
         assertThat(fc.device()).isEqualTo(DEVICE);
-        // silence unused-warning on `event` placeholder in IDE
-        assertThat(event).isNull();
     }
 
     @Test
@@ -118,13 +115,6 @@ class AsioFormatChangeShimTest {
         }
         assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
         return ref.get();
-    }
-
-    private static AudioDeviceEvent invokeAndCapture(AudioFormat opened, Runnable runnable) {
-        // Helper kept for symmetry with other shim tests; the real work
-        // happens in subscribeAndDispatch above.
-        runnable.run();
-        return null;
     }
 
     private record CapturingSubscriber(AtomicReference<AudioDeviceEvent> ref, CountDownLatch latch)

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShimTest.java
@@ -1,0 +1,141 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AsioFormatChangeShim} — story 218 FFM upcall
+ * plumbing for ASIO's {@code asioMessage} host-callback.
+ */
+class AsioFormatChangeShimTest {
+
+    private static final DeviceId DEVICE = new DeviceId("ASIO", "Mock ASIO Device");
+
+    @Test
+    void shimBuildsValidUpcallStubOnAnyPlatform() {
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        try (AsioFormatChangeShim shim = new AsioFormatChangeShim(backend, support, DEVICE)) {
+            // Construction must succeed even on Linux / hosts without
+            // an ASIO driver — the FFM upcall stub itself does not
+            // require any platform library.
+            assertThat(shim.upcallStub()).isNotNull();
+            assertThat(shim.upcallStub().equals(MemorySegment.NULL)).isFalse();
+            // Registration must transparently no-op when asioshim is missing.
+            assertThat(shim.isRegistered()).isFalse();
+        }
+    }
+
+    @Test
+    void closeIsIdempotent() {
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        AsioFormatChangeShim shim = new AsioFormatChangeShim(backend, support, DEVICE);
+        shim.close();
+        shim.close(); // must not throw
+    }
+
+    @Test
+    void bufferSizeChangeSelectorEmitsBufferSizeChange() throws Exception {
+        AudioFormat opened = new AudioFormat(48_000.0, 2, 24);
+        AudioDeviceEvent event = invokeAndCapture(opened, () -> {});
+        // First, set up a real opened-support so the proposed format can
+        // be built from the previously opened sample rate / channels /
+        // bit depth, per the BufferSizeChange contract.
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        support.markOpen(opened, 256);
+        AudioDeviceEvent received = subscribeAndDispatch(backend, support,
+                shim -> shim.dispatch(AsioFormatChangeShim.kAsioBufferSizeChange, 512));
+        assertThat(received).isInstanceOf(AudioDeviceEvent.FormatChangeRequested.class);
+        AudioDeviceEvent.FormatChangeRequested fc =
+                (AudioDeviceEvent.FormatChangeRequested) received;
+        assertThat(fc.reason()).isInstanceOf(FormatChangeReason.BufferSizeChange.class);
+        assertThat(fc.proposedFormat()).contains(opened);
+        assertThat(fc.device()).isEqualTo(DEVICE);
+        // silence unused-warning on `event` placeholder in IDE
+        assertThat(event).isNull();
+    }
+
+    @Test
+    void resyncRequestSelectorEmitsClockSourceChange() throws Exception {
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        AudioDeviceEvent received = subscribeAndDispatch(backend, support,
+                shim -> shim.dispatch(AsioFormatChangeShim.kAsioResyncRequest, 0L));
+        assertThat(received).isInstanceOf(AudioDeviceEvent.FormatChangeRequested.class);
+        AudioDeviceEvent.FormatChangeRequested fc =
+                (AudioDeviceEvent.FormatChangeRequested) received;
+        assertThat(fc.reason()).isInstanceOf(FormatChangeReason.ClockSourceChange.class);
+        assertThat(fc.proposedFormat()).isEmpty();
+    }
+
+    @Test
+    void resetRequestSelectorEmitsDriverReset() throws Exception {
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        AudioDeviceEvent received = subscribeAndDispatch(backend, support,
+                shim -> shim.dispatch(AsioFormatChangeShim.kAsioResetRequest, 0L));
+        assertThat(received).isInstanceOf(AudioDeviceEvent.FormatChangeRequested.class);
+        AudioDeviceEvent.FormatChangeRequested fc =
+                (AudioDeviceEvent.FormatChangeRequested) received;
+        assertThat(fc.reason()).isInstanceOf(FormatChangeReason.DriverReset.class);
+        assertThat(fc.proposedFormat()).isEmpty();
+    }
+
+    @Test
+    void unknownSelectorReturnsZeroAndEmitsNothing() throws Exception {
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        AtomicReference<AudioDeviceEvent> ref = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new CapturingSubscriber(ref, new CountDownLatch(1)));
+        Thread.sleep(50);
+        try (AsioFormatChangeShim shim = new AsioFormatChangeShim(backend, support, DEVICE)) {
+            long status = shim.dispatch(/* unrecognized */ 9999, 0L);
+            assertThat(status).isEqualTo(0L);
+        }
+        Thread.sleep(50);
+        assertThat(ref.get()).isNull();
+    }
+
+    /** Subscribes, dispatches via the shim, and returns the first event. */
+    private static AudioDeviceEvent subscribeAndDispatch(
+            AsioBackend backend, AudioBackendSupport support,
+            java.util.function.Consumer<AsioFormatChangeShim> action) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<AudioDeviceEvent> ref = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new CapturingSubscriber(ref, latch));
+        Thread.sleep(50);
+        try (AsioFormatChangeShim shim = new AsioFormatChangeShim(backend, support, DEVICE)) {
+            action.accept(shim);
+        }
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+        return ref.get();
+    }
+
+    private static AudioDeviceEvent invokeAndCapture(AudioFormat opened, Runnable runnable) {
+        // Helper kept for symmetry with other shim tests; the real work
+        // happens in subscribeAndDispatch above.
+        runnable.run();
+        return null;
+    }
+
+    private record CapturingSubscriber(AtomicReference<AudioDeviceEvent> ref, CountDownLatch latch)
+            implements Flow.Subscriber<AudioDeviceEvent> {
+        @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+        @Override public void onNext(AudioDeviceEvent e) {
+            if (ref.compareAndSet(null, e)) {
+                latch.countDown();
+            }
+        }
+        @Override public void onError(Throwable t) {}
+        @Override public void onComplete() {}
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShimTest.java
@@ -57,6 +57,8 @@ class AsioFormatChangeShimTest {
         AudioDeviceEvent.FormatChangeRequested fc =
                 (AudioDeviceEvent.FormatChangeRequested) received;
         assertThat(fc.reason()).isInstanceOf(FormatChangeReason.BufferSizeChange.class);
+        FormatChangeReason.BufferSizeChange bsc = (FormatChangeReason.BufferSizeChange) fc.reason();
+        assertThat(bsc.newBufferFrames()).isEqualTo(512);
         assertThat(fc.proposedFormat()).contains(opened);
         assertThat(fc.device()).isEqualTo(DEVICE);
     }

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioFormatChangeShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioFormatChangeShimTest.java
@@ -83,6 +83,24 @@ class CoreAudioFormatChangeShimTest {
     }
 
     @Test
+    void callbackFromUnrelatedObjectIsIgnored() throws Exception {
+        CoreAudioBackend backend = new CoreAudioBackend();
+        AtomicReference<AudioDeviceEvent> ref = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new CapturingSubscriber(ref, new CountDownLatch(1)));
+        Thread.sleep(50);
+        try (Arena scratch = Arena.ofConfined();
+             CoreAudioFormatChangeShim shim =
+                     new CoreAudioFormatChangeShim(backend, DEVICE, /* objectID */ 42)) {
+            MemorySegment addr = scratch.allocate(12);
+            addr.set(ValueLayout.JAVA_INT, 0, CoreAudioFormatChangeShim.kSelNominalSampleRate);
+            // Dispatch with a different objectID — should be filtered out.
+            shim.dispatch(/* unrelated objectID */ 999, 1, addr);
+        }
+        Thread.sleep(50);
+        assertThat(ref.get()).isNull();
+    }
+
+    @Test
     void nullAddressArrayIsTolerated() {
         CoreAudioBackend backend = new CoreAudioBackend();
         try (CoreAudioFormatChangeShim shim = new CoreAudioFormatChangeShim(backend, DEVICE)) {

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioFormatChangeShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/CoreAudioFormatChangeShimTest.java
@@ -1,0 +1,148 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link CoreAudioFormatChangeShim} — story 218 FFM
+ * upcall plumbing for CoreAudio's
+ * {@code AudioObjectPropertyListenerProc}.
+ */
+class CoreAudioFormatChangeShimTest {
+
+    private static final DeviceId DEVICE = new DeviceId("CoreAudio", "Mock CoreAudio Device");
+
+    @Test
+    void shimBuildsValidUpcallStubOnAnyPlatform() {
+        try (CoreAudioFormatChangeShim shim =
+                     new CoreAudioFormatChangeShim(new CoreAudioBackend(), DEVICE)) {
+            assertThat(shim.upcallStub()).isNotNull();
+            assertThat(shim.upcallStub().equals(MemorySegment.NULL)).isFalse();
+            // CoreAudio.framework is absent on non-macOS hosts.
+            assertThat(shim.isRegistered()).isFalse();
+        }
+    }
+
+    @Test
+    void closeIsIdempotent() {
+        CoreAudioFormatChangeShim shim =
+                new CoreAudioFormatChangeShim(new CoreAudioBackend(), DEVICE);
+        shim.close();
+        shim.close();
+    }
+
+    @Test
+    void nominalSampleRateSelectorEmitsSampleRateChange() throws Exception {
+        AudioDeviceEvent received = dispatchSelector(CoreAudioFormatChangeShim.kSelNominalSampleRate);
+        AudioDeviceEvent.FormatChangeRequested fc =
+                (AudioDeviceEvent.FormatChangeRequested) received;
+        assertThat(fc.reason()).isInstanceOf(FormatChangeReason.SampleRateChange.class);
+        assertThat(fc.proposedFormat()).isEmpty();
+        assertThat(fc.device()).isEqualTo(DEVICE);
+    }
+
+    @Test
+    void bufferFrameSizeSelectorEmitsBufferSizeChange() throws Exception {
+        AudioDeviceEvent received = dispatchSelector(CoreAudioFormatChangeShim.kSelBufferFrameSize);
+        AudioDeviceEvent.FormatChangeRequested fc =
+                (AudioDeviceEvent.FormatChangeRequested) received;
+        assertThat(fc.reason()).isInstanceOf(FormatChangeReason.BufferSizeChange.class);
+    }
+
+    @Test
+    void clockSourceSelectorEmitsClockSourceChange() throws Exception {
+        AudioDeviceEvent received = dispatchSelector(CoreAudioFormatChangeShim.kSelClockSource);
+        AudioDeviceEvent.FormatChangeRequested fc =
+                (AudioDeviceEvent.FormatChangeRequested) received;
+        assertThat(fc.reason()).isInstanceOf(FormatChangeReason.ClockSourceChange.class);
+    }
+
+    @Test
+    void unknownSelectorIsIgnored() throws Exception {
+        CoreAudioBackend backend = new CoreAudioBackend();
+        AtomicReference<AudioDeviceEvent> ref = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new CapturingSubscriber(ref, new CountDownLatch(1)));
+        Thread.sleep(50);
+        try (Arena scratch = Arena.ofConfined();
+             CoreAudioFormatChangeShim shim = new CoreAudioFormatChangeShim(backend, DEVICE)) {
+            MemorySegment addr = scratch.allocate(12);
+            addr.set(ValueLayout.JAVA_INT, 0, /* unrecognized */ 0xDEADBEEF);
+            shim.dispatch(CoreAudioFormatChangeShim.kAudioObjectSystemObject, 1, addr);
+        }
+        Thread.sleep(50);
+        assertThat(ref.get()).isNull();
+    }
+
+    @Test
+    void nullAddressArrayIsTolerated() {
+        CoreAudioBackend backend = new CoreAudioBackend();
+        try (CoreAudioFormatChangeShim shim = new CoreAudioFormatChangeShim(backend, DEVICE)) {
+            int status = shim.dispatch(CoreAudioFormatChangeShim.kAudioObjectSystemObject,
+                    1, MemorySegment.NULL);
+            assertThat(status).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void multipleAddressesInOneCallAllDispatch() throws Exception {
+        CoreAudioBackend backend = new CoreAudioBackend();
+        CountDownLatch latch = new CountDownLatch(2);
+        java.util.List<AudioDeviceEvent> received = new java.util.concurrent.CopyOnWriteArrayList<>();
+        backend.deviceEvents().subscribe(new Flow.Subscriber<>() {
+            @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+            @Override public void onNext(AudioDeviceEvent e) {
+                received.add(e);
+                latch.countDown();
+            }
+            @Override public void onError(Throwable t) {}
+            @Override public void onComplete() {}
+        });
+        Thread.sleep(50);
+        try (Arena scratch = Arena.ofConfined();
+             CoreAudioFormatChangeShim shim = new CoreAudioFormatChangeShim(backend, DEVICE)) {
+            MemorySegment addrs = scratch.allocate(24);
+            addrs.set(ValueLayout.JAVA_INT, 0, CoreAudioFormatChangeShim.kSelNominalSampleRate);
+            addrs.set(ValueLayout.JAVA_INT, 12, CoreAudioFormatChangeShim.kSelClockSource);
+            shim.dispatch(CoreAudioFormatChangeShim.kAudioObjectSystemObject, 2, addrs);
+        }
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(received).hasSize(2);
+    }
+
+    private static AudioDeviceEvent dispatchSelector(int selector) throws Exception {
+        CoreAudioBackend backend = new CoreAudioBackend();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<AudioDeviceEvent> ref = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new CapturingSubscriber(ref, latch));
+        Thread.sleep(50);
+        try (Arena scratch = Arena.ofConfined();
+             CoreAudioFormatChangeShim shim = new CoreAudioFormatChangeShim(backend, DEVICE)) {
+            MemorySegment addr = scratch.allocate(12);
+            addr.set(ValueLayout.JAVA_INT, 0, selector);
+            shim.dispatch(CoreAudioFormatChangeShim.kAudioObjectSystemObject, 1, addr);
+        }
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+        return ref.get();
+    }
+
+    private record CapturingSubscriber(AtomicReference<AudioDeviceEvent> ref, CountDownLatch latch)
+            implements Flow.Subscriber<AudioDeviceEvent> {
+        @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+        @Override public void onNext(AudioDeviceEvent e) {
+            if (ref.compareAndSet(null, e)) {
+                latch.countDown();
+            }
+        }
+        @Override public void onError(Throwable t) {}
+        @Override public void onComplete() {}
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/FormatChangeRequestedTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/FormatChangeRequestedTest.java
@@ -1,0 +1,116 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link AudioDeviceEvent.FormatChangeRequested} and
+ * {@link FormatChangeReason} — the structured driver-initiated
+ * "drop and reopen" signal from story 218.
+ */
+class FormatChangeRequestedTest {
+
+    private static final DeviceId DEVICE = new DeviceId("Mock", "Mock Device");
+
+    @Test
+    void recordExposesAllThreeAccessors() {
+        AudioFormat fmt = new AudioFormat(48_000.0, 2, 24);
+        AudioDeviceEvent.FormatChangeRequested event =
+                new AudioDeviceEvent.FormatChangeRequested(
+                        DEVICE,
+                        Optional.of(fmt),
+                        new FormatChangeReason.BufferSizeChange());
+        assertThat(event.device()).isEqualTo(DEVICE);
+        assertThat(event.proposedFormat()).contains(fmt);
+        assertThat(event.reason()).isInstanceOf(FormatChangeReason.BufferSizeChange.class);
+    }
+
+    @Test
+    void emptyProposedFormatIsAllowed() {
+        AudioDeviceEvent.FormatChangeRequested event =
+                new AudioDeviceEvent.FormatChangeRequested(
+                        DEVICE,
+                        Optional.empty(),
+                        new FormatChangeReason.DriverReset());
+        assertThat(event.proposedFormat()).isEmpty();
+    }
+
+    @Test
+    void deviceMustNotBeNull() {
+        assertThatThrownBy(() -> new AudioDeviceEvent.FormatChangeRequested(
+                null, Optional.empty(), new FormatChangeReason.DriverReset()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("device");
+    }
+
+    @Test
+    void proposedFormatOptionalMustNotBeNull() {
+        assertThatThrownBy(() -> new AudioDeviceEvent.FormatChangeRequested(
+                DEVICE, null, new FormatChangeReason.DriverReset()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("proposedFormat");
+    }
+
+    @Test
+    void reasonMustNotBeNull() {
+        assertThatThrownBy(() -> new AudioDeviceEvent.FormatChangeRequested(
+                DEVICE, Optional.empty(), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("reason");
+    }
+
+    @Test
+    void allFourReasonCasesArePermitted() {
+        // Just construct each one and verify they are FormatChangeReason
+        // instances — keeps the sealed permits list honest as the codebase
+        // evolves.
+        FormatChangeReason buffer = new FormatChangeReason.BufferSizeChange();
+        FormatChangeReason rate = new FormatChangeReason.SampleRateChange();
+        FormatChangeReason clock = new FormatChangeReason.ClockSourceChange();
+        FormatChangeReason reset = new FormatChangeReason.DriverReset();
+        assertThat(buffer).isInstanceOf(FormatChangeReason.class);
+        assertThat(rate).isInstanceOf(FormatChangeReason.class);
+        assertThat(clock).isInstanceOf(FormatChangeReason.class);
+        assertThat(reset).isInstanceOf(FormatChangeReason.class);
+    }
+
+    @Test
+    void mockBackendSimulatesFormatChangeRequestedEvent() throws Exception {
+        // Story 218 deliverable: MockAudioBackend can drive subscribers
+        // through the FormatChangeRequested flow without real hardware.
+        try (MockAudioBackend backend = new MockAudioBackend()) {
+            java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
+            java.util.concurrent.atomic.AtomicReference<AudioDeviceEvent> received =
+                    new java.util.concurrent.atomic.AtomicReference<>();
+            backend.deviceEvents().subscribe(new java.util.concurrent.Flow.Subscriber<>() {
+                @Override public void onSubscribe(java.util.concurrent.Flow.Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+                @Override public void onNext(AudioDeviceEvent e) {
+                    received.set(e);
+                    latch.countDown();
+                }
+                @Override public void onError(Throwable t) { /* ignore */ }
+                @Override public void onComplete() { /* ignore */ }
+            });
+            // Allow the SubmissionPublisher subscription to settle before publishing.
+            Thread.sleep(50);
+            backend.simulateFormatChangeRequested(
+                    DEVICE,
+                    Optional.of(new AudioFormat(44_100.0, 2, 24)),
+                    new FormatChangeReason.SampleRateChange());
+            assertThat(latch.await(2, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+            assertThat(received.get())
+                    .isInstanceOf(AudioDeviceEvent.FormatChangeRequested.class);
+            AudioDeviceEvent.FormatChangeRequested event =
+                    (AudioDeviceEvent.FormatChangeRequested) received.get();
+            assertThat(event.device()).isEqualTo(DEVICE);
+            assertThat(event.proposedFormat()).isPresent();
+            assertThat(event.reason()).isInstanceOf(FormatChangeReason.SampleRateChange.class);
+        }
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/WasapiFormatChangeShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/WasapiFormatChangeShimTest.java
@@ -1,0 +1,135 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link WasapiFormatChangeShim} — story 218 FFM upcall
+ * plumbing for WASAPI's {@code IMMNotificationClient::OnPropertyValueChanged}.
+ */
+class WasapiFormatChangeShimTest {
+
+    private static final DeviceId DEVICE = new DeviceId("WASAPI", "Mock WASAPI Device");
+
+    @Test
+    void shimBuildsValidVtableOnAnyPlatform() {
+        try (WasapiFormatChangeShim shim =
+                     new WasapiFormatChangeShim(new WasapiBackend(), DEVICE)) {
+            // Vtable + COM "fat pointer" must be allocated even on Linux.
+            assertThat(shim.vtable()).isNotNull();
+            assertThat(shim.vtable().equals(MemorySegment.NULL)).isFalse();
+            assertThat(shim.instance()).isNotNull();
+            assertThat(shim.instance().equals(MemorySegment.NULL)).isFalse();
+            // First slot of the instance points to the vtable (COM
+            // convention) — verify the layout is correct.
+            MemorySegment first = shim.instance().reinterpret(8)
+                    .get(ValueLayout.ADDRESS, 0);
+            assertThat(first.address()).isEqualTo(shim.vtable().address());
+            // Ole32 absent on non-Windows hosts.
+            assertThat(shim.isRegistered()).isFalse();
+        }
+    }
+
+    @Test
+    void closeIsIdempotent() {
+        WasapiFormatChangeShim shim =
+                new WasapiFormatChangeShim(new WasapiBackend(), DEVICE);
+        shim.close();
+        shim.close();
+    }
+
+    @Test
+    void matchingPropertyKeyEmitsSampleRateChange() throws Exception {
+        WasapiBackend backend = new WasapiBackend();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<AudioDeviceEvent> ref = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new CapturingSubscriber(ref, latch));
+        Thread.sleep(50);
+        try (Arena scratch = Arena.ofConfined();
+             WasapiFormatChangeShim shim = new WasapiFormatChangeShim(backend, DEVICE)) {
+            MemorySegment key = scratch.allocate(WasapiFormatChangeShim.PROPERTYKEY_SIZE);
+            // Copy GUID bytes.
+            for (int i = 0; i < WasapiFormatChangeShim.PKEY_AUDIO_ENGINE_DEVICE_FORMAT_GUID.length; i++) {
+                key.set(ValueLayout.JAVA_BYTE, i,
+                        WasapiFormatChangeShim.PKEY_AUDIO_ENGINE_DEVICE_FORMAT_GUID[i]);
+            }
+            key.set(ValueLayout.JAVA_INT, 16,
+                    WasapiFormatChangeShim.PKEY_AUDIO_ENGINE_DEVICE_FORMAT_PID);
+            int status = shim.dispatchPropertyChanged(key);
+            assertThat(status).isEqualTo(WasapiFormatChangeShim.S_OK);
+        }
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+        AudioDeviceEvent.FormatChangeRequested fc =
+                (AudioDeviceEvent.FormatChangeRequested) ref.get();
+        assertThat(fc.reason()).isInstanceOf(FormatChangeReason.SampleRateChange.class);
+        assertThat(fc.proposedFormat()).isEmpty();
+        assertThat(fc.device()).isEqualTo(DEVICE);
+    }
+
+    @Test
+    void nonMatchingGuidProducesNoEvent() throws Exception {
+        WasapiBackend backend = new WasapiBackend();
+        AtomicReference<AudioDeviceEvent> ref = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new CapturingSubscriber(ref, new CountDownLatch(1)));
+        Thread.sleep(50);
+        try (Arena scratch = Arena.ofConfined();
+             WasapiFormatChangeShim shim = new WasapiFormatChangeShim(backend, DEVICE)) {
+            MemorySegment key = scratch.allocate(WasapiFormatChangeShim.PROPERTYKEY_SIZE);
+            // All zeros — definitely not the audio-engine device-format GUID.
+            shim.dispatchPropertyChanged(key);
+        }
+        Thread.sleep(50);
+        assertThat(ref.get()).isNull();
+    }
+
+    @Test
+    void matchingGuidWithWrongPidProducesNoEvent() throws Exception {
+        WasapiBackend backend = new WasapiBackend();
+        AtomicReference<AudioDeviceEvent> ref = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new CapturingSubscriber(ref, new CountDownLatch(1)));
+        Thread.sleep(50);
+        try (Arena scratch = Arena.ofConfined();
+             WasapiFormatChangeShim shim = new WasapiFormatChangeShim(backend, DEVICE)) {
+            MemorySegment key = scratch.allocate(WasapiFormatChangeShim.PROPERTYKEY_SIZE);
+            for (int i = 0; i < WasapiFormatChangeShim.PKEY_AUDIO_ENGINE_DEVICE_FORMAT_GUID.length; i++) {
+                key.set(ValueLayout.JAVA_BYTE, i,
+                        WasapiFormatChangeShim.PKEY_AUDIO_ENGINE_DEVICE_FORMAT_GUID[i]);
+            }
+            // Wrong pid.
+            key.set(ValueLayout.JAVA_INT, 16, 99);
+            shim.dispatchPropertyChanged(key);
+        }
+        Thread.sleep(50);
+        assertThat(ref.get()).isNull();
+    }
+
+    @Test
+    void nullKeyIsTolerated() {
+        try (WasapiFormatChangeShim shim =
+                     new WasapiFormatChangeShim(new WasapiBackend(), DEVICE)) {
+            int status = shim.dispatchPropertyChanged(MemorySegment.NULL);
+            assertThat(status).isEqualTo(WasapiFormatChangeShim.S_OK);
+        }
+    }
+
+    private record CapturingSubscriber(AtomicReference<AudioDeviceEvent> ref, CountDownLatch latch)
+            implements Flow.Subscriber<AudioDeviceEvent> {
+        @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+        @Override public void onNext(AudioDeviceEvent e) {
+            if (ref.compareAndSet(null, e)) {
+                latch.countDown();
+            }
+        }
+        @Override public void onError(Throwable t) {}
+        @Override public void onComplete() {}
+    }
+}


### PR DESCRIPTION
# Driver-Initiated Reset Request Handling for Mid-Session Format Changes

## Motivation

When a user opens the native driver control panel mid-session (story 212) and changes the buffer size, sample rate, USB streaming mode, or clock source, the driver does not silently apply the new format — it raises a structured "please drop and reopen" signal. ASIO drivers fire `kAsioResetRequest` through the host callback; ASIO drivers fire `kAsioBufferSizeChange` with the new size; CoreAudio fires `kAudioDevicePropertyNominalSampleRate` listeners; WASAPI invalidates the active `IAudioClient` and requires a full reinitialisation. Today the engine has no plan: the next render callback reads stale buffer-size assumptions, fails, and the controller crashes the same way as a device disconnect (story 214) — except in this case the device is fine, the *format* changed.

Every professional DAW handles this gracefully. Cubase displays "Audio device settings changed — restarting engine" and reopens. Pro Tools logs the change, freezes transport for ~200 ms, and resumes. The mechanism is straightforward — listen to the driver's reset signal, drain the render thread, reopen with the new format, restart transport in `STOPPED` state. The cost of *not* handling this is the same crashy experience as a yanked cable for what is in fact a deliberate user action.

Story 214 covers device-loss; this story covers driver-initiated format change while the device is still present.

## Goals

- Extend `AudioDeviceEvent` (story 214) with a new `FormatChangeRequested(DeviceId, Optional<AudioFormat> proposedFormat, FormatChangeReason reason)` record. `FormatChangeReason` is sealed: `BufferSizeChange`, `SampleRateChange`, `ClockSourceChange`, `DriverReset`.
- `AsioBackend` translates `kAsioResetRequest`, `kAsioBufferSizeChange`, `kAsioResyncRequest` into `FormatChangeRequested` events with the appropriate reason. Following the ASIO host-callback contract, the actual reopen happens on a dedicated worker thread, never on the audio callback thread.
- `CoreAudioBackend` installs property listeners for `kAudioDevicePropertyNominalSampleRate`, `kAudioDevicePropertyBufferFrameSize`, and `kAudioDevicePropertyClockSource` and emits the corresponding events.
- `WasapiBackend` listens for `IMMNotificationClient::OnPropertyValueChanged` on the active endpoint and emits `FormatChangeRequested` when the mix format changes.
- `DefaultAudioEngineController` consumes the event: pause transport, drain the render queue (deadline 200 ms), close the stream, re-query device capabilities (story 213), reopen with the proposed format if provided or the existing settings otherwise, and resume in `STOPPED`. While reopening, the UI shows "Reconfiguring audio engine…" in the transport bar.
- Recording: if `FormatChangeRequested` arrives while recording, behave like `DeviceRemoved` for the in-progress take — flush partially captured frames to `.daw/incomplete-takes/`, show a recovery dialog after reopen.
- Sample-rate change is treated specially: the project session rate does *not* change. The engine inserts SRC at the device boundary (story 126's `SampleRateConverter`) so a project authored at 48 kHz keeps playing at 48 kHz internally even if the driver is now running at 44.1 kHz. Surface a notification suggesting the user pick the matching project rate from the driver panel.
- Coalesce rapid-fire reset requests (the user spinning a buffer-size dropdown produces multiple events): wait 250 ms after the last event before reopening.
- Tests: a `MockAudioBackend` emits `FormatChangeRequested(BufferSizeChange, 256→512)` mid-render; the controller reopens with 512, transport state is preserved, no audio thread exception is raised. A second test covers the SRC-fallback path when the driver moves from 48k to 44.1k.

## Non-Goals

- Hot-patching the in-flight render graph for the new format (e.g., resizing buffer pools without a stream reopen). The reopen is a clean teardown / rebuild.
- Persisting the driver-initiated change as the new DAW default — settings the user made in the driver panel apply only to that session unless they confirm "save as default" in the audio settings dialog.
- Recovering plugin internal state across the reopen for plugins that are not real-time-state-safe; lookahead buffers and reverb tails are flushed.
- Exposing a "block driver-initiated changes" mode; the driver always wins, the DAW always reconciles.
