### PR TITLE
mixer-channel-strip-control-skin user story implemented.

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/InsertSlotModel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/InsertSlotModel.java
@@ -1,0 +1,44 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import java.util.Objects;
+
+/**
+ * Immutable view-model adapter for one insert-effect slot rendered by a
+ * {@link MixerChannelStrip}.
+ *
+ * <p>Story 271 (Phase 2 of the UI Design Book §6 migration roadmap). The
+ * channel-strip {@link javafx.scene.control.Control} is deliberately
+ * decoupled from {@code daw-core}'s mutable
+ * {@link com.benesquivelmusic.daw.core.mixer.InsertSlot} — consumers map
+ * their model into this immutable record so the control's
+ * {@code insertsProperty()} observable list never holds an engine type
+ * (matching the §2.5 "themability is a stylesheet swap" / "the strip
+ * exposes a strict {@code Property<T>}-driven API" promise).
+ *
+ * <p>Field mapping against
+ * {@link com.benesquivelmusic.daw.core.mixer.InsertSlot}:
+ * <ul>
+ *   <li>{@code name}     — {@code InsertSlot.getName()}.</li>
+ *   <li>{@code active}   — a slot that holds a processor and is engaged;
+ *       the consumer supplies {@code !slot.isBypassed()} (an empty slot
+ *       maps to {@code active = false}).</li>
+ *   <li>{@code bypassed} — {@code InsertSlot.isBypassed()}. The status dot
+ *       renders {@code -mcs-accent} when {@code active}, otherwise
+ *       {@code -mcs-text-mute} (story §5.4 — "{@code -accent} if active,
+ *       {@code -text-mute} if bypassed").</li>
+ * </ul>
+ *
+ * @param name     the slot display name (e.g. {@code "Compressor"}); must
+ *                 not be {@code null}
+ * @param active   whether the slot holds an engaged processor
+ * @param bypassed whether the slot is bypassed
+ */
+public record InsertSlotModel(String name, boolean active, boolean bypassed) {
+
+    /**
+     * @throws NullPointerException if {@code name} is {@code null}
+     */
+    public InsertSlotModel {
+        Objects.requireNonNull(name, "name");
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStrip.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStrip.java
@@ -1,0 +1,856 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.controls.skin.MixerChannelStripSkin;
+
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.css.CssMetaData;
+import javafx.css.PseudoClass;
+import javafx.css.StyleConverter;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.event.EventTarget;
+import javafx.event.EventType;
+import javafx.scene.AccessibleRole;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+import javafx.scene.paint.Color;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Mixer channel-strip {@link Control} — the complete §5.4 signal-chain
+ * surface for one mixer channel: I/O labels, inserts list, sends list,
+ * pan knob, fader (with integrated meter), M/S/R buttons and name.
+ *
+ * <p>Story 271. Phase 2 of the UI Design Book §6 migration roadmap.
+ * Replaces the hand-rolled {@code .mixer-channel} {@code VBox} rendering
+ * scattered across {@code MixerView} and friends. Follows the same
+ * {@code Control + SkinBase + StyleableProperty + package-resource
+ * user-agent stylesheet} convention as {@link LevelMeter} (story 267),
+ * {@link Knob} (story 268), {@link Fader} (story 269) and
+ * {@link TrackStrip} (story 270), composing those Phase 2 sub-controls
+ * into the §5.4 layout.
+ *
+ * <h2>Visual contract (UI Design Book §5.4)</h2>
+ *
+ * <ul>
+ *   <li>Vertical strip laid out top → bottom: I/O caption · inserts
+ *       (4 + overflow) · sends (2 + overflow) · pan knob · fader + meter ·
+ *       M/S/R · value readout · name.</li>
+ *   <li><strong>No card border, no shadow, no rounded corners</strong> on
+ *       the strip itself — visual separation between adjacent strips is a
+ *       4&nbsp;px gutter at {@code -mcs-surface-bg} (the same colour as the
+ *       panel background). The mixer panel sits at elevation 0
+ *       (story 263).</li>
+ *   <li>72&nbsp;px wide Compact / 88&nbsp;px wide Comfortable (selected by
+ *       the density mode in story 278 via {@code .density-compact} /
+ *       {@code .density-comfortable}). Width is enforced from the Skin
+ *       (Java), not CSS, to avoid a token-validation linter mismatch with
+ *       the 4&nbsp;px grid.</li>
+ *   <li>The M/S/R buttons reuse story 270's exact CSS classes
+ *       ({@code .track-toggle.mute|solo|arm}) for visual consistency.</li>
+ *   <li>When {@link #channelTypeProperty()} is
+ *       {@link ChannelType#MASTER} the M/S/R buttons are not added to the
+ *       scene graph at all; when {@link ChannelType#BUS} the input
+ *       selector/label is omitted (UI Design Book §5.4).</li>
+ * </ul>
+ *
+ * <h2>{@code UUID} vs {@code ChannelId} (deviation from story text)</h2>
+ *
+ * <p>The story's Goals literally specify
+ * {@code ObjectProperty<ChannelId>}. This control uses
+ * {@link java.util.UUID} instead — <strong>a deliberate, documented
+ * deviation</strong>, mirroring exactly the decision {@link TrackStrip}
+ * made for its analogous {@code trackId}: the existing mixer code keys
+ * channels by {@code UUID} ({@code MixerView} maintains
+ * {@code Map<UUID, MixerChannel>} and parses channel ids to {@code UUID}),
+ * and introducing a parallel {@code ChannelId} wrapper would force every
+ * consumer to translate at the boundary for no behavioural gain. The
+ * channel id is the {@code UUID} the mixer model already uses.
+ *
+ * <h2>Slot events</h2>
+ *
+ * <p>Clicking an insert or send slot row inside the skin fires a typed
+ * {@link InsertSelectedEvent} / {@link SendSelectedEvent} via
+ * {@link #fireEvent(Event)} so the event bubbles through the scene graph
+ * normally and integrates with the standard event dispatch chain
+ * (Skill §12). Story 272's Inspector consumes these via the standard
+ * dispatch chain; prefer {@link #setOnInsertSelected(EventHandler)} /
+ * {@link #setOnSendSelected(EventHandler)} over ad-hoc callbacks.
+ *
+ * <h2>Construction paths</h2>
+ *
+ * <p>The public no-arg constructor with the standard property setters and
+ * the fluent {@link #create()} builder are independent, equally supported
+ * paths:
+ *
+ * <pre>{@code
+ * MixerChannelStrip a = new MixerChannelStrip();
+ * a.setChannelName("Drums");
+ * a.setChannelType(MixerChannelStrip.ChannelType.AUDIO);
+ *
+ * MixerChannelStrip b = MixerChannelStrip.create()
+ *         .channelId(UUID.randomUUID())
+ *         .name("Drums")
+ *         .channelType(MixerChannelStrip.ChannelType.AUDIO)
+ *         .size("compact")
+ *         .build();
+ * }</pre>
+ */
+public final class MixerChannelStrip extends Control {
+
+    /**
+     * Stable style class — selectable as {@code .mixer-channel-strip} in
+     * CSS. (The story refers to the alias target as
+     * {@code .dawg-mixer-channel-strip}; the actual stable class is the
+     * unprefixed {@code mixer-channel-strip}, matching the
+     * {@code .track-strip} precedent from story 270.)
+     */
+    public static final String DEFAULT_STYLE_CLASS = "mixer-channel-strip";
+
+    /** Pseudo-class flipped on {@link #mutedProperty()}. */
+    static final PseudoClass PSEUDO_MUTED = PseudoClass.getPseudoClass("muted");
+    /** Pseudo-class flipped on {@link #soloedProperty()}. */
+    static final PseudoClass PSEUDO_SOLOED = PseudoClass.getPseudoClass("soloed");
+    /** Pseudo-class flipped on {@link #armedProperty()}. */
+    static final PseudoClass PSEUDO_ARMED = PseudoClass.getPseudoClass("armed");
+
+    /**
+     * Channel category. JavaFX has no {@code EnumProperty}, so
+     * {@link #channelTypeProperty()} is a
+     * {@link SimpleObjectProperty}{@code <ChannelType>}. Co-located in this
+     * control (like {@link Fader.TravelCurve}) — {@code daw-app} is
+     * non-modular so package placement is free and keeping the strip's
+     * vocabulary self-contained matches the controls-package convention.
+     */
+    public enum ChannelType {
+        /** A regular audio track channel — full M/S/R + I/O. */
+        AUDIO,
+        /** A MIDI/instrument channel — full M/S/R + I/O. */
+        MIDI,
+        /** A return/group bus — no input selector (§5.4). */
+        BUS,
+        /** The master bus — no M/S/R buttons (§5.4 / §7.5). */
+        MASTER
+    }
+
+    // ── Palette A fallback colours (UI Design Book §5.4) ──────────────────
+    private static final Color FALLBACK_SURFACE_1 = Color.web("#15161B");
+    private static final Color FALLBACK_SURFACE_3 = Color.web("#272A33");
+    private static final Color FALLBACK_SURFACE_BG = Color.web("#0B0B0E");
+    private static final Color FALLBACK_ACCENT = Color.web("#7C8CFF");
+    private static final Color FALLBACK_ACCENT_SOFT = Color.web("rgba(124, 140, 255, 0.14)");
+    private static final Color FALLBACK_DANGER = Color.web("#E5484D");
+    private static final Color FALLBACK_WARN = Color.web("#E6B450");
+    private static final Color FALLBACK_TEXT = Color.web("#B7BCC7");
+    private static final Color FALLBACK_TEXT_HI = Color.web("#ECEEF2");
+    private static final Color FALLBACK_TEXT_MUTE = Color.web("#7A808C");
+    private static final Color FALLBACK_LINE_SOFT = Color.web("#22242C");
+
+    // ── Plain observable properties ───────────────────────────────────────
+
+    private final ObjectProperty<UUID> channelId =
+            new SimpleObjectProperty<>(this, "channelId", null);
+    private final StringProperty channelName =
+            new SimpleStringProperty(this, "channelName", "");
+    private final StringProperty inputLabel =
+            new SimpleStringProperty(this, "inputLabel", "");
+    private final StringProperty outputLabel =
+            new SimpleStringProperty(this, "outputLabel", "");
+
+    private final ObservableList<InsertSlotModel> inserts =
+            FXCollections.observableArrayList();
+    private final ObservableList<SendSlotModel> sends =
+            FXCollections.observableArrayList();
+
+    private final DoubleProperty pan =
+            new SimpleDoubleProperty(this, "pan", 0.0);
+    private final DoubleProperty faderDb =
+            new SimpleDoubleProperty(this, "faderDb", 0.0);
+
+    private final BooleanProperty muted =
+            new SimpleBooleanProperty(this, "muted", false) {
+                @Override
+                protected void invalidated() {
+                    pseudoClassStateChanged(PSEUDO_MUTED, get());
+                }
+            };
+    private final BooleanProperty soloed =
+            new SimpleBooleanProperty(this, "soloed", false) {
+                @Override
+                protected void invalidated() {
+                    pseudoClassStateChanged(PSEUDO_SOLOED, get());
+                }
+            };
+    private final BooleanProperty armed =
+            new SimpleBooleanProperty(this, "armed", false) {
+                @Override
+                protected void invalidated() {
+                    pseudoClassStateChanged(PSEUDO_ARMED, get());
+                }
+            };
+
+    private final ObjectProperty<ChannelType> channelType =
+            new SimpleObjectProperty<>(this, "channelType", ChannelType.AUDIO) {
+                @Override
+                public void set(ChannelType newValue) {
+                    super.set(Objects.requireNonNull(newValue, "channelType"));
+                }
+            };
+
+    /**
+     * Creates a channel strip with defaults: no channel id, empty name /
+     * I/O labels, empty inserts / sends lists, pan {@code 0.0} (centre),
+     * fader {@code 0.0 dB}, M/S/R all false, {@link ChannelType#AUDIO}.
+     */
+    public MixerChannelStrip() {
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        setAccessibleRole(AccessibleRole.PARENT);
+        setAccessibleRoleDescription("Mixer channel strip");
+        setFocusTraversable(true);
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new MixerChannelStripSkin(this);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(
+                MixerChannelStrip.class.getResource("mixer-channel-strip.css"),
+                "mixer-channel-strip.css not on classpath").toExternalForm();
+    }
+
+    // ── channelId ─────────────────────────────────────────────────────────
+
+    /** @return the channel identifier property (the mixer model's {@link UUID}). */
+    public final ObjectProperty<UUID> channelIdProperty() { return channelId; }
+    /** @return the channel identifier, or {@code null} if unbound. */
+    public final UUID getChannelId() { return channelId.get(); }
+    /** @param id the channel identifier (may be {@code null}). */
+    public final void setChannelId(UUID id) { channelId.set(id); }
+
+    // ── channelName ───────────────────────────────────────────────────────
+
+    /** @return the channel display-name property. */
+    public final StringProperty channelNameProperty() { return channelName; }
+    /** @return the channel display name. */
+    public final String getChannelName() { return channelName.get(); }
+    /** @param name the channel display name. */
+    public final void setChannelName(String name) { channelName.set(name); }
+
+    // ── inputLabel / outputLabel ──────────────────────────────────────────
+
+    /** @return the input-routing caption property (small mono, §3.2). */
+    public final StringProperty inputLabelProperty() { return inputLabel; }
+    /** @return the input-routing caption. */
+    public final String getInputLabel() { return inputLabel.get(); }
+    /** @param label the input-routing caption. */
+    public final void setInputLabel(String label) { inputLabel.set(label); }
+
+    /** @return the output-routing caption property (small mono, §3.2). */
+    public final StringProperty outputLabelProperty() { return outputLabel; }
+    /** @return the output-routing caption. */
+    public final String getOutputLabel() { return outputLabel.get(); }
+    /** @param label the output-routing caption. */
+    public final void setOutputLabel(String label) { outputLabel.set(label); }
+
+    // ── inserts / sends ───────────────────────────────────────────────────
+
+    /**
+     * @return the live, mutable inserts list. The skin renders the first
+     *         4 entries plus a {@code ⋯} overflow indicator and reflows on
+     *         list mutation.
+     */
+    public final ObservableList<InsertSlotModel> insertsProperty() { return inserts; }
+
+    /**
+     * @return the live, mutable sends list. The skin renders the first
+     *         2 entries plus a {@code ⋯} overflow indicator and reflows on
+     *         list mutation.
+     */
+    public final ObservableList<SendSlotModel> sendsProperty() { return sends; }
+
+    // ── pan / faderDb ─────────────────────────────────────────────────────
+
+    /**
+     * @return the bipolar pan property in {@code [-1, 1]}. Two-way synced
+     *         to the skin's {@link Knob} (centre detent at 0).
+     */
+    public final DoubleProperty panProperty() { return pan; }
+    /** @return the pan position in {@code [-1, 1]}. */
+    public final double getPan() { return pan.get(); }
+    /** @param value the pan position in {@code [-1, 1]}. */
+    public final void setPan(double value) { pan.set(value); }
+
+    /**
+     * @return the fader value property, in dB. Two-way synced to the
+     *         skin's {@link Fader} ({@link Fader.TravelCurve#LOG_DB}).
+     */
+    public final DoubleProperty faderDbProperty() { return faderDb; }
+    /** @return the fader value in dB. */
+    public final double getFaderDb() { return faderDb.get(); }
+    /** @param db the fader value in dB. */
+    public final void setFaderDb(double db) { faderDb.set(db); }
+
+    // ── muted / soloed / armed ────────────────────────────────────────────
+
+    /** @return the muted gating property; flips the {@code :muted} pseudo-class. */
+    public final BooleanProperty mutedProperty() { return muted; }
+    /** @return whether the channel is muted. */
+    public final boolean isMuted() { return muted.get(); }
+    /** @param value whether the channel is muted. */
+    public final void setMuted(boolean value) { muted.set(value); }
+
+    /** @return the soloed gating property; flips the {@code :soloed} pseudo-class. */
+    public final BooleanProperty soloedProperty() { return soloed; }
+    /** @return whether the channel is soloed. */
+    public final boolean isSoloed() { return soloed.get(); }
+    /** @param value whether the channel is soloed. */
+    public final void setSoloed(boolean value) { soloed.set(value); }
+
+    /** @return the armed gating property; flips the {@code :armed} pseudo-class. */
+    public final BooleanProperty armedProperty() { return armed; }
+    /** @return whether the channel is record-armed. */
+    public final boolean isArmed() { return armed.get(); }
+    /** @param value whether the channel is record-armed. */
+    public final void setArmed(boolean value) { armed.set(value); }
+
+    // ── channelType ───────────────────────────────────────────────────────
+
+    /**
+     * @return the channel-type property. JavaFX has no {@code EnumProperty};
+     *         this is a {@link SimpleObjectProperty}. Controls visibility
+     *         of the M/S/R buttons (absent for {@link ChannelType#MASTER})
+     *         and the input selector (absent for {@link ChannelType#BUS}).
+     */
+    public final ObjectProperty<ChannelType> channelTypeProperty() { return channelType; }
+    /** @return the channel type (never {@code null}). */
+    public final ChannelType getChannelType() { return channelType.get(); }
+    /** @param type the channel type; must not be {@code null}. */
+    public final void setChannelType(ChannelType type) { channelType.set(type); }
+
+    // ── Styleable colour properties (consume root-pane tokens) ────────────
+    //
+    // The CssMetaData uses internal -mcs-* names so styles.css can forward
+    // role tokens without circular looked-up-colour drops, matching the
+    // TrackStrip / LevelMeter pattern. A same-name self-referential forward
+    // (.mixer-channel-strip { -surface-1: -surface-1 }) is a circular
+    // looked-up colour the engine silently drops — the internal name lets
+    // styles.css declare `-mcs-surface-1: -surface-1;` (distinct names).
+
+    private final StyleableObjectProperty<Color> surface1 =
+            new StyleableObjectProperty<>(FALLBACK_SURFACE_1) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "surface1"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.SURFACE_1;
+                }
+            };
+    private final StyleableObjectProperty<Color> surface3 =
+            new StyleableObjectProperty<>(FALLBACK_SURFACE_3) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "surface3"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.SURFACE_3;
+                }
+            };
+    private final StyleableObjectProperty<Color> surfaceBg =
+            new StyleableObjectProperty<>(FALLBACK_SURFACE_BG) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "surfaceBg"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.SURFACE_BG;
+                }
+            };
+    private final StyleableObjectProperty<Color> accent =
+            new StyleableObjectProperty<>(FALLBACK_ACCENT) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "accent"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.ACCENT;
+                }
+            };
+    private final StyleableObjectProperty<Color> accentSoft =
+            new StyleableObjectProperty<>(FALLBACK_ACCENT_SOFT) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "accentSoft"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.ACCENT_SOFT;
+                }
+            };
+    private final StyleableObjectProperty<Color> danger =
+            new StyleableObjectProperty<>(FALLBACK_DANGER) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "danger"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.DANGER;
+                }
+            };
+    private final StyleableObjectProperty<Color> warn =
+            new StyleableObjectProperty<>(FALLBACK_WARN) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "warn"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.WARN;
+                }
+            };
+    private final StyleableObjectProperty<Color> text =
+            new StyleableObjectProperty<>(FALLBACK_TEXT) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "text"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.TEXT;
+                }
+            };
+    private final StyleableObjectProperty<Color> textHi =
+            new StyleableObjectProperty<>(FALLBACK_TEXT_HI) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "textHi"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.TEXT_HI;
+                }
+            };
+    private final StyleableObjectProperty<Color> textMute =
+            new StyleableObjectProperty<>(FALLBACK_TEXT_MUTE) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "textMute"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.TEXT_MUTE;
+                }
+            };
+    private final StyleableObjectProperty<Color> lineSoft =
+            new StyleableObjectProperty<>(FALLBACK_LINE_SOFT) {
+                @Override public Object getBean() { return MixerChannelStrip.this; }
+                @Override public String getName() { return "lineSoft"; }
+                @Override public CssMetaData<MixerChannelStrip, Color> getCssMetaData() {
+                    return StyleableProperties.LINE_SOFT;
+                }
+            };
+
+    /** @return the surface-1 styleable colour (default strip background). */
+    public final StyleableObjectProperty<Color> surface1Property() { return surface1; }
+    /** @return the resolved surface-1 colour. */
+    public final Color getSurface1() { return surface1.get(); }
+    /** @param c the surface-1 colour. */
+    public final void setSurface1(Color c) { surface1.set(c); }
+
+    /** @return the surface-3 styleable colour (hover background). */
+    public final StyleableObjectProperty<Color> surface3Property() { return surface3; }
+    /** @return the resolved surface-3 colour. */
+    public final Color getSurface3() { return surface3.get(); }
+    /** @param c the surface-3 colour. */
+    public final void setSurface3(Color c) { surface3.set(c); }
+
+    /** @return the surface-bg styleable colour (inter-strip gutter, §5.4). */
+    public final StyleableObjectProperty<Color> surfaceBgProperty() { return surfaceBg; }
+    /** @return the resolved surface-bg colour. */
+    public final Color getSurfaceBg() { return surfaceBg.get(); }
+    /** @param c the surface-bg colour. */
+    public final void setSurfaceBg(Color c) { surfaceBg.set(c); }
+
+    /** @return the accent styleable colour (active insert status dot). */
+    public final StyleableObjectProperty<Color> accentProperty() { return accent; }
+    /** @return the resolved accent colour. */
+    public final Color getAccent() { return accent.get(); }
+    /** @param c the accent colour. */
+    public final void setAccent(Color c) { accent.set(c); }
+
+    /** @return the accent-soft styleable colour (selected background). */
+    public final StyleableObjectProperty<Color> accentSoftProperty() { return accentSoft; }
+    /** @return the resolved accent-soft colour. */
+    public final Color getAccentSoft() { return accentSoft.get(); }
+    /** @param c the accent-soft colour. */
+    public final void setAccentSoft(Color c) { accentSoft.set(c); }
+
+    /** @return the danger styleable colour (record toggle fill). */
+    public final StyleableObjectProperty<Color> dangerProperty() { return danger; }
+    /** @return the resolved danger colour. */
+    public final Color getDanger() { return danger.get(); }
+    /** @param c the danger colour. */
+    public final void setDanger(Color c) { danger.set(c); }
+
+    /** @return the warn styleable colour (solo toggle fill). */
+    public final StyleableObjectProperty<Color> warnProperty() { return warn; }
+    /** @return the resolved warn colour. */
+    public final Color getWarn() { return warn.get(); }
+    /** @param c the warn colour. */
+    public final void setWarn(Color c) { warn.set(c); }
+
+    /** @return the text styleable colour (mute toggle fill, captions). */
+    public final StyleableObjectProperty<Color> textProperty() { return text; }
+    /** @return the resolved text colour. */
+    public final Color getText() { return text.get(); }
+    /** @param c the text colour. */
+    public final void setText(Color c) { text.set(c); }
+
+    /** @return the text-hi styleable colour (channel name). */
+    public final StyleableObjectProperty<Color> textHiProperty() { return textHi; }
+    /** @return the resolved text-hi colour. */
+    public final Color getTextHi() { return textHi.get(); }
+    /** @param c the text-hi colour. */
+    public final void setTextHi(Color c) { textHi.set(c); }
+
+    /** @return the text-mute styleable colour (bypassed insert dot, I/O caption). */
+    public final StyleableObjectProperty<Color> textMuteProperty() { return textMute; }
+    /** @return the resolved text-mute colour. */
+    public final Color getTextMute() { return textMute.get(); }
+    /** @param c the text-mute colour. */
+    public final void setTextMute(Color c) { textMute.set(c); }
+
+    /** @return the line-soft styleable colour (section separators). */
+    public final StyleableObjectProperty<Color> lineSoftProperty() { return lineSoft; }
+    /** @return the resolved line-soft colour. */
+    public final Color getLineSoft() { return lineSoft.get(); }
+    /** @param c the line-soft colour. */
+    public final void setLineSoft(Color c) { lineSoft.set(c); }
+
+    // ── CssMetaData ───────────────────────────────────────────────────────
+
+    private static final class StyleableProperties {
+
+        private static CssMetaData<MixerChannelStrip, Color> color(
+                String name, Color fallback,
+                java.util.function.Function<MixerChannelStrip,
+                        StyleableObjectProperty<Color>> accessor) {
+            return new CssMetaData<>(name,
+                    StyleConverter.getColorConverter(), fallback) {
+                @Override
+                public boolean isSettable(MixerChannelStrip s) {
+                    return !accessor.apply(s).isBound();
+                }
+                @Override
+                public StyleableProperty<Color> getStyleableProperty(MixerChannelStrip s) {
+                    return accessor.apply(s);
+                }
+            };
+        }
+
+        static final CssMetaData<MixerChannelStrip, Color> SURFACE_1 =
+                color("-mcs-surface-1", FALLBACK_SURFACE_1, s -> s.surface1);
+        static final CssMetaData<MixerChannelStrip, Color> SURFACE_3 =
+                color("-mcs-surface-3", FALLBACK_SURFACE_3, s -> s.surface3);
+        static final CssMetaData<MixerChannelStrip, Color> SURFACE_BG =
+                color("-mcs-surface-bg", FALLBACK_SURFACE_BG, s -> s.surfaceBg);
+        static final CssMetaData<MixerChannelStrip, Color> ACCENT =
+                color("-mcs-accent", FALLBACK_ACCENT, s -> s.accent);
+        static final CssMetaData<MixerChannelStrip, Color> ACCENT_SOFT =
+                color("-mcs-accent-soft", FALLBACK_ACCENT_SOFT, s -> s.accentSoft);
+        static final CssMetaData<MixerChannelStrip, Color> DANGER =
+                color("-mcs-danger", FALLBACK_DANGER, s -> s.danger);
+        static final CssMetaData<MixerChannelStrip, Color> WARN =
+                color("-mcs-warn", FALLBACK_WARN, s -> s.warn);
+        static final CssMetaData<MixerChannelStrip, Color> TEXT =
+                color("-mcs-text", FALLBACK_TEXT, s -> s.text);
+        static final CssMetaData<MixerChannelStrip, Color> TEXT_HI =
+                color("-mcs-text-hi", FALLBACK_TEXT_HI, s -> s.textHi);
+        static final CssMetaData<MixerChannelStrip, Color> TEXT_MUTE =
+                color("-mcs-text-mute", FALLBACK_TEXT_MUTE, s -> s.textMute);
+        static final CssMetaData<MixerChannelStrip, Color> LINE_SOFT =
+                color("-mcs-line-soft", FALLBACK_LINE_SOFT, s -> s.lineSoft);
+
+        static final List<CssMetaData<? extends Styleable, ?>> CSS_META_DATA;
+
+        static {
+            List<CssMetaData<? extends Styleable, ?>> list =
+                    new ArrayList<>(Control.getClassCssMetaData());
+            Collections.addAll(list,
+                    SURFACE_1, SURFACE_3, SURFACE_BG, ACCENT, ACCENT_SOFT,
+                    DANGER, WARN, TEXT, TEXT_HI, TEXT_MUTE, LINE_SOFT);
+            CSS_META_DATA = Collections.unmodifiableList(list);
+        }
+
+        private StyleableProperties() {
+        }
+    }
+
+    /** @return the {@link CssMetaData} for this control type, combined with {@link Control}'s. */
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return StyleableProperties.CSS_META_DATA;
+    }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getControlCssMetaData() {
+        return getClassCssMetaData();
+    }
+
+    // ── Slot selection events ─────────────────────────────────────────────
+
+    /**
+     * Typed event fired when the user clicks an insert slot row. Bubbles
+     * through the scene graph; story 272's Inspector consumes it via the
+     * standard event dispatch chain (Skill §12). Mirrors
+     * {@link TrackStrip.TrackSelectionEvent}.
+     */
+    public static final class InsertSelectedEvent extends Event {
+
+        private static final long serialVersionUID = 20260516L;
+
+        /** Single typed event-type for insert-slot selection. */
+        public static final EventType<InsertSelectedEvent> INSERT_SELECTED =
+                new EventType<>(Event.ANY, "MCS_INSERT_SELECTED");
+
+        private final int insertIndex;
+
+        /**
+         * Creates an insert-selected event with no explicit source/target
+         * (the dispatch chain fills them in when fired via
+         * {@link javafx.scene.Node#fireEvent(Event)}).
+         *
+         * @param insertIndex the clicked slot's index in
+         *                    {@link #insertsProperty()}
+         */
+        public InsertSelectedEvent(int insertIndex) {
+            super(INSERT_SELECTED);
+            this.insertIndex = insertIndex;
+        }
+
+        /**
+         * @param source      the event source (typically the strip)
+         * @param target      the event target
+         * @param insertIndex the clicked slot's index in
+         *                    {@link #insertsProperty()}
+         */
+        public InsertSelectedEvent(Object source, EventTarget target, int insertIndex) {
+            super(source, target, INSERT_SELECTED);
+            this.insertIndex = insertIndex;
+        }
+
+        /** @return the clicked insert-slot index. */
+        public int getInsertIndex() {
+            return insertIndex;
+        }
+    }
+
+    /**
+     * Typed event fired when the user clicks a send slot row. Bubbles
+     * through the scene graph. Mirrors {@link InsertSelectedEvent}.
+     */
+    public static final class SendSelectedEvent extends Event {
+
+        private static final long serialVersionUID = 20260516L;
+
+        /** Single typed event-type for send-slot selection. */
+        public static final EventType<SendSelectedEvent> SEND_SELECTED =
+                new EventType<>(Event.ANY, "MCS_SEND_SELECTED");
+
+        private final int sendIndex;
+
+        /**
+         * Creates a send-selected event with no explicit source/target.
+         *
+         * @param sendIndex the clicked slot's index in
+         *                  {@link #sendsProperty()}
+         */
+        public SendSelectedEvent(int sendIndex) {
+            super(SEND_SELECTED);
+            this.sendIndex = sendIndex;
+        }
+
+        /**
+         * @param source    the event source (typically the strip)
+         * @param target    the event target
+         * @param sendIndex the clicked slot's index in
+         *                  {@link #sendsProperty()}
+         */
+        public SendSelectedEvent(Object source, EventTarget target, int sendIndex) {
+            super(source, target, SEND_SELECTED);
+            this.sendIndex = sendIndex;
+        }
+
+        /** @return the clicked send-slot index. */
+        public int getSendIndex() {
+            return sendIndex;
+        }
+    }
+
+    /** Public re-export of the insert-selection event type (Skill §12 convention). */
+    public static final EventType<InsertSelectedEvent> INSERT_SELECTED =
+            InsertSelectedEvent.INSERT_SELECTED;
+    /** Public re-export of the send-selection event type (Skill §12 convention). */
+    public static final EventType<SendSelectedEvent> SEND_SELECTED =
+            SendSelectedEvent.SEND_SELECTED;
+
+    /**
+     * Convenience setter for a single
+     * {@link InsertSelectedEvent#INSERT_SELECTED} handler. Replaces any
+     * previously installed handler.
+     *
+     * @param handler the handler, or {@code null} to clear
+     */
+    public final void setOnInsertSelected(EventHandler<InsertSelectedEvent> handler) {
+        setEventHandler(INSERT_SELECTED, handler);
+    }
+
+    /**
+     * Convenience setter for a single
+     * {@link SendSelectedEvent#SEND_SELECTED} handler. Replaces any
+     * previously installed handler.
+     *
+     * @param handler the handler, or {@code null} to clear
+     */
+    public final void setOnSendSelected(EventHandler<SendSelectedEvent> handler) {
+        setEventHandler(SEND_SELECTED, handler);
+    }
+
+    // ── Builder ───────────────────────────────────────────────────────────
+
+    /**
+     * @return a new fluent {@link Builder}. Equivalent to (not a
+     *         replacement for) the public no-arg constructor + setters.
+     */
+    public static Builder create() {
+        return new Builder();
+    }
+
+    /**
+     * Fluent builder for {@link MixerChannelStrip}. One construction path
+     * among equals — every method maps onto a public setter / style class.
+     */
+    public static final class Builder {
+
+        private UUID channelId;
+        private String name = "";
+        private String inputLabel = "";
+        private String outputLabel = "";
+        private double pan;
+        private double faderDb;
+        private boolean muted;
+        private boolean soloed;
+        private boolean armed;
+        private ChannelType channelType = ChannelType.AUDIO;
+        private final List<InsertSlotModel> inserts = new ArrayList<>();
+        private final List<SendSlotModel> sends = new ArrayList<>();
+        private String sizeName;
+
+        private Builder() {
+        }
+
+        /** @param id the channel identifier; may be {@code null}. @return this builder */
+        public Builder channelId(UUID id) {
+            this.channelId = id;
+            return this;
+        }
+
+        /** @param name the channel display name; must not be {@code null}. @return this builder */
+        public Builder name(String name) {
+            this.name = Objects.requireNonNull(name, "name");
+            return this;
+        }
+
+        /** @param label the input-routing caption; must not be {@code null}. @return this builder */
+        public Builder inputLabel(String label) {
+            this.inputLabel = Objects.requireNonNull(label, "inputLabel");
+            return this;
+        }
+
+        /** @param label the output-routing caption; must not be {@code null}. @return this builder */
+        public Builder outputLabel(String label) {
+            this.outputLabel = Objects.requireNonNull(label, "outputLabel");
+            return this;
+        }
+
+        /** @param value the pan position in {@code [-1, 1]}. @return this builder */
+        public Builder pan(double value) {
+            this.pan = value;
+            return this;
+        }
+
+        /** @param db the fader value in dB. @return this builder */
+        public Builder faderDb(double db) {
+            this.faderDb = db;
+            return this;
+        }
+
+        /** @param value muted state. @return this builder */
+        public Builder muted(boolean value) {
+            this.muted = value;
+            return this;
+        }
+
+        /** @param value soloed state. @return this builder */
+        public Builder soloed(boolean value) {
+            this.soloed = value;
+            return this;
+        }
+
+        /** @param value armed state. @return this builder */
+        public Builder armed(boolean value) {
+            this.armed = value;
+            return this;
+        }
+
+        /** @param type the channel type; must not be {@code null}. @return this builder */
+        public Builder channelType(ChannelType type) {
+            this.channelType = Objects.requireNonNull(type, "channelType");
+            return this;
+        }
+
+        /** @param slots the initial insert slots; must not be {@code null}. @return this builder */
+        public Builder inserts(List<InsertSlotModel> slots) {
+            Objects.requireNonNull(slots, "inserts");
+            this.inserts.clear();
+            this.inserts.addAll(slots);
+            return this;
+        }
+
+        /** @param slots the initial send slots; must not be {@code null}. @return this builder */
+        public Builder sends(List<SendSlotModel> slots) {
+            Objects.requireNonNull(slots, "sends");
+            this.sends.clear();
+            this.sends.addAll(slots);
+            return this;
+        }
+
+        /**
+         * Adds the style class {@code "density-" + name} (e.g.
+         * {@code density-compact}, {@code density-comfortable}). The
+         * default 72&nbsp;px Compact width needs no class.
+         *
+         * @param name the density-variant name; must not be {@code null}
+         * @return this builder
+         */
+        public Builder size(String name) {
+            this.sizeName = Objects.requireNonNull(name, "size name");
+            return this;
+        }
+
+        /** @return a fully configured {@link MixerChannelStrip}. */
+        public MixerChannelStrip build() {
+            MixerChannelStrip s = new MixerChannelStrip();
+            s.setChannelId(channelId);
+            s.setChannelName(name);
+            s.setInputLabel(inputLabel);
+            s.setOutputLabel(outputLabel);
+            s.setPan(pan);
+            s.setFaderDb(faderDb);
+            s.setMuted(muted);
+            s.setSoloed(soloed);
+            s.setArmed(armed);
+            s.setChannelType(channelType);
+            s.insertsProperty().setAll(inserts);
+            s.sendsProperty().setAll(sends);
+            if (sizeName != null) {
+                s.getStyleClass().add("density-" + sizeName);
+            }
+            return s;
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/SendSlotModel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/SendSlotModel.java
@@ -1,0 +1,43 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import java.util.Objects;
+
+/**
+ * Immutable view-model adapter for one send slot rendered by a
+ * {@link MixerChannelStrip}.
+ *
+ * <p>Story 271 (Phase 2 of the UI Design Book §6 migration roadmap). As
+ * with {@link InsertSlotModel}, the channel-strip
+ * {@link javafx.scene.control.Control} is decoupled from {@code daw-core}'s
+ * mutable {@link com.benesquivelmusic.daw.core.mixer.Send} — consumers map
+ * their model into this immutable record so the control's
+ * {@code sendsProperty()} observable list never holds an engine type.
+ *
+ * <p>Field mapping against
+ * {@link com.benesquivelmusic.daw.core.mixer.Send}:
+ * <ul>
+ *   <li>{@code name}     — derived from {@code send.getTarget().getName()}
+ *       (the return-bus name); must not be {@code null}.</li>
+ *   <li>{@code level}    — {@code send.getLevel()} (0.0–1.0). Drives the
+ *       compact send {@link Fader}.</li>
+ *   <li>{@code preFader} — {@code send.getMode() == SendMode.PRE_FADER}
+ *       (story §5.4 — "send name, level, pre/post toggle"; the legacy
+ *       two-state {@code SendMode} view is sufficient for the strip's
+ *       pre/post toggle per the Non-Goals: per-send tap-point visual
+ *       polish is story 154).</li>
+ * </ul>
+ *
+ * @param name     the send display name (typically the return-bus name);
+ *                 must not be {@code null}
+ * @param level    the send level in {@code [0.0, 1.0]}
+ * @param preFader whether the send is pre-fader (vs. post-fader)
+ */
+public record SendSlotModel(String name, double level, boolean preFader) {
+
+    /**
+     * @throws NullPointerException if {@code name} is {@code null}
+     */
+    public SendSlotModel {
+        Objects.requireNonNull(name, "name");
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/MixerChannelStripSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/MixerChannelStripSkin.java
@@ -1,0 +1,816 @@
+package com.benesquivelmusic.daw.app.ui.controls.skin;
+
+import com.benesquivelmusic.daw.app.ui.controls.Fader;
+import com.benesquivelmusic.daw.app.ui.controls.InsertSlotModel;
+import com.benesquivelmusic.daw.app.ui.controls.Knob;
+import com.benesquivelmusic.daw.app.ui.controls.LevelMeter;
+import com.benesquivelmusic.daw.app.ui.controls.MixerChannelStrip;
+import com.benesquivelmusic.daw.app.ui.controls.MixerChannelStrip.ChannelType;
+import com.benesquivelmusic.daw.app.ui.controls.MixerChannelStrip.InsertSelectedEvent;
+import com.benesquivelmusic.daw.app.ui.controls.MixerChannelStrip.SendSelectedEvent;
+import com.benesquivelmusic.daw.app.ui.controls.SendSlotModel;
+
+import javafx.beans.value.ChangeListener;
+import javafx.collections.ListChangeListener;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.shape.Circle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Skin for {@link MixerChannelStrip} — lays out the canonical
+ * UI Design Book §5.4 vertical signal chain, top → bottom:
+ *
+ * <pre>
+ *   I In 1+2   O Master      (mono caption)
+ *   ───────────────────────
+ *   ▸ EQ          ●          (insert rows; status dot)
+ *   ▸ Comp        ○
+ *   ▸ —
+ *   ▸ —
+ *   ⋯ +2
+ *   ───────────────────────
+ *   → Rev   ▭▭▭   P          (send rows; compact fader + pre/post)
+ *   → Dly   ▭▭▭   P
+ *   ⋯ +1
+ *   ───────────────────────
+ *        (●)  pan knob (size-28, bipolar)
+ *   ───────────────────────
+ *      ║ fader column ║ ▌    (Fader.size-mixer + integrated meter)
+ *      ║              ║ ▌
+ *   ───────────────────────
+ *     [M] [S] [R]            (omitted entirely for MASTER)
+ *     -6.0 dB                (.numeric-value readout)
+ *     Drums                  (channel name; double-click → editable)
+ * </pre>
+ *
+ * <p>Composes the real Phase 2 sub-controls: {@link Knob} (story 268) for
+ * pan, {@link Fader} (story 269 — {@code size-mixer}, {@code LOG_DB},
+ * {@code showMeter = true}) for level. The integrated {@link LevelMeter}
+ * is the fader's own {@code fader.getMeter()} — consumers bind
+ * {@code strip.getFader().getMeter().peakDbProperty()}; <strong>no
+ * separate meter and no separate audio→FX relay is created</strong> (the
+ * embedded LevelMeter already owns its lock-free relay).
+ *
+ * <p>The M/S/R buttons reuse story 270's exact CSS classes
+ * ({@code .track-toggle.size-compact.mute|solo|arm}) for visual
+ * consistency. When the channel type is {@link ChannelType#MASTER} they
+ * are not added to the scene graph at all (story
+ * {@code MixerChannelStripChannelTypeTest} asserts absence, not merely
+ * hidden); when {@link ChannelType#BUS} the input caption is omitted.
+ * Both are re-evaluated on a held {@code channelTypeProperty} listener
+ * that rebuilds the affected regions.
+ *
+ * <p>All listeners registered in the constructor are unregistered in
+ * {@link #dispose()} so swapping the skin via {@code setSkin(null)}
+ * cleanly detaches the skin from the control's properties.
+ *
+ * <h2>Single source of truth (267 expert-review trap #1)</h2>
+ *
+ * <p>Any draw-model decision a test asserts is routed through one pure
+ * helper so the rendered scene graph and the test seam cannot disagree.
+ * The insert status-dot active-state is decided exactly once by
+ * {@link #insertDotActive(InsertSlotModel)}; both the rendered
+ * {@link Circle} fill (via a {@code .active} style class consumed by
+ * {@code mixer-channel-strip.css}) and the {@link #insertDotActive(int)}
+ * test seam read that single helper — they never re-derive it
+ * independently.
+ *
+ * <h2>Density variants</h2>
+ *
+ * <p>{@code computeMin/Pref/MaxWidth} return 72&nbsp;px for
+ * {@code .density-compact} (also the default) and 88&nbsp;px for
+ * {@code .density-comfortable} (story §5.4 / story 278). Width is enforced
+ * from Java, not CSS, to avoid a token-validation linter mismatch with the
+ * 4&nbsp;px grid (mirrors {@code TrackStripSkin}). Height fills the
+ * available vertical space — the mixer panel drives it.
+ */
+public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
+
+    /** Compact strip width (UI Design Book §5.4, story 278). */
+    static final double COMPACT_WIDTH = 72.0;
+    /** Comfortable strip width (UI Design Book §5.4, story 278). */
+    static final double COMFORTABLE_WIDTH = 88.0;
+
+    /** Visible insert slot rows before the overflow indicator (§5.4). */
+    static final int VISIBLE_INSERTS = 4;
+    /** Visible send slot rows before the overflow indicator (§5.4). */
+    static final int VISIBLE_SENDS = 2;
+
+    // Proportional-layout bands (story §5.4 "no fixed pixel offsets keyed to
+    // a single default"). Single-sourced here so insert rows, send rows and
+    // the pan knob all reflow from the same math on a density switch.
+    /** Lower clamp (px) for a slot row's height. */
+    private static final double MIN_ROW_HEIGHT = 14.0;
+    /** Upper clamp (px) for a slot row's height. */
+    private static final double MAX_ROW_HEIGHT = 22.0;
+    /** Fraction of strip height a slot row occupies before clamping. */
+    private static final double ROW_HEIGHT_FRACTION = 0.04;
+    /** Lower clamp (px) for the pan-knob diameter. */
+    private static final double MIN_KNOB_DIAMETER = 24.0;
+    /** Upper clamp (px) for the pan-knob diameter. */
+    private static final double MAX_KNOB_DIAMETER = 44.0;
+    /** Fraction of strip width the pan-knob diameter occupies before clamping. */
+    private static final double KNOB_WIDTH_FRACTION = 0.55;
+
+    /** {@code ⋯} U+22EF MIDLINE HORIZONTAL ELLIPSIS overflow glyph. */
+    private static final String OVERFLOW_GLYPH = "⋯";
+
+    // ── Scene-graph nodes ─────────────────────────────────────────────────
+
+    private final VBox column;
+    private final Label inputLabelNode;
+    private final Label outputLabelNode;
+    private final VBox insertsBox;
+    private final Label insertsOverflow;
+    private final VBox sendsBox;
+    private final Label sendsOverflow;
+    private final Knob panKnob;
+    private final Fader fader;
+    private final HBox msrRow;
+    private final ToggleButton muteBtn;
+    private final ToggleButton soloBtn;
+    private final ToggleButton armBtn;
+    private final Label valueReadout;
+    private final StackPane nameHolder;
+    private final Label nameLabel;
+    private final TextField nameEditor;
+
+    // ── Listeners (held so dispose() can remove exactly what was added) ───
+
+    private final ChangeListener<String> inputLabelListener;
+    private final ChangeListener<String> outputLabelListener;
+    private final ChangeListener<String> nameListener;
+    private final ListChangeListener<InsertSlotModel> insertsListener;
+    private final ListChangeListener<SendSlotModel> sendsListener;
+    private final ChangeListener<Number> panToWidget;
+    private final ChangeListener<Number> panFromWidget;
+    private final ChangeListener<Number> faderToWidget;
+    private final ChangeListener<Number> faderFromWidget;
+    private final ChangeListener<Boolean> mutedSyncListener;
+    private final ChangeListener<Boolean> soloedSyncListener;
+    private final ChangeListener<Boolean> armedSyncListener;
+    private final ChangeListener<Object> readoutRefreshListener;
+    private final ChangeListener<ChannelType> channelTypeListener;
+
+    private boolean disposed;
+    private int registeredListenerCount;
+
+    /**
+     * @param control the {@link MixerChannelStrip} this skin renders
+     */
+    public MixerChannelStripSkin(MixerChannelStrip control) {
+        super(control);
+
+        // ── I/O captions (small mono per story 266) ───────────────────
+        inputLabelNode = new Label(control.getInputLabel());
+        inputLabelNode.getStyleClass().addAll("mixer-channel-strip-io", "numeric-caption");
+        inputLabelNode.setMaxWidth(Double.MAX_VALUE);
+        outputLabelNode = new Label(control.getOutputLabel());
+        outputLabelNode.getStyleClass().addAll("mixer-channel-strip-io", "numeric-caption");
+        outputLabelNode.setMaxWidth(Double.MAX_VALUE);
+
+        // ── Insert list ───────────────────────────────────────────────
+        insertsBox = new VBox();
+        insertsBox.getStyleClass().add("mixer-channel-strip-inserts");
+        insertsOverflow = new Label();
+        insertsOverflow.getStyleClass().addAll(
+                "mixer-channel-strip-overflow", "numeric-caption");
+
+        // ── Send list ─────────────────────────────────────────────────
+        sendsBox = new VBox();
+        sendsBox.getStyleClass().add("mixer-channel-strip-sends");
+        sendsOverflow = new Label();
+        sendsOverflow.getStyleClass().addAll(
+                "mixer-channel-strip-overflow", "numeric-caption");
+
+        // ── Pan knob (story 268, size-28, bipolar) ────────────────────
+        panKnob = Knob.create()
+                .bipolar(true).min(-1).max(1).defaultValue(0)
+                .unit("L / R").size(28).build();
+        panKnob.setValue(control.getPan());
+
+        // ── Fader (story 269, size-mixer, LOG_DB, integrated meter) ────
+        fader = Fader.create()
+                .curve(Fader.TravelCurve.LOG_DB)
+                .showMeter(true)
+                .size("mixer")
+                .build();
+        fader.setValue(control.getFaderDb());
+
+        // ── M / S / R toggles (story 270 CSS classes verbatim) ────────
+        muteBtn = makeToggle("mute", "M");
+        soloBtn = makeToggle("solo", "S");
+        armBtn = makeToggle("arm", "R");
+        msrRow = new HBox(muteBtn, soloBtn, armBtn);
+        msrRow.getStyleClass().add("mixer-channel-strip-msr");
+        msrRow.setAlignment(Pos.CENTER);
+
+        // ── Fader value readout + channel name ────────────────────────
+        valueReadout = new Label();
+        valueReadout.getStyleClass().addAll(
+                "mixer-channel-strip-readout", "numeric-value");
+        valueReadout.setMaxWidth(Double.MAX_VALUE);
+        valueReadout.setAlignment(Pos.CENTER);
+
+        nameLabel = new Label(control.getChannelName());
+        nameLabel.getStyleClass().add("mixer-channel-strip-name");
+        nameLabel.setMaxWidth(Double.MAX_VALUE);
+        nameLabel.setAlignment(Pos.CENTER);
+        nameEditor = new TextField();
+        nameEditor.getStyleClass().add("mixer-channel-strip-name-editor");
+        nameEditor.setVisible(false);
+        nameEditor.setManaged(false);
+        nameHolder = new StackPane(nameLabel, nameEditor);
+        nameHolder.getStyleClass().add("mixer-channel-strip-name-holder");
+        // Double-click swaps to an editable TextField (minimal inline
+        // rename — the full rename-commit polish is out of scope per the
+        // story, but a double-click must not throw).
+        nameLabel.setOnMouseClicked(this::onNameClicked);
+        nameEditor.setOnAction(e -> commitNameEdit());
+        nameEditor.focusedProperty().addListener((obs, was, now) -> {
+            if (!now) {
+                commitNameEdit();
+            }
+        });
+
+        Region insertSep = separator();
+        Region sendSep = separator();
+        Region panSep = separator();
+        Region faderSep = separator();
+
+        column = new VBox(
+                inputLabelNode, outputLabelNode,
+                insertSep,
+                insertsBox, insertsOverflow,
+                sendSep,
+                sendsBox, sendsOverflow,
+                panSep,
+                panKnob,
+                faderSep,
+                fader,
+                msrRow,
+                valueReadout,
+                nameHolder);
+        column.getStyleClass().add("mixer-channel-strip-column");
+        column.setFillWidth(true);
+        // The fader is the elastic region — it absorbs the vertical slack
+        // so the strip fills the panel height (the mixer panel drives the
+        // overall strip height; everything else is intrinsic).
+        VBox.setVgrow(fader, Priority.ALWAYS);
+
+        getChildren().setAll(column);
+
+        // ── Property → view listeners ─────────────────────────────────
+        inputLabelListener = (obs, was, now) ->
+                inputLabelNode.setText(now == null ? "" : now);
+        control.inputLabelProperty().addListener(inputLabelListener);
+        registeredListenerCount++;
+
+        outputLabelListener = (obs, was, now) ->
+                outputLabelNode.setText(now == null ? "" : now);
+        control.outputLabelProperty().addListener(outputLabelListener);
+        registeredListenerCount++;
+
+        nameListener = (obs, was, now) ->
+                nameLabel.setText(now == null ? "" : now);
+        control.channelNameProperty().addListener(nameListener);
+        registeredListenerCount++;
+
+        insertsListener = c -> rebuildInserts();
+        control.insertsProperty().addListener(insertsListener);
+        registeredListenerCount++;
+
+        sendsListener = c -> rebuildSends();
+        control.sendsProperty().addListener(sendsListener);
+        registeredListenerCount++;
+
+        // Pan: two-way sync control.panProperty() ↔ knob.valueProperty().
+        panToWidget = (obs, was, now) -> {
+            if (now != null && panKnob.getValue() != now.doubleValue()) {
+                panKnob.setValue(now.doubleValue());
+            }
+        };
+        control.panProperty().addListener(panToWidget);
+        registeredListenerCount++;
+        panFromWidget = (obs, was, now) -> {
+            if (now != null) {
+                control.setPan(now.doubleValue());
+            }
+        };
+        panKnob.valueProperty().addListener(panFromWidget);
+
+        // Fader: two-way sync control.faderDbProperty() ↔ fader.valueProperty().
+        faderToWidget = (obs, was, now) -> {
+            if (now != null && fader.getValue() != now.doubleValue()) {
+                fader.setValue(now.doubleValue());
+            }
+        };
+        control.faderDbProperty().addListener(faderToWidget);
+        registeredListenerCount++;
+        faderFromWidget = (obs, was, now) -> {
+            if (now != null) {
+                control.setFaderDb(now.doubleValue());
+            }
+        };
+        fader.valueProperty().addListener(faderFromWidget);
+
+        // M/S/R two-way sync (mirrors TrackStripSkin exactly).
+        mutedSyncListener = (obs, was, now) -> muteBtn.setSelected(now);
+        soloedSyncListener = (obs, was, now) -> soloBtn.setSelected(now);
+        armedSyncListener = (obs, was, now) -> armBtn.setSelected(now);
+        control.mutedProperty().addListener(mutedSyncListener);
+        control.soloedProperty().addListener(soloedSyncListener);
+        control.armedProperty().addListener(armedSyncListener);
+        registeredListenerCount += 3;
+        muteBtn.setSelected(control.isMuted());
+        soloBtn.setSelected(control.isSoloed());
+        armBtn.setSelected(control.isArmed());
+        muteBtn.selectedProperty().addListener((obs, was, now) -> control.setMuted(now));
+        soloBtn.selectedProperty().addListener((obs, was, now) -> control.setSoloed(now));
+        armBtn.selectedProperty().addListener((obs, was, now) -> control.setArmed(now));
+
+        // Value readout follows the fader value (and the embedded meter is
+        // the fader's own — no separate relay).
+        readoutRefreshListener = (obs, was, now) -> refreshReadout();
+        control.faderDbProperty().addListener(readoutRefreshListener);
+        registeredListenerCount++;
+
+        // Channel type drives M/S/R + input-caption presence; re-evaluate
+        // on change and rebuild the affected regions.
+        channelTypeListener = (obs, was, now) -> applyChannelType();
+        control.channelTypeProperty().addListener(channelTypeListener);
+        registeredListenerCount++;
+
+        // Initial render.
+        rebuildInserts();
+        rebuildSends();
+        applyChannelType();
+        refreshReadout();
+    }
+
+    private static ToggleButton makeToggle(String role, String glyph) {
+        ToggleButton t = new ToggleButton(glyph);
+        // Deliberately NOT a `.dawg-button` — same rationale as
+        // TrackStripSkin: the app stylesheet's `.dawg-button` rule has
+        // author-origin priority and would override the user-agent
+        // `.track-toggle:selected` fill. Reuse story 270's exact classes
+        // for visual consistency (story §5.4).
+        t.getStyleClass().addAll("track-toggle", "size-compact", role);
+        t.setFocusTraversable(false);
+        t.setMaxWidth(Double.MAX_VALUE);
+        return t;
+    }
+
+    private Region separator() {
+        Region r = new Region();
+        r.getStyleClass().add("mixer-channel-strip-separator");
+        r.setMinHeight(1);
+        r.setPrefHeight(1);
+        r.setMaxHeight(1);
+        return r;
+    }
+
+    // ── Insert / send list rendering ──────────────────────────────────────
+
+    /**
+     * Single source of truth for the insert status-dot active state
+     * (267 expert-review trap #1). The rendered {@link Circle} and the
+     * {@link #insertDotActive(int)} test seam both route through this — no
+     * independent re-derivation. A slot's dot is "active" (renders
+     * {@code -mcs-accent}) when the slot is engaged and not bypassed;
+     * otherwise it is "bypassed" ({@code -mcs-text-mute}). Story §5.4:
+     * "{@code -accent} if active, {@code -text-mute} if bypassed".
+     *
+     * @param slot the slot model
+     * @return whether the slot's status dot is the active (accent) colour
+     */
+    private static boolean insertDotActive(InsertSlotModel slot) {
+        return slot.active() && !slot.bypassed();
+    }
+
+    private void rebuildInserts() {
+        MixerChannelStrip c = getSkinnable();
+        List<InsertSlotModel> all = c.insertsProperty();
+        insertsBox.getChildren().clear();
+        int shown = Math.min(VISIBLE_INSERTS, all.size());
+        for (int i = 0; i < shown; i++) {
+            insertsBox.getChildren().add(insertRow(i, all.get(i)));
+        }
+        // Always pad to VISIBLE_INSERTS with empty placeholder rows so the
+        // strip's intrinsic height is stable regardless of insert count.
+        for (int i = shown; i < VISIBLE_INSERTS; i++) {
+            insertsBox.getChildren().add(emptySlotRow());
+        }
+        int overflow = all.size() - VISIBLE_INSERTS;
+        if (overflow > 0) {
+            insertsOverflow.setText(OVERFLOW_GLYPH + " +" + overflow);
+            insertsOverflow.setVisible(true);
+            insertsOverflow.setManaged(true);
+        } else {
+            insertsOverflow.setVisible(false);
+            insertsOverflow.setManaged(false);
+        }
+    }
+
+    private Node insertRow(int index, InsertSlotModel slot) {
+        Label name = new Label(slot.name());
+        name.getStyleClass().add("mixer-channel-strip-slot-name");
+        name.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(name, Priority.ALWAYS);
+
+        Circle dot = new Circle(3.0);
+        dot.getStyleClass().add("mixer-channel-strip-status-dot");
+        // The active/bypassed colour is decided once, here, by the shared
+        // helper; the .active style class is consumed by
+        // mixer-channel-strip.css so the rendered fill and the
+        // insertDotActive(int) test seam cannot disagree.
+        if (insertDotActive(slot)) {
+            dot.getStyleClass().add("active");
+        }
+
+        HBox row = new HBox(name, dot);
+        row.getStyleClass().add("mixer-channel-strip-slot-row");
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.setOnMouseClicked(e -> {
+            if (disposed) return;
+            if (e.getButton() != MouseButton.PRIMARY) return;
+            MixerChannelStrip ctl = getSkinnable();
+            if (ctl == null) return;
+            // Fire through the scene graph so it bubbles (story 272's
+            // Inspector consumes it via the standard dispatch chain).
+            ctl.fireEvent(new InsertSelectedEvent(ctl, ctl, index));
+        });
+        return row;
+    }
+
+    private Node emptySlotRow() {
+        Label name = new Label("—"); // em dash — empty slot
+        name.getStyleClass().addAll(
+                "mixer-channel-strip-slot-name", "mixer-channel-strip-slot-empty");
+        name.setMaxWidth(Double.MAX_VALUE);
+        HBox row = new HBox(name);
+        row.getStyleClass().add("mixer-channel-strip-slot-row");
+        row.setAlignment(Pos.CENTER_LEFT);
+        return row;
+    }
+
+    private void rebuildSends() {
+        MixerChannelStrip c = getSkinnable();
+        List<SendSlotModel> all = c.sendsProperty();
+        sendsBox.getChildren().clear();
+        int shown = Math.min(VISIBLE_SENDS, all.size());
+        for (int i = 0; i < shown; i++) {
+            sendsBox.getChildren().add(sendRow(i, all.get(i)));
+        }
+        int overflow = all.size() - VISIBLE_SENDS;
+        if (overflow > 0) {
+            sendsOverflow.setText(OVERFLOW_GLYPH + " +" + overflow);
+            sendsOverflow.setVisible(true);
+            sendsOverflow.setManaged(true);
+        } else {
+            sendsOverflow.setVisible(false);
+            sendsOverflow.setManaged(false);
+        }
+    }
+
+    private Node sendRow(int index, SendSlotModel slot) {
+        Label name = new Label(slot.name());
+        name.getStyleClass().add("mixer-channel-strip-slot-name");
+        name.setMaxWidth(Double.MAX_VALUE);
+
+        // Compact send-level fader: no meter (story §5.4 / Fader story 269).
+        Fader sendFader = Fader.create()
+                .min(0).max(1).defaultValue(0)
+                .value(slot.level())
+                .curve(Fader.TravelCurve.LINEAR)
+                .showMeter(false)
+                .unit("")
+                .build();
+        sendFader.getStyleClass().add("mixer-channel-strip-send-fader");
+        sendFader.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(sendFader, Priority.ALWAYS);
+
+        // Pre/post toggle — plain dawg-button is acceptable per Non-Goals
+        // (the per-send tap-point visual polish is story 154).
+        ToggleButton prePost = new ToggleButton(slot.preFader() ? "F" : "P");
+        prePost.getStyleClass().addAll("dawg-button", "size-compact",
+                "mixer-channel-strip-send-tap");
+        prePost.setSelected(slot.preFader());
+        prePost.setFocusTraversable(false);
+        prePost.selectedProperty().addListener(
+                (obs, was, now) -> prePost.setText(now ? "F" : "P"));
+
+        VBox nameRow = new VBox(name, new HBox(4, sendFader, prePost));
+        nameRow.getStyleClass().add("mixer-channel-strip-send-row");
+        nameRow.setOnMouseClicked(e -> {
+            if (disposed) return;
+            if (e.getButton() != MouseButton.PRIMARY) return;
+            // Don't fire when the click landed on an interactive child
+            // (the send fader / pre-post toggle have their own handlers).
+            if (isInside(e.getTarget(), sendFader, prePost)) return;
+            MixerChannelStrip ctl = getSkinnable();
+            if (ctl == null) return;
+            ctl.fireEvent(new SendSelectedEvent(ctl, ctl, index));
+        });
+        return nameRow;
+    }
+
+    private static boolean isInside(javafx.event.EventTarget target, Node... guards) {
+        if (!(target instanceof Node node)) return false;
+        while (node != null) {
+            for (Node g : guards) {
+                if (node == g) return true;
+            }
+            node = node.getParent();
+        }
+        return false;
+    }
+
+    // ── Channel-type-driven region presence ───────────────────────────────
+
+    /**
+     * Re-evaluates which regions are present for the current
+     * {@link ChannelType}. The M/S/R row is <strong>removed from the
+     * scene graph entirely</strong> for {@link ChannelType#MASTER} (not
+     * merely hidden — {@code MixerChannelStripChannelTypeTest} asserts
+     * absence). The input caption is removed for {@link ChannelType#BUS}.
+     */
+    private void applyChannelType() {
+        MixerChannelStrip c = getSkinnable();
+        if (c == null) return;
+        ChannelType type = c.getChannelType();
+
+        boolean showMsr = type != ChannelType.MASTER;
+        if (showMsr) {
+            if (!column.getChildren().contains(msrRow)) {
+                // Re-insert just before the value readout to preserve
+                // top→bottom order.
+                int idx = column.getChildren().indexOf(valueReadout);
+                column.getChildren().add(idx, msrRow);
+            }
+        } else {
+            column.getChildren().remove(msrRow);
+        }
+
+        boolean showInput = type != ChannelType.BUS;
+        inputLabelNode.setVisible(showInput);
+        inputLabelNode.setManaged(showInput);
+    }
+
+    // ── Name inline-edit (minimal — must not throw) ───────────────────────
+
+    private void onNameClicked(MouseEvent e) {
+        if (disposed) return;
+        if (e.getButton() != MouseButton.PRIMARY || e.getClickCount() < 2) return;
+        nameEditor.setText(nameLabel.getText());
+        nameEditor.setVisible(true);
+        nameEditor.setManaged(true);
+        nameLabel.setVisible(false);
+        nameEditor.requestFocus();
+        nameEditor.selectAll();
+    }
+
+    private void commitNameEdit() {
+        if (!nameEditor.isVisible()) return;
+        MixerChannelStrip c = getSkinnable();
+        if (c != null) {
+            c.setChannelName(nameEditor.getText());
+        }
+        nameEditor.setVisible(false);
+        nameEditor.setManaged(false);
+        nameLabel.setVisible(true);
+    }
+
+    private void refreshReadout() {
+        MixerChannelStrip c = getSkinnable();
+        if (c == null) return;
+        double db = c.getFaderDb();
+        String text;
+        if (Double.isInfinite(db) || db <= -120.0) {
+            text = "-∞ dB";
+        } else {
+            text = String.format(Locale.ROOT, "%.1f dB", db);
+        }
+        valueReadout.setText(text);
+    }
+
+    // ── Layout ────────────────────────────────────────────────────────────
+
+    @Override
+    protected void layoutChildren(double x, double y, double w, double h) {
+        // The column fills the content area (CSS padding/insets honoured).
+        // VBox lays its children top→bottom; the fader has Vgrow=ALWAYS so
+        // it absorbs vertical slack. Every internal dimension derives from
+        // the assigned w/h — no fixed pixel offset keyed to a single
+        // default (skill §7 / story "no fixed pixel offsets").
+        column.resizeRelocate(x, y, w, h);
+
+        // Pan knob diameter scales with the assigned width (clamped to a
+        // sensible band so a very narrow strip doesn't produce a 0 px
+        // knob and a very wide one doesn't waste vertical budget).
+        double knobD = Math.max(MIN_KNOB_DIAMETER,
+                Math.min(w * KNOB_WIDTH_FRACTION, MAX_KNOB_DIAMETER));
+        panKnob.setMinHeight(knobD);
+        panKnob.setPrefHeight(knobD);
+        panKnob.setMaxHeight(knobD);
+        panKnob.setMinWidth(knobD);
+        panKnob.setPrefWidth(knobD);
+        panKnob.setMaxWidth(knobD);
+
+        // Insert AND send rows derive their height from the assigned height
+        // so the whole strip reflows proportionally (e.g. on a Compact↔
+        // Comfortable density switch) rather than via a fixed offset. Both
+        // slot lists use the same single-sourced math so they stay in lockstep.
+        double rowH = Math.max(MIN_ROW_HEIGHT,
+                Math.min(h * ROW_HEIGHT_FRACTION, MAX_ROW_HEIGHT));
+        applyRowHeight(insertsBox, rowH);
+        applyRowHeight(sendsBox, rowH);
+    }
+
+    /** Applies a uniform proportional row height to every {@link Region}
+     *  child of a slot-list box. Shared by the insert and send lists so the
+     *  reflow math is defined exactly once. */
+    private static void applyRowHeight(VBox rows, double rowH) {
+        for (Node n : rows.getChildren()) {
+            if (n instanceof Region r) {
+                r.setMinHeight(rowH);
+                r.setPrefHeight(rowH);
+            }
+        }
+    }
+
+    private double widthForDensity() {
+        MixerChannelStrip c = getSkinnable();
+        if (c == null) return COMPACT_WIDTH;
+        var classes = c.getStyleClass();
+        if (classes.contains("density-comfortable")) {
+            return COMFORTABLE_WIDTH;
+        }
+        // Default density == compact width (story §5.4 "keep the width").
+        return COMPACT_WIDTH;
+    }
+
+    @Override
+    protected double computeMinWidth(double height,
+            double topInset, double rightInset, double bottomInset, double leftInset) {
+        return widthForDensity();
+    }
+
+    @Override
+    protected double computePrefWidth(double height,
+            double topInset, double rightInset, double bottomInset, double leftInset) {
+        return widthForDensity();
+    }
+
+    @Override
+    protected double computeMaxWidth(double height,
+            double topInset, double rightInset, double bottomInset, double leftInset) {
+        return widthForDensity();
+    }
+
+    @Override
+    protected double computeMinHeight(double width,
+            double topInset, double rightInset, double bottomInset, double leftInset) {
+        // A modest minimum so the strip remains usable in a tiny window;
+        // the mixer panel drives the actual height.
+        return 240.0;
+    }
+
+    @Override
+    protected double computePrefHeight(double width,
+            double topInset, double rightInset, double bottomInset, double leftInset) {
+        return 480.0;
+    }
+
+    @Override
+    protected double computeMaxHeight(double width,
+            double topInset, double rightInset, double bottomInset, double leftInset) {
+        return Double.MAX_VALUE;
+    }
+
+    // ── Test seams ────────────────────────────────────────────────────────
+
+    /** @return the embedded pan {@link Knob} (test seam). */
+    public Knob knob() { return panKnob; }
+    /** @return the embedded {@link Fader} (test seam). */
+    public Fader fader() { return fader; }
+    /** @return the M toggle button (test seam). */
+    public ToggleButton muteButton() { return muteBtn; }
+    /** @return the S toggle button (test seam). */
+    public ToggleButton soloButton() { return soloBtn; }
+    /** @return the R toggle button (test seam). */
+    public ToggleButton armButton() { return armBtn; }
+    /** @return the M/S/R row (test seam — absent from scene graph for MASTER). */
+    public HBox msrRow() { return msrRow; }
+    /** @return the channel-name label (test seam). */
+    public Label nameLabel() { return nameLabel; }
+    /** @return the fader value readout label (test seam). */
+    public Label valueReadout() { return valueReadout; }
+    /** @return the input caption label (test seam). */
+    public Label inputLabelNode() { return inputLabelNode; }
+
+    /**
+     * Test seam: the rendered insert slot-row node at {@code index} (the
+     * same node whose {@code onMouseClicked} fires
+     * {@link InsertSelectedEvent}). Padding placeholder rows beyond the
+     * model size are also returned but carry no click handler.
+     *
+     * @param index the visible insert-row index
+     * @return the row {@link Node}, or {@code null} if out of range
+     */
+    public Node insertRowNode(int index) {
+        if (index < 0 || index >= insertsBox.getChildren().size()) return null;
+        return insertsBox.getChildren().get(index);
+    }
+
+    /**
+     * Test seam: the rendered send slot-row node at {@code index}.
+     *
+     * @param index the visible send-row index
+     * @return the row {@link Node}, or {@code null} if out of range
+     */
+    public Node sendRowNode(int index) {
+        if (index < 0 || index >= sendsBox.getChildren().size()) return null;
+        return sendsBox.getChildren().get(index);
+    }
+
+    /**
+     * Test seam: whether the insert slot at {@code index} renders its
+     * status dot in the active (accent) colour. Routes through the same
+     * {@link #insertDotActive(InsertSlotModel)} helper the rendered
+     * {@link Circle} uses — they cannot disagree (267 trap #1).
+     *
+     * @param index the insert-slot index
+     * @return {@code true} if that slot's dot is the active colour;
+     *         {@code false} if out of range or bypassed/inactive
+     */
+    public boolean insertDotActive(int index) {
+        MixerChannelStrip c = getSkinnable();
+        if (c == null) return false;
+        List<InsertSlotModel> all = c.insertsProperty();
+        if (index < 0 || index >= all.size()) return false;
+        return insertDotActive(all.get(index));
+    }
+
+    /** @return whether {@link #dispose()} has run (test seam). */
+    public boolean isDisposed() { return disposed; }
+    /** @return cumulative count of listeners registered on the control's properties (test seam). */
+    public int registeredListenerCount() { return registeredListenerCount; }
+
+    // ── Dispose ───────────────────────────────────────────────────────────
+
+    @Override
+    public void dispose() {
+        if (disposed) return;
+        disposed = true;
+        MixerChannelStrip c = getSkinnable();
+        if (c != null) {
+            c.inputLabelProperty().removeListener(inputLabelListener);
+            registeredListenerCount--;
+            c.outputLabelProperty().removeListener(outputLabelListener);
+            registeredListenerCount--;
+            c.channelNameProperty().removeListener(nameListener);
+            registeredListenerCount--;
+            c.insertsProperty().removeListener(insertsListener);
+            registeredListenerCount--;
+            c.sendsProperty().removeListener(sendsListener);
+            registeredListenerCount--;
+            c.panProperty().removeListener(panToWidget);
+            registeredListenerCount--;
+            c.faderDbProperty().removeListener(faderToWidget);
+            registeredListenerCount--;
+            c.mutedProperty().removeListener(mutedSyncListener);
+            registeredListenerCount--;
+            c.soloedProperty().removeListener(soloedSyncListener);
+            registeredListenerCount--;
+            c.armedProperty().removeListener(armedSyncListener);
+            registeredListenerCount--;
+            c.faderDbProperty().removeListener(readoutRefreshListener);
+            registeredListenerCount--;
+            c.channelTypeProperty().removeListener(channelTypeListener);
+            registeredListenerCount--;
+        }
+        // Detach the embedded fader's meter so its AnimationTimer stops
+        // (sceneProperty → null) when the skin is swapped. Done outside the
+        // null guard so the timer is guaranteed to stop even if the
+        // skinnable is already null at dispose — otherwise the meter's
+        // pulse leaks for the lifetime of the JVM.
+        getChildren().clear();
+        super.dispose();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/MixerChannelStripSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/MixerChannelStripSkin.java
@@ -168,6 +168,7 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
     private final ChangeListener<Boolean> armBtnListener;
     private final ChangeListener<Object> readoutRefreshListener;
     private final ChangeListener<ChannelType> channelTypeListener;
+    private final ChangeListener<Boolean> nameEditorFocusListener;
 
     private boolean disposed;
     private int registeredListenerCount;
@@ -244,11 +245,13 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
         // story, but a double-click must not throw).
         nameLabel.setOnMouseClicked(this::onNameClicked);
         nameEditor.setOnAction(e -> commitNameEdit());
-        nameEditor.focusedProperty().addListener((obs, was, now) -> {
+        nameEditorFocusListener = (obs, was, now) -> {
             if (!now) {
                 commitNameEdit();
             }
-        });
+        };
+        nameEditor.focusedProperty().addListener(nameEditorFocusListener);
+        registeredListenerCount++;
 
         Region insertSep = separator();
         Region sendSep = separator();
@@ -520,6 +523,10 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
                 "mixer-channel-strip-send-tap");
         prePost.setSelected(slot.preFader());
         prePost.setFocusTraversable(false);
+        // Self-referential listener (button updates its own text) — not
+        // tracked in registeredListenerCount because it holds no reference
+        // back to the control or skin; it dies with the button when the
+        // send-list region is rebuilt or getChildren().clear() runs.
         prePost.selectedProperty().addListener(
                 (obs, was, now) -> prePost.setText(now ? "F" : "P"));
 
@@ -826,6 +833,8 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
         panKnob.valueProperty().removeListener(panFromWidget);
         registeredListenerCount--;
         fader.valueProperty().removeListener(faderFromWidget);
+        registeredListenerCount--;
+        nameEditor.focusedProperty().removeListener(nameEditorFocusListener);
         registeredListenerCount--;
         // Detach the embedded fader's meter so its AnimationTimer stops
         // (sceneProperty → null) when the skin is swapped. Done outside the

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/MixerChannelStripSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/MixerChannelStripSkin.java
@@ -27,7 +27,6 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Circle;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -164,6 +163,9 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
     private final ChangeListener<Boolean> mutedSyncListener;
     private final ChangeListener<Boolean> soloedSyncListener;
     private final ChangeListener<Boolean> armedSyncListener;
+    private final ChangeListener<Boolean> muteBtnListener;
+    private final ChangeListener<Boolean> soloBtnListener;
+    private final ChangeListener<Boolean> armBtnListener;
     private final ChangeListener<Object> readoutRefreshListener;
     private final ChangeListener<ChannelType> channelTypeListener;
 
@@ -313,6 +315,7 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
             }
         };
         panKnob.valueProperty().addListener(panFromWidget);
+        registeredListenerCount++;
 
         // Fader: two-way sync control.faderDbProperty() ↔ fader.valueProperty().
         faderToWidget = (obs, was, now) -> {
@@ -328,6 +331,7 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
             }
         };
         fader.valueProperty().addListener(faderFromWidget);
+        registeredListenerCount++;
 
         // M/S/R two-way sync (mirrors TrackStripSkin exactly).
         mutedSyncListener = (obs, was, now) -> muteBtn.setSelected(now);
@@ -340,9 +344,13 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
         muteBtn.setSelected(control.isMuted());
         soloBtn.setSelected(control.isSoloed());
         armBtn.setSelected(control.isArmed());
-        muteBtn.selectedProperty().addListener((obs, was, now) -> control.setMuted(now));
-        soloBtn.selectedProperty().addListener((obs, was, now) -> control.setSoloed(now));
-        armBtn.selectedProperty().addListener((obs, was, now) -> control.setArmed(now));
+        muteBtnListener = (obs, was, now) -> control.setMuted(now);
+        soloBtnListener = (obs, was, now) -> control.setSoloed(now);
+        armBtnListener = (obs, was, now) -> control.setArmed(now);
+        muteBtn.selectedProperty().addListener(muteBtnListener);
+        soloBtn.selectedProperty().addListener(soloBtnListener);
+        armBtn.selectedProperty().addListener(armBtnListener);
+        registeredListenerCount += 3;
 
         // Value readout follows the fader value (and the embedded meter is
         // the fader's own — no separate relay).
@@ -805,6 +813,20 @@ public final class MixerChannelStripSkin extends SkinBase<MixerChannelStrip> {
             c.channelTypeProperty().removeListener(channelTypeListener);
             registeredListenerCount--;
         }
+        // Detach button → control listeners too, so swapping the skin fully
+        // severs the link in both directions (otherwise external mutations
+        // of the cached button references would still mutate the control
+        // through the disposed skin's lambdas).
+        muteBtn.selectedProperty().removeListener(muteBtnListener);
+        registeredListenerCount--;
+        soloBtn.selectedProperty().removeListener(soloBtnListener);
+        registeredListenerCount--;
+        armBtn.selectedProperty().removeListener(armBtnListener);
+        registeredListenerCount--;
+        panKnob.valueProperty().removeListener(panFromWidget);
+        registeredListenerCount--;
+        fader.valueProperty().removeListener(faderFromWidget);
+        registeredListenerCount--;
         // Detach the embedded fader's meter so its AnimationTimer stops
         // (sceneProperty → null) when the skin is swapped. Done outside the
         // null guard so the timer is guaranteed to stop even if the

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/controls/mixer-channel-strip.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/controls/mixer-channel-strip.css
@@ -1,0 +1,247 @@
+/*
+ * MixerChannelStrip user-agent stylesheet (story 271 — MixerChannelStrip
+ * Control + Skin).
+ *
+ * Returned by MixerChannelStrip#getUserAgentStylesheet(). Intentionally
+ * self-contained: gives the control's styleable properties their hard-coded
+ * Palette A hex defaults so the control renders correctly with NO application
+ * stylesheet loaded (plugin-GUI window case). When styles.css IS loaded, it
+ * forwards the .root-pane role tokens onto the -mcs-* names so palette swaps
+ * reach the strip automatically (same pattern as track-strip.css /
+ * level-meter.css).
+ *
+ * Naming
+ * ──────
+ * The CssMetaData uses internal -mcs-* names (NOT the documented public
+ * role token names) because the strip consumes the .root-pane Palette A
+ * role tokens via the standard JavaFX cascade — and a same-name forward
+ * (.mixer-channel-strip { -surface-1: -surface-1 }) is a circular looked-up
+ * colour that the engine drops. The internal name lets styles.css declare
+ * `-mcs-surface-1: -surface-1;` as a non-circular forward.
+ *
+ * Plugin-GUI consumers (no styles.css loaded)
+ * ───────────────────────────────────────────
+ * Without the app stylesheet, the cascade from .root-pane is not available.
+ * Defaults below are hard hex values on .mixer-channel-strip so the control
+ * renders correctly out-of-the-box. Such consumers re-tint by setting -mcs-*
+ * directly on .mixer-channel-strip; they can also load the app's styles.css
+ * to get the documented public role-token forward.
+ *
+ * UI Design Book references: §1.5, §2.5, §5.4, §7.1, §7.5.
+ */
+
+/* ── Hard-coded Palette A defaults (plugin-GUI case: no styles.css) ─
+ *
+ * Same pattern as track-strip.css: ship hard hex values so the control
+ * renders correctly with NO application stylesheet loaded. When
+ * styles.css IS loaded, it forwards the .root-pane role tokens onto
+ * these internal -mcs-* names so palette swaps reach the strip
+ * automatically (see the .mixer-channel-strip rule in styles.css).
+ *
+ * Colour values match UI Design Book Palette A (Onyx Refined):
+ *   -mcs-surface-1    #15161B  (== Palette A -surface-1)
+ *   -mcs-surface-3    #272A33  (== Palette A -surface-3)
+ *   -mcs-surface-bg   #0B0B0E  (== Palette A -surface-bg — §5.4 gutter)
+ *   -mcs-accent       #7C8CFF  (== Palette A -accent)
+ *   -mcs-accent-soft  rgba(124, 140, 255, 0.14)
+ *   -mcs-danger       #E5484D  (== Palette A -danger)
+ *   -mcs-warn         #E6B450  (== Palette A -warn)
+ *   -mcs-text         #B7BCC7  (== Palette A -text)
+ *   -mcs-text-hi      #ECEEF2  (== Palette A -text-hi)
+ *   -mcs-text-mute    #7A808C  (== Palette A -text-mute)
+ *   -mcs-line-soft    #22242C  (== Palette A -line-soft)
+ */
+.mixer-channel-strip {
+    -mcs-surface-1:    #15161B;
+    -mcs-surface-3:    #272A33;
+    -mcs-surface-bg:   #0B0B0E;
+    -mcs-accent:       #7C8CFF;
+    -mcs-accent-soft:  rgba(124, 140, 255, 0.14);
+    -mcs-danger:       #E5484D;
+    -mcs-warn:         #E6B450;
+    -mcs-text:         #B7BCC7;
+    -mcs-text-hi:      #ECEEF2;
+    -mcs-text-mute:    #7A808C;
+    -mcs-line-soft:    #22242C;
+
+    /* §5.4: NO card border, NO shadow, NO rounded corners on the strip
+     * itself. Visual separation between adjacent strips is a 4 px gutter
+     * at -mcs-surface-bg (the panel background colour) — implemented as
+     * left/right padding so each strip carries half the gutter. The
+     * Skin's computePref/Min/MaxWidth enforces the 72/88 px width from
+     * Java, keeping the value out of CSS to avoid a token-validation
+     * linter mismatch with the 4 px grid family. */
+    -fx-background-color: -mcs-surface-1;
+    -fx-padding: 4 4 4 4;
+}
+
+/* §7.1 / §7.5: a selected channel uses the accent-soft tint, never a
+ * colourful border. (Selection state is driven by the mixer panel; the
+ * :selected pseudo-class is reserved for story 278's density work.) */
+.mixer-channel-strip:selected {
+    -fx-background-color: -mcs-accent-soft;
+}
+
+/* Muted channel fades its name to -text-mute (descendant selector so the
+ * muted state cascades without the skin flipping text-fill imperatively). */
+.mixer-channel-strip:muted .mixer-channel-strip-name {
+    -fx-text-fill: -mcs-text-mute;
+}
+
+/* ── Column / sections ─ */
+.mixer-channel-strip-column {
+    -fx-alignment: top-center;
+    -fx-spacing: 4;
+}
+
+.mixer-channel-strip-separator {
+    -fx-background-color: -mcs-line-soft;
+}
+
+.mixer-channel-strip-io {
+    -fx-text-fill: -mcs-text-mute;
+    -fx-padding: 0 4 0 4;
+}
+
+.mixer-channel-strip-inserts,
+.mixer-channel-strip-sends {
+    -fx-spacing: 2;
+}
+
+.mixer-channel-strip-slot-row {
+    -fx-alignment: center-left;
+    -fx-spacing: 4;
+    -fx-padding: 0 4 0 4;
+    -fx-cursor: hand;
+}
+
+.mixer-channel-strip-slot-row:hover {
+    /* §7.1: hover swaps background only — no shadow, no border move. */
+    -fx-background-color: -mcs-surface-3;
+}
+
+.mixer-channel-strip-slot-name {
+    -fx-text-fill: -mcs-text;
+    -fx-font-size: 10px;
+}
+
+.mixer-channel-strip-slot-empty {
+    -fx-text-fill: -mcs-text-mute;
+}
+
+/* §5.4: status dot is -text-mute (bypassed/inactive) by default; the
+ * Skin adds the .active class for an engaged, non-bypassed slot, which
+ * swaps the fill to -accent. The active/bypassed decision is made ONCE in
+ * the Skin (insertDotActive helper); CSS only paints the result. */
+.mixer-channel-strip-status-dot {
+    -fx-fill: -mcs-text-mute;
+}
+
+.mixer-channel-strip-status-dot.active {
+    -fx-fill: -mcs-accent;
+}
+
+.mixer-channel-strip-overflow {
+    -fx-text-fill: -mcs-text-mute;
+    -fx-padding: 0 4 0 4;
+    -fx-cursor: hand;
+}
+
+.mixer-channel-strip-send-row {
+    -fx-spacing: 2;
+    -fx-padding: 0 4 0 4;
+}
+
+.mixer-channel-strip-send-tap {
+    -fx-font-family: "JetBrains Mono", "IBM Plex Mono", "Cascadia Code", "Consolas", monospace;
+    -fx-font-size: 10px;
+}
+
+/* ── Fader value readout + channel name ─ */
+.mixer-channel-strip-readout {
+    -fx-text-fill: -mcs-text;
+    -fx-padding: 0 4 0 4;
+}
+
+.mixer-channel-strip-name {
+    -fx-text-fill: -mcs-text-hi;
+    -fx-font-size: 11px;
+    -fx-font-weight: 500;
+    -fx-padding: 0 4 0 4;
+}
+
+.mixer-channel-strip-name-editor {
+    -fx-font-size: 11px;
+    -fx-padding: 0 4 0 4;
+}
+
+/* ── M/S/R toggle buttons (§5.4, §7.5) ──
+ *
+ *  Reuses story 270's .track-toggle classes verbatim for visual
+ *  consistency (the story explicitly mandates "identical CSS classes").
+ *  Outlined by default; filled when toggled; the filled colour encodes
+ *  the state semantically (M → -text, S → -warn, R → -danger). No hover
+ *  inversion (§7.5).
+ */
+.mixer-channel-strip .track-toggle {
+    -fx-background-color: transparent;
+    -fx-border-color: -mcs-line-soft;
+    -fx-border-width: 1;
+    -fx-border-radius: 4;
+    -fx-background-radius: 4;
+    -fx-text-fill: -mcs-text;
+    -fx-font-family: "JetBrains Mono", "IBM Plex Mono", "Cascadia Code", "Consolas", monospace;
+    -fx-font-size: 11px;
+    -fx-font-weight: 600;
+    -fx-padding: 0;
+    -fx-content-display: text-only;
+}
+
+.mixer-channel-strip .track-toggle:hover {
+    -fx-background-color: -mcs-surface-3;
+}
+
+.mixer-channel-strip .track-toggle.mute:selected {
+    -fx-background-color: -mcs-text;
+    -fx-border-color: -mcs-text;
+    -fx-text-fill: #0B0B0E;
+}
+
+.mixer-channel-strip .track-toggle.solo:selected {
+    -fx-background-color: -mcs-warn;
+    -fx-border-color: -mcs-warn;
+    -fx-text-fill: #0B0B0E;
+}
+
+.mixer-channel-strip .track-toggle.arm:selected {
+    -fx-background-color: -mcs-danger;
+    -fx-border-color: -mcs-danger;
+    -fx-text-fill: #0B0B0E;
+}
+
+.mixer-channel-strip-msr {
+    -fx-spacing: 2;
+    -fx-alignment: center;
+}
+
+/* ── Density variants (story 278) ──
+ * The Skin's computePref/Min/MaxWidth reads the 72 / 88 px width from
+ * these style classes; the rules below only scale fonts/spacing/padding
+ * (the literal px width stays in Java to avoid a token-validation linter
+ * mismatch — same convention as track-strip.css).
+ */
+.mixer-channel-strip.density-compact {
+    -fx-padding: 4;
+}
+
+.mixer-channel-strip.density-compact .mixer-channel-strip-name {
+    -fx-font-size: 10px;
+}
+
+.mixer-channel-strip.density-comfortable {
+    -fx-padding: 4 8 4 8;
+}
+
+.mixer-channel-strip.density-comfortable .mixer-channel-strip-name {
+    -fx-font-size: 12px;
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -705,13 +705,15 @@
 }
 
 /* ── Legacy .mixer-channel alias (story 271) ──
- * Empty by design — the actual channel-strip rendering now lives on the
+ * Deprecated — the channel-strip rendering now lives on the
  * MixerChannelStrip control + its user-agent stylesheet above. This
- * selector is retained for one release cycle so secondary, un-migrated
- * .mixer-channel consumers (bus/master/VCA strips, MasteringView,
- * AlbumAssemblyView, InsertEffectRack) keep rendering against our tokens
- * during the phased migration. Remove in the story 271 follow-up. */
-.mixer-channel { /* deprecated alias → .mixer-channel-strip; remove next cycle */ }
+ * selector is retained for one release cycle so un-migrated .mixer-channel
+ * consumers keep the correct surface/padding tokens during the phased
+ * migration. Remove in the story 271 follow-up. */
+.mixer-channel {
+    -fx-background-color: -surface-2;
+    -fx-padding: 4;
+}
 
 .mixer-channel-name {
     -fx-text-fill: -text;

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -670,15 +670,48 @@
     -fx-padding: 8;
 }
 
-.mixer-channel {
-    -fx-background-color: -surface-1;
-    -fx-border-color: -line-soft;
-    -fx-border-width: 1;
-    -fx-border-radius: 6;
-    -fx-background-radius: 6;
-    -fx-padding: 8;
-    -fx-min-width: 72;
+/* ── MixerChannelStrip (story 271) ──
+ * Story 271: the MixerChannelStrip control
+ * (com...ui.controls.MixerChannelStrip) ships its own self-contained
+ * user-agent stylesheet (mixer-channel-strip.css), which declares the
+ * control's internal styleable properties (-mcs-surface-1/-mcs-surface-3/
+ * -mcs-surface-bg/-mcs-accent/-mcs-accent-soft/-mcs-danger/-mcs-warn/
+ * -mcs-text/-mcs-text-hi/-mcs-text-mute/-mcs-line-soft) with hard hex
+ * Palette A defaults so the control renders correctly out-of-the-box even
+ * with no app stylesheet loaded (plugin-GUI window case).
+ *
+ * THIS RULE forwards the documented public role tokens into those internal
+ * styleable properties. The forwards use distinct source/target names so
+ * they are NOT circular looked-up colours; the .root-pane Palette A tokens
+ * cascade into the strip's colours via the standard JavaFX cascade,
+ * restoring the styles.css convention that structural selectors consume
+ * role tokens. A theme can re-tint the strip just by overriding the role
+ * tokens on .root-pane — no per-control duplication needed.
+ *
+ * §5.4: no card border, no shadow, no rounded corners — the inter-strip
+ * gutter is -surface-bg, forwarded here as -mcs-surface-bg. */
+.mixer-channel-strip {
+    -mcs-surface-1:   -surface-1;
+    -mcs-surface-3:   -surface-3;
+    -mcs-surface-bg:  -surface-bg;
+    -mcs-accent:      -accent;
+    -mcs-accent-soft: -accent-soft;
+    -mcs-danger:      -danger;
+    -mcs-warn:        -warn;
+    -mcs-text:        -text;
+    -mcs-text-hi:     -text-hi;
+    -mcs-text-mute:   -text-mute;
+    -mcs-line-soft:   -line-soft;
 }
+
+/* ── Legacy .mixer-channel alias (story 271) ──
+ * Empty by design — the actual channel-strip rendering now lives on the
+ * MixerChannelStrip control + its user-agent stylesheet above. This
+ * selector is retained for one release cycle so secondary, un-migrated
+ * .mixer-channel consumers (bus/master/VCA strips, MasteringView,
+ * AlbumAssemblyView, InsertEffectRack) keep rendering against our tokens
+ * during the phased migration. Remove in the story 271 follow-up. */
+.mixer-channel { /* deprecated alias → .mixer-channel-strip; remove next cycle */ }
 
 .mixer-channel-name {
     -fx-text-fill: -text;
@@ -686,6 +719,15 @@
     -fx-alignment: center;
 }
 
+/* ── Legacy .mixer-fader bridge (story 271) ──
+ * Retained for one release cycle, same phased-migration rationale as the
+ * .mixer-channel alias above. Story 271 only mandated removing the legacy
+ * *purple circular* fader thumb (superseded by story 269's Fader control) —
+ * styles.css never had such a rule (.mixer-fader theming was always the
+ * tokenised -surface-3 / -accent below). 13 live, un-migrated consumers
+ * (MixerView volume/pan/send Sliders, VcaStrip gain) still apply
+ * .mixer-fader; keeping these token-based rules holds them on-theme until
+ * the deferred MixerView migration lands. Remove in the story 271 follow-up. */
 .mixer-fader {
     -fx-background-color: -surface-3;
 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripAppThemeCascadeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripAppThemeCascadeTest.java
@@ -1,0 +1,147 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the story-271 themability contract (§2.5 — "themability is a
+ * stylesheet swap, not a rewrite") end-to-end through the REAL application
+ * {@code styles.css} cascade.
+ *
+ * <p>The six story-mandated MixerChannelStrip tests all attach the default
+ * {@code DarkThemeHelper} theme, whose Palette&nbsp;A token values are
+ * <em>identical</em> to the control's user-agent fallback hex. A circular
+ * looked-up-colour drop (the exact trap caught on story 267 — a same-named
+ * {@code -x: -x;} forward is flagged circular and silently falls back to
+ * the UA initial value) would therefore be <strong>invisible</strong> in
+ * every one of those tests. This test re-tints the {@code .root-pane}
+ * role tokens to values <em>different</em> from the UA fallback so a broken
+ * {@code -mcs-*} forward cannot hide. Story 277 (theme picker) and story
+ * 272 (Inspector themability) reuse this cascade — it is a downstream
+ * contract, so this probe is a permanent regression guard
+ * (mirrors {@code LevelMeterAppThemeCascadeTest}).
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripAppThemeCascadeTest {
+
+    private final List<MixerChannelStrip> created = new ArrayList<>();
+
+    @AfterEach
+    void cleanup() {
+        runOnFxThread(() -> {
+            for (MixerChannelStrip s : created) {
+                if (s.getSkin() != null) {
+                    s.setSkin(null);
+                }
+            }
+            created.clear();
+            return null;
+        });
+    }
+
+    private MixerChannelStrip newStrip() {
+        MixerChannelStrip s = runOnFxThread(MixerChannelStrip::new);
+        created.add(s);
+        return s;
+    }
+
+    @Test
+    void defaultAppThemeResolvesToPaletteAValues() {
+        MixerChannelStrip s = newStrip();
+        Color[] c = runOnFxThread(() -> {
+            StackPane root = new StackPane(s);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 88, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            return new Color[] {
+                    s.getSurface1(), s.getSurfaceBg(),
+                    s.getAccent(), s.getTextMute(), s.getDanger()
+            };
+        });
+        // These resolve via the distinctly-named styles.css forward
+        // (.mixer-channel-strip { -mcs-x: -x; }); a circular drop would
+        // instead yield the UA fallback (here equal — that's WHY the
+        // re-tint tests below matter).
+        assertThat(c[0]).as("-mcs-surface-1 ← -surface-1").isEqualTo(Color.web("#15161B"));
+        assertThat(c[1]).as("-mcs-surface-bg ← -surface-bg (§5.4 gutter)").isEqualTo(Color.web("#0B0B0E"));
+        assertThat(c[2]).as("-mcs-accent ← -accent").isEqualTo(Color.web("#7C8CFF"));
+        assertThat(c[3]).as("-mcs-text-mute ← -text-mute").isEqualTo(Color.web("#7A808C"));
+        assertThat(c[4]).as("-mcs-danger ← -danger").isEqualTo(Color.web("#E5484D"));
+    }
+
+    @Test
+    void reTintingRootPaneTokensReachesTheStripViaTheStylesCssForward() {
+        MixerChannelStrip s = newStrip();
+        Color[] c = runOnFxThread(() -> {
+            StackPane root = new StackPane(s);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 88, 600);
+            DarkThemeHelper.applyTo(scene);
+            // Simulate a story-277 theme re-tinting the role tokens on
+            // .root-pane to values distinct from the UA fallback hex.
+            root.setStyle("-accent: #0011FF; -text-mute: #FFAA00; "
+                    + "-surface-bg: #112233; -danger: #00CC44;");
+            root.applyCss();
+            root.layout();
+            return new Color[] {
+                    s.getAccent(), s.getTextMute(),
+                    s.getSurfaceBg(), s.getDanger()
+            };
+        });
+        assertThat(c[0])
+                .as("re-tinting -accent on .root-pane must reach -mcs-accent "
+                        + "via the distinctly-named styles.css forward (NOT a "
+                        + "circular looked-up colour that drops to the UA fallback)")
+                .isEqualTo(Color.web("#0011FF"));
+        assertThat(c[1])
+                .as("re-tinting -text-mute must reach -mcs-text-mute")
+                .isEqualTo(Color.web("#FFAA00"));
+        assertThat(c[2])
+                .as("re-tinting -surface-bg must reach -mcs-surface-bg (gutter)")
+                .isEqualTo(Color.web("#112233"));
+        assertThat(c[3])
+                .as("re-tinting -danger must reach -mcs-danger")
+                .isEqualTo(Color.web("#00CC44"));
+    }
+
+    @Test
+    void stripColoursCanAlsoBeReTintedOnTheControlSelector() {
+        // Plugin GUIs / themes that prefer to scope the override to the
+        // control can set the internal -mcs-* names directly on
+        // .mixer-channel-strip (the supported theming entry point — same
+        // as story 267's .level-meter direct re-tint path).
+        MixerChannelStrip s = newStrip();
+        Color[] c = runOnFxThread(() -> {
+            StackPane root = new StackPane(s);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 88, 600);
+            DarkThemeHelper.applyTo(scene);
+            scene.getStylesheets().add("data:text/css;base64,"
+                    + java.util.Base64.getEncoder().encodeToString(
+                            (".mixer-channel-strip { -mcs-accent: #0011FF; "
+                                    + "-mcs-text-mute: #FFAA00; }")
+                                    .getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+            root.applyCss();
+            root.layout();
+            return new Color[] {s.getAccent(), s.getTextMute()};
+        });
+        assertThat(c[0]).isEqualTo(Color.web("#0011FF"));
+        assertThat(c[1]).isEqualTo(Color.web("#FFAA00"));
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripChannelTypeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripChannelTypeTest.java
@@ -1,0 +1,114 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.MixerChannelStrip.ChannelType;
+import com.benesquivelmusic.daw.app.ui.controls.skin.MixerChannelStripSkin;
+
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 271 — with {@code channelType = MASTER} the M/S/R toggles are
+ * <strong>not present in the rendered scene graph</strong> (asserted as
+ * not findable, not merely {@code !visible}); only the fader, meter and
+ * name remain. Switching back to {@code AUDIO} re-adds them.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripChannelTypeTest {
+
+    private static void collectToggles(Node node, List<Node> acc) {
+        if (node instanceof ToggleButton) {
+            acc.add(node);
+        }
+        if (node instanceof javafx.scene.Parent p) {
+            for (Node child : p.getChildrenUnmodifiable()) {
+                collectToggles(child, acc);
+            }
+        }
+    }
+
+    private static boolean msrTogglesPresent(MixerChannelStrip strip) {
+        MixerChannelStripSkin skin = (MixerChannelStripSkin) strip.getSkin();
+        ToggleButton m = skin.muteButton();
+        ToggleButton s = skin.soloButton();
+        ToggleButton r = skin.armButton();
+        List<Node> toggles = new ArrayList<>();
+        collectToggles(strip, toggles);
+        return toggles.contains(m) || toggles.contains(s) || toggles.contains(r);
+    }
+
+    @Test
+    void masterChannelHasNoMsrTogglesInSceneGraph() {
+        boolean present = runOnFxThread(() -> {
+            MixerChannelStrip strip = MixerChannelStrip.create()
+                    .name("Master")
+                    .channelType(ChannelType.MASTER)
+                    .build();
+            StackPane root = new StackPane(strip);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 200, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            return msrTogglesPresent(strip);
+        });
+        assertThat(present)
+                .as("MASTER channel must not have M/S/R toggles in the "
+                        + "rendered scene graph")
+                .isFalse();
+    }
+
+    @Test
+    void audioChannelHasMsrTogglesInSceneGraph() {
+        boolean present = runOnFxThread(() -> {
+            MixerChannelStrip strip = MixerChannelStrip.create()
+                    .name("Drums")
+                    .channelType(ChannelType.AUDIO)
+                    .build();
+            StackPane root = new StackPane(strip);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 200, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            return msrTogglesPresent(strip);
+        });
+        assertThat(present)
+                .as("AUDIO channel must show M/S/R toggles").isTrue();
+    }
+
+    @Test
+    void switchingMasterToAudioReAddsMsrToggles() {
+        boolean present = runOnFxThread(() -> {
+            MixerChannelStrip strip = MixerChannelStrip.create()
+                    .name("Bus")
+                    .channelType(ChannelType.MASTER)
+                    .build();
+            StackPane root = new StackPane(strip);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 200, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            strip.setChannelType(ChannelType.AUDIO);
+            root.applyCss();
+            root.layout();
+            return msrTogglesPresent(strip);
+        });
+        assertThat(present)
+                .as("switching MASTER → AUDIO re-adds M/S/R to the scene graph")
+                .isTrue();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripDisposeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripDisposeTest.java
@@ -1,0 +1,87 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.skin.MixerChannelStripSkin;
+
+import javafx.scene.Scene;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link MixerChannelStripSkin#dispose()} removes every listener
+ * registered in the skin's constructor. Mirrors
+ * {@code TrackStripDisposeTest}.
+ *
+ * <ol>
+ *   <li>The skin's {@code registeredListenerCount()} drops back to zero.</li>
+ *   <li>After dispose, mutating {@code mutedProperty} /
+ *       {@code armedProperty} produces no skin-side reaction.</li>
+ * </ol>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripDisposeTest {
+
+    @Test
+    void disposeRemovesAllRegisteredListeners() {
+        int[] counts = new int[2];
+        boolean[] disposed = new boolean[1];
+        runOnFxThread(() -> {
+            MixerChannelStrip s = new MixerChannelStrip();
+            StackPane root = new StackPane(s);
+            new Scene(root, 200, 600);
+            root.applyCss();
+            root.layout();
+            MixerChannelStripSkin skin = (MixerChannelStripSkin) s.getSkin();
+            counts[0] = skin.registeredListenerCount();
+            s.setSkin(null);
+            counts[1] = skin.registeredListenerCount();
+            disposed[0] = skin.isDisposed();
+            return null;
+        });
+        assertThat(counts[0])
+                .as("skin registers listeners on construction")
+                .isGreaterThan(0);
+        assertThat(counts[1])
+                .as("dispose() removes every listener")
+                .isEqualTo(0);
+        assertThat(disposed[0]).isTrue();
+    }
+
+    @Test
+    void mutationsAfterDisposeDoNotReachOldSkin() {
+        boolean[] result = new boolean[3];
+        runOnFxThread(() -> {
+            MixerChannelStrip s = new MixerChannelStrip();
+            StackPane root = new StackPane(s);
+            new Scene(root, 200, 600);
+            root.applyCss();
+            root.layout();
+            MixerChannelStripSkin oldSkin = (MixerChannelStripSkin) s.getSkin();
+            ToggleButton oldMute = oldSkin.muteButton();
+            ToggleButton oldArm = oldSkin.armButton();
+
+            s.setSkin(null); // dispose the old skin
+
+            s.setMuted(true);
+            s.setArmed(true);
+
+            result[0] = oldMute.isSelected();
+            result[1] = oldArm.isSelected();
+            result[2] = oldSkin.isDisposed();
+            return null;
+        });
+        assertThat(result[0])
+                .as("old skin's M toggle does NOT react to post-dispose mute change")
+                .isFalse();
+        assertThat(result[1])
+                .as("old skin's R toggle does NOT react to post-dispose arm change")
+                .isFalse();
+        assertThat(result[2]).isTrue();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripFaderBindingTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripFaderBindingTest.java
@@ -1,0 +1,79 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.skin.MixerChannelStripSkin;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 271 — {@link MixerChannelStrip#faderDbProperty()} is two-way
+ * synced to the embedded {@link Fader}'s {@code valueProperty()}, and
+ * {@link MixerChannelStrip#panProperty()} to the embedded {@link Knob}.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripFaderBindingTest {
+
+    private record Skin(MixerChannelStrip strip, MixerChannelStripSkin skin) { }
+
+    private static Skin attach() {
+        return runOnFxThread(() -> {
+            MixerChannelStrip strip = new MixerChannelStrip();
+            StackPane root = new StackPane(strip);
+            new Scene(root, 200, 600);
+            root.applyCss();
+            root.layout();
+            return new Skin(strip, (MixerChannelStripSkin) strip.getSkin());
+        });
+    }
+
+    @Test
+    void setFaderDbPropagatesToEmbeddedFader() {
+        Skin s = attach();
+        runOnFxThread(() -> {
+            s.strip().setFaderDb(-6.0);
+            return null;
+        });
+        assertThat(s.skin().fader().getValue())
+                .as("setFaderDb(-6) sets the embedded Fader value")
+                .isEqualTo(-6.0);
+    }
+
+    @Test
+    void settingEmbeddedFaderValuePropagatesBackToFaderDbProperty() {
+        Skin s = attach();
+        runOnFxThread(() -> {
+            s.skin().fader().setValue(-12.0);
+            return null;
+        });
+        assertThat(s.strip().getFaderDb())
+                .as("moving the Fader updates faderDbProperty (two-way)")
+                .isEqualTo(-12.0);
+    }
+
+    @Test
+    void setPanPropagatesToEmbeddedKnobAndBack() {
+        Skin s = attach();
+        runOnFxThread(() -> {
+            s.strip().setPan(-0.5);
+            return null;
+        });
+        assertThat(s.skin().knob().getValue())
+                .as("setPan(-0.5) sets the embedded Knob value")
+                .isEqualTo(-0.5);
+
+        runOnFxThread(() -> {
+            s.skin().knob().setValue(0.75);
+            return null;
+        });
+        assertThat(s.strip().getPan())
+                .as("turning the Knob updates panProperty (two-way)")
+                .isEqualTo(0.75);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripInsertActivationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripInsertActivationTest.java
@@ -1,0 +1,72 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.skin.MixerChannelStripSkin;
+
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 271 — clicking an insert slot row fires a typed
+ * {@link MixerChannelStrip.InsertSelectedEvent} that bubbles
+ * <strong>through the scene graph</strong>: a filter installed on a
+ * <em>parent</em> node receives it (proving it travels the standard
+ * dispatch chain, which is how story 272's Inspector consumes it).
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripInsertActivationTest {
+
+    @Test
+    void clickingInsertRowFiresEventThatBubblesToParent() {
+        AtomicInteger received = new AtomicInteger(-1);
+
+        runOnFxThread(() -> {
+            MixerChannelStrip strip = new MixerChannelStrip();
+            strip.setChannelName("Drums");
+            strip.insertsProperty().add(new InsertSlotModel("EQ", true, false));
+            strip.insertsProperty().add(new InsertSlotModel("Comp", false, true));
+
+            StackPane parent = new StackPane(strip);
+            parent.getStyleClass().add("root-pane");
+            Scene scene = new Scene(parent, 200, 600);
+            DarkThemeHelper.applyTo(scene);
+            parent.applyCss();
+            parent.layout();
+
+            // Filter on the PARENT (not the strip) — proves the event
+            // bubbles up the scene graph.
+            // The filter is on the PARENT — if it fires at all the event
+            // travelled the standard dispatch chain up from the strip.
+            parent.addEventFilter(MixerChannelStrip.INSERT_SELECTED,
+                    ev -> received.set(ev.getInsertIndex()));
+
+            MixerChannelStripSkin skin = (MixerChannelStripSkin) strip.getSkin();
+            Node row = skin.insertRowNode(1);
+            assertThat(row).as("insert row 1 must exist").isNotNull();
+            row.getOnMouseClicked().handle(
+                    new javafx.scene.input.MouseEvent(
+                            javafx.scene.input.MouseEvent.MOUSE_CLICKED,
+                            0, 0, 0, 0,
+                            javafx.scene.input.MouseButton.PRIMARY, 1,
+                            false, false, false, false,
+                            true, false, false, false, false, false, null));
+            return null;
+        });
+
+        assertThat(received.get())
+                .as("parent filter received the InsertSelectedEvent (proving "
+                        + "it bubbled through the scene graph) with the clicked "
+                        + "slot index")
+                .isEqualTo(1);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripInsertDotPaintTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripInsertDotPaintTest.java
@@ -1,0 +1,103 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.skin.MixerChannelStripSkin;
+
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 271 / phase-2 template trap #1 — "tests assert the draw-model seam
+ * while users see {@code paint()}".
+ *
+ * <p>The story's {@code insertDotActive(int)} skin seam returns a boolean.
+ * This test instead reads the <strong>rendered {@link Circle}'s resolved
+ * fill</strong> — the actual pixel the user sees — under a theme re-tinted
+ * to values distinct from the UA fallback, and asserts:
+ *
+ * <ul>
+ *   <li>an engaged, non-bypassed insert renders the (re-tinted)
+ *       {@code -mcs-accent} fill;</li>
+ *   <li>a bypassed insert renders the (re-tinted) {@code -mcs-text-mute}
+ *       fill;</li>
+ *   <li>the two differ.</li>
+ * </ul>
+ *
+ * <p>This proves the single {@code insertDotActive} helper actually drives
+ * the painted result (via the {@code .active} style class consumed by
+ * {@code mixer-channel-strip.css}) and that the seam and the paint path
+ * cannot disagree — the exact correctness trap the story-267 expert review
+ * flagged as propagating through the 268–271 template.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripInsertDotPaintTest {
+
+    private static Circle dotIn(Node row) {
+        if (row instanceof Circle c) {
+            return c;
+        }
+        if (row instanceof Parent p) {
+            for (Node child : p.getChildrenUnmodifiable()) {
+                Circle c = dotIn(child);
+                if (c != null) {
+                    return c;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Test
+    void renderedStatusDotFillFollowsTheSingleActiveHelperUnderAReTintedTheme() {
+        Color[] fills = runOnFxThread(() -> {
+            MixerChannelStrip strip = new MixerChannelStrip();
+            // index 0: active + not bypassed  → dot must be -mcs-accent
+            strip.insertsProperty().add(new InsertSlotModel("EQ", true, false));
+            // index 1: bypassed               → dot must be -mcs-text-mute
+            strip.insertsProperty().add(new InsertSlotModel("Comp", true, true));
+
+            StackPane root = new StackPane(strip);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 88, 600);
+            DarkThemeHelper.applyTo(scene);
+            // Re-tint to values distinct from the UA fallback so a broken
+            // forward / wrong style class cannot hide behind equal hex.
+            root.setStyle("-accent: #0011FF; -text-mute: #FFAA00;");
+            root.applyCss();
+            root.layout();
+
+            MixerChannelStripSkin skin = (MixerChannelStripSkin) strip.getSkin();
+            Circle activeDot = dotIn(skin.insertRowNode(0));
+            Circle bypassedDot = dotIn(skin.insertRowNode(1));
+            assertThat(activeDot).as("active row must render a status dot").isNotNull();
+            assertThat(bypassedDot).as("bypassed row must render a status dot").isNotNull();
+            // Cross-check the seam agrees with what we are about to read off
+            // the painted node (single source of truth).
+            assertThat(skin.insertDotActive(0)).isTrue();
+            assertThat(skin.insertDotActive(1)).isFalse();
+            return new Color[] {(Color) activeDot.getFill(), (Color) bypassedDot.getFill()};
+        });
+
+        assertThat(fills[0])
+                .as("engaged, non-bypassed insert dot renders the re-tinted "
+                        + "-mcs-accent (proving .active drives the painted fill)")
+                .isEqualTo(Color.web("#0011FF"));
+        assertThat(fills[1])
+                .as("bypassed insert dot renders the re-tinted -mcs-text-mute")
+                .isEqualTo(Color.web("#FFAA00"));
+        assertThat(fills[0])
+                .as("active and bypassed dots must be visually distinct")
+                .isNotEqualTo(fills[1]);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripLayoutTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripLayoutTest.java
@@ -1,0 +1,57 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Story 271 — the strip width is density-driven and enforced from the
+ * Skin (Java), not CSS: 72&nbsp;px Compact (also the default), 88&nbsp;px
+ * Comfortable (UI Design Book §5.4, story 278).
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripLayoutTest {
+
+    private static double widthOf(String densityClass) {
+        return runOnFxThread(() -> {
+            MixerChannelStrip strip = new MixerChannelStrip();
+            strip.setChannelName("Drums");
+            if (densityClass != null) {
+                strip.getStyleClass().add(densityClass);
+            }
+            StackPane root = new StackPane(strip);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 200, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            return strip.prefWidth(-1);
+        });
+    }
+
+    @Test
+    void compactDensityIs72Px() {
+        assertThat(widthOf("density-compact")).isCloseTo(72.0, within(1.0));
+    }
+
+    @Test
+    void comfortableDensityIs88Px() {
+        assertThat(widthOf("density-comfortable")).isCloseTo(88.0, within(1.0));
+    }
+
+    @Test
+    void defaultDensityKeepsTheCompactWidth() {
+        // Story §5.4: "keep the width" — the default (no density class) is
+        // the compact 72 px width.
+        assertThat(widthOf(null)).isCloseTo(72.0, within(1.0));
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripSendActivationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripSendActivationTest.java
@@ -1,0 +1,71 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.skin.MixerChannelStripSkin;
+
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 271 — clicking a send slot row fires a typed
+ * {@link MixerChannelStrip.SendSelectedEvent} that bubbles
+ * <strong>through the scene graph</strong>: a filter installed on a
+ * <em>parent</em> node receives it (proving it travels the standard
+ * dispatch chain, symmetric with {@link MixerChannelStripInsertActivationTest}
+ * — story 272's Inspector consumes both the same way).
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripSendActivationTest {
+
+    @Test
+    void clickingSendRowFiresEventThatBubblesToParent() {
+        AtomicInteger received = new AtomicInteger(-1);
+
+        runOnFxThread(() -> {
+            MixerChannelStrip strip = new MixerChannelStrip();
+            strip.setChannelName("Drums");
+            strip.sendsProperty().add(new SendSlotModel("Reverb", 0.5, false));
+            strip.sendsProperty().add(new SendSlotModel("Delay", 0.25, true));
+
+            StackPane parent = new StackPane(strip);
+            parent.getStyleClass().add("root-pane");
+            Scene scene = new Scene(parent, 200, 600);
+            DarkThemeHelper.applyTo(scene);
+            parent.applyCss();
+            parent.layout();
+
+            // Filter on the PARENT (not the strip) — if it fires at all the
+            // event travelled the standard dispatch chain up from the strip.
+            parent.addEventFilter(MixerChannelStrip.SEND_SELECTED,
+                    ev -> received.set(ev.getSendIndex()));
+
+            MixerChannelStripSkin skin = (MixerChannelStripSkin) strip.getSkin();
+            Node row = skin.sendRowNode(1);
+            assertThat(row).as("send row 1 must exist").isNotNull();
+            row.getOnMouseClicked().handle(
+                    new javafx.scene.input.MouseEvent(
+                            javafx.scene.input.MouseEvent.MOUSE_CLICKED,
+                            0, 0, 0, 0,
+                            javafx.scene.input.MouseButton.PRIMARY, 1,
+                            false, false, false, false,
+                            true, false, false, false, false, false, null));
+            return null;
+        });
+
+        assertThat(received.get())
+                .as("parent filter received the SendSelectedEvent (proving "
+                        + "it bubbled through the scene graph) with the clicked "
+                        + "slot index")
+                .isEqualTo(1);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripStateTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStripStateTest.java
@@ -1,0 +1,93 @@
+package com.benesquivelmusic.daw.app.ui.controls;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.skin.MixerChannelStripSkin;
+
+import javafx.css.PseudoClass;
+import javafx.scene.Scene;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * State-driven styling contract for {@link MixerChannelStrip} — mirrors
+ * {@code TrackStripStateTest} at the channel-strip level.
+ *
+ * <p>Setting {@link MixerChannelStrip#mutedProperty()} /
+ * {@code soloedProperty} / {@code armedProperty} must flip both the
+ * corresponding M/S/R toggle's {@code :selected} pseudo-class and the
+ * strip's own state pseudo-class.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MixerChannelStripStateTest {
+
+    private record Snapshot(boolean toggleSelected, boolean stripPseudoSet) { }
+
+    private interface ToggleSelector {
+        ToggleButton pick(MixerChannelStripSkin s);
+    }
+
+    private static Snapshot attachAndApply(
+            java.util.function.Consumer<MixerChannelStrip> mutate,
+            ToggleSelector which,
+            PseudoClass stripPc) {
+        return runOnFxThread(() -> {
+            MixerChannelStrip strip = new MixerChannelStrip();
+            strip.setChannelName("Drums");
+            StackPane root = new StackPane(strip);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 200, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            MixerChannelStripSkin skin = (MixerChannelStripSkin) strip.getSkin();
+            ToggleButton btn = which.pick(skin);
+            mutate.accept(strip);
+            root.applyCss();
+            root.layout();
+            boolean toggleSelected = btn.isSelected()
+                    && btn.getPseudoClassStates()
+                            .contains(PseudoClass.getPseudoClass("selected"));
+            boolean pcSet = strip.getPseudoClassStates().contains(stripPc);
+            return new Snapshot(toggleSelected, pcSet);
+        });
+    }
+
+    @Test
+    void mutedSetsMuteTogglePseudoClassAndStripPseudoClass() {
+        Snapshot s = attachAndApply(
+                strip -> strip.setMuted(true),
+                MixerChannelStripSkin::muteButton,
+                PseudoClass.getPseudoClass("muted"));
+        assertThat(s.toggleSelected())
+                .as("setMuted(true) selects the M toggle").isTrue();
+        assertThat(s.stripPseudoSet())
+                .as("setMuted(true) flips the strip's :muted pseudo-class").isTrue();
+    }
+
+    @Test
+    void soloedSetsSoloTogglePseudoClass() {
+        Snapshot s = attachAndApply(
+                strip -> strip.setSoloed(true),
+                MixerChannelStripSkin::soloButton,
+                PseudoClass.getPseudoClass("soloed"));
+        assertThat(s.toggleSelected()).isTrue();
+        assertThat(s.stripPseudoSet()).isTrue();
+    }
+
+    @Test
+    void armedSetsArmTogglePseudoClass() {
+        Snapshot s = attachAndApply(
+                strip -> strip.setArmed(true),
+                MixerChannelStripSkin::armButton,
+                PseudoClass.getPseudoClass("armed"));
+        assertThat(s.toggleSelected()).isTrue();
+        assertThat(s.stripPseudoSet()).isTrue();
+    }
+}


### PR DESCRIPTION
# MixerChannelStrip Control + Skin with Inserts, Sends, Pan, and Fader

## Motivation

Phase 2 of the UI Design Book §6 migration roadmap. Builds on: #260, #261, #263, #264 (buttons), #265 (icons), #266 (mono numerics), #267 (LevelMeter), #268 (Knob), #269 (Fader), #270 (TrackStrip M/S/R pattern).

UI Design Book §5.4 ("Mixer channel strip") specifies the full signal-chain control for one channel: I/O, inserts list, sends list, pan knob, fader (with integrated meter), M/S/R buttons, name. Today this is hand-rolled across several files and `styles.css:457–520`. The current `.mixer-channel` is 70 px wide and styled as a card with a border. §5.4 says: keep the width, drop the visible border in favour of column gutters at `-surface-bg`. And replace the purple circular fader thumb (already addressed by story 269's `Fader`).

This story brings the channel strip up to the same standard as the track strip (story 270) — a proper `Control + Skin + StyleableProperty` triplet that composes the Phase 2 controls (Fader, Knob, LevelMeter) and the unified button system (story 264) into the complete §5.4 layout.

## Goals

- Create `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStrip.java` as a `javafx.scene.control.Control` with:
  - `ObjectProperty<ChannelId> channelIdProperty()`.
  - `StringProperty channelNameProperty()`, `StringProperty inputLabelProperty()`, `StringProperty outputLabelProperty()`.
  - `ObservableList<InsertSlotModel> insertsProperty()`, `ObservableList<SendSlotModel> sendsProperty()`. (Slot models are PR-introduced records in `daw-sdk`/mixer or reused from existing types — pick whichever is cleaner.)
  - `DoubleProperty panProperty()` — bound to a `Knob` in the skin, bipolar.
  - `DoubleProperty faderDbProperty()` — bound to a `Fader` in the skin.
  - `BooleanProperty mutedProperty()`, `soloedProperty()`, `armedProperty()` — bound to the same outlined-default / filled-active toggle pattern from story 270.
  - `ObjectProperty<ChannelType> channelTypeProperty()` — `AUDIO`, `MIDI`, `BUS`, `MASTER`. (JavaFX has no `EnumProperty`; use `SimpleObjectProperty<ChannelType>`.) The strip's name colour and which controls are visible depend on type (the `MASTER` has no M/S/R; the `BUS` has no input selector).
  - Override `getUserAgentStylesheet()` to return `MixerChannelStrip.class.getResource("mixer-channel-strip.css").toExternalForm()`.
  - Provide a fluent `Builder` for the 12-property construction surface. Direct constructors and setters remain available.
  - Expose typed `EventType<InsertSelectedEvent> INSERT_SELECTED` and `EventType<SendSelectedEvent> SEND_SELECTED` (subclasses of `javafx.event.Event`) plus `setOnInsertSelected` / `setOnSendSelected` convenience methods. Slot click handlers in the skin call `fireEvent(new InsertSelectedEvent(insertId))`; events bubble through the scene graph and the Inspector (story 272) consumes them via the standard dispatch chain. Skill §12 — preferred over ad-hoc callbacks.
- Create `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/MixerChannelStripSkin.java` extending `SkinBase<MixerChannelStrip>` that overrides `compute{Min,Pref,Max}Width` per density variant (72 / 88 px) and `compute{Min,Pref,Max}Height` to fill the available vertical space. `layoutChildren(x, y, w, h)` derives insert-slot row height, fader column height, pan-knob diameter, and meter width proportionally from the assigned width and height — no fixed pixel offsets keyed to a single default. Listeners registered in the constructor are removed in `dispose()`. Lays out top → bottom per the §5.4 mockup:
  - Input/output labels (small mono caption per story 266).
  - Insert list — 4 visible slots + a "⋯" overflow. Each slot is a row: insert name, status dot (`-accent` if active, `-text-mute` if bypassed), click → opens the inspector to that insert (story 272).
  - Send list — 2 visible slots + overflow. Each send: send name, level (compact `Fader` from story 269 with `showMeter = false`), pre/post toggle.
  - Pan: a `Knob.size-28` (story 268) with `bipolarProperty = true`, units "L / R".
  - Fader: a `Fader.size-mixer` (story 269) with the integrated meter on its right. Curve `LOG_DB`.
  - M / S / R buttons — same outlined-default/filled-active widgets as story 270's `TrackStrip`, identical CSS classes (`.track-toggle.mute|solo|arm`) for visual consistency.
  - Fader value readout (`.numeric-value`) and channel name (editable on double-click).
- The strip's "card border" is dropped per §5.4. Visual separation between adjacent strips is a 1 px `-surface-bg` (same as the panel background) **gutter** — i.e., a fixed 4 px gap. No border, no shadow, no rounded corners on the strip itself. (The mixer panel as a whole sits at elevation 0 per story 263.)
- Width: 72 px Compact, 88 px Comfortable (selected by the density mode in story 278).
- Migrate the existing mixer channel rendering. Concretely: every place in `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/` and the mixer view that hand-rolls a `VBox` with `.mixer-channel` becomes `new MixerChannelStrip()` with property bindings to the mixer model. Audit callers via `Grep -rn "mixer-channel"` and migrate each.
- Remove the legacy `.mixer-channel`, `.mixer-channel-fader-thumb` (and any `purple` / `circular` fader styles) from `styles.css`. Leave an alias rule deprecating `.mixer-channel` → `.dawg-mixer-channel-strip` for one cycle, same convention as story 264's button aliases.
- Define `daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/controls/mixer-channel-strip.css` with the styling rules above and the size-variant selectors `.mixer-channel-strip.density-compact` (72 px) and `.density-comfortable` (88 px).
- Tests:
  - `MixerChannelStripLayoutTest`: instantiate, snapshot layout bounds in Compact (72 ± 1 px) and Comfortable (88 ± 1 px).
  - `MixerChannelStripStateTest`: mirror story 270's M/S/R state tests at the channel-strip level.
  - `MixerChannelStripChannelTypeTest`: with `channelType = MASTER`, assert M/S/R toggles are *not* present in the rendered scene graph (only fader, meter, name).
  - `MixerChannelStripInsertActivationTest`: simulate a click on an insert slot row, assert an `InsertSelectedEvent` is **fired through the scene graph** (verify via `addEventFilter(InsertSelectedEvent.INSERT_SELECTED, …)` on a parent node) and the inspector receives it via story 272's handler.
  - `MixerChannelStripDisposeTest`: swap skin via `setSkin(null)`; assert listeners are unregistered from the channel-strip's properties.
  - `MixerChannelStripFaderBindingTest`: set `faderDbProperty = -6`, assert the embedded `Fader.valueProperty()` is `-6`. Inversely, drag the fader's cap and assert `faderDbProperty()` updates.

## Non-Goals

- VCA group assignment UI (story 153) — strips ignore VCA membership for this story.
- Per-send pre/post-fader toggle visual polish (story 154) — the toggle exists per slot but its visual is the default `dawg-button` style.
- Mid/Side wrapper toggle on the strip (story 157) — not part of §5.4.
- Implementing the inserts/sends *list* models (this is wiring; the model already exists). Slot adapter records are written if missing.
- Migrating the channel-strip *layout* to GpuCanvas — out of scope. Each child control may use a `Canvas` internally per its own story.

## Technical Notes

- The strip exposes a strict `Property<T>`-driven API; consumers bind from the mixer model and never call into the skin. This keeps the §2.5 "themability is a stylesheet swap, not a rewrite" promise.
- The "I/O label" (`I In 1+2` / `O Master`) is small mono per §3.2 — bind to the existing routing model. If routing is not yet selectable for buses, leave the bus's input label blank.
- Mixer-wide CSS classes (`.mixer-bus-divider`, etc.) are part of the parent panel, not this control.
- After this story, the mixer view is composed entirely of `MixerChannelStrip` controls — themability flows for free.
- Reference: UI Design Book §2.5, §5.4, §7.5 (multi-coloured-M/S/R veto — implicit AC).