### PR TITLE
275 browser panel accent bar search and row audition

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
@@ -5,44 +5,79 @@ import com.benesquivelmusic.daw.app.ui.drag.DragVisualAdvisor;
 import com.benesquivelmusic.daw.app.ui.drag.DropTargetKind;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCombination;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.text.Text;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.logging.Logger;
 
 /**
  * A resizable side panel for browsing audio samples, presets, project files,
- * and navigating the local file system.
+ * and navigating the local file system (UI Design Book §5.5, §7.1, §7.3,
+ * story 275).
  *
- * <p>The panel contains a search/filter bar at the top and a tabbed section
- * with four tabs:</p>
+ * <p>The panel is a hand-built tab strip ({@link HBox} of unified
+ * {@code .dawg-button} toggles, story 264) over a content
+ * {@link StackPane} — <em>not</em> a {@link TabPane}. The active tab
+ * carries an {@code -accent} 2 px under-text bar drawn as a child
+ * {@link Rectangle} ({@code .browser-tab-indicator}), the same
+ * "drawn bar, not a CSS border" discipline as {@link NotificationPill}
+ * (§7.3 — no border swap, no layout shift).</p>
+ *
+ * <p>The four sections are:</p>
  * <ul>
- *   <li><b>File System</b> — Navigate local directories filtered by audio file type</li>
- *   <li><b>Samples</b> — Dedicated sample library with preview playback</li>
- *   <li><b>Presets</b> — Plugin preset browser</li>
- *   <li><b>Project Files</b> — Quick access to recently used audio files</li>
+ *   <li><b>Files</b> — local file-system tree filtered to audio types</li>
+ *   <li><b>Samples</b> — sample library with per-row audition</li>
+ *   <li><b>Presets</b> — plugin preset names (not audio — no audition)</li>
+ *   <li><b>Project</b> — recently used audio files</li>
  * </ul>
  *
- * <p>Uses existing CSS classes and follows the dark neon theme styling of the
- * application.</p>
+ * <p>A persistent search field sits below the tab strip; its text is
+ * preserved across tab switches and is re-applied to the newly active
+ * section's list. {@code Ctrl+F} while the panel is focused moves focus
+ * into the search field.</p>
+ *
+ * <p>Every list row (Samples / Presets / Project) carries an audition
+ * button when the row is an audio file. Clicking it drives the injected
+ * {@link SampleAuditioner}; the icon swaps to a pause-circle while that
+ * row is playing. With no auditioner installed the button is
+ * {@code :disabled} (the unified {@code .dawg-button:disabled} rule).</p>
  */
 public final class BrowserPanel extends VBox {
 
     private static final Logger LOG = Logger.getLogger(BrowserPanel.class.getName());
+
+    /** Resource bundle for chrome strings (Skill §14) — Locale.ROOT. */
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
 
     /** Supported audio file extensions for filtering. */
     static final Set<String> AUDIO_EXTENSIONS = Set.of(
@@ -52,10 +87,33 @@ public final class BrowserPanel extends VBox {
     private static final double DEFAULT_WIDTH = 250.0;
     private static final double MIN_WIDTH = 180.0;
     private static final double ICON_SIZE = 14.0;
-    private static final double PREVIEW_ICON_SIZE = 12.0;
+    private static final double TAB_ICON_SIZE = 12.0;
+    private static final double AUDITION_ICON_SIZE = 16.0;
+    private static final double INDICATOR_HEIGHT = 2.0;
+
+    /**
+     * The four browser sections. Replaces the former {@code TabPane} +
+     * {@code Tab} model (story 275). Order is the tab-strip order.
+     */
+    public enum BrowserSection {
+        /** Local file-system tree. */
+        FILES,
+        /** Sample library. */
+        SAMPLES,
+        /** Plugin preset names. */
+        PRESETS,
+        /** Recently used project audio files. */
+        PROJECT
+    }
 
     private final TextField searchField;
-    private final TabPane tabPane;
+
+    private final HBox tabStrip;
+    private final StackPane contentArea;
+    private final Map<BrowserSection, Button> tabButtons = new EnumMap<>(BrowserSection.class);
+    private final Map<BrowserSection, Rectangle> tabIndicators = new EnumMap<>(BrowserSection.class);
+    private final Map<BrowserSection, Node> sectionContent = new EnumMap<>(BrowserSection.class);
+
     private final TreeView<String> fileSystemTree;
     private final ListView<String> samplesListView;
     private final ListView<String> presetsListView;
@@ -68,11 +126,20 @@ public final class BrowserPanel extends VBox {
     private final FilteredList<String> filteredPresetItems;
     private final FilteredList<String> filteredProjectFileItems;
 
-    private final Button previewPlayButton;
-    private final Button previewStopButton;
-    private final Slider previewVolumeSlider;
-    private final Label previewMetadataLabel;
-    private final HBox previewControlBar;
+    private BrowserSection activeSection = BrowserSection.FILES;
+
+    /**
+     * The injected single-channel auditioner (story 275). When
+     * {@code null} every row's audition button is {@code :disabled}.
+     */
+    private SampleAuditioner sampleAuditioner;
+
+    /**
+     * The path currently being auditioned, or {@code null}. Used so only
+     * the playing row shows the pause-circle glyph; the engine itself is
+     * single-channel so at most one path is ever active.
+     */
+    private volatile String auditioningItem;
 
     /**
      * The shared {@link DragVisualAdvisor} consulted on every sample-drag
@@ -96,18 +163,21 @@ public final class BrowserPanel extends VBox {
         headerLabel.getStyleClass().add("panel-header");
         headerLabel.setGraphic(IconNode.of(DawIcon.LIBRARY, ICON_SIZE));
 
-        // ── Search/Filter bar ───────────────────────────────────────────────
+        // ── Persistent search field (story 275, UI Design Book §5.5) ────────
+        // SEARCH icon (story 265) as a leading affordance; the text is
+        // preserved across tab switches and re-applied on selectSection.
         searchField = new TextField();
-        searchField.setPromptText("Filter files...");
-        searchField.getStyleClass().add("browser-search-field");
+        searchField.setPromptText(msg("browser.search.placeholder"));
+        searchField.getStyleClass().add("search-field");
         HBox searchBar = new HBox(4);
+        searchBar.getStyleClass().add("browser-search-bar");
         searchBar.setAlignment(Pos.CENTER_LEFT);
         Label searchIcon = new Label();
-        searchIcon.setGraphic(IconNode.of(DawIcon.SEARCH, 12));
+        searchIcon.setGraphic(IconNode.of(DawIcon.SEARCH, TAB_ICON_SIZE));
         HBox.setHgrow(searchField, Priority.ALWAYS);
         searchBar.getChildren().addAll(searchIcon, searchField);
 
-        // ── File System tab ─────────────────────────────────────────────────
+        // ── Files section — file-system tree ────────────────────────────────
         TreeItem<String> rootItem = new TreeItem<>("File System");
         rootItem.setExpanded(true);
         addUserHomeDirectories(rootItem);
@@ -117,6 +187,7 @@ public final class BrowserPanel extends VBox {
         VBox.setVgrow(fileSystemTree, Priority.ALWAYS);
 
         // Enable drag-and-drop from the file tree onto the arrangement view
+        // (story 197 — preserved through the story-275 refactor).
         fileSystemTree.setOnDragDetected(event -> {
             TreeItem<String> selected = fileSystemTree.getSelectionModel().getSelectedItem();
             if (selected != null && isAudioFile(selected.getValue())) {
@@ -133,19 +204,16 @@ public final class BrowserPanel extends VBox {
         });
         fileSystemTree.setOnDragDone(this::notifyAdvisorEndDrag);
 
-        Tab fileSystemTab = new Tab("Files");
-        fileSystemTab.setClosable(false);
-        fileSystemTab.setGraphic(IconNode.of(DawIcon.FOLDER, 12));
-        fileSystemTab.setContent(fileSystemTree);
-
-        // ── Samples tab ─────────────────────────────────────────────────────
+        // ── Samples section ─────────────────────────────────────────────────
         sampleItems = FXCollections.observableArrayList();
         filteredSampleItems = new FilteredList<>(sampleItems, item -> true);
         samplesListView = new ListView<>(filteredSampleItems);
         samplesListView.setPlaceholder(new Label("No samples found"));
         samplesListView.getStyleClass().add("browser-list");
+        samplesListView.setCellFactory(lv -> new BrowserRowCell());
 
         // Enable drag-and-drop from the samples list onto the arrangement view
+        // (story 197 — preserved through the story-275 refactor).
         samplesListView.setOnDragDetected(event -> {
             String selected = samplesListView.getSelectionModel().getSelectedItem();
             if (selected != null && isAudioFile(selected)) {
@@ -159,91 +227,172 @@ public final class BrowserPanel extends VBox {
         });
         samplesListView.setOnDragDone(this::notifyAdvisorEndDrag);
 
-        Tab samplesTab = new Tab("Samples");
-        samplesTab.setClosable(false);
-        samplesTab.setGraphic(IconNode.of(DawIcon.WAVEFORM, 12));
-        samplesTab.setContent(samplesListView);
-
-        // ── Presets tab ─────────────────────────────────────────────────────
+        // ── Presets section ─────────────────────────────────────────────────
         presetItems = FXCollections.observableArrayList();
         filteredPresetItems = new FilteredList<>(presetItems, item -> true);
         presetsListView = new ListView<>(filteredPresetItems);
         presetsListView.setPlaceholder(new Label("No presets found"));
         presetsListView.getStyleClass().add("browser-list");
+        presetsListView.setCellFactory(lv -> new BrowserRowCell());
 
-        Tab presetsTab = new Tab("Presets");
-        presetsTab.setClosable(false);
-        presetsTab.setGraphic(IconNode.of(DawIcon.KNOB, 12));
-        presetsTab.setContent(presetsListView);
-
-        // ── Project Files tab ───────────────────────────────────────────────
+        // ── Project Files section ───────────────────────────────────────────
         projectFileItems = FXCollections.observableArrayList();
         filteredProjectFileItems = new FilteredList<>(projectFileItems, item -> true);
         projectFilesListView = new ListView<>(filteredProjectFileItems);
         projectFilesListView.setPlaceholder(new Label("No project files"));
         projectFilesListView.getStyleClass().add("browser-list");
+        projectFilesListView.setCellFactory(lv -> new BrowserRowCell());
 
-        Tab projectFilesTab = new Tab("Project");
-        projectFilesTab.setClosable(false);
-        projectFilesTab.setGraphic(IconNode.of(DawIcon.ALBUM, 12));
-        projectFilesTab.setContent(projectFilesListView);
+        sectionContent.put(BrowserSection.FILES, fileSystemTree);
+        sectionContent.put(BrowserSection.SAMPLES, samplesListView);
+        sectionContent.put(BrowserSection.PRESETS, presetsListView);
+        sectionContent.put(BrowserSection.PROJECT, projectFilesListView);
 
-        // ── Tab pane ────────────────────────────────────────────────────────
-        tabPane = new TabPane(fileSystemTab, samplesTab, presetsTab, projectFilesTab);
-        tabPane.getStyleClass().add("browser-tab-pane");
-        VBox.setVgrow(tabPane, Priority.ALWAYS);
+        // ── Hand-built tab strip (UI Design Book §2.5, §5.5, §7.3) ──────────
+        tabStrip = new HBox(4);
+        tabStrip.getStyleClass().add("browser-tab-strip");
+        tabStrip.setAlignment(Pos.CENTER_LEFT);
+        tabStrip.getChildren().addAll(
+                buildTab(BrowserSection.FILES, "browser.tab.files", DawIcon.FOLDER),
+                buildTab(BrowserSection.SAMPLES, "browser.tab.samples", DawIcon.WAVEFORM),
+                buildTab(BrowserSection.PRESETS, "browser.tab.presets", DawIcon.KNOB),
+                buildTab(BrowserSection.PROJECT, "browser.tab.project", DawIcon.ALBUM));
 
-        // ── Preview controls ────────────────────────────────────────────────
-        previewPlayButton = new Button();
-        previewPlayButton.setGraphic(IconNode.of(DawIcon.PLAY, PREVIEW_ICON_SIZE));
-        previewPlayButton.getStyleClass().add("browser-preview-button");
-        previewPlayButton.setTooltip(new Tooltip("Play selected sample"));
-
-        previewStopButton = new Button();
-        previewStopButton.setGraphic(IconNode.of(DawIcon.STOP, PREVIEW_ICON_SIZE));
-        previewStopButton.getStyleClass().add("browser-preview-button");
-        previewStopButton.setTooltip(new Tooltip("Stop preview"));
-
-        previewVolumeSlider = new Slider(0.0, 1.0, 1.0);
-        previewVolumeSlider.setPrefWidth(80);
-        previewVolumeSlider.setMaxWidth(100);
-        previewVolumeSlider.getStyleClass().add("browser-volume-slider");
-        previewVolumeSlider.setTooltip(new Tooltip("Preview volume"));
-
-        Label volumeIcon = new Label();
-        volumeIcon.setGraphic(IconNode.of(DawIcon.VOLUME_UP, 10));
-
-        previewControlBar = new HBox(4);
-        previewControlBar.setAlignment(Pos.CENTER_LEFT);
-        previewControlBar.setPadding(new Insets(4, 0, 0, 0));
-        previewControlBar.getChildren().addAll(previewPlayButton, previewStopButton, volumeIcon, previewVolumeSlider);
-
-        previewMetadataLabel = new Label("");
-        previewMetadataLabel.getStyleClass().add("browser-metadata-label");
-        previewMetadataLabel.setMaxWidth(Double.MAX_VALUE);
+        contentArea = new StackPane();
+        contentArea.getStyleClass().add("browser-content-area");
+        contentArea.getChildren().addAll(
+                fileSystemTree, samplesListView, presetsListView, projectFilesListView);
+        VBox.setVgrow(contentArea, Priority.ALWAYS);
 
         // ── Wire search filter ──────────────────────────────────────────────
-        searchField.textProperty().addListener((observable, oldValue, newValue) -> {
-            applyFilter(newValue);
+        searchField.textProperty().addListener((obs, oldValue, newValue) -> applyFilter(newValue));
+
+        // ── Ctrl+F focuses the search field while the panel is focused ──────
+        addEventHandler(javafx.scene.input.KeyEvent.KEY_PRESSED, event -> {
+            if (KeyCombination.keyCombination("Shortcut+F").match(event)
+                    || (event.isControlDown() && event.getCode() == KeyCode.F)) {
+                searchField.requestFocus();
+                event.consume();
+            }
         });
 
-        getChildren().addAll(headerLabel, searchBar, tabPane, previewControlBar, previewMetadataLabel);
+        getChildren().addAll(headerLabel, searchBar, tabStrip, contentArea);
+
+        selectSection(BrowserSection.FILES);
 
         LOG.fine("Browser panel created");
     }
 
     /**
-     * Returns the search/filter text field.
+     * Builds one tab: a {@code .dawg-button.size-default} (story 264, no
+     * border) wrapped in a {@link StackPane} container that also holds
+     * the under-text accent {@link Rectangle}. The Rectangle is
+     * {@code managed=false} so it never perturbs layout (§7.3); its fill
+     * is CSS-driven via {@code .browser-tab-indicator}.
+     */
+    private StackPane buildTab(BrowserSection section, String labelKey, DawIcon icon) {
+        Button button = new Button(msg(labelKey));
+        button.getStyleClass().addAll("dawg-button", "size-default", "browser-tab");
+        button.setGraphic(IconNode.of(icon, TAB_ICON_SIZE));
+        button.setMaxWidth(Region.USE_PREF_SIZE);
+        button.setOnAction(e -> selectSection(section));
+
+        Rectangle indicator = new Rectangle(0, INDICATOR_HEIGHT);
+        indicator.getStyleClass().add("browser-tab-indicator");
+        indicator.setManaged(false);
+        indicator.setMouseTransparent(true);
+        indicator.setVisible(false);
+
+        StackPane container = new StackPane(button, indicator);
+        container.getStyleClass().add("browser-tab-container");
+        StackPane.setAlignment(indicator, Pos.BOTTOM_CENTER);
+
+        tabButtons.put(section, button);
+        tabIndicators.put(section, indicator);
+        return container;
+    }
+
+    /**
+     * Returns the persistent search/filter text field.
      */
     public TextField getSearchField() {
         return searchField;
     }
 
     /**
-     * Returns the tab pane containing the browser sections.
+     * @return the currently active browser section
      */
-    public TabPane getTabPane() {
-        return tabPane;
+    public BrowserSection getActiveSection() {
+        return activeSection;
+    }
+
+    /**
+     * Selects {@code section}: shows its content, marks its tab active
+     * (its accent indicator becomes visible, all others hidden), and
+     * re-applies the retained search query to the newly active list so
+     * the search text is preserved across tab switches (story 275).
+     *
+     * @param section the section to activate
+     */
+    public void selectSection(BrowserSection section) {
+        this.activeSection = section;
+        for (BrowserSection s : BrowserSection.values()) {
+            boolean active = s == section;
+            Node content = sectionContent.get(s);
+            content.setVisible(active);
+            content.setManaged(active);
+            Button tab = tabButtons.get(s);
+            if (active) {
+                if (!tab.getStyleClass().contains("active")) {
+                    tab.getStyleClass().add("active");
+                }
+            } else {
+                tab.getStyleClass().remove("active");
+            }
+            tabIndicators.get(s).setVisible(active);
+        }
+        updateIndicatorWidth(section);
+        // Re-apply the retained query to the now-active section's list.
+        applyFilter(searchField.getText());
+    }
+
+    /**
+     * Sizes the active tab's accent indicator to the rendered width of
+     * the tab's label text (story 275 / §7.3 — an under-text bar, not a
+     * full-width or border indicator). Recomputed on every section
+     * change and after a layout pass.
+     */
+    private void updateIndicatorWidth(BrowserSection section) {
+        Button tab = tabButtons.get(section);
+        Rectangle indicator = tabIndicators.get(section);
+        Runnable measure = () -> {
+            double textWidth = measureLabelTextWidth(tab);
+            if (textWidth > 0) {
+                indicator.setWidth(textWidth);
+            }
+        };
+        measure.run();
+        // The button may not be laid out yet on first selection; remeasure
+        // once a layout pass has produced a real text width.
+        Platform.runLater(measure);
+    }
+
+    /**
+     * Measures the rendered width of {@code button}'s text using the
+     * button's resolved font, so the indicator hugs the glyphs rather
+     * than the padded button box (§7.3 under-text bar).
+     */
+    private static double measureLabelTextWidth(Button button) {
+        String text = button.getText();
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+        Text helper = new Text(text);
+        if (button.getFont() != null) {
+            helper.setFont(button.getFont());
+        }
+        Bounds bounds = helper.getLayoutBounds();
+        return bounds.getWidth();
     }
 
     /**
@@ -275,38 +424,75 @@ public final class BrowserPanel extends VBox {
     }
 
     /**
-     * Returns the play button for sample preview.
+     * Returns the tab {@link Button} for {@code section} — exposed for
+     * styling/interaction tests.
      */
-    public Button getPreviewPlayButton() {
-        return previewPlayButton;
+    Button getTabButton(BrowserSection section) {
+        return tabButtons.get(section);
     }
 
     /**
-     * Returns the stop button for sample preview.
+     * Returns the accent indicator {@link Rectangle} for {@code section}
+     * — exposed for styling tests. Only the active section's indicator
+     * is visible.
      */
-    public Button getPreviewStopButton() {
-        return previewStopButton;
+    Rectangle getTabIndicator(BrowserSection section) {
+        return tabIndicators.get(section);
     }
 
     /**
-     * Returns the volume slider for sample preview.
+     * Installs the single-channel {@link SampleAuditioner} that the
+     * per-row audition buttons drive (story 275). When {@code null} (the
+     * default), every audition button is {@code :disabled}.
+     *
+     * @param auditioner the auditioner, or {@code null} to disable
      */
-    public Slider getPreviewVolumeSlider() {
-        return previewVolumeSlider;
+    public void setSampleAuditioner(SampleAuditioner auditioner) {
+        this.sampleAuditioner = auditioner;
+        // Reflect playback-finished into the row icon state. The callback
+        // fires on the player's daemon thread, so marshal to the FX
+        // thread before touching the scene graph (JavaFX threading rule).
+        if (auditioner != null) {
+            auditioner.setOnPlaybackFinished(() -> Platform.runLater(() -> {
+                auditioningItem = null;
+                refreshListCells();
+            }));
+        }
+    }
+
+    /** @return the installed auditioner, primarily for tests. */
+    Optional<SampleAuditioner> getSampleAuditioner() {
+        return Optional.ofNullable(sampleAuditioner);
     }
 
     /**
-     * Returns the label displaying metadata for the selected sample.
+     * Toggles audition for {@code item}: starts it (stopping any
+     * previous preview — single-channel) or stops it if it is already
+     * the playing row.
      */
-    public Label getPreviewMetadataLabel() {
-        return previewMetadataLabel;
+    private void toggleAudition(String item) {
+        if (sampleAuditioner == null || item == null) {
+            return;
+        }
+        if (item.equals(auditioningItem)) {
+            sampleAuditioner.stop();
+            auditioningItem = null;
+        } else {
+            sampleAuditioner.play(Path.of(item));
+            auditioningItem = item;
+        }
+        refreshListCells();
     }
 
-    /**
-     * Returns the preview control bar container.
-     */
-    public HBox getPreviewControlBar() {
-        return previewControlBar;
+    private boolean isAuditioning(String item) {
+        return item != null && item.equals(auditioningItem);
+    }
+
+    /** Forces the list cells to re-render so audition glyphs update. */
+    private void refreshListCells() {
+        samplesListView.refresh();
+        presetsListView.refresh();
+        projectFilesListView.refresh();
     }
 
     /**
@@ -367,7 +553,7 @@ public final class BrowserPanel extends VBox {
         if (fileName == null || fileName.isEmpty()) {
             return false;
         }
-        String lower = fileName.toLowerCase();
+        String lower = fileName.toLowerCase(Locale.ROOT);
         for (String ext : AUDIO_EXTENSIONS) {
             if (lower.endsWith(ext)) {
                 return true;
@@ -472,16 +658,25 @@ public final class BrowserPanel extends VBox {
         return DragVisualAdvisor.canDropOn(DragSourceKind.SAMPLE, target);
     }
 
+    /**
+     * Filters the active section's list against {@code filterText}. The
+     * three {@link FilteredList}s each filter their own backing data, so
+     * the search text is naturally scoped to whichever list is showing —
+     * the presets list filters the presets index, never the samples
+     * index (story 275 — search scoped to the active tab). Filtering all
+     * three keeps the retained query consistent so a tab switch shows
+     * already-filtered results without re-typing.
+     */
     private void applyFilter(String filterText) {
         if (filterText == null || filterText.isBlank()) {
             filteredSampleItems.setPredicate(item -> true);
             filteredPresetItems.setPredicate(item -> true);
             filteredProjectFileItems.setPredicate(item -> true);
         } else {
-            String lower = filterText.toLowerCase();
-            filteredSampleItems.setPredicate(item -> item.toLowerCase().contains(lower));
-            filteredPresetItems.setPredicate(item -> item.toLowerCase().contains(lower));
-            filteredProjectFileItems.setPredicate(item -> item.toLowerCase().contains(lower));
+            String lower = filterText.toLowerCase(Locale.ROOT);
+            filteredSampleItems.setPredicate(item -> item.toLowerCase(Locale.ROOT).contains(lower));
+            filteredPresetItems.setPredicate(item -> item.toLowerCase(Locale.ROOT).contains(lower));
+            filteredProjectFileItems.setPredicate(item -> item.toLowerCase(Locale.ROOT).contains(lower));
         }
     }
 
@@ -557,5 +752,90 @@ public final class BrowserPanel extends VBox {
             resolved = resolved.resolve(segment);
         }
         return resolved.toString();
+    }
+
+    /**
+     * Resolves a chrome string from the shared {@link ResourceBundle},
+     * falling back to the raw key if absent (mirrors
+     * {@link NotificationPill#msg(String)}).
+     */
+    static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (MissingResourceException e) {
+            return key;
+        }
+    }
+
+    /**
+     * List row for the Samples / Presets / Project lists (story 275,
+     * UI Design Book §5.5). Lays out the file name, an empty
+     * {@code .numeric-caption} metadata cell (story 027 populates it —
+     * intentional stub; cell factories stay cheap, no per-row file I/O),
+     * and a right-edge 16 px audition button on audio rows.
+     *
+     * <p>Hover / selection visuals are CSS-driven via
+     * {@code .browser-list .list-cell} (§7.1 glow veto, §7.3 border
+     * veto) — this class adds no inline effect.</p>
+     */
+    private final class BrowserRowCell extends ListCell<String> {
+
+        private final Label nameLabel = new Label();
+        // Story 027 populates size / rate / bit-depth here. Left present
+        // but empty so the row reserves the mono-numeric cell now (no
+        // per-row blocking file I/O in the cell factory — perf rule).
+        private final Label metadataLabel = new Label();
+        private final Button auditionButton = new Button();
+        private final HBox layout;
+
+        BrowserRowCell() {
+            getStyleClass().add("browser-list-cell");
+
+            nameLabel.getStyleClass().add("browser-row-name");
+            nameLabel.setMaxWidth(Double.MAX_VALUE);
+            HBox.setHgrow(nameLabel, Priority.ALWAYS);
+
+            metadataLabel.getStyleClass().add("numeric-caption");
+
+            auditionButton.getStyleClass().addAll(
+                    "dawg-button", "icon-only", "size-compact", "browser-audition-button");
+            auditionButton.setFocusTraversable(false);
+            auditionButton.setOnAction(e -> {
+                e.consume();
+                toggleAudition(getItem());
+            });
+
+            layout = new HBox(6, nameLabel, metadataLabel, auditionButton);
+            layout.setAlignment(Pos.CENTER_LEFT);
+            setText(null);
+        }
+
+        @Override
+        protected void updateItem(String item, boolean empty) {
+            super.updateItem(item, empty);
+            if (empty || item == null) {
+                setGraphic(null);
+                return;
+            }
+            nameLabel.setText(item);
+
+            boolean audio = isAudioFile(item);
+            // Presets are names, not audio — no audition affordance.
+            auditionButton.setVisible(audio);
+            auditionButton.setManaged(audio);
+            // With no auditioner installed the button is :disabled (the
+            // unified .dawg-button:disabled rule fades it to 0.45).
+            auditionButton.setDisable(sampleAuditioner == null);
+            if (audio) {
+                boolean playing = isAuditioning(item);
+                auditionButton.setGraphic(IconNode.of(
+                        playing ? DawIcon.PAUSE_CIRCLE : DawIcon.PLAY,
+                        AUDITION_ICON_SIZE));
+                auditionButton.setTooltip(new Tooltip(
+                        playing ? msg("browser.audition.stop")
+                                : msg("browser.audition.play")));
+            }
+            setGraphic(layout);
+        }
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
@@ -18,6 +18,7 @@ import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -29,6 +30,7 @@ import javafx.scene.text.Text;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
@@ -106,6 +108,22 @@ public final class BrowserPanel extends VBox {
         PROJECT
     }
 
+    /**
+     * Immutable snapshot of one file-system node. The FILES model is
+     * captured once at construction (the panel's only disk I/O);
+     * {@link #rebuildFileTree(String)} prunes a filtered view from it so
+     * the persistent search query scopes the FILES tab too, without
+     * re-touching the disk (story 275, review S1). Package-private +
+     * {@code static} (records are implicitly static) so the pure
+     * {@link #buildFilteredItem} filter is unit-testable with a
+     * synthetic model — no FX scene, no real I/O.
+     */
+    record FileNode(String name, boolean directory, List<FileNode> children) {
+        FileNode {
+            children = List.copyOf(children);
+        }
+    }
+
     private final TextField searchField;
 
     private final HBox tabStrip;
@@ -115,6 +133,8 @@ public final class BrowserPanel extends VBox {
     private final Map<BrowserSection, Node> sectionContent = new EnumMap<>(BrowserSection.class);
 
     private final TreeView<String> fileSystemTree;
+    /** Captured-once FILES model the search query prunes (story 275, S1). */
+    private final FileNode fileModelRoot;
     private final ListView<String> samplesListView;
     private final ListView<String> presetsListView;
     private final ListView<String> projectFilesListView;
@@ -138,6 +158,11 @@ public final class BrowserPanel extends VBox {
      * The path currently being auditioned, or {@code null}. Used so only
      * the playing row shows the pause-circle glyph; the engine itself is
      * single-channel so at most one path is ever active.
+     *
+     * <p>TODO(027): key by the resolved {@link Path}, not the display
+     * string — once rows carry real paths (story 027) two identically
+     * named files in different folders would otherwise both show the
+     * pause glyph.</p>
      */
     private volatile String auditioningItem;
 
@@ -178,13 +203,19 @@ public final class BrowserPanel extends VBox {
         searchBar.getChildren().addAll(searchIcon, searchField);
 
         // ── Files section — file-system tree ────────────────────────────────
-        TreeItem<String> rootItem = new TreeItem<>("File System");
+        // The model is captured once (the panel's only disk I/O); the
+        // visible tree is (re)built from it by rebuildFileTree so the
+        // persistent search query can prune it without re-touching the
+        // disk (story 275, S1 — search scoped to the active tab, FILES
+        // included).
+        fileModelRoot = buildFileModel();
+        TreeItem<String> rootItem = new TreeItem<>(fileModelRoot.name());
         rootItem.setExpanded(true);
-        addUserHomeDirectories(rootItem);
         fileSystemTree = new TreeView<>(rootItem);
         fileSystemTree.setShowRoot(true);
         fileSystemTree.getStyleClass().add("browser-tree");
         VBox.setVgrow(fileSystemTree, Priority.ALWAYS);
+        rebuildFileTree("");
 
         // Enable drag-and-drop from the file tree onto the arrangement view
         // (story 197 — preserved through the story-275 refactor).
@@ -268,7 +299,7 @@ public final class BrowserPanel extends VBox {
         searchField.textProperty().addListener((obs, oldValue, newValue) -> applyFilter(newValue));
 
         // ── Ctrl+F focuses the search field while the panel is focused ──────
-        addEventHandler(javafx.scene.input.KeyEvent.KEY_PRESSED, event -> {
+        addEventHandler(KeyEvent.KEY_PRESSED, event -> {
             if (KeyCombination.keyCombination("Shortcut+F").match(event)
                     || (event.isControlDown() && event.getCode() == KeyCode.F)) {
                 searchField.requestFocus();
@@ -488,11 +519,16 @@ public final class BrowserPanel extends VBox {
         return item != null && item.equals(auditioningItem);
     }
 
-    /** Forces the list cells to re-render so audition glyphs update. */
+    /**
+     * Re-renders the visible section's list so audition glyphs update.
+     * Only the active section is on screen, so refreshing the other two
+     * is wasted work (story 275 review, N1); a hidden list re-renders
+     * from {@link #isAuditioning} the next time its section is shown.
+     */
     private void refreshListCells() {
-        samplesListView.refresh();
-        presetsListView.refresh();
-        projectFilesListView.refresh();
+        if (sectionContent.get(activeSection) instanceof ListView<?> list) {
+            list.refresh();
+        }
     }
 
     /**
@@ -659,13 +695,14 @@ public final class BrowserPanel extends VBox {
     }
 
     /**
-     * Filters the active section's list against {@code filterText}. The
-     * three {@link FilteredList}s each filter their own backing data, so
-     * the search text is naturally scoped to whichever list is showing —
-     * the presets list filters the presets index, never the samples
-     * index (story 275 — search scoped to the active tab). Filtering all
-     * three keeps the retained query consistent so a tab switch shows
-     * already-filtered results without re-typing.
+     * Applies {@code filterText} to <em>every</em> section so the
+     * persistent query is genuinely scoped to whichever tab is active
+     * (story 275, review S1). The three {@link FilteredList}s each
+     * filter their own backing data — the presets list filters the
+     * presets index, never the samples index — and the FILES tree is
+     * pruned from its captured model by {@link #rebuildFileTree}.
+     * Filtering all four keeps the retained query consistent so a tab
+     * switch shows already-filtered results without re-typing.
      */
     private void applyFilter(String filterText) {
         if (filterText == null || filterText.isBlank()) {
@@ -678,14 +715,22 @@ public final class BrowserPanel extends VBox {
             filteredPresetItems.setPredicate(item -> item.toLowerCase(Locale.ROOT).contains(lower));
             filteredProjectFileItems.setPredicate(item -> item.toLowerCase(Locale.ROOT).contains(lower));
         }
+        rebuildFileTree(filterText);
     }
 
-    private void addUserHomeDirectories(TreeItem<String> root) {
+    /**
+     * Captures the user-home audio tree once (the panel's only disk
+     * I/O). Mirrors the previous {@code addUserHomeDirectories}
+     * traversal — one directory level deep, audio files only — but
+     * yields an immutable {@link FileNode} model the search filter can
+     * prune cheaply (story 275, S1).
+     */
+    private static FileNode buildFileModel() {
+        List<FileNode> rootChildren = new ArrayList<>();
         Path userHome = Path.of(System.getProperty("user.home"));
         File homeDir = userHome.toFile();
         if (homeDir.exists() && homeDir.isDirectory()) {
-            TreeItem<String> homeItem = new TreeItem<>(homeDir.getName());
-            homeItem.setExpanded(false);
+            List<FileNode> homeChildren = new ArrayList<>();
             File[] children = homeDir.listFiles();
             if (children != null) {
                 for (File child : children) {
@@ -693,24 +738,82 @@ public final class BrowserPanel extends VBox {
                         continue;
                     }
                     if (child.isDirectory()) {
-                        TreeItem<String> dirItem = new TreeItem<>(child.getName());
-                        // Add audio files inside the directory (one level)
+                        List<FileNode> dirChildren = new ArrayList<>();
+                        // Audio files inside the directory (one level).
                         File[] grandChildren = child.listFiles();
                         if (grandChildren != null) {
                             for (File gc : grandChildren) {
                                 if (gc.isFile() && isAudioFile(gc.getName())) {
-                                    dirItem.getChildren().add(new TreeItem<>(gc.getName()));
+                                    dirChildren.add(new FileNode(gc.getName(), false, List.of()));
                                 }
                             }
                         }
-                        homeItem.getChildren().add(dirItem);
+                        homeChildren.add(new FileNode(child.getName(), true, dirChildren));
                     } else if (child.isFile() && isAudioFile(child.getName())) {
-                        homeItem.getChildren().add(new TreeItem<>(child.getName()));
+                        homeChildren.add(new FileNode(child.getName(), false, List.of()));
                     }
                 }
             }
-            root.getChildren().add(homeItem);
+            rootChildren.add(new FileNode(homeDir.getName(), true, homeChildren));
         }
+        return new FileNode("File System", true, rootChildren);
+    }
+
+    /**
+     * Rebuilds the visible FILES tree from {@link #fileModelRoot},
+     * pruned to {@code query} (story 275, S1 — the persistent search is
+     * scoped to the active tab, FILES included). A blank query restores
+     * the full collapsed tree; a non-blank query keeps only matching
+     * leaves (and their ancestor directories) and expands them so hits
+     * are visible. The "File System" root itself is never pruned, so the
+     * tree never collapses to nothing and {@code resolveTreeItemPath}'s
+     * root → home → … → leaf parent chain is preserved for drag-drop.
+     */
+    private void rebuildFileTree(String query) {
+        TreeItem<String> root = fileSystemTree.getRoot();
+        if (root == null) {
+            return;
+        }
+        String lower = (query == null) ? "" : query.toLowerCase(Locale.ROOT);
+        root.getChildren().clear();
+        for (FileNode child : fileModelRoot.children()) {
+            TreeItem<String> item = buildFilteredItem(child, lower);
+            if (item != null) {
+                root.getChildren().add(item);
+            }
+        }
+    }
+
+    /**
+     * Pure recursive filter: returns a {@link TreeItem} for {@code node}
+     * when it (or, for a directory, any descendant) matches
+     * {@code lowerQuery}, or {@code null} when it is pruned. A blank
+     * {@code lowerQuery} keeps everything with directories collapsed (as
+     * before the search wiring); a non-blank query keeps matching
+     * leaves, keeps a directory whose own name matches or that retains
+     * any child, and expands surviving directories so the hits are
+     * visible. {@code lowerQuery} must already be lower-cased
+     * ({@link Locale#ROOT}). Package-private + {@code static} so it is
+     * unit-testable with a synthetic model (no FX scene, no disk).
+     */
+    static TreeItem<String> buildFilteredItem(FileNode node, String lowerQuery) {
+        boolean searching = !lowerQuery.isEmpty();
+        boolean nameMatches = node.name().toLowerCase(Locale.ROOT).contains(lowerQuery);
+        if (!node.directory()) {
+            return (!searching || nameMatches) ? new TreeItem<>(node.name()) : null;
+        }
+        TreeItem<String> item = new TreeItem<>(node.name());
+        for (FileNode child : node.children()) {
+            TreeItem<String> childItem = buildFilteredItem(child, lowerQuery);
+            if (childItem != null) {
+                item.getChildren().add(childItem);
+            }
+        }
+        if (searching && item.getChildren().isEmpty() && !nameMatches) {
+            return null;
+        }
+        item.setExpanded(searching);
+        return item;
     }
 
     /**
@@ -787,6 +890,13 @@ public final class BrowserPanel extends VBox {
         private final Label metadataLabel = new Label();
         private final Button auditionButton = new Button();
         private final HBox layout;
+        // Cached per-cell glyphs/tooltips, swapped by reference in
+        // updateItem — never reallocated per render (refresh()/scroll
+        // fires updateItem on every cell reuse; story 275 review S3/S4).
+        private final Node playGlyph = IconNode.of(DawIcon.PLAY, AUDITION_ICON_SIZE);
+        private final Node pauseGlyph = IconNode.of(DawIcon.PAUSE_CIRCLE, AUDITION_ICON_SIZE);
+        private final Tooltip playTooltip = new Tooltip(msg("browser.audition.play"));
+        private final Tooltip pauseTooltip = new Tooltip(msg("browser.audition.stop"));
 
         BrowserRowCell() {
             getStyleClass().add("browser-list-cell");
@@ -828,12 +938,8 @@ public final class BrowserPanel extends VBox {
             auditionButton.setDisable(sampleAuditioner == null);
             if (audio) {
                 boolean playing = isAuditioning(item);
-                auditionButton.setGraphic(IconNode.of(
-                        playing ? DawIcon.PAUSE_CIRCLE : DawIcon.PLAY,
-                        AUDITION_ICON_SIZE));
-                auditionButton.setTooltip(new Tooltip(
-                        playing ? msg("browser.audition.stop")
-                                : msg("browser.audition.play")));
+                auditionButton.setGraphic(playing ? pauseGlyph : playGlyph);
+                auditionButton.setTooltip(playing ? pauseTooltip : playTooltip);
             }
             setGraphic(layout);
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1423,6 +1423,9 @@ public final class MainController {
 
     private void buildBrowserPanel(boolean initiallyVisible) {
         BrowserPanel browserPanel = new BrowserPanel();
+        // Per-row audition wiring (story 275) — single-channel preview
+        // engine from daw.core (com.benesquivelmusic.daw.core.browser).
+        browserPanel.setSampleAuditioner(new SamplePreviewAuditioner());
         browserPanelController = new BrowserPanelController(browserPanel, browserButton, rootPane);
         browserPanelController.setOnVisibilityChanged(() -> {
             toolbarStateStore.saveBrowserVisible(browserPanelController.isPanelVisible());

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SampleAuditioner.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SampleAuditioner.java
@@ -1,0 +1,46 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import java.nio.file.Path;
+
+/**
+ * Single-channel sample auditioner seam for the browser panel's per-row
+ * audition button (story 275, UI Design Book §5.5).
+ *
+ * <p>{@link BrowserPanel} depends on this interface rather than the
+ * concrete engine so headless tests can inject a fake that opens no
+ * audio device. The production binding is
+ * {@link SamplePreviewAuditioner}, which delegates to
+ * {@code com.benesquivelmusic.daw.core.browser.SamplePreviewPlayer}.</p>
+ *
+ * <p>The contract is deliberately single-channel: {@link #play(Path)}
+ * stops any preview already in progress before starting the new one, so
+ * the user can never layer ten samples on top of each other.</p>
+ */
+public interface SampleAuditioner {
+
+    /**
+     * Starts auditioning {@code file}, stopping any preview already in
+     * progress first (single-channel auditioner).
+     *
+     * @param file the audio file to audition
+     */
+    void play(Path file);
+
+    /** Stops any currently playing preview. */
+    void stop();
+
+    /**
+     * @return {@code true} while a preview is playing
+     */
+    boolean isPlaying();
+
+    /**
+     * Sets a callback invoked when playback finishes (naturally or
+     * because it was stopped). The callback may run on a background
+     * thread — consumers that touch the scene graph must marshal to the
+     * JavaFX Application Thread themselves.
+     *
+     * @param callback the callback, or {@code null} to clear
+     */
+    void setOnPlaybackFinished(Runnable callback);
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SamplePreviewAuditioner.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SamplePreviewAuditioner.java
@@ -1,0 +1,42 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.core.browser.SamplePreviewPlayer;
+
+import java.nio.file.Path;
+
+/**
+ * Production {@link SampleAuditioner} binding (story 275) — a thin
+ * adapter over the engine's
+ * {@link SamplePreviewPlayer}. The player is itself single-channel
+ * ({@code play(Path)} stops any current preview first), so this adapter
+ * is a straight delegation.
+ *
+ * <p>{@code SamplePreviewPlayer} runs playback on its own daemon thread
+ * and fires the playback-finished callback off the JavaFX Application
+ * Thread; callers (e.g. {@link BrowserPanel}) marshal that callback back
+ * to the FX thread before touching the scene graph.</p>
+ */
+public final class SamplePreviewAuditioner implements SampleAuditioner {
+
+    private final SamplePreviewPlayer player = new SamplePreviewPlayer();
+
+    @Override
+    public void play(Path file) {
+        player.play(file);
+    }
+
+    @Override
+    public void stop() {
+        player.stop();
+    }
+
+    @Override
+    public boolean isPlaying() {
+        return player.isPlaying();
+    }
+
+    @Override
+    public void setOnPlaybackFinished(Runnable callback) {
+        player.setOnPlaybackFinished(callback);
+    }
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -49,6 +49,7 @@ statusbar.autosave.on=· Auto-save: ON
 statusbar.io.initializing=· Initializing I/O...
 statusbar.monitoring.mono=· Mono
 statusbar.monitoring.stereo=· Stereo
+statusbar.monitoring.surround=· {0}ch Surround
 
 # Browser (story 275) — UI Design Book §5.5. Hand-built tab strip,
 # persistent search, per-row audition. Section-scoped prefix per the
@@ -61,4 +62,3 @@ browser.tab.project=Project
 browser.search.placeholder=Search samples and presets…
 browser.audition.play=Audition
 browser.audition.stop=Stop preview
-statusbar.monitoring.surround=· {0}ch Surround

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -49,4 +49,16 @@ statusbar.autosave.on=· Auto-save: ON
 statusbar.io.initializing=· Initializing I/O...
 statusbar.monitoring.mono=· Mono
 statusbar.monitoring.stereo=· Stereo
+
+# Browser (story 275) — UI Design Book §5.5. Hand-built tab strip,
+# persistent search, per-row audition. Section-scoped prefix per the
+# file convention; all user-facing browser chrome flows through here
+# rather than being hard-coded in BrowserPanel.
+browser.tab.files=Files
+browser.tab.samples=Samples
+browser.tab.presets=Presets
+browser.tab.project=Project
+browser.search.placeholder=Search samples and presets…
+browser.audition.play=Audition
+browser.audition.stop=Stop preview
 statusbar.monitoring.surround=· {0}ch Surround

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -1066,6 +1066,19 @@
     -fx-background-color: transparent;
 }
 
+/* The base .dawg-button:armed/:pressed/:active accent-box fill (the
+ * "Pressed / armed / active" rule above) outweighs
+ * .browser-tab.dawg-button.active by cascade order; without this
+ * override a held/clicked tab flashes the §7.3-vetoed full -accent
+ * box. Tabs signal active state ONLY via the drawn
+ * .browser-tab-indicator bar — never a box (story 275 review S2). */
+.browser-tab.dawg-button:armed,
+.browser-tab.dawg-button:pressed,
+.browser-tab.dawg-button:active {
+    -fx-background-color: -surface-3;
+    -fx-text-fill: -text-hi;
+}
+
 /* Drawn accent bar — CSS is the single source of truth for the fill so
  * a future palette swap (story 277) recolours it with no Java change. */
 .browser-tab-indicator {

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -1014,7 +1014,10 @@
     -fx-border-width: 0 0 0 1;
 }
 
-.browser-search-field {
+/* Persistent search field (story 275, UI Design Book §5.5). Replaces
+ * the old .browser-search-field; the SEARCH glyph (story 265) is a
+ * sibling leading affordance in .browser-search-bar, not a CSS pseudo. */
+.search-field {
     -fx-background-color: -surface-1;
     -fx-text-fill: -text-hi;
     -fx-prompt-text-fill: -text-mute;
@@ -1025,36 +1028,51 @@
     -fx-padding: 4 8;
 }
 
-.browser-search-field:focused {
+.search-field:focused {
     -fx-border-color: -focus-ring;
 }
 
-.browser-tab-pane > .tab-header-area > .tab-header-background {
-    -fx-background-color: -surface-bg;
+/* ── Hand-built browser tab strip (story 275, UI Design Book §2.5,
+ * §5.5, §7.3) ──
+ * Replaces the removed .browser-tab-pane TabPane. Tabs are unified
+ * .dawg-button.size-default toggles (story 264) with NO border — the
+ * base .dawg-button rule is overridden here to drop the border so the
+ * active state reads only from the drawn accent bar, never a box. The
+ * active tab carries a 2 px -accent under-text Rectangle child
+ * (.browser-tab-indicator) — a DRAWN bar, not a CSS border and not a
+ * layout-shifting border swap (§7.3, same discipline as the
+ * .notification-accent-bar). */
+.browser-tab-strip {
+    -fx-padding: 0 0 2 0;
 }
 
-.browser-tab-pane > .tab-header-area > .headers-region > .tab {
-    -fx-background-color: -surface-1;
-    -fx-border-color: -line-soft;
-    -fx-padding: 4 8;
+.browser-tab-container {
+    -fx-padding: 0;
 }
 
-.browser-tab-pane > .tab-header-area > .headers-region > .tab:selected {
-    -fx-background-color: -surface-2;
-    -fx-border-color: transparent transparent -accent transparent;
-    -fx-border-width: 0 0 2 0;
-}
-
-.browser-tab-pane > .tab-header-area > .headers-region > .tab > .tab-container > .tab-label {
+.browser-tab.dawg-button {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+    -fx-border-width: 0;
     -fx-text-fill: -text-mute;
-    -fx-font-size: 10px;
 }
 
-.browser-tab-pane > .tab-header-area > .headers-region > .tab:selected > .tab-container > .tab-label {
+.browser-tab.dawg-button:hover {
+    -fx-background-color: -surface-3;
+}
+
+.browser-tab.dawg-button.active {
     -fx-text-fill: -text-hi;
+    -fx-background-color: transparent;
 }
 
-.browser-tab-pane > .tab-content-area {
+/* Drawn accent bar — CSS is the single source of truth for the fill so
+ * a future palette swap (story 277) recolours it with no Java change. */
+.browser-tab-indicator {
+    -fx-fill: -accent;
+}
+
+.browser-content-area {
     -fx-background-color: -surface-bg;
 }
 
@@ -1085,9 +1103,17 @@
     -fx-background-color: transparent;
 }
 
-.browser-list .list-cell:selected {
-    -fx-background-color: -surface-2;
-    -fx-text-fill: -accent;
+/* Row hover / selection (story 275, UI Design Book §7.1 glow veto,
+ * §7.3 border veto). Hover → -surface-3, NO drop-shadow/effect.
+ * Selection → -accent-soft, NO left border, and the text stays -text
+ * (the old `-fx-text-fill: -accent` accent-text is dropped). */
+.browser-list .list-cell:filled:hover {
+    -fx-background-color: -surface-3;
+}
+
+.browser-list .list-cell:filled:selected {
+    -fx-background-color: -accent-soft;
+    -fx-text-fill: -text;
 }
 
 /* ── Notification pill (UI Design Book §5.10, §7.3, story 273) ──

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserFileTreeFilterTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserFileTreeFilterTest.java
@@ -1,0 +1,90 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.BrowserPanel.FileNode;
+
+import javafx.scene.control.TreeItem;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 275 (review S1) — the persistent search query is scoped to the
+ * FILES tab too: {@link BrowserPanel#buildFilteredItem} prunes the
+ * file-system model to matching leaves plus their ancestor directories,
+ * keeps a directory whose own name matches, and expands survivors so
+ * hits are visible; a blank query keeps the full, collapsed tree.
+ *
+ * <p>Pure model test — no FX scene and no disk I/O (a synthetic
+ * {@link FileNode}), so none of the headless-JavaFX pitfalls apply and
+ * the result is deterministic on every platform.</p>
+ */
+class BrowserFileTreeFilterTest {
+
+    private static FileNode model() {
+        return new FileNode("home", true, List.of(
+                new FileNode("Samples", true, List.of(
+                        new FileNode("kick.wav", false, List.of()),
+                        new FileNode("snare.wav", false, List.of()))),
+                new FileNode("Documents", true, List.of(
+                        new FileNode("readme.wav", false, List.of()))),
+                new FileNode("loop_kick.wav", false, List.of())));
+    }
+
+    @Test
+    void blankQueryKeepsEverythingCollapsed() {
+        TreeItem<String> item = BrowserPanel.buildFilteredItem(model(), "");
+
+        assertThat(item).isNotNull();
+        assertThat(item.getValue()).isEqualTo("home");
+        assertThat(item.isExpanded())
+                .as("blank query → collapsed, as before the search wiring")
+                .isFalse();
+        assertThat(item.getChildren()).extracting(TreeItem::getValue)
+                .containsExactly("Samples", "Documents", "loop_kick.wav");
+        assertThat(item.getChildren().get(0).getChildren())
+                .extracting(TreeItem::getValue)
+                .containsExactly("kick.wav", "snare.wav");
+    }
+
+    @Test
+    void nonBlankQueryPrunesToMatchesAndExpands() {
+        TreeItem<String> item = BrowserPanel.buildFilteredItem(model(), "kick");
+
+        assertThat(item).as("home retained — it has a matching descendant").isNotNull();
+        assertThat(item.isExpanded())
+                .as("surviving directories expand so hits are visible")
+                .isTrue();
+        // Documents is pruned (no descendant contains "kick"); Samples
+        // is kept but only its matching leaf; the top-level
+        // loop_kick.wav leaf is kept.
+        assertThat(item.getChildren()).extracting(TreeItem::getValue)
+                .containsExactly("Samples", "loop_kick.wav");
+        TreeItem<String> samples = item.getChildren().get(0);
+        assertThat(samples.getChildren()).extracting(TreeItem::getValue)
+                .containsExactly("kick.wav");
+        assertThat(samples.isExpanded()).isTrue();
+    }
+
+    @Test
+    void nonMatchingQueryPrunesEntireBranch() {
+        assertThat(BrowserPanel.buildFilteredItem(model(), "zzz-no-match"))
+                .as("nothing matches → whole subtree pruned")
+                .isNull();
+    }
+
+    @Test
+    void directoryNameMatchKeepsDirectoryEvenWithoutMatchingLeaves() {
+        TreeItem<String> item = BrowserPanel.buildFilteredItem(model(), "sample");
+
+        assertThat(item).isNotNull();
+        // "Samples" dir name matches "sample" → kept even though its
+        // leaves (kick.wav / snare.wav) do not contain "sample". This
+        // also proves matching is case-insensitive w.r.t. node casing
+        // (lower-case query vs. capitalised "Samples").
+        assertThat(item.getChildren()).extracting(TreeItem::getValue)
+                .containsExactly("Samples");
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserHoverStyleTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserHoverStyleTest.java
@@ -1,0 +1,131 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.BrowserPanel.BrowserSection;
+
+import javafx.application.Platform;
+import javafx.css.PseudoClass;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.ListCell;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+/**
+ * Story 275 / UI Design Book §7.1 (glow veto), §7.3 (border veto) — a
+ * hovered browser row's background resolves to {@code -surface-3} with
+ * NO drop-shadow / effect.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class BrowserHoverStyleTest {
+
+    private <T> T onFx(java.util.concurrent.Callable<T> action) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Exception> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(action.call());
+            } catch (Exception e) {
+                err.set(e);
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await(5, TimeUnit.SECONDS);
+        if (err.get() != null) {
+            throw err.get();
+        }
+        return ref.get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void hoveredRowResolvesToSurface3WithNoEffect() throws Exception {
+        Color[] result = onFx(() -> {
+            BrowserPanel panel = new BrowserPanel();
+            panel.selectSection(BrowserSection.SAMPLES);
+            panel.addSamples(List.of("kick.wav"));
+
+            StackPane root = new StackPane(panel);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 320, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            root.snapshot(null, null);
+            root.applyCss();
+            root.layout();
+
+            ListCell<String> cell = null;
+            Set<Node> cells = panel.getSamplesListView().lookupAll(".list-cell");
+            for (Node n : cells) {
+                if (n instanceof ListCell<?> lc && lc.getItem() != null) {
+                    cell = (ListCell<String>) lc;
+                    break;
+                }
+            }
+            if (cell == null) {
+                return null;
+            }
+
+            // Drive :hover via the pseudo-class directly — synthetic
+            // MOUSE_ENTERED is unreliable headless.
+            cell.pseudoClassStateChanged(PseudoClass.getPseudoClass("hover"), true);
+            cell.applyCss();
+            root.layout();
+
+            Color bg = cell.getBackground() == null
+                    || cell.getBackground().getFills().isEmpty()
+                    ? null
+                    : (Color) cell.getBackground().getFills().getLast().getFill();
+
+            // Sibling probe for the expected -surface-3 token value
+            // (palette-swap safe — no hex literal pinned in the test).
+            javafx.scene.layout.Region probe = new javafx.scene.layout.Region();
+            probe.setStyle("-fx-background-color: -surface-3;");
+            root.getChildren().add(probe);
+            root.applyCss();
+            root.layout();
+            Color expected = (Color) probe.getBackground().getFills().getFirst().getFill();
+
+            boolean hasEffect = cell.getEffect() != null;
+            return new Color[] {
+                    bg, expected, hasEffect ? Color.RED : null
+            };
+        });
+
+        assertThat(result).as("an audio row cell was realized").isNotNull();
+        Color hoverBg = result[0];
+        Color surface3 = result[1];
+
+        assertThat(hoverBg).as("hovered row background resolves (not null)").isNotNull();
+        assertThat(hoverBg.getRed()).as("hover bg red == -surface-3")
+                .isCloseTo(surface3.getRed(), offset(0.01));
+        assertThat(hoverBg.getGreen()).as("hover bg green == -surface-3")
+                .isCloseTo(surface3.getGreen(), offset(0.01));
+        assertThat(hoverBg.getBlue()).as("hover bg blue == -surface-3")
+                .isCloseTo(surface3.getBlue(), offset(0.01));
+        // Prove it differs from the default transparent / unstyled state.
+        assertThat(hoverBg)
+                .as("hover bg must NOT be transparent (proves the cascade fired)")
+                .isNotEqualTo(Color.TRANSPARENT);
+
+        // §7.1 — no glow/drop-shadow on hover. result[2] is non-null only
+        // if the cell carried an Effect.
+        assertThat(result[2])
+                .as("hovered row must have NO effect (§7.1 glow veto)")
+                .isNull();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserPanelTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserPanelTest.java
@@ -1,13 +1,15 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.BrowserPanel.BrowserSection;
+
 import javafx.application.Platform;
-import javafx.scene.control.Tab;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -54,30 +56,40 @@ class BrowserPanelTest {
     void shouldHaveSearchField() throws Exception {
         BrowserPanel panel = createOnFxThread();
         assertThat(panel.getSearchField()).isNotNull();
-        assertThat(panel.getSearchField().getPromptText()).isEqualTo("Filter files...");
+        // story 275 — persistent search; placeholder comes from the
+        // resource bundle (browser.search.placeholder), no longer the
+        // hard-coded "Filter files...".
+        assertThat(panel.getSearchField().getPromptText())
+                .isEqualTo("Search samples and presets…");
+        assertThat(panel.getSearchField().getStyleClass()).contains("search-field");
     }
 
     @Test
-    void shouldHaveFourTabs() throws Exception {
-        BrowserPanel panel = createOnFxThread();
-        assertThat(panel.getTabPane().getTabs()).hasSize(4);
+    void shouldHaveFourSections() throws Exception {
+        // story 275 — the TabPane was replaced by a hand-built tab strip;
+        // the four BrowserSections remain (Files/Samples/Presets/Project).
+        assertThat(BrowserSection.values()).hasSize(4);
     }
 
     @Test
-    void shouldHaveExpectedTabNames() throws Exception {
-        BrowserPanel panel = createOnFxThread();
-        List<String> tabNames = panel.getTabPane().getTabs().stream()
-                .map(Tab::getText)
-                .toList();
-        assertThat(tabNames).containsExactly("Files", "Samples", "Presets", "Project");
+    void shouldHaveExpectedSectionNames() throws Exception {
+        assertThat(Arrays.stream(BrowserSection.values()).map(Enum::name).toList())
+                .containsExactly("FILES", "SAMPLES", "PRESETS", "PROJECT");
     }
 
     @Test
-    void shouldHaveNonClosableTabs() throws Exception {
+    void shouldDefaultToFilesSection() throws Exception {
         BrowserPanel panel = createOnFxThread();
-        for (Tab tab : panel.getTabPane().getTabs()) {
-            assertThat(tab.isClosable()).isFalse();
-        }
+        assertThat(panel.getActiveSection()).isEqualTo(BrowserSection.FILES);
+    }
+
+    @Test
+    void shouldSwitchActiveSection() throws Exception {
+        BrowserPanel panel = createOnFxThread();
+        runOnFxThread(() -> {
+            panel.selectSection(BrowserSection.PRESETS);
+            assertThat(panel.getActiveSection()).isEqualTo(BrowserSection.PRESETS);
+        });
     }
 
     @Test
@@ -201,39 +213,32 @@ class BrowserPanelTest {
                 .containsExactlyInAnyOrder(".wav", ".flac", ".mp3", ".aiff", ".ogg");
     }
 
+    // ── story 275 ──
+    // The shared preview control bar (previewPlayButton / StopButton /
+    // VolumeSlider / MetadataLabel / ControlBar) was removed: it was an
+    // unwired dead stub. Per-row audition replaces it; the surviving
+    // intent ("the panel exposes audition") is covered here and in
+    // BrowserRowAuditionTest.
+
     @Test
-    void shouldHavePreviewPlayButton() throws Exception {
+    void shouldExposeAuditionerSeam() throws Exception {
         BrowserPanel panel = createOnFxThread();
-        assertThat(panel.getPreviewPlayButton()).isNotNull();
-        assertThat(panel.getPreviewPlayButton().getTooltip()).isNotNull();
+        // No auditioner by default — the per-row buttons render :disabled.
+        assertThat(panel.getSampleAuditioner()).isEmpty();
     }
 
     @Test
-    void shouldHavePreviewStopButton() throws Exception {
+    void shouldAcceptInjectedAuditioner() throws Exception {
         BrowserPanel panel = createOnFxThread();
-        assertThat(panel.getPreviewStopButton()).isNotNull();
-        assertThat(panel.getPreviewStopButton().getTooltip()).isNotNull();
-    }
-
-    @Test
-    void shouldHavePreviewVolumeSlider() throws Exception {
-        BrowserPanel panel = createOnFxThread();
-        assertThat(panel.getPreviewVolumeSlider()).isNotNull();
-        assertThat(panel.getPreviewVolumeSlider().getMin()).isEqualTo(0.0);
-        assertThat(panel.getPreviewVolumeSlider().getMax()).isEqualTo(1.0);
-        assertThat(panel.getPreviewVolumeSlider().getValue()).isEqualTo(1.0);
-    }
-
-    @Test
-    void shouldHavePreviewMetadataLabel() throws Exception {
-        BrowserPanel panel = createOnFxThread();
-        assertThat(panel.getPreviewMetadataLabel()).isNotNull();
-    }
-
-    @Test
-    void shouldHavePreviewControlBar() throws Exception {
-        BrowserPanel panel = createOnFxThread();
-        assertThat(panel.getPreviewControlBar()).isNotNull();
-        assertThat(panel.getPreviewControlBar().getChildren()).isNotEmpty();
+        runOnFxThread(() -> {
+            SampleAuditioner fake = new SampleAuditioner() {
+                @Override public void play(java.nio.file.Path file) { }
+                @Override public void stop() { }
+                @Override public boolean isPlaying() { return false; }
+                @Override public void setOnPlaybackFinished(Runnable callback) { }
+            };
+            panel.setSampleAuditioner(fake);
+            assertThat(panel.getSampleAuditioner()).containsSame(fake);
+        });
     }
 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserRowAuditionTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserRowAuditionTest.java
@@ -1,0 +1,122 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.BrowserPanel.BrowserSection;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 275 — clicking a row's audition button drives the injected
+ * {@link SampleAuditioner} with the row's {@link Path}; clicking again
+ * stops it. A fake auditioner keeps the test deterministic and opens no
+ * audio device.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class BrowserRowAuditionTest {
+
+    /** Records calls; never touches an audio device. */
+    private static final class FakeAuditioner implements SampleAuditioner {
+        volatile Path lastPlayed;
+        volatile boolean playing;
+        volatile int stopCalls;
+
+        @Override public void play(Path file) {
+            lastPlayed = file;
+            playing = true;
+        }
+        @Override public void stop() {
+            stopCalls++;
+            playing = false;
+        }
+        @Override public boolean isPlaying() { return playing; }
+        @Override public void setOnPlaybackFinished(Runnable callback) { }
+    }
+
+    private <T> T onFx(java.util.concurrent.Callable<T> action) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Exception> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(action.call());
+            } catch (Exception e) {
+                err.set(e);
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await(5, TimeUnit.SECONDS);
+        if (err.get() != null) {
+            throw err.get();
+        }
+        return ref.get();
+    }
+
+    @Test
+    void rowAuditionButtonTogglesTheInjectedAuditioner() throws Exception {
+        FakeAuditioner fake = new FakeAuditioner();
+
+        // Locate the audition button on the single audio row, fire it.
+        Button auditionButton = onFx(() -> {
+            BrowserPanel panel = new BrowserPanel();
+            panel.setSampleAuditioner(fake);
+            panel.selectSection(BrowserSection.SAMPLES);
+            panel.addSamples(List.of("kick.wav"));
+
+            StackPane root = new StackPane(panel);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 320, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            // Force a raster pass so the ListView realizes its cells.
+            root.snapshot(null, null);
+            root.applyCss();
+            root.layout();
+
+            Set<Node> buttons = panel.getSamplesListView()
+                    .lookupAll(".browser-audition-button");
+            return buttons.stream()
+                    .filter(n -> n instanceof Button)
+                    .map(n -> (Button) n)
+                    .filter(Node::isVisible)
+                    .findFirst()
+                    .orElse(null);
+        });
+
+        assertThat(auditionButton)
+                .as("realized audio row exposes an audition button")
+                .isNotNull();
+
+        // First click → play(kick.wav), isPlaying() == true.
+        onFx(() -> {
+            auditionButton.fire();
+            return null;
+        });
+        assertThat(fake.lastPlayed).isEqualTo(Path.of("kick.wav"));
+        assertThat(fake.isPlaying()).isTrue();
+
+        // Second click on the same row → stop(), isPlaying() == false.
+        onFx(() -> {
+            auditionButton.fire();
+            return null;
+        });
+        assertThat(fake.stopCalls).isGreaterThanOrEqualTo(1);
+        assertThat(fake.isPlaying()).isFalse();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserSearchScopeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserSearchScopeTest.java
@@ -1,0 +1,81 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.BrowserPanel.BrowserSection;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 275 — the persistent search field's text is preserved across a
+ * tab switch and is re-applied to the newly active section's index. The
+ * presets list filters the presets data, never the samples data.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class BrowserSearchScopeTest {
+
+    private BrowserPanel createOnFxThread() throws Exception {
+        AtomicReference<BrowserPanel> ref = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(new BrowserPanel());
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await(5, TimeUnit.SECONDS);
+        return ref.get();
+    }
+
+    private void runOnFxThread(Runnable action) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void searchTextSurvivesTabSwitchAndScopesToActiveIndex() throws Exception {
+        BrowserPanel panel = createOnFxThread();
+        runOnFxThread(() -> {
+            panel.addSamples(List.of("kick.wav", "snare.wav", "kick_hard.wav"));
+            // A preset whose name contains "kick" so we can prove the
+            // filter scopes to the presets index, not the samples index.
+            panel.addPresets(List.of("Kick Punch", "Lead Synth", "Pad Warm"));
+
+            panel.selectSection(BrowserSection.SAMPLES);
+            panel.getSearchField().setText("kick");
+
+            // SAMPLES active: only the two "kick" samples are shown.
+            assertThat(panel.getSamplesListView().getItems())
+                    .containsExactly("kick.wav", "kick_hard.wav");
+
+            panel.selectSection(BrowserSection.PRESETS);
+
+            // The search text is preserved verbatim across the switch.
+            assertThat(panel.getSearchField().getText()).isEqualTo("kick");
+
+            // The presets list is filtered against the PRESETS index —
+            // "Kick Punch" matches (case-insensitive), the samples are
+            // irrelevant. Proves scoping to the active section's data.
+            assertThat(panel.getPresetsListView().getItems())
+                    .containsExactly("Kick Punch");
+            assertThat(panel.getPresetsListView().getItems())
+                    .doesNotContain("kick.wav", "kick_hard.wav");
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserSearchScopeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserSearchScopeTest.java
@@ -24,28 +24,48 @@ class BrowserSearchScopeTest {
 
     private BrowserPanel createOnFxThread() throws Exception {
         AtomicReference<BrowserPanel> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
         Platform.runLater(() -> {
             try {
                 ref.set(new BrowserPanel());
+            } catch (Throwable t) {
+                err.set(t);
             } finally {
                 latch.countDown();
             }
         });
-        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX construction completed within timeout")
+                .isTrue();
+        if (err.get() != null) {
+            throw new AssertionError("FX thread failed during construction", err.get());
+        }
         return ref.get();
     }
 
     private void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> err = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
         Platform.runLater(() -> {
             try {
                 action.run();
+            } catch (Throwable t) {
+                // Assertions run on the FX thread; without this capture
+                // an AssertionError is swallowed by the FX uncaught
+                // handler while the latch still counts down, so a real
+                // failure would pass green (story 275 review TQ2).
+                err.set(t);
             } finally {
                 latch.countDown();
             }
         });
-        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX action completed within timeout")
+                .isTrue();
+        if (err.get() != null) {
+            throw new AssertionError("FX thread assertion failed", err.get());
+        }
     }
 
     @Test

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserTabIndicatorTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserTabIndicatorTest.java
@@ -1,0 +1,115 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.BrowserPanel.BrowserSection;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+/**
+ * Story 275 / UI Design Book §5.5, §7.3 — the active browser tab carries
+ * a DRAWN {@code -accent} 2 px under-text {@link Rectangle}, not a CSS
+ * border and not a layout-shifting border swap.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class BrowserTabIndicatorTest {
+
+    private <T> T onFx(java.util.concurrent.Callable<T> action) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Exception> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(action.call());
+            } catch (Exception e) {
+                err.set(e);
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await(5, TimeUnit.SECONDS);
+        if (err.get() != null) {
+            throw err.get();
+        }
+        return ref.get();
+    }
+
+    @Test
+    void activeTabHasAccentUnderBarPreviousDoesNot() throws Exception {
+        Rectangle[] bars = onFx(() -> {
+            BrowserPanel panel = new BrowserPanel();
+            StackPane root = new StackPane(panel);
+            root.getStyleClass().add("root-pane");
+            Scene scene = new Scene(root, 320, 600);
+            DarkThemeHelper.applyTo(scene);
+            root.applyCss();
+            root.layout();
+            // Force a full CSS + raster pass so scene-stylesheet rules
+            // that reference .root-pane looked-up colours resolve (a
+            // plain applyCss() leaves them unresolved in a fresh headless
+            // scene — see memory: JavaFX headless pitfalls).
+            root.snapshot(null, null);
+            root.applyCss();
+            root.layout();
+
+            panel.selectSection(BrowserSection.SAMPLES);
+            root.applyCss();
+            root.layout();
+            root.snapshot(null, null);
+
+            return new Rectangle[] {
+                    panel.getTabIndicator(BrowserSection.SAMPLES),
+                    panel.getTabIndicator(BrowserSection.FILES)
+            };
+        });
+
+        Rectangle active = bars[0];
+        Rectangle inactive = bars[1];
+
+        // §7.3 — a drawn 2 px Rectangle, unmanaged so it never reflows.
+        assertThat(active).as("active tab indicator exists").isNotNull();
+        assertThat(active.getHeight()).as("indicator height is 2 px").isEqualTo(2.0);
+        assertThat(active.isManaged())
+                .as("indicator is unmanaged so it never perturbs layout")
+                .isFalse();
+        assertThat(active.isVisible())
+                .as("only the active tab's indicator is visible")
+                .isTrue();
+        assertThat(active.getWidth())
+                .as("indicator width hugs the tab label text (> 0)")
+                .isGreaterThan(0.0);
+
+        // The resolved fill must be the -accent token (#7C8CFF) and
+        // explicitly NOT the JavaFX default Rectangle fill (BLACK) —
+        // proving the CSS cascade drives the fill, not a coincidence.
+        assertThat(active.getFill()).isInstanceOf(Color.class);
+        Color fill = (Color) active.getFill();
+        Color accent = Color.web("#7C8CFF");
+        assertThat(fill.getRed()).as("indicator fill red == -accent")
+                .isCloseTo(accent.getRed(), offset(0.01));
+        assertThat(fill.getGreen()).as("indicator fill green == -accent")
+                .isCloseTo(accent.getGreen(), offset(0.01));
+        assertThat(fill.getBlue()).as("indicator fill blue == -accent")
+                .isCloseTo(accent.getBlue(), offset(0.01));
+        assertThat(fill)
+                .as("indicator fill must NOT be the JavaFX default Rectangle BLACK")
+                .isNotEqualTo(Color.BLACK);
+
+        // The previously-active tab (FILES) no longer shows its bar.
+        assertThat(inactive.isVisible())
+                .as("previously active tab's indicator is hidden")
+                .isFalse();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserTabIndicatorTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BrowserTabIndicatorTest.java
@@ -48,7 +48,7 @@ class BrowserTabIndicatorTest {
 
     @Test
     void activeTabHasAccentUnderBarPreviousDoesNot() throws Exception {
-        Rectangle[] bars = onFx(() -> {
+        Object[] bars = onFx(() -> {
             BrowserPanel panel = new BrowserPanel();
             StackPane root = new StackPane(panel);
             root.getStyleClass().add("root-pane");
@@ -69,14 +69,26 @@ class BrowserTabIndicatorTest {
             root.layout();
             root.snapshot(null, null);
 
-            return new Rectangle[] {
+            // Sibling probe for the resolved -accent token value
+            // (palette-swap safe — no hex literal pinned; survives the
+            // story-277 theme work, unlike a hard-coded #7C8CFF).
+            javafx.scene.layout.Region probe = new javafx.scene.layout.Region();
+            probe.setStyle("-fx-background-color: -accent;");
+            root.getChildren().add(probe);
+            root.applyCss();
+            root.layout();
+            Color accent = (Color) probe.getBackground().getFills().getFirst().getFill();
+
+            return new Object[] {
                     panel.getTabIndicator(BrowserSection.SAMPLES),
-                    panel.getTabIndicator(BrowserSection.FILES)
+                    panel.getTabIndicator(BrowserSection.FILES),
+                    accent
             };
         });
 
-        Rectangle active = bars[0];
-        Rectangle inactive = bars[1];
+        Rectangle active = (Rectangle) bars[0];
+        Rectangle inactive = (Rectangle) bars[1];
+        Color accent = (Color) bars[2];
 
         // §7.3 — a drawn 2 px Rectangle, unmanaged so it never reflows.
         assertThat(active).as("active tab indicator exists").isNotNull();
@@ -91,12 +103,12 @@ class BrowserTabIndicatorTest {
                 .as("indicator width hugs the tab label text (> 0)")
                 .isGreaterThan(0.0);
 
-        // The resolved fill must be the -accent token (#7C8CFF) and
-        // explicitly NOT the JavaFX default Rectangle fill (BLACK) —
-        // proving the CSS cascade drives the fill, not a coincidence.
+        // The resolved fill must be the -accent token (resolved via the
+        // sibling probe, not a pinned hex) and explicitly NOT the JavaFX
+        // default Rectangle fill (BLACK) — proving the CSS cascade
+        // drives the fill, not a coincidence.
         assertThat(active.getFill()).isInstanceOf(Color.class);
         Color fill = (Color) active.getFill();
-        Color accent = Color.web("#7C8CFF");
         assertThat(fill.getRed()).as("indicator fill red == -accent")
                 .isCloseTo(accent.getRed(), offset(0.01));
         assertThat(fill.getGreen()).as("indicator fill green == -accent")

--- a/daw-core/src/main/java/module-info.java
+++ b/daw-core/src/main/java/module-info.java
@@ -60,6 +60,9 @@ module daw.core {
     exports com.benesquivelmusic.daw.core.audio.portaudio;
     exports com.benesquivelmusic.daw.core.audioimport;
     exports com.benesquivelmusic.daw.core.automation;
+    // Sample preview engine — surfaced to daw.app's BrowserPanel per-row
+    // audition button (story 275). Single-channel auditioner.
+    exports com.benesquivelmusic.daw.core.browser;
     exports com.benesquivelmusic.daw.core.comping;
     exports com.benesquivelmusic.daw.core.dsp;
     exports com.benesquivelmusic.daw.core.dsp.acoustics;
@@ -151,7 +154,6 @@ module daw.core {
     //   com.benesquivelmusic.daw.core.analysis.quality
     //   com.benesquivelmusic.daw.core.audio.processing
     //   com.benesquivelmusic.daw.core.audio.ringbuffer
-    //   com.benesquivelmusic.daw.core.browser
     //   com.benesquivelmusic.daw.core.clip
     //   com.benesquivelmusic.daw.core.concurrent
     //   com.benesquivelmusic.daw.core.event


### PR DESCRIPTION
# Browser Panel: Accent-Bar Tabs, Persistent Search, and Audition Button Per Row

## Motivation

Phase 2 of the UI Design Book §6 migration roadmap. Builds on user stories: 260, 261, 263, 264, 265, 266.

UI Design Book §5.5 ("Browser") points to two specific complaints with the current browser. First, the tab indicator is a 2 px **purple bottom border** (`styles.css:746–750`), which is the same offence as the sidebar's active-item indicator that §5.2 already corrects with a left accent bar. The browser should be consistent with the sidebar: active tab = `-accent` *bar* (left-edge or under-text, but the colour is the design system's `-accent`, not a hue picked for the browser alone).

Second, the browser today does not have a persistent search and rows are not auditionable from the panel — the user has to drag the sample onto a track and then play to hear it. UI Design Book §5.5 specifies:

- Tabs at top (Files / Samples / Presets / Plugins / Recent) — active tab uses `-accent` indicator.
- Persistent search field below the tabs, scoped to the active tab.
- A tree on the left and a list on the right.
- A **preview / audition button on every row** so the user can audition without dragging.

This story upgrades `BrowserPanel.java` and `BrowserPanelController.java` to the §5.5 layout. Sample preview wiring (story 027) is already filed — this story focuses on the **UI** and surfaces the existing preview API on each row.

## Goals

- Update `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java` (or its FXML, if any) so the tab strip uses the unified design system:
  - Tabs are `dawg-button.size-default` toggles (story 264) without borders, in a horizontal group.
  - The active tab carries an `-accent` 2 px **under-text bar** drawn as a child `Rectangle` (per §7.3 — no border swap, no layout shift).
  - **Remove** the purple `bottom-border` style at `styles.css:746–750`.
- Add a persistent search field below the tab strip:
  - Single-row `TextField` styled with `.search-field` (uses the `search` icon from story 265 as a leading affordance).
  - Scope: search filters the active tab's list only. Tab change does not clear the search.
  - Keyboard shortcut: `Ctrl+F` while the browser is focused puts focus into this field.
- Add an "audition" button to every row in the list:
  - At the right edge of each row, a 16 × 16 `play` icon (from story 265).
  - Click → triggers the existing preview engine (story 027's API, or — if 027 has not yet landed — a stub that calls into the existing waveform preview if any). If no preview engine is available, the icon is `:disabled` per the story-264 disabled rule.
  - During playback, the icon swaps to `pause-circle`; click stops the preview.
  - Only one preview plays at a time; starting a new preview stops the previous one (single-channel auditioner).
- Apply the unified row-hover behaviour:
  - Hover: `-surface-3` background. No purple drop-shadow.
  - Selection: `-accent-soft` background. Left edge no longer carries a border.
- Apply mono numerics (story 266) to the right-side cells that show sample metadata (`1.2 MB`, `44.1k`, `24-b`).
- Tests:
  - `BrowserTabIndicatorTest`: render the browser, switch tabs, assert the active tab has a child Rectangle of fill `-accent` width = tab text width, height 2; assert the previously-active tab does *not*.
  - `BrowserSearchScopeTest`: type into the search field with the "Samples" tab active; switch to "Presets"; assert the search field text is preserved but the displayed list is filtered against the presets index, not samples.
  - `BrowserRowAuditionTest`: click the audition glyph on a row, assert the preview engine receives the row's path and `isPlaying() == true`; click again, assert preview stops.
  - `BrowserHoverStyleTest`: simulate `MOUSE_ENTERED` on a row, assert background resolves to `-surface-3` and `Effect == null` (per §7.1 veto).

## Non-Goals

- Implementing the audio preview engine — story 027's territory. This story wires the UI to the existing API or stubs.
- Adding waveform thumbnails on each row — also story 027. This story leaves room for them in the row layout (the cell factory can render a thumbnail behind the metadata when 027 lands).
- Drag-and-drop polish — story 197 covers drag-target feedback project-wide.
- Adding more tabs (Cloud, Project Folder, etc.) — out of scope.
- Replacing the underlying `BrowserPanelController` model logic — the search filter and tab change wire into existing model methods.

## Technical Notes

- The browser is currently a `TabPane` with `Tab` children. Replacing the indicator with a custom Rectangle requires either (a) extending `TabPaneSkin` (heavy) or (b) replacing the `TabPane` with a custom `HBox` + content `StackPane` (lighter; less JavaFX magic; matches the design book's preference for hand-built skins per §2.5). Option (b) is preferred.
- The "single-channel auditioner" is a simple convention — the preview engine kills any previous preview when a new one starts. This avoids the user accidentally layering ten samples on top of each other.
- Tab labels ("Files", "Samples", "Presets", "Plugins", "Recent"), the search-field placeholder, and the audition tooltip come from the existing `Messages.properties` resource bundle; don't hard-code them. Skill §14.
- Reference: UI Design Book §5.5, §7.1 (glow veto), §7.3 (border-swap veto).
