### PR TITLE
274 status bar single row dot separated cells

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -52,6 +52,8 @@ import javafx.util.Duration;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
@@ -66,6 +68,11 @@ import java.util.prefs.Preferences;
 public final class MainController {
 
     private static final Logger LOG = Logger.getLogger(MainController.class.getName());
+
+    /** Resource bundle for status-bar chrome strings (story 274 / Skill
+     *  §14) — Locale.ROOT, mirroring NotificationPill / InspectorDrawer. */
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
 
     @FXML private BorderPane rootPane;
     @FXML private Button skipBackButton;
@@ -96,6 +103,16 @@ public final class MainController {
     @FXML private StackPane arrangementContentPane;
     @FXML private Label tracksPanelHeader;
     @FXML private Label ioRoutingLabel;
+    // Story 274 — status-bar cells. cpuLabel/memLabel/dskLabel are STATIC
+    // PLACEHOLDER cells: no system CPU/memory/disk telemetry source exists
+    // in this codebase (PerformanceMonitor tracks only audio-DSP-thread
+    // load). Their text comes from Messages.properties (Skill §14).
+    // TODO story-274 follow-on: wire cpu/mem/dsk to a real telemetry
+    // source (out of scope per story Non-Goals — no polling Service /
+    // OperatingSystemMXBean / Runtime probe is introduced here).
+    @FXML private Label cpuLabel;
+    @FXML private Label memLabel;
+    @FXML private Label dskLabel;
     @FXML private Label recIndicator;
     @FXML private HBox notificationBarContainer;
     @FXML private HBox transportGroup;
@@ -372,6 +389,7 @@ public final class MainController {
         updateProjectInfo();
         mountLockStatusIndicator();
         updateCheckpointStatus();
+        initializeStatusBarPlaceholders();
         updateUndoRedoState();
         installIoLatencyClickHandler();
         animationController.start();
@@ -2394,11 +2412,36 @@ public final class MainController {
 
     private void updateProjectInfo() {
         AudioFormat fmt = project.getFormat();
+        // Story 274 \u2014 projectInfoLabel is the FIRST status-bar cell, so it
+        // carries NO leading "\u00b7 " dot. Every later dynamic cell gets the
+        // "\u00b7 " prefix (the dot is part of the text \u2014 JavaFX CSS has no
+        // :first-child, story \u00a76 / Skill \u00a715).
         projectInfoLabel.setText(String.format("%s  \u00b7  %.0f kHz / %d-bit / %dch",
                 project.getName(), fmt.sampleRate() / 1000.0, fmt.bitDepth(), fmt.channels()));
-        monitoringLabel.setText(switch (fmt.channels()) { case 1 -> "Mono"; case 2 -> "Stereo"; default -> fmt.channels() + "ch Surround"; });
-        ioRoutingLabel.setText(String.format("%.0f kHz I/O", fmt.sampleRate() / 1000.0));
+        monitoringLabel.setText("\u00b7 " + switch (fmt.channels()) {
+            case 1 -> "Mono"; case 2 -> "Stereo"; default -> fmt.channels() + "ch Surround"; });
+        ioRoutingLabel.setText(String.format("\u00b7 %.0f kHz I/O", fmt.sampleRate() / 1000.0));
         refreshLockStatusIndicator();
+    }
+
+    /**
+     * Story 274 \u2014 fills the static placeholder status-bar cells
+     * (CPU / MEM / DSK) from {@link #MESSAGES}. These are
+     * design-time placeholders only; the bundle value is the runtime
+     * authoritative text (Skill \u00a714). Each carries its own leading "\u00b7 "
+     * dot in the bundle string because every cell after projectInfoLabel
+     * is dot-prefixed (the dot is part of the text \u2014 \u00a76).
+     *
+     * <p><b>TODO story-274 follow-on:</b> CPU / MEM / DSK have no live
+     * telemetry source today (PerformanceMonitor tracks only audio-DSP
+     * load; there is no system mem/disk probe and one is explicitly out
+     * of scope per the story Non-Goals). Wiring them to a real source is
+     * a tracked follow-on.
+     */
+    private void initializeStatusBarPlaceholders() {
+        cpuLabel.setText(MESSAGES.getString("statusbar.cpu"));
+        memLabel.setText(MESSAGES.getString("statusbar.mem"));
+        dskLabel.setText(MESSAGES.getString("statusbar.dsk"));
     }
 
     /**
@@ -2438,8 +2481,11 @@ public final class MainController {
     }
 
     private void updateCheckpointStatus() {
-        checkpointLabel.setText("Auto-save: ON");
-        ioRoutingLabel.setText("Initializing I/O...");
+        // Story 274 — both are dot-prefixed status-bar cells (not the
+        // first cell). Keeps the existing semantics (checkpointLabel =
+        // autosave on/off; ioRoutingLabel = transient I/O init message).
+        checkpointLabel.setText("· Auto-save: ON");
+        ioRoutingLabel.setText("· Initializing I/O...");
     }
 
     private void updateArrangementPlaceholder() {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -51,6 +51,7 @@ import javafx.stage.Window;
 import javafx.util.Duration;
 
 import java.nio.file.Path;
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -2413,13 +2414,19 @@ public final class MainController {
     private void updateProjectInfo() {
         AudioFormat fmt = project.getFormat();
         // Story 274 \u2014 projectInfoLabel is the FIRST status-bar cell, so it
-        // carries NO leading "\u00b7 " dot. Every later dynamic cell gets the
-        // "\u00b7 " prefix (the dot is part of the text \u2014 JavaFX CSS has no
-        // :first-child, story \u00a76 / Skill \u00a715).
+        // carries NO leading "\u00b7 " dot (JavaFX CSS has no :first-child, \u00a76).
+        // Later non-first cells carry it: monitoring chrome words come from
+        // the bundle (Skill \u00a714) already dot-prefixed; the kHz I/O figure is
+        // a dynamic numeric value (\u00a75.11) so it stays a code-formatted
+        // string with its own dot.
         projectInfoLabel.setText(String.format("%s  \u00b7  %.0f kHz / %d-bit / %dch",
                 project.getName(), fmt.sampleRate() / 1000.0, fmt.bitDepth(), fmt.channels()));
-        monitoringLabel.setText("\u00b7 " + switch (fmt.channels()) {
-            case 1 -> "Mono"; case 2 -> "Stereo"; default -> fmt.channels() + "ch Surround"; });
+        monitoringLabel.setText(switch (fmt.channels()) {
+            case 1 -> MESSAGES.getString("statusbar.monitoring.mono");
+            case 2 -> MESSAGES.getString("statusbar.monitoring.stereo");
+            default -> MessageFormat.format(
+                    MESSAGES.getString("statusbar.monitoring.surround"), fmt.channels());
+        });
         ioRoutingLabel.setText(String.format("\u00b7 %.0f kHz I/O", fmt.sampleRate() / 1000.0));
         refreshLockStatusIndicator();
     }
@@ -2481,11 +2488,13 @@ public final class MainController {
     }
 
     private void updateCheckpointStatus() {
-        // Story 274 — both are dot-prefixed status-bar cells (not the
-        // first cell). Keeps the existing semantics (checkpointLabel =
-        // autosave on/off; ioRoutingLabel = transient I/O init message).
-        checkpointLabel.setText("· Auto-save: ON");
-        ioRoutingLabel.setText("· Initializing I/O...");
+        // Story 274 — static chrome strings from the bundle (Skill §14).
+        // checkpointLabel = autosave state; ioRoutingLabel = transient I/O
+        // init message. Both are non-first cells, dot-prefixed in the
+        // bundle value (checkpointLabel is also a StatusCellLabel, which
+        // re-asserts the dot for its ~30 dynamic writers).
+        checkpointLabel.setText(MESSAGES.getString("statusbar.autosave.on"));
+        ioRoutingLabel.setText(MESSAGES.getString("statusbar.io.initializing"));
     }
 
     private void updateArrangementPlaceholder() {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -2419,15 +2419,17 @@ public final class MainController {
         // the bundle (Skill \u00a714) already dot-prefixed; the kHz I/O figure is
         // a dynamic numeric value (\u00a75.11) so it stays a code-formatted
         // string with its own dot.
-        projectInfoLabel.setText(String.format("%s  \u00b7  %.0f kHz / %d-bit / %dch",
+        projectInfoLabel.setText(String.format(Locale.ROOT, "%s  \u00b7  %.0f kHz / %d-bit / %dch",
                 project.getName(), fmt.sampleRate() / 1000.0, fmt.bitDepth(), fmt.channels()));
         monitoringLabel.setText(switch (fmt.channels()) {
             case 1 -> MESSAGES.getString("statusbar.monitoring.mono");
             case 2 -> MESSAGES.getString("statusbar.monitoring.stereo");
-            default -> MessageFormat.format(
-                    MESSAGES.getString("statusbar.monitoring.surround"), fmt.channels());
+            default -> new MessageFormat(
+                    MESSAGES.getString("statusbar.monitoring.surround"), Locale.ROOT)
+                    .format(new Object[]{fmt.channels()});
         });
-        ioRoutingLabel.setText(String.format("\u00b7 %.0f kHz I/O", fmt.sampleRate() / 1000.0));
+        ioRoutingLabel.setText(String.format(Locale.ROOT,
+                StatusCellLabel.CELL_SEPARATOR + "%.0f kHz I/O", fmt.sampleRate() / 1000.0));
         refreshLockStatusIndicator();
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/StatusCellLabel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/StatusCellLabel.java
@@ -33,8 +33,16 @@ public final class StatusCellLabel extends Label {
 
     public StatusCellLabel() {
         textProperty().addListener((obs, old, value) -> {
-            if (value != null && !value.isBlank() && !value.startsWith("·")) {
-                setText(CELL_SEPARATOR + value);
+            if (value != null && !value.isBlank()) {
+                if (value.startsWith(CELL_SEPARATOR)) {
+                    // Already correctly prefixed — nothing to do.
+                } else if (value.startsWith("·")) {
+                    // Leading middle dot without the required trailing space —
+                    // normalize to the canonical "· " form.
+                    setText(CELL_SEPARATOR + value.substring(1).stripLeading());
+                } else {
+                    setText(CELL_SEPARATOR + value);
+                }
             }
         });
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/StatusCellLabel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/StatusCellLabel.java
@@ -1,0 +1,41 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import javafx.scene.control.Label;
+
+/**
+ * Story 274 — a status-bar cell that is never the first cell, so it must
+ * always carry the leading "· " separator (UI Design Book §5.11 / §7.7:
+ * the eye reads cell grouping from the dot, JavaFX CSS has no
+ * {@code :first-child} so the separator is part of the cell text).
+ *
+ * <p><b>Why a dedicated type instead of prefixing at the call site:</b>
+ * {@code statusBarLabel} and {@code checkpointLabel} are written from ~30
+ * sites across {@link MainController}, {@link TransportController} and
+ * {@link ProjectLifecycleController}, which hold the label by its
+ * {@link Label} base reference and call {@code setText(...)} with raw,
+ * dynamic action messages ("Stopped", "Saved (checkpoint #3)", …) that
+ * cannot themselves carry the separator. Prefixing at every site is the
+ * exact "magic string in N places" trap flagged in review; this type is
+ * the single seam that guarantees the invariant for <em>all</em> writers.
+ *
+ * <p>{@link javafx.scene.control.Labeled#setText} is {@code final} and
+ * cannot be overridden, so the invariant is enforced by a self-normalising
+ * {@code textProperty} listener: any value lacking the leading middle dot
+ * is rewritten with the separator. The rewrite re-fires the listener once
+ * with an already-prefixed value and then converges (no recursion). It is
+ * idempotent, so call sites and {@code Messages.properties} values that
+ * already include the dot (for cross-cell uniformity) never double up.
+ */
+public final class StatusCellLabel extends Label {
+
+    /** MIDDLE DOT (U+00B7) + space — the inter-cell separator (§5.11). */
+    public static final String CELL_SEPARATOR = "· ";
+
+    public StatusCellLabel() {
+        textProperty().addListener((obs, old, value) -> {
+            if (value != null && !value.isBlank() && !value.startsWith("·")) {
+                setText(CELL_SEPARATOR + value);
+            }
+        });
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportController.java
@@ -303,7 +303,9 @@ final class TransportController {
         host.stopTimeTicker();
         updateStatus();
         timeDisplay.setText("00:00:00.0");
-        if (statusBarLabel.getText() == null || !statusBarLabel.getText().startsWith("Recording stopped")) {
+        // contains (not startsWith): statusBarLabel is a StatusCellLabel,
+        // so getText() carries the leading "· " separator (story 274).
+        if (statusBarLabel.getText() == null || !statusBarLabel.getText().contains("Recording stopped")) {
             statusBarLabel.setText("Stopped");
         }
         statusBarLabel.setGraphic(IconNode.of(DawIcon.POWER, 12));
@@ -759,8 +761,10 @@ final class TransportController {
         if (totalNotes > 0) {
             String msg = "Recording stopped — " + totalNotes + " MIDI note"
                     + (totalNotes > 1 ? "s" : "") + " captured";
+            // contains (not startsWith): StatusCellLabel prepends "· "
+            // (story 274), so the literal would never match at offset 0.
             if (statusBarLabel.getText() == null
-                    || !statusBarLabel.getText().startsWith("Recording stopped")) {
+                    || !statusBarLabel.getText().contains("Recording stopped")) {
                 statusBarLabel.setText(msg);
             }
             notificationBar.show(NotificationLevel.SUCCESS, msg);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportController.java
@@ -303,9 +303,8 @@ final class TransportController {
         host.stopTimeTicker();
         updateStatus();
         timeDisplay.setText("00:00:00.0");
-        // contains (not startsWith): statusBarLabel is a StatusCellLabel,
-        // so getText() carries the leading "· " separator (story 274).
-        if (statusBarLabel.getText() == null || !statusBarLabel.getText().contains("Recording stopped")) {
+        if (statusBarLabel.getText() == null
+                || !stripCellSeparator(statusBarLabel.getText()).startsWith("Recording stopped")) {
             statusBarLabel.setText("Stopped");
         }
         statusBarLabel.setGraphic(IconNode.of(DawIcon.POWER, 12));
@@ -761,10 +760,8 @@ final class TransportController {
         if (totalNotes > 0) {
             String msg = "Recording stopped — " + totalNotes + " MIDI note"
                     + (totalNotes > 1 ? "s" : "") + " captured";
-            // contains (not startsWith): StatusCellLabel prepends "· "
-            // (story 274), so the literal would never match at offset 0.
             if (statusBarLabel.getText() == null
-                    || !statusBarLabel.getText().contains("Recording stopped")) {
+                    || !stripCellSeparator(statusBarLabel.getText()).startsWith("Recording stopped")) {
                 statusBarLabel.setText(msg);
             }
             notificationBar.show(NotificationLevel.SUCCESS, msg);
@@ -842,5 +839,15 @@ final class TransportController {
         // Wire the one-accent-at-a-time active state (UI Design Book §2.1).
         playButton.pseudoClassStateChanged(ACTIVE, state == TransportState.PLAYING);
         recordButton.pseudoClassStateChanged(ACTIVE, state == TransportState.RECORDING);
+    }
+
+    /**
+     * Strips the leading {@link StatusCellLabel#CELL_SEPARATOR} so callers
+     * can use {@code startsWith} on the raw cell text (story 274).
+     */
+    private static String stripCellSeparator(String text) {
+        return text.startsWith(StatusCellLabel.CELL_SEPARATOR)
+                ? text.substring(StatusCellLabel.CELL_SEPARATOR.length())
+                : text;
     }
 }

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -33,17 +33,20 @@ notification.level.warning=Warning
 notification.level.error=Error
 notification.empty=No notifications
 
-# Status bar (story 274) — UI Design Book §5.11.
-#
-# Static placeholder cells. There is no live system CPU/memory/disk
-# telemetry source in this codebase (PerformanceMonitor tracks only
-# audio-DSP-thread load); live wiring is a documented follow-on. The
-# numeric portions are intentionally neutral placeholders ("--").
-#
-# Every cell after the first (projectInfoLabel) is dot-prefixed: the
-# "· " (MIDDLE DOT + space) is part of the cell text because
-# JavaFX CSS has no :first-child / :not(:first-child) (story §6,
-# Skill §15). So these values carry their own leading "· ".
+# Status bar (story 274) — UI Design Book §5.11. Static chrome strings
+# only; numeric values stay dynamic in code (§5.11). Every cell after
+# the first carries a leading "· " (MIDDLE DOT + space): JavaFX CSS has
+# no :first-child, so the separator is part of the cell text (story §6,
+# Skill §15). CPU/MEM/DSK are placeholders — no system telemetry source
+# exists yet (PerformanceMonitor tracks only audio-DSP load; live wiring
+# is a documented follow-on). statusbar.cpu/mem/dsk also appear as the
+# design-time text in main-view.fxml; StatusBarFxmlTest pins the two to
+# the same value so they cannot drift.
 statusbar.cpu=· CPU --
 statusbar.mem=· MEM --
 statusbar.dsk=· DSK --
+statusbar.autosave.on=· Auto-save: ON
+statusbar.io.initializing=· Initializing I/O...
+statusbar.monitoring.mono=· Mono
+statusbar.monitoring.stereo=· Stereo
+statusbar.monitoring.surround=· {0}ch Surround

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -32,3 +32,18 @@ notification.level.info=Information
 notification.level.warning=Warning
 notification.level.error=Error
 notification.empty=No notifications
+
+# Status bar (story 274) — UI Design Book §5.11.
+#
+# Static placeholder cells. There is no live system CPU/memory/disk
+# telemetry source in this codebase (PerformanceMonitor tracks only
+# audio-DSP-thread load); live wiring is a documented follow-on. The
+# numeric portions are intentionally neutral placeholders ("--").
+#
+# Every cell after the first (projectInfoLabel) is dot-prefixed: the
+# "· " (MIDDLE DOT + space) is part of the cell text because
+# JavaFX CSS has no :first-child / :not(:first-child) (story §6,
+# Skill §15). So these values carry their own leading "· ".
+statusbar.cpu=· CPU --
+statusbar.mem=· MEM --
+statusbar.dsk=· DSK --

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import com.benesquivelmusic.daw.app.ui.inspector.InspectorDrawer?>
+<?import com.benesquivelmusic.daw.app.ui.StatusCellLabel?>
 <BorderPane fx:id="rootPane"
             xmlns="http://javafx.com/javafx"
             xmlns:fx="http://javafx.com/fxml"
@@ -169,56 +170,21 @@
         <VBox>
             <Separator/>
             <HBox fx:id="notificationBarContainer"/>
-            <!-- Story 274 — Status bar: a single row of dot-separated cells,
-                 ZERO <Separator> nodes (UI Design Book §5.11, §7.7). The eye
-                 reads grouping from the 16 px gap (spacing="16" = -spacing-lg,
-                 story 261/264), not from drawn lines.
-
-                 Dot separators: the story's CSS :first-child / :not(:first-child)
-                 approach is impossible — JavaFX CSS has no :first-child (Skill
-                 §15, story 273 memory). The story endorses the cleaner
-                 alternative: make the "· " dot part of the cell text. Every
-                 cell after the first carries a leading "· ". For dynamic cells
-                 (projectInfoLabel/monitoringLabel/ioRoutingLabel/checkpointLabel
-                 + the placeholder cells) the controller writes the authoritative
-                 text — including the "· " prefix where needed and, for the
-                 placeholder cells, sourced from Messages.properties (Skill §14).
-                 The text="…" values below are design-time only; the controller
-                 overwrites them at runtime.
-
-                 Padding stays as numeric <Insets top=4/right=16/bottom=4/left=16>
-                 (= -spacing-xs / -spacing-lg = §5.11's 24 px height). It is NOT
-                 expressed as `-fx-padding: -spacing-xs -spacing-lg` in styles.css
-                 because JavaFX CSS has no looked-up numeric values (styles.css
-                 header lines 28-31; TokenValidationTest + MainViewFxmlSpacingTest
-                 enforce numeric FXML Insets that are multiples of 4).
-
-                 Cell arrangement (preserves every existing fx:id + semantic
-                 order — story Non-Goal "preserve existing order"):
-                   1. projectInfoLabel — project name + "· kHz / bit / ch"
-                      (.body weight-500, NO purple; carries numerics so also
-                      .numeric-value). First cell → no leading dot.
-                      LockStatusIndicator is inserted right after this at
-                      runtime by mountLockStatusIndicator() (HBox index + 1).
-                   2. monitoringLabel  — mono/stereo/surround prose (.body)
-                   3. ioRoutingLabel   — "kHz I/O" (.numeric-value); keeps its
-                      HAND cursor + click handler (installIoLatencyClickHandler)
-                   4. cpuLabel/memLabel/dskLabel — STATIC PLACEHOLDER numeric
-                      cells (.numeric-value). No live system telemetry source
-                      exists in this codebase (PerformanceMonitor tracks only
-                      audio-DSP load); live wiring is a documented follow-on.
-                   5. <Region hgrow=ALWAYS> spacer → right-aligned trailing group
-                   6. checkpointLabel — the live last-save / autosave-state
-                      cell (§5.11 right group). Existing fx:id; consumed by
-                      updateCheckpointStatus() and ProjectLifecycleController
-                      ("Saved (checkpoint #N)"). .body, dot-prefixed. NO
-                      separate last-save / autosave placeholder cells are
-                      added — checkpointLabel already IS that data, so a
-                      dead sibling would only duplicate it (story Non-Goal
-                      "only existing cells migrated").
-                   7. rippleBannerLabel — unchanged (visible/managed false).
-                   8. statusBarLabel — transport "Ready/…" status (.body),
-                      dot-prefixed at design time. -->
+            <!-- Story 274 — Status bar: one row of dot-separated cells, ZERO
+                 <Separator> nodes (UI Design Book §5.11/§7.7). Grouping reads
+                 from the 16 px gap, not drawn lines. The "· " separator is
+                 part of each non-first cell's text because JavaFX CSS has no
+                 :first-child (Skill §15). projectInfoLabel is the first cell →
+                 no leading dot. checkpointLabel/statusBarLabel are written
+                 from ~30 dynamic sites (Transport/ProjectLifecycle), so they
+                 are StatusCellLabel — the single seam that guarantees their
+                 leading "· " for every writer (idempotent). Padding stays a
+                 numeric <Insets 4/16/4/16> (= -spacing-xs/-lg, §5.11's 24 px
+                 height) because JavaFX CSS has no looked-up numeric values;
+                 TokenValidationTest + MainViewFxmlSpacingTest guard it. The
+                 text="…" values are design-time only (controller overwrites
+                 at runtime). Cell roles + order are pinned by
+                 StatusBarFxmlTest. -->
             <HBox alignment="CENTER_LEFT" spacing="16" styleClass="status-bar">
                 <padding>
                     <Insets top="4" right="16" bottom="4" left="16"/>
@@ -236,12 +202,12 @@
                 <Label fx:id="dskLabel" text="· DSK --"
                        styleClass="body, numeric-value"/>
                 <Region HBox.hgrow="ALWAYS"/>
-                <Label fx:id="checkpointLabel" text="· Auto-save: ON"
+                <StatusCellLabel fx:id="checkpointLabel" text="· Auto-save: ON"
                        styleClass="body"/>
                 <!-- Ripple-mode red banner (visible only when ripple is active) -->
                 <Label fx:id="rippleBannerLabel" text="" styleClass="ripple-banner"
                        visible="false" managed="false"/>
-                <Label fx:id="statusBarLabel" text="· Ready" styleClass="body"/>
+                <StatusCellLabel fx:id="statusBarLabel" text="· Ready" styleClass="body"/>
             </HBox>
         </VBox>
     </bottom>

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml
@@ -169,31 +169,79 @@
         <VBox>
             <Separator/>
             <HBox fx:id="notificationBarContainer"/>
+            <!-- Story 274 — Status bar: a single row of dot-separated cells,
+                 ZERO <Separator> nodes (UI Design Book §5.11, §7.7). The eye
+                 reads grouping from the 16 px gap (spacing="16" = -spacing-lg,
+                 story 261/264), not from drawn lines.
+
+                 Dot separators: the story's CSS :first-child / :not(:first-child)
+                 approach is impossible — JavaFX CSS has no :first-child (Skill
+                 §15, story 273 memory). The story endorses the cleaner
+                 alternative: make the "· " dot part of the cell text. Every
+                 cell after the first carries a leading "· ". For dynamic cells
+                 (projectInfoLabel/monitoringLabel/ioRoutingLabel/checkpointLabel
+                 + the placeholder cells) the controller writes the authoritative
+                 text — including the "· " prefix where needed and, for the
+                 placeholder cells, sourced from Messages.properties (Skill §14).
+                 The text="…" values below are design-time only; the controller
+                 overwrites them at runtime.
+
+                 Padding stays as numeric <Insets top=4/right=16/bottom=4/left=16>
+                 (= -spacing-xs / -spacing-lg = §5.11's 24 px height). It is NOT
+                 expressed as `-fx-padding: -spacing-xs -spacing-lg` in styles.css
+                 because JavaFX CSS has no looked-up numeric values (styles.css
+                 header lines 28-31; TokenValidationTest + MainViewFxmlSpacingTest
+                 enforce numeric FXML Insets that are multiples of 4).
+
+                 Cell arrangement (preserves every existing fx:id + semantic
+                 order — story Non-Goal "preserve existing order"):
+                   1. projectInfoLabel — project name + "· kHz / bit / ch"
+                      (.body weight-500, NO purple; carries numerics so also
+                      .numeric-value). First cell → no leading dot.
+                      LockStatusIndicator is inserted right after this at
+                      runtime by mountLockStatusIndicator() (HBox index + 1).
+                   2. monitoringLabel  — mono/stereo/surround prose (.body)
+                   3. ioRoutingLabel   — "kHz I/O" (.numeric-value); keeps its
+                      HAND cursor + click handler (installIoLatencyClickHandler)
+                   4. cpuLabel/memLabel/dskLabel — STATIC PLACEHOLDER numeric
+                      cells (.numeric-value). No live system telemetry source
+                      exists in this codebase (PerformanceMonitor tracks only
+                      audio-DSP load); live wiring is a documented follow-on.
+                   5. <Region hgrow=ALWAYS> spacer → right-aligned trailing group
+                   6. checkpointLabel — the live last-save / autosave-state
+                      cell (§5.11 right group). Existing fx:id; consumed by
+                      updateCheckpointStatus() and ProjectLifecycleController
+                      ("Saved (checkpoint #N)"). .body, dot-prefixed. NO
+                      separate last-save / autosave placeholder cells are
+                      added — checkpointLabel already IS that data, so a
+                      dead sibling would only duplicate it (story Non-Goal
+                      "only existing cells migrated").
+                   7. rippleBannerLabel — unchanged (visible/managed false).
+                   8. statusBarLabel — transport "Ready/…" status (.body),
+                      dot-prefixed at design time. -->
             <HBox alignment="CENTER_LEFT" spacing="16" styleClass="status-bar">
                 <padding>
                     <Insets top="4" right="16" bottom="4" left="16"/>
                 </padding>
-                <!-- projectInfoLabel and ioRoutingLabel get rewritten at runtime
-                     to "… 96 kHz / 24-bit / 8ch" and "96 kHz I/O" by
-                     MainController#applyProjectInfoLabels(...) — story 266 /
-                     §3.2 numeric class so the sample-rate / bit-depth / channel
-                     digits use tabular figures. -->
                 <Label fx:id="projectInfoLabel" text="Untitled Project  ·  96 kHz / 24-bit"
-                       styleClass="project-info-label, numeric-caption"/>
-                <Separator orientation="VERTICAL"/>
-                <Label fx:id="monitoringLabel" text="Monitoring"
-                       styleClass="status-bar-label"/>
-                <Separator orientation="VERTICAL"/>
-                <Label fx:id="ioRoutingLabel" text="I/O"
-                       styleClass="status-bar-label, numeric-caption"/>
+                       styleClass="body, numeric-value"/>
+                <Label fx:id="monitoringLabel" text="· Stereo"
+                       styleClass="body"/>
+                <Label fx:id="ioRoutingLabel" text="· 96 kHz I/O"
+                       styleClass="body, numeric-value"/>
+                <Label fx:id="cpuLabel" text="· CPU --"
+                       styleClass="body, numeric-value"/>
+                <Label fx:id="memLabel" text="· MEM --"
+                       styleClass="body, numeric-value"/>
+                <Label fx:id="dskLabel" text="· DSK --"
+                       styleClass="body, numeric-value"/>
                 <Region HBox.hgrow="ALWAYS"/>
-                <Label fx:id="checkpointLabel" text="Auto-save: ON"
-                       styleClass="checkpoint-label"/>
-                <Separator orientation="VERTICAL"/>
+                <Label fx:id="checkpointLabel" text="· Auto-save: ON"
+                       styleClass="body"/>
                 <!-- Ripple-mode red banner (visible only when ripple is active) -->
                 <Label fx:id="rippleBannerLabel" text="" styleClass="ripple-banner"
                        visible="false" managed="false"/>
-                <Label fx:id="statusBarLabel" text="Ready" styleClass="status-bar-label"/>
+                <Label fx:id="statusBarLabel" text="· Ready" styleClass="body"/>
             </HBox>
         </VBox>
     </bottom>

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -790,13 +790,14 @@
 /* Prose / project-name body cell (story 274). The story says the
  * project filename uses ".body"; no .body rule existed in this file
  * and there is no .body token class — so this is the minimal
- * definition. -text colour + weight 500, NO purple accent (§5.11,
- * §7.6 project-info-purple veto). Sans family + size are inherited
- * (no override needed for the 24 px bar; mono numeric cells compose
- * .numeric-value on top, story 266 / §3.2). The old purple
+ * definition. -text colour + weight 500 + 12 px to match
+ * .numeric-value, NO purple accent (§5.11, §7.6 project-info-purple
+ * veto). Mono numeric cells compose .numeric-value on top,
+ * story 266 / §3.2). The old purple
  * .project-info-label rule was deleted (story 274). */
 .body {
     -fx-text-fill: -text;
+    -fx-font-size: 12px;
     -fx-font-weight: 500;
 }
 

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -748,29 +748,56 @@
     -fx-padding: 0 4 0 4;
 }
 
-/* ── Status Bar ── */
+/* ── Status Bar (story 274 — UI Design Book §5.11) ──
+ *
+ * A single row of dot-separated cells, surface-1, top border only.
+ *
+ * Reconciliations with the story text (codebase contracts win):
+ *  • §5.11 says "-surface-1 background"; the rule previously used
+ *    -surface-bg. Story wins → -surface-1.
+ *  • The story's `-fx-padding: -spacing-xs -spacing-lg` is NOT used:
+ *    JavaFX CSS has no looked-up numeric values (file header lines
+ *    28-31). The 4 px / 16 px padding stays as a numeric <Insets>
+ *    in main-view.fxml, guarded by TokenValidationTest +
+ *    MainViewFxmlSpacingTest. So this rule sets background/border only.
+ *  • §5.11 says "all cells: -text colour". The status-bar cells get
+ *    that from .body (-text + weight 500); numeric cells compose
+ *    .numeric-value on top for mono figures. .status-bar-label is
+ *    deliberately NOT repurposed for this — it is shared with
+ *    non-status-bar UI (TrackStripController io/output/param labels),
+ *    so it is left at its original -text-mute / 11 px and the status
+ *    bar simply no longer references it (changing it here would have
+ *    silently restyled the track strip). */
 .status-bar {
-    -fx-background-color: -surface-bg;
+    -fx-background-color: -surface-1;
     -fx-border-color: -line-soft transparent transparent transparent;
     -fx-border-width: 1 0 0 0;
 }
 
+/* Shared with TrackStripController (io/output/param labels) — NOT a
+ * status-bar cell class anymore (story 274). Left at its original
+ * values; do not fold the §5.11 -text rule into it. */
 .status-bar-label {
     -fx-text-fill: -text-mute;
     -fx-font-size: 11px;
 }
 
-.checkpoint-label {
-    -fx-text-fill: -ok;
-    -fx-font-size: 11px;
-    -fx-font-weight: bold;
-}
+/* .checkpoint-label (the old green/bold autosave style) was deleted in
+ * story 274: checkpointLabel is now a plain .body status-bar cell per
+ * §5.11 ("all cells -text colour, no per-cell colour"), so the rule
+ * had no remaining consumer (FXML or Java). */
 
-.project-info-label {
-    -fx-text-fill: -accent;
-    -fx-font-size: 11px;
-    -fx-text-overrun: ellipsis;
-    -fx-max-width: 300;
+/* Prose / project-name body cell (story 274). The story says the
+ * project filename uses ".body"; no .body rule existed in this file
+ * and there is no .body token class — so this is the minimal
+ * definition. -text colour + weight 500, NO purple accent (§5.11,
+ * §7.6 project-info-purple veto). Sans family + size are inherited
+ * (no override needed for the 24 px bar; mono numeric cells compose
+ * .numeric-value on top, story 266 / §3.2). The old purple
+ * .project-info-label rule was deleted (story 274). */
+.body {
+    -fx-text-fill: -text;
+    -fx-font-weight: 500;
 }
 
 /* ── Separator ── */

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarFxmlTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarFxmlTest.java
@@ -1,0 +1,187 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 274 — UI Design Book §5.11 / §7.7.
+ *
+ * <p>The status bar is a single row of dot-separated cells with
+ * <strong>zero</strong> {@code <Separator>} nodes. We parse
+ * {@code main-view.fxml} as XML rather than via {@link javafx.fxml.FXMLLoader}
+ * — loading the FXML through FXMLLoader transitively constructs
+ * {@link MainController}, whose {@code @FXML initialize()} spins up a real
+ * {@code AudioEngine}, autosave timers, etc. None of that is needed (or
+ * safe) for a structural check, and it would hang a headless test.
+ *
+ * <p>The secure {@link DocumentBuilderFactory} setup mirrors
+ * {@link NumericClassAuditTest} (FEATURE_SECURE_PROCESSING + DOCTYPE
+ * disabled, namespace-unaware so {@code fx:id} reads as a literal
+ * attribute).
+ */
+final class StatusBarFxmlTest {
+
+    private static final String FXML_RESOURCE =
+            "/com/benesquivelmusic/daw/app/ui/main-view.fxml";
+
+    /**
+     * The exact direct children of the {@code .status-bar} HBox, in order,
+     * as authored in {@code main-view.fxml}. The {@code LockStatusIndicator}
+     * is NOT in this list — it is inserted at runtime by
+     * {@link MainController#mountLockStatusIndicator()} (HBox index + 1
+     * after {@code projectInfoLabel}), not declared in the FXML.
+     *
+     * <p>Cells (9) + 1 spacer {@code <Region>} = 10 direct children:
+     * <ol>
+     *   <li>projectInfoLabel  (project name + format — first cell, no dot)
+     *   <li>monitoringLabel   (mono/stereo/surround prose)
+     *   <li>ioRoutingLabel    (kHz I/O — numeric, keeps click handler)
+     *   <li>cpuLabel          (static placeholder, numeric)
+     *   <li>memLabel          (static placeholder, numeric)
+     *   <li>dskLabel          (static placeholder, numeric)
+     *   <li><Region hgrow=ALWAYS>  (the single spacer)
+     *   <li>checkpointLabel   (live last-save / autosave cell — existing
+     *       fx:id kept; §5.11 right group. No separate last-save /
+     *       autosave placeholder cells: checkpointLabel already IS that
+     *       data, a dead sibling would only duplicate it.)
+     *   <li>rippleBannerLabel (visible/managed false)
+     *   <li>statusBarLabel    (transport status prose)
+     * </ol>
+     * That is 9 {@code <Label>} + 1 {@code <Region>} = 10 children.
+     */
+    private static final int EXPECTED_LABEL_CHILDREN = 9;
+    private static final int EXPECTED_SPACER_CHILDREN = 1;
+    private static final int EXPECTED_TOTAL_CHILDREN =
+            EXPECTED_LABEL_CHILDREN + EXPECTED_SPACER_CHILDREN;
+
+    @Test
+    void statusBarHasZeroSeparatorsAndExpectedChildCount() throws Exception {
+        Document doc = loadFxml();
+
+        Element statusBar = findStatusBarHBox(doc);
+        assertThat(statusBar)
+                .as("main-view.fxml must contain an <HBox styleClass=\"status-bar\">")
+                .isNotNull();
+
+        // 1. Zero <Separator> descendants anywhere inside the status bar.
+        NodeList separators = statusBar.getElementsByTagName("Separator");
+        assertThat(separators.getLength())
+                .as("The status bar must have ZERO <Separator> nodes — grouping "
+                        + "reads from the 16 px gap, not drawn lines "
+                        + "(story 274, UI Design Book §5.11 / §7.7).")
+                .isZero();
+
+        // 2. Direct children: <Label>* + exactly one <Region> spacer.
+        List<Element> directChildren = directElementChildren(statusBar);
+        long labels = directChildren.stream()
+                .filter(e -> "Label".equals(e.getTagName())).count();
+        long regions = directChildren.stream()
+                .filter(e -> "Region".equals(e.getTagName())).count();
+
+        assertThat(regions)
+                .as("The status bar must have exactly one <Region hgrow=ALWAYS> "
+                        + "spacer separating the left/centre cells from the "
+                        + "right-aligned trailing group (story 274 §5.11).")
+                .isEqualTo(EXPECTED_SPACER_CHILDREN);
+
+        assertThat(labels)
+                .as("The status bar must declare exactly %d <Label> cells "
+                        + "(every existing fx:id preserved + the new static "
+                        + "placeholder cells — story 274).", EXPECTED_LABEL_CHILDREN)
+                .isEqualTo(EXPECTED_LABEL_CHILDREN);
+
+        assertThat(directChildren.size())
+                .as("The status bar must have exactly %d direct children "
+                        + "(%d cells + %d spacer) — no Separator, no padding "
+                        + "<padding> element is counted (it is a property "
+                        + "element, not a child node).",
+                        EXPECTED_TOTAL_CHILDREN, EXPECTED_LABEL_CHILDREN,
+                        EXPECTED_SPACER_CHILDREN)
+                .isEqualTo(EXPECTED_TOTAL_CHILDREN);
+    }
+
+    /**
+     * Story 274 also removed the {@code .project-info-label} purple class
+     * from the FXML (§5.11 / §7.6 project-info-purple veto). Guard the
+     * regression directly.
+     */
+    @Test
+    void noStatusBarCellReferencesTheRemovedProjectInfoLabelClass() throws Exception {
+        Document doc = loadFxml();
+        List<String> offences = new ArrayList<>();
+        NodeList labels = doc.getElementsByTagName("Label");
+        for (int i = 0; i < labels.getLength(); i++) {
+            Element label = (Element) labels.item(i);
+            String styleClass = label.getAttribute("styleClass");
+            if (styleClass.contains("project-info-label")) {
+                offences.add("<Label fx:id=\"" + label.getAttribute("fx:id")
+                        + "\"> still carries the removed 'project-info-label' "
+                        + "purple class (story 274 — UI Design Book §7.6).");
+            }
+        }
+        assertThat(offences)
+                .as("The purple project-info-label class must be gone:%n%s",
+                        String.join(System.lineSeparator(), offences))
+                .isEmpty();
+    }
+
+    private static Element findStatusBarHBox(Document doc) {
+        NodeList hboxes = doc.getElementsByTagName("HBox");
+        for (int i = 0; i < hboxes.getLength(); i++) {
+            Element hbox = (Element) hboxes.item(i);
+            String styleClass = hbox.getAttribute("styleClass");
+            for (String token : styleClass.split("[,\\s]+")) {
+                if ("status-bar".equals(token)) {
+                    return hbox;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static List<Element> directElementChildren(Element parent) {
+        List<Element> out = new ArrayList<>();
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node n = children.item(i);
+            if (n instanceof Element child) {
+                // <padding> is a JavaFX property element, not a scene-graph
+                // child. The Separator/cell-count contract concerns scene
+                // children only, so exclude property elements explicitly.
+                if ("padding".equals(child.getTagName())) {
+                    continue;
+                }
+                out.add(child);
+            }
+        }
+        return out;
+    }
+
+    private static Document loadFxml() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        factory.setNamespaceAware(false);
+        try (InputStream in = StatusBarFxmlTest.class.getResourceAsStream(FXML_RESOURCE)) {
+            assertThat(in)
+                    .as("main-view.fxml must be on the test classpath at %s", FXML_RESOURCE)
+                    .isNotNull();
+            Document doc = factory.newDocumentBuilder().parse(in);
+            doc.getDocumentElement().normalize();
+            return doc;
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarFxmlTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarFxmlTest.java
@@ -11,6 +11,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,14 +38,17 @@ final class StatusBarFxmlTest {
     private static final String FXML_RESOURCE =
             "/com/benesquivelmusic/daw/app/ui/main-view.fxml";
 
+    private static final String MESSAGES_BUNDLE =
+            "com.benesquivelmusic.daw.app.i18n.Messages";
+
     /**
-     * The exact direct children of the {@code .status-bar} HBox, in order,
-     * as authored in {@code main-view.fxml}. The {@code LockStatusIndicator}
-     * is NOT in this list — it is inserted at runtime by
+     * The direct children of the {@code .status-bar} HBox, in order, as
+     * authored in {@code main-view.fxml}. {@code LockStatusIndicator} is
+     * NOT here — it is inserted at runtime by
      * {@link MainController#mountLockStatusIndicator()} (HBox index + 1
      * after {@code projectInfoLabel}), not declared in the FXML.
      *
-     * <p>Cells (9) + 1 spacer {@code <Region>} = 10 direct children:
+     * <p>9 cells + 1 spacer {@code <Region>} = 10 direct children:
      * <ol>
      *   <li>projectInfoLabel  (project name + format — first cell, no dot)
      *   <li>monitoringLabel   (mono/stereo/surround prose)
@@ -51,19 +57,25 @@ final class StatusBarFxmlTest {
      *   <li>memLabel          (static placeholder, numeric)
      *   <li>dskLabel          (static placeholder, numeric)
      *   <li><Region hgrow=ALWAYS>  (the single spacer)
-     *   <li>checkpointLabel   (live last-save / autosave cell — existing
-     *       fx:id kept; §5.11 right group. No separate last-save /
-     *       autosave placeholder cells: checkpointLabel already IS that
-     *       data, a dead sibling would only duplicate it.)
-     *   <li>rippleBannerLabel (visible/managed false)
-     *   <li>statusBarLabel    (transport status prose)
+     *   <li>checkpointLabel   (live last-save / autosave cell —
+     *       {@code <StatusCellLabel>}: written from ~30 dynamic sites, so
+     *       the type is the seam that guarantees its leading "· ")
+     *   <li>rippleBannerLabel (plain Label; visible/managed false — a
+     *       special banner, NOT a dot cell)
+     *   <li>statusBarLabel    (transport status — {@code <StatusCellLabel>}
+     *       for the same reason as checkpointLabel)
      * </ol>
-     * That is 9 {@code <Label>} + 1 {@code <Region>} = 10 children.
+     * A "cell" is any direct child that is not the {@code <Region>} spacer:
+     * {@code <Label>} or {@code <StatusCellLabel>}. Exactly two cells are
+     * {@code <StatusCellLabel>} — locking in the story-274 dot seam so a
+     * regression back to plain {@code <Label>} (which would drop the
+     * separator on the first runtime status update) fails this test.
      */
-    private static final int EXPECTED_LABEL_CHILDREN = 9;
+    private static final int EXPECTED_CELL_CHILDREN = 9;
     private static final int EXPECTED_SPACER_CHILDREN = 1;
+    private static final int EXPECTED_STATUS_CELL_LABELS = 2;
     private static final int EXPECTED_TOTAL_CHILDREN =
-            EXPECTED_LABEL_CHILDREN + EXPECTED_SPACER_CHILDREN;
+            EXPECTED_CELL_CHILDREN + EXPECTED_SPACER_CHILDREN;
 
     @Test
     void statusBarHasZeroSeparatorsAndExpectedChildCount() throws Exception {
@@ -82,12 +94,14 @@ final class StatusBarFxmlTest {
                         + "(story 274, UI Design Book §5.11 / §7.7).")
                 .isZero();
 
-        // 2. Direct children: <Label>* + exactly one <Region> spacer.
+        // 2. Direct children: cells (<Label>|<StatusCellLabel>) + 1 <Region>.
         List<Element> directChildren = directElementChildren(statusBar);
-        long labels = directChildren.stream()
-                .filter(e -> "Label".equals(e.getTagName())).count();
         long regions = directChildren.stream()
                 .filter(e -> "Region".equals(e.getTagName())).count();
+        long cells = directChildren.stream()
+                .filter(e -> !"Region".equals(e.getTagName())).count();
+        long statusCellLabels = directChildren.stream()
+                .filter(e -> "StatusCellLabel".equals(e.getTagName())).count();
 
         assertThat(regions)
                 .as("The status bar must have exactly one <Region hgrow=ALWAYS> "
@@ -95,43 +109,95 @@ final class StatusBarFxmlTest {
                         + "right-aligned trailing group (story 274 §5.11).")
                 .isEqualTo(EXPECTED_SPACER_CHILDREN);
 
-        assertThat(labels)
-                .as("The status bar must declare exactly %d <Label> cells "
-                        + "(every existing fx:id preserved + the new static "
-                        + "placeholder cells — story 274).", EXPECTED_LABEL_CHILDREN)
-                .isEqualTo(EXPECTED_LABEL_CHILDREN);
+        assertThat(cells)
+                .as("The status bar must declare exactly %d cells "
+                        + "(<Label> or <StatusCellLabel> — every existing fx:id "
+                        + "preserved + the new static placeholder cells, "
+                        + "story 274).", EXPECTED_CELL_CHILDREN)
+                .isEqualTo(EXPECTED_CELL_CHILDREN);
+
+        assertThat(statusCellLabels)
+                .as("checkpointLabel and statusBarLabel must be "
+                        + "<StatusCellLabel> (not plain <Label>): they are "
+                        + "written from ~30 dynamic sites, so the type is the "
+                        + "single seam that keeps their leading \"· \" "
+                        + "separator (story 274 S1). A regression to <Label> "
+                        + "would silently drop the dot on the first runtime "
+                        + "status update.")
+                .isEqualTo(EXPECTED_STATUS_CELL_LABELS);
 
         assertThat(directChildren.size())
                 .as("The status bar must have exactly %d direct children "
-                        + "(%d cells + %d spacer) — no Separator, no padding "
-                        + "<padding> element is counted (it is a property "
-                        + "element, not a child node).",
-                        EXPECTED_TOTAL_CHILDREN, EXPECTED_LABEL_CHILDREN,
+                        + "(%d cells + %d spacer) — no Separator; the "
+                        + "<padding> property element is not counted.",
+                        EXPECTED_TOTAL_CHILDREN, EXPECTED_CELL_CHILDREN,
                         EXPECTED_SPACER_CHILDREN)
                 .isEqualTo(EXPECTED_TOTAL_CHILDREN);
     }
 
     /**
      * Story 274 also removed the {@code .project-info-label} purple class
-     * from the FXML (§5.11 / §7.6 project-info-purple veto). Guard the
-     * regression directly.
+     * from the FXML (§5.11 / §7.6 project-info-purple veto). Scans every
+     * element (any tag, including {@code <StatusCellLabel>}) so the guard
+     * cannot be evaded by a cell-type change.
      */
     @Test
     void noStatusBarCellReferencesTheRemovedProjectInfoLabelClass() throws Exception {
         Document doc = loadFxml();
         List<String> offences = new ArrayList<>();
-        NodeList labels = doc.getElementsByTagName("Label");
-        for (int i = 0; i < labels.getLength(); i++) {
-            Element label = (Element) labels.item(i);
-            String styleClass = label.getAttribute("styleClass");
-            if (styleClass.contains("project-info-label")) {
-                offences.add("<Label fx:id=\"" + label.getAttribute("fx:id")
-                        + "\"> still carries the removed 'project-info-label' "
-                        + "purple class (story 274 — UI Design Book §7.6).");
+        NodeList all = doc.getElementsByTagName("*");
+        for (int i = 0; i < all.getLength(); i++) {
+            Element el = (Element) all.item(i);
+            if (el.getAttribute("styleClass").contains("project-info-label")) {
+                offences.add("<" + el.getTagName() + " fx:id=\""
+                        + el.getAttribute("fx:id") + "\"> still carries the "
+                        + "removed 'project-info-label' purple class "
+                        + "(story 274 — UI Design Book §7.6).");
             }
         }
         assertThat(offences)
                 .as("The purple project-info-label class must be gone:%n%s",
+                        String.join(System.lineSeparator(), offences))
+                .isEmpty();
+    }
+
+    /**
+     * Story 274 S2 — the CPU/MEM/DSK placeholder cells have their
+     * authoritative text in {@code Messages.properties} (the controller
+     * overwrites from the bundle at init), but also a design-time
+     * {@code text="…"} in the FXML. Pin the two to the same value so a
+     * maintainer editing one cannot let them silently drift.
+     */
+    @Test
+    void cpuMemDskDesignTimeTextMatchesMessagesBundle() throws Exception {
+        Document doc = loadFxml();
+        ResourceBundle bundle = ResourceBundle.getBundle(MESSAGES_BUNDLE, Locale.ROOT);
+
+        Map<String, String> fxIdToKey = Map.of(
+                "cpuLabel", "statusbar.cpu",
+                "memLabel", "statusbar.mem",
+                "dskLabel", "statusbar.dsk");
+
+        List<String> offences = new ArrayList<>();
+        for (Map.Entry<String, String> e : fxIdToKey.entrySet()) {
+            Element cell = findElementByFxId(doc, e.getKey());
+            if (cell == null) {
+                offences.add("Placeholder cell fx:id=\"" + e.getKey()
+                        + "\" is missing from main-view.fxml (story 274).");
+                continue;
+            }
+            String fxmlText = cell.getAttribute("text");
+            String bundleText = bundle.getString(e.getValue());
+            if (!bundleText.equals(fxmlText)) {
+                offences.add("fx:id=\"" + e.getKey() + "\" design-time text \""
+                        + fxmlText + "\" != Messages key '" + e.getValue()
+                        + "' = \"" + bundleText + "\" — the two sources of "
+                        + "truth have drifted (story 274 S2).");
+            }
+        }
+        assertThat(offences)
+                .as("FXML design-time text and Messages.properties must "
+                        + "agree for the CPU/MEM/DSK placeholders:%n%s",
                         String.join(System.lineSeparator(), offences))
                 .isEmpty();
     }
@@ -145,6 +211,17 @@ final class StatusBarFxmlTest {
                 if ("status-bar".equals(token)) {
                     return hbox;
                 }
+            }
+        }
+        return null;
+    }
+
+    private static Element findElementByFxId(Document doc, String fxId) {
+        NodeList all = doc.getElementsByTagName("*");
+        for (int i = 0; i < all.getLength(); i++) {
+            Element el = (Element) all.item(i);
+            if (fxId.equals(el.getAttribute("fx:id"))) {
+                return el;
             }
         }
         return null;

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarMonoNumericsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarMonoNumericsTest.java
@@ -1,0 +1,111 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 274 — every numeric status-bar cell carries {@code .numeric-value}
+ * (mono tabular figures per story 266 / UI Design Book §3.2, §5.11).
+ *
+ * <p><b>Reconciliation note (story text vs. codebase contract):</b> the
+ * existing status labels used {@code .numeric-caption} (11 px). Story §5.11
+ * explicitly prescribes {@code .numeric-value} for the status-bar numeric
+ * cells, so this test asserts {@code .numeric-value} (the switch is
+ * documented in main-view.fxml). {@code NumericClassAuditTest} accepts any
+ * of the four numeric classes, so it stays green either way.
+ *
+ * <p>Structural XML parse — no FXMLLoader (it would boot the AudioEngine
+ * via {@code MainController.initialize()}).
+ */
+final class StatusBarMonoNumericsTest {
+
+    private static final String FXML_RESOURCE =
+            "/com/benesquivelmusic/daw/app/ui/main-view.fxml";
+
+    /**
+     * The status-bar cells whose displayed value is a number per §5.11
+     * (sample-rate / bit-depth / channels live in projectInfoLabel; the
+     * kHz I/O figure in ioRoutingLabel; the CPU/MEM/DSK placeholders).
+     * The prose cells — monitoringLabel, checkpointLabel, statusBarLabel,
+     * rippleBannerLabel — are NOT numeric and carry {@code .body} only.
+     */
+    private static final List<String> NUMERIC_CELL_IDS = List.of(
+            "projectInfoLabel",
+            "ioRoutingLabel",
+            "cpuLabel",
+            "memLabel",
+            "dskLabel");
+
+    @Test
+    void everyNumericStatusBarCellCarriesNumericValueClass() throws Exception {
+        Document doc = loadFxml();
+
+        List<String> offences = new ArrayList<>();
+        NodeList labels = doc.getElementsByTagName("Label");
+        for (String id : NUMERIC_CELL_IDS) {
+            Element label = findLabelByFxId(labels, id);
+            if (label == null) {
+                offences.add("Numeric status-bar cell fx:id=\"" + id
+                        + "\" is missing from main-view.fxml (story 274).");
+                continue;
+            }
+            String styleClass = label.getAttribute("styleClass");
+            if (!containsClass(styleClass, "numeric-value")) {
+                offences.add("<Label fx:id=\"" + id + "\" styleClass=\""
+                        + styleClass + "\"> must carry 'numeric-value' "
+                        + "(story 274 §5.11 / story 266 §3.2).");
+            }
+        }
+
+        assertThat(offences)
+                .as("Every numeric status-bar cell must carry the "
+                        + "'numeric-value' mono class:%n%s",
+                        String.join(System.lineSeparator(), offences))
+                .isEmpty();
+    }
+
+    private static Element findLabelByFxId(NodeList labels, String fxId) {
+        for (int i = 0; i < labels.getLength(); i++) {
+            Element label = (Element) labels.item(i);
+            if (fxId.equals(label.getAttribute("fx:id"))) {
+                return label;
+            }
+        }
+        return null;
+    }
+
+    private static boolean containsClass(String styleClassAttr, String className) {
+        if (styleClassAttr == null || styleClassAttr.isBlank()) return false;
+        for (String token : styleClassAttr.split("[,\\s]+")) {
+            if (token.equals(className)) return true;
+        }
+        return false;
+    }
+
+    private static Document loadFxml() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        factory.setNamespaceAware(false);
+        try (InputStream in = StatusBarMonoNumericsTest.class.getResourceAsStream(FXML_RESOURCE)) {
+            assertThat(in)
+                    .as("main-view.fxml must be on the test classpath at %s", FXML_RESOURCE)
+                    .isNotNull();
+            Document doc = factory.newDocumentBuilder().parse(in);
+            doc.getDocumentElement().normalize();
+            return doc;
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarStyleTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarStyleTest.java
@@ -1,0 +1,164 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+/**
+ * Story 274 — renders the project-filename status-bar cell and asserts the
+ * UI Design Book §5.11 colour contract: the project filename is
+ * {@code -text} weight 500, with <strong>no</strong> purple accent (the
+ * {@code .project-info-label} purple was removed; §7.6 veto).
+ *
+ * <p>Fixture pattern mirrors {@link TokenResolutionSmokeTest}: a
+ * {@code BorderPane.root-pane} (the same token anchor {@code main-view.fxml}
+ * declares) with {@code styles.css} attached, then {@code applyCss()} +
+ * {@code layout()} on the FX thread. It deliberately does <em>not</em> load
+ * {@code main-view.fxml} via {@link javafx.fxml.FXMLLoader} — that boots
+ * {@code MainController.initialize()} (real AudioEngine, autosave timers)
+ * and would hang a headless test.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class StatusBarStyleTest {
+
+    private static final String STYLES_CSS_RESOURCE =
+            "/com/benesquivelmusic/daw/app/ui/styles.css";
+
+    /** Palette A — UI Design Book §3.1. */
+    private static final Color TEXT = Color.web("#B7BCC7");
+    private static final Color ACCENT = Color.web("#7C8CFF");
+
+    @Test
+    void projectFilenameCellResolvesToTextColourNotPurple() throws Exception {
+        Color fill = onFxThread(() -> {
+            BorderPane rootPane = new BorderPane();
+            rootPane.getStyleClass().add("root-pane");
+
+            // Reproduce the project-filename cell exactly: same style
+            // classes (.body composes the -text/weight-500 colour;
+            // .numeric-value composes the mono typography) inside a
+            // .status-bar HBox with the same numeric padding the FXML
+            // declares (top=4 right=16 bottom=4 left=16).
+            HBox statusBar = new HBox(16);
+            statusBar.getStyleClass().add("status-bar");
+            statusBar.setPadding(new Insets(4, 16, 4, 16));
+
+            Label projectInfo = new Label("Untitled Project  ·  96 kHz / 24-bit / 8ch");
+            projectInfo.getStyleClass().addAll("body", "numeric-value");
+            statusBar.getChildren().add(projectInfo);
+
+            rootPane.setBottom(statusBar);
+
+            Scene scene = new Scene(rootPane, 600, 200);
+            URL css = getClass().getResource(STYLES_CSS_RESOURCE);
+            assertThat(css)
+                    .as("styles.css must be on the test classpath at %s", STYLES_CSS_RESOURCE)
+                    .isNotNull();
+            scene.getStylesheets().add(css.toExternalForm());
+            rootPane.applyCss();
+            rootPane.layout();
+
+            Paint textFill = projectInfo.getTextFill();
+            assertThat(textFill)
+                    .as("project-filename cell text fill must be a Color")
+                    .isInstanceOf(Color.class);
+            return (Color) textFill;
+        });
+
+        // Strict: must be -text (#B7BCC7), component-wise within the same
+        // tolerance the token smoke test uses (CSS rounds 8-bit channels
+        // through double precision).
+        assertThat(fill.getRed())
+                .as("project filename red component must resolve to -text")
+                .isCloseTo(TEXT.getRed(), offset(0.002));
+        assertThat(fill.getGreen())
+                .as("project filename green component must resolve to -text")
+                .isCloseTo(TEXT.getGreen(), offset(0.002));
+        assertThat(fill.getBlue())
+                .as("project filename blue component must resolve to -text")
+                .isCloseTo(TEXT.getBlue(), offset(0.002));
+
+        // And it must NOT be the purple accent (the §7.6 regression guard).
+        boolean isAccent =
+                Math.abs(fill.getRed() - ACCENT.getRed()) < 0.01
+                        && Math.abs(fill.getGreen() - ACCENT.getGreen()) < 0.01
+                        && Math.abs(fill.getBlue() - ACCENT.getBlue()) < 0.01;
+        assertThat(isAccent)
+                .as("project filename must NOT be the -accent purple "
+                        + "(#7C8CFF) — the .project-info-label purple was "
+                        + "removed in story 274 (UI Design Book §7.6).")
+                .isFalse();
+    }
+
+    @Test
+    void statusBarHeightResolvesToApproximately24px() throws Exception {
+        double height = onFxThread(() -> {
+            BorderPane rootPane = new BorderPane();
+            rootPane.getStyleClass().add("root-pane");
+
+            HBox statusBar = new HBox(16);
+            statusBar.getStyleClass().add("status-bar");
+            statusBar.setPadding(new Insets(4, 16, 4, 16));
+            Label cell = new Label("44.1 kHz");
+            cell.getStyleClass().addAll("body", "numeric-value");
+            statusBar.getChildren().add(cell);
+            rootPane.setBottom(statusBar);
+
+            Scene scene = new Scene(rootPane, 600, 200);
+            URL css = getClass().getResource(STYLES_CSS_RESOURCE);
+            scene.getStylesheets().add(css.toExternalForm());
+            rootPane.applyCss();
+            rootPane.layout();
+            return statusBar.getHeight();
+        });
+
+        // §5.11 prescribes 24 px (8 px vertical padding + ~12 px mono line
+        // height + 1 px top border). Headless font metrics vary, so a
+        // ±5 px tolerance keeps the assertion meaningful without being
+        // flaky on the headless Glass platform — the text-fill assertion
+        // above is the strict contract; this is a sanity bound.
+        assertThat(height)
+                .as("status bar height should resolve to ~24 px "
+                        + "(story 274 §5.11) — got %.2f px", height)
+                .isBetween(19.0, 29.0);
+    }
+
+    private static <T> T onFxThread(Supplier<T> supplier) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(supplier.get());
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("FX thread did not complete within 5 seconds");
+        }
+        if (err.get() != null) {
+            throw new RuntimeException("FX thread action failed", err.get());
+        }
+        return ref.get();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusCellLabelTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusCellLabelTest.java
@@ -1,0 +1,88 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 274 S1 — {@link StatusCellLabel} is the single seam that keeps the
+ * leading "· " separator on the non-first status-bar cells
+ * ({@code checkpointLabel}, {@code statusBarLabel}) no matter which of the
+ * ~30 writers in MainController / TransportController /
+ * ProjectLifecycleController set the text. These tests pin that behaviour
+ * directly (the FXML test only pins that the <em>type</em> is used).
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class StatusCellLabelTest {
+
+    @Test
+    void bareTextGetsTheLeadingSeparator() {
+        assertThat(textAfterSet("Stopped"))
+                .isEqualTo(StatusCellLabel.CELL_SEPARATOR + "Stopped");
+    }
+
+    @Test
+    void dynamicWriterMessageGetsTheSeparator() {
+        // The exact shape ProjectLifecycleController emits — the S1 case.
+        assertThat(textAfterSet("Saved (checkpoint #3)"))
+                .isEqualTo("· Saved (checkpoint #3)");
+    }
+
+    @Test
+    void alreadyPrefixedTextIsLeftUnchanged_idempotent() {
+        // Bundle values / design-time FXML carry the dot for cross-cell
+        // uniformity; the seam must not double it.
+        assertThat(textAfterSet("· Auto-save: ON"))
+                .isEqualTo("· Auto-save: ON");
+    }
+
+    @Test
+    void blankAndNullAreLeftUntouched() {
+        assertThat(textAfterSet("")).isEmpty();
+        assertThat(textAfterSet("   ")).isEqualTo("   ");
+        assertThat(textAfterSet(null)).isNull();
+    }
+
+    private static String textAfterSet(String value) {
+        return onFxThread(() -> {
+            StatusCellLabel label = new StatusCellLabel();
+            label.setText(value);
+            return label.getText();
+        });
+    }
+
+    private static <T> T onFxThread(Supplier<T> supplier) {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(supplier.get());
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("FX thread did not complete within 5 seconds");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("interrupted waiting for FX thread", e);
+        }
+        if (err.get() != null) {
+            throw new RuntimeException("FX thread action failed", err.get());
+        }
+        return ref.get();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusCellLabelTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusCellLabelTest.java
@@ -45,6 +45,14 @@ final class StatusCellLabelTest {
     }
 
     @Test
+    void leadingDotWithoutSpaceIsNormalized() {
+        // "·Auto-save" carries the middle dot but not the required trailing
+        // space — the seam normalises it to "· Auto-save" (CELL_SEPARATOR).
+        assertThat(textAfterSet("·Auto-save"))
+                .isEqualTo(StatusCellLabel.CELL_SEPARATOR + "Auto-save");
+    }
+
+    @Test
     void blankAndNullAreLeftUntouched() {
         assertThat(textAfterSet("")).isEmpty();
         assertThat(textAfterSet("   ")).isEqualTo("   ");


### PR DESCRIPTION
# Status Bar as a Single Row of Dot-Separated Cells, No Separator Nodes

## Motivation

Phase 2 of the UI Design Book §6 migration roadmap. Builds on user stories: 260, 261, 263, and 266 (mono numerics).

UI Design Book §5.11 ("Status bar") and §7.7 ("Separators between every cell") describe a small but high-visibility cleanup. Today the status bar lives in `main-view.fxml:152–172` and mixes labels with `Separator` nodes between cells:

```xml
<Label fx:id="sampleRateLabel" text="44.1 kHz" .../>
<Separator orientation="VERTICAL"/>
<Label fx:id="bitDepthLabel" text="24-bit" .../>
<Separator orientation="VERTICAL"/>
<Label fx:id="projectInfoLabel" text="Untitled.daw" styleClass="project-info-label"/>
```

`project-info-label` is purple per the current style (`styles.css` near the bottom). §1.6 (no design tokens) and §7.6 (saturated section headers / project-info purple) both call this out — it's the most prominent piece of purple still left in the chrome after Phase 1.

UI Design Book §5.11 spec:
- 24 px tall, `-surface-1` background.
- Cells separated by 16 px gaps — *no* separator lines.
- Right-aligned cells: time of last save, autosave state.
- All cells: `-text` colour, `.numeric-value` (mono per story 266) for numeric cells, `.body` for prose cells.
- Project filename is `-text` weight 500 — **no colour**.

## Goals

- Rewrite the status bar in `daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml`:
  - Single `HBox` with `spacing="16"` (matches `-spacing-lg` from story 261).
  - Remove every `<Separator/>` node.
  - Each cell is one `Label` or one tiny `HBox` (for cells that are an icon + value).
  - Project filename uses `.body` style; **remove** `.project-info-label` style class.
  - Right-aligned cells (last-save time, autosave state) sit in a trailing `Region` with `HBox.hgrow="ALWAYS"` followed by another `HBox` that hosts them. Use the existing `spacer` pattern.
- Remove the `.project-info-label` rule (and any companion purple styling) from `daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css`.
- Add a `.status-bar` rule with:
  - `-fx-background-color: -surface-1`
  - `-fx-padding: -spacing-xs -spacing-lg` (4 px vertical, 16 px horizontal — matches §5.11's 24 px height)
  - `-fx-border-color: -line-soft`
  - `-fx-border-width: 1 0 0 0` (top border only — visually separates from the panel above)
- Add dot separators between cells. Implementation: instead of inserting `·` labels between cells (which clutters the FXML), use a CSS `:not(:first-child)` pseudo-class pattern by drawing the dot as a leading character of each cell beyond the first via a `dot-cell` style class. (JavaFX CSS supports `:hover`, `:focused`, etc.; `:first-child` is *not* in the JavaFX CSS subset — so use an explicit `.dot-cell` style class on each cell-after-the-first and let CSS prepend the dot via a `Label`'s text. Document this in the file.)
  - Alternative implementation (cleaner): write the FXML labels as `"44.1 kHz"`, `"· 24-bit"`, `"· ASIO Focusrite USB"`, etc. — the dot is part of the text. Acceptable per §5.11.
- Cells (per the §5.11 mockup `44.1 kHz · 24-bit · ASIO Focusrite USB · 64 spl | CPU 18% · MEM 1.4 GB · DSK 4 MB/s | Saved 14:22:01`):
  - Left group: sample rate, bit depth, IO device, buffer size (spl).
  - Centre group: CPU %, memory, disk throughput.
  - Right group: last save time, autosave state.
- Verify the `MainController` still updates each label by `fx:id`. Add new `fx:id`s for cells that didn't have one (e.g. `cpuLabel`, `memLabel`, `dskLabel`, `lastSaveLabel`, `autosaveStateLabel`).
- Tests:
  - `StatusBarFxmlTest`: parse `main-view.fxml`, locate the `.status-bar` HBox, assert child count is `cells + 1 spacer` and that the count of `Separator` children is 0.
  - `StatusBarStyleTest`: render the scene, assert `projectInfoLabel`'s text-fill is `-text` (not purple). Assert the status bar's height resolves to 24 ± 2 px (24 px content; small variance from font metrics).
  - `StatusBarMonoNumericsTest`: assert each numeric cell carries `.numeric-value` style class per story 266.

## Non-Goals

- Adding new status indicators (e.g., online/offline, MIDI clock state, network status) — out of scope; only existing cells are migrated.
- Making cells clickable to open settings (e.g. clicking sample rate → audio settings) — that is a nice-to-have follow-on.
- Custom tooltip styling on status cells — defer.
- Reordering cells to a different priority — preserve existing semantic order.

## Technical Notes

- The "no separator lines, use 16 px gaps" rule means the eye reads grouping from *spacing*, not from drawn lines. Story 264's grid (16 px = `-spacing-lg`) is exactly the right gap size for this purpose; per the UI Design Book §3.3 spacing scale, 16 px is the "panel padding" tier, and using it inside the status bar is consistent.
- If keeping FXML legibility wins over CSS purity, accept the "dot as part of the label text" approach. The footprint test still passes.
- Any newly introduced static prefix labels ("Saved", "CPU", "MEM", "DSK", autosave-state strings like "Saved", "Saving…", "Autosave off") come from the existing `Messages.properties` resource bundle. Numeric values themselves are dynamic and unchanged. Skill §14.
- Reference: UI Design Book §5.11, §7.6 (project-info-purple veto — implicit AC), §7.7 (separator veto — implicit AC).
