### PR TITLE
276-dialog-and-modal-chrome-flat-header-accent-primary.md implementat…

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ArchiveSummaryDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ArchiveSummaryDialog.java
@@ -1,7 +1,9 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
+import com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog;
 import com.benesquivelmusic.daw.core.persistence.archive.ProjectArchiveSummary;
-import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 
 import java.nio.file.Path;
@@ -23,9 +25,13 @@ import java.util.Optional;
  *       size in human-readable form.</li>
  * </ul>
  *
- * <p>This class is a thin wrapper around standard JavaFX {@link Alert}s
- * styled with {@link DarkThemeHelper}; it has no state of its own.</p>
+ * <p>This class is a thin static-helper wrapper (private constructor,
+ * no state). It cannot {@code extends DawgDialog} so the §5.9 chrome is
+ * delegated to {@link DawgDialog#confirm}/{@link DawgDialog#info}; it is
+ * exempt from the structural migration via {@link LegacyDialog}.</p>
  */
+@LegacyDialog("Alert-wrapper static helper; chrome delegated to "
+        + "DawgDialog.confirm/info — not a Dialog subclass, exempt by annotation")
 final class ArchiveSummaryDialog {
 
     private ArchiveSummaryDialog() {
@@ -43,12 +49,11 @@ final class ArchiveSummaryDialog {
      *         assets, {@code false} if they want to abort
      */
     static boolean confirmMissingAssets(List<String> missingAssetPaths) {
-        Alert alert = new Alert(Alert.AlertType.WARNING);
-        alert.setTitle("Missing Assets");
-        alert.setHeaderText(missingAssetPaths.size()
+        String header = missingAssetPaths.size()
                 + " referenced asset" + (missingAssetPaths.size() == 1 ? "" : "s")
-                + " could not be found on disk.");
-        StringBuilder body = new StringBuilder("These files will be omitted from the archive:\n\n");
+                + " could not be found on disk.";
+        StringBuilder body = new StringBuilder(header)
+                .append("\n\nThese files will be omitted from the archive:\n\n");
         int shown = 0;
         for (String path : missingAssetPaths) {
             if (shown >= 10) {
@@ -60,13 +65,14 @@ final class ArchiveSummaryDialog {
             shown++;
         }
         body.append("\nContinue with missing assets?");
-        alert.setContentText(body.toString());
-        ButtonType continueBtn = new ButtonType("Continue with missing assets");
-        ButtonType cancelBtn = ButtonType.CANCEL;
-        alert.getButtonTypes().setAll(continueBtn, cancelBtn);
-        DarkThemeHelper.applyTo(alert);
-        Optional<ButtonType> result = alert.showAndWait();
-        return result.isPresent() && result.get() == continueBtn;
+        // story 276 \u2014 \u00a75.9 chrome via DawgDialog.confirm (NOT a JavaFX
+        // Alert, whose header gradient bypasses the author stylesheet).
+        DawgDialog<ButtonType> dialog =
+                DawgDialog.confirm("Missing Assets", body.toString(),
+                        "Continue with missing assets");
+        Optional<ButtonType> result = dialog.showAndWait();
+        return result.isPresent()
+                && result.get().getButtonData() == ButtonBar.ButtonData.OK_DONE;
     }
 
     /**
@@ -75,12 +81,11 @@ final class ArchiveSummaryDialog {
      * dialog.
      */
     static void showSummary(ProjectArchiveSummary summary) {
-        Alert alert = new Alert(Alert.AlertType.INFORMATION);
-        alert.setTitle("Archive Saved");
-        alert.setHeaderText(formatHeadline(summary));
-        alert.setContentText("Archive: " + summary.outputPath());
-        DarkThemeHelper.applyTo(alert);
-        alert.showAndWait();
+        // story 276 — §5.9 chrome via DawgDialog.info (NOT a JavaFX
+        // Alert, whose header gradient bypasses the author stylesheet).
+        DawgDialog.info("Archive Saved",
+                formatHeadline(summary) + "\n\nArchive: " + summary.outputPath())
+                .showAndWait();
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AtmosSessionConfigDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AtmosSessionConfigDialog.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.core.spatial.objectbased.AtmosSessionConfig;
 import com.benesquivelmusic.daw.core.spatial.objectbased.AtmosSessionValidator;
 import com.benesquivelmusic.daw.core.spatial.objectbased.AudioObject;
@@ -30,7 +31,7 @@ import java.util.Objects;
  * <p>An optional {@link ExportRequestListener} can be registered to handle
  * the actual export when the user clicks the Export button.</p>
  */
-public final class AtmosSessionConfigDialog extends Dialog<AtmosSessionConfig> {
+public final class AtmosSessionConfigDialog extends DawgDialog<AtmosSessionConfig> {
 
     /**
      * Callback interface invoked when the user requests an ADM BWF export.
@@ -145,8 +146,10 @@ public final class AtmosSessionConfigDialog extends Dialog<AtmosSessionConfig> {
 
         getDialogPane().setContent(tabPane);
         getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
-
-        DarkThemeHelper.applyTo(this);
+        // story 276 — §5.9 width band; flat header / accent primary /
+        // tokenized section-header chrome applied by the DawgDialog
+        // super-constructor. TabPane preserved (Non-Goal).
+        sized(DawgDialog.Size.MEDIUM);
 
         Button exportButton = (Button) getDialogPane().lookupButton(ButtonType.OK);
         exportButton.setText("Export ADM BWF");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AudioSettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AudioSettingsDialog.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.sdk.audio.AudioBackendException;
@@ -19,13 +20,10 @@ import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
-import javafx.scene.control.Alert;
-import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
-import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.Separator;
@@ -63,7 +61,7 @@ import java.util.logging.Logger;
  * engine. The user is warned first that playback will be briefly
  * interrupted.</p>
  */
-public final class AudioSettingsDialog extends Dialog<Void> {
+public final class AudioSettingsDialog extends DawgDialog<Void> {
 
     private static final Logger LOG = Logger.getLogger(AudioSettingsDialog.class.getName());
 
@@ -329,7 +327,10 @@ public final class AudioSettingsDialog extends Dialog<Void> {
 
         getDialogPane().setContent(buildContent());
         getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
-        getDialogPane().setPrefWidth(540);
+        // story 276 — §5.9 width band (was a bespoke 540 px). Flat
+        // header / accent primary / tokenized section-header chrome is
+        // applied by the DawgDialog super-constructor; tabs preserved.
+        sized(DawgDialog.Size.MEDIUM);
 
         initializeFromModelAndController();
         wireListeners();
@@ -339,8 +340,6 @@ public final class AudioSettingsDialog extends Dialog<Void> {
         cpuPollTimer.setCycleCount(Timeline.INDEFINITE);
         setOnShown(_ -> cpuPollTimer.play());
         setOnHidden(_ -> cpuPollTimer.stop());
-
-        DarkThemeHelper.applyTo(this);
 
         setResultConverter(button -> {
             if (button == ButtonType.APPLY) {
@@ -1273,14 +1272,11 @@ public final class AudioSettingsDialog extends Dialog<Void> {
     }
 
     private void showError(String header, String content) {
-        Platform.runLater(() -> {
-            Alert alert = new Alert(AlertType.ERROR);
-            alert.setTitle("Audio Settings");
-            alert.setHeaderText(header);
-            alert.setContentText(content);
-            DarkThemeHelper.applyTo(alert);
-            alert.showAndWait();
-        });
+        // story 276 — route through DawgDialog.error(...) so the error
+        // dialog gets the §5.9 flat chrome instead of JavaFX's Alert
+        // (whose header gradient bypasses the author stylesheet).
+        Platform.runLater(() ->
+                DawgDialog.error(header, content).showAndWait());
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BackupSettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BackupSettingsDialog.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.core.persistence.backup.BackupRetentionService;
@@ -13,7 +14,6 @@ import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.chart.PieChart;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.Separator;
 import javafx.scene.control.Slider;
@@ -46,7 +46,7 @@ import java.util.stream.Stream;
  * <p>On Apply the dialog resolves to the new {@link BackupRetentionPolicy};
  * on Cancel (or close) it resolves to {@code null}.</p>
  */
-public final class BackupSettingsDialog extends Dialog<BackupRetentionPolicy> {
+public final class BackupSettingsDialog extends DawgDialog<BackupRetentionPolicy> {
 
     private static final int MAX_RECENT = 100;
     private static final int MAX_HOURLY = 168;   // one week of hours
@@ -152,9 +152,10 @@ public final class BackupSettingsDialog extends Dialog<BackupRetentionPolicy> {
 
         getDialogPane().setContent(buildContent());
         getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
-        getDialogPane().setPrefWidth(620);
-
-        DarkThemeHelper.applyTo(this);
+        // story 276 — sized() applies the §5.9 width band; the flat
+        // header / accent primary button / tokenized section header
+        // chrome is applied by the DawgDialog super-constructor.
+        sized(DawgDialog.Size.MEDIUM);
 
         setResultConverter(button -> button == ButtonType.APPLY ? buildPolicy() : null);
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ChannelCpuBudgetDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ChannelCpuBudgetDialog.java
@@ -1,12 +1,12 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.core.mixer.MixerChannel;
 import com.benesquivelmusic.daw.sdk.audio.performance.DegradationPolicy;
 import com.benesquivelmusic.daw.sdk.audio.performance.TrackCpuBudget;
 import javafx.geometry.Insets;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
-import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.layout.GridPane;
@@ -36,7 +36,7 @@ import java.util.Objects;
  * {@link com.benesquivelmusic.daw.core.audio.performance.TrackCpuBudgetEnforcer
  * TrackCpuBudgetEnforcer}.</p>
  */
-public final class ChannelCpuBudgetDialog extends Dialog<Void> {
+public final class ChannelCpuBudgetDialog extends DawgDialog<Void> {
 
     /** Default {@code maxFractionOfBlock} suggested by the issue. */
     public static final double DEFAULT_MAX_FRACTION = 0.5;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HelpDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HelpDialog.java
@@ -29,6 +29,10 @@ import java.util.List;
  *
  * <p>Uses the {@link DawIcon} icon pack for all tab and header graphics.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up; CLOSE-only "
+        + "informational dialog (would keep the §5.9 close glyph), "
+        + "tokenized .shortcut-category-header already de-saturated by 276")
 public final class HelpDialog extends Dialog<Void> {
 
     private static final double HEADER_ICON_SIZE = 18;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HrtfProfileBrowserDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HrtfProfileBrowserDialog.java
@@ -39,6 +39,8 @@ import java.util.Optional;
  * time — typically the profile the user wants the binaural plugin to switch
  * to.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class HrtfProfileBrowserDialog extends Dialog<String> {
 
     private final HrtfImportController controller;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HrtfProfileImportDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HrtfProfileImportDialog.java
@@ -47,6 +47,8 @@ import java.util.Optional;
  * {@link HrtfImportController} — all I/O and validation happens in the
  * controller, which is testable without an FX runtime.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class HrtfProfileImportDialog extends Dialog<String> {
 
     private final HrtfImportController controller;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/InputPortSelectionDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/InputPortSelectionDialog.java
@@ -19,6 +19,8 @@ import java.util.Optional;
  * and input latency. The user selects a device and confirms with OK,
  * or cancels to abort.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class InputPortSelectionDialog extends Dialog<AudioDeviceInfo> {
 
     private static final double HEADER_ICON_SIZE = 24;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyCalibrationDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyCalibrationDialog.java
@@ -60,6 +60,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * a deterministic synthetic capture — the issue specifies a
  * 208-frame round-trip impulse for the harness test.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class LatencyCalibrationDialog extends Dialog<LatencyCalibrationDialog.Result> {
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LockConflictDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LockConflictDialog.java
@@ -31,6 +31,9 @@ import java.util.function.Supplier;
  * For headless tests, supply a deterministic {@link LockConflictHandler}
  * directly instead of this dialog.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up; not a Dialog "
+        + "subclass (LockConflictHandler that builds Alerts internally)")
 public final class LockConflictDialog implements LockConflictHandler {
 
     /** Default cancel resolution when the dialog is dismissed without a choice. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MetronomeSettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MetronomeSettingsDialog.java
@@ -54,6 +54,8 @@ import java.util.UUID;
  * globally via
  * {@link com.benesquivelmusic.daw.core.recording.MetronomeSettingsStore}).</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class MetronomeSettingsDialog extends Dialog<MetronomeSettingsDialog.Result> {
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MidiInputPortSelectionDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MidiInputPortSelectionDialog.java
@@ -23,6 +23,8 @@ import java.util.logging.Logger;
  * {@link javax.sound.midi.MidiSystem} and presents them in a list.
  * The user selects a device and confirms with OK, or cancels to abort.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class MidiInputPortSelectionDialog extends Dialog<MidiDevice.Info> {
 
     private static final Logger LOG = Logger.getLogger(MidiInputPortSelectionDialog.class.getName());

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MigrationReportDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MigrationReportDialog.java
@@ -32,6 +32,8 @@ import java.util.Optional;
  * backup of the pre-migration file (handled by
  * {@code com.benesquivelmusic.daw.core.persistence.ProjectManager}).</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class MigrationReportDialog extends Dialog<Void> {
 
     /** Roll-back button (Story 247). Only attached when a rollback action is supplied. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PitchShiftClipDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PitchShiftClipDialog.java
@@ -34,6 +34,9 @@ import java.util.Optional;
  * The combined offset surfaced through {@link Result#totalSemitones()} is
  * the value passed to {@link com.benesquivelmusic.daw.core.audio.PitchShiftClipAction}.
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up; not a Dialog "
+        + "subclass (static helper that builds a Dialog internally)")
 public final class PitchShiftClipDialog {
 
     /** Lower clamp on combined semitones (engine constraint). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginFaultLogDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginFaultLogDialog.java
@@ -29,6 +29,9 @@ import java.util.concurrent.Flow;
  * <p>The dialog subscribes to {@link PluginInvocationSupervisor#publisher()}
  * and marshals incoming events onto the JavaFX application thread.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up; not a Dialog "
+        + "subclass (controller that builds a Dialog internally)")
 public final class PluginFaultLogDialog {
 
     private static final DateTimeFormatter TIME = DateTimeFormatter.ISO_INSTANT;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginManagerDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginManagerDialog.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
@@ -29,7 +30,7 @@ import java.nio.file.Path;
  *
  * <p>Uses the {@link DawIcon} icon pack for all button graphics.</p>
  */
-public final class PluginManagerDialog extends Dialog<Void> {
+public final class PluginManagerDialog extends DawgDialog<Void> {
 
     private static final double BUTTON_ICON_SIZE = 16;
     private static final double HEADER_ICON_SIZE = 18;
@@ -142,8 +143,13 @@ public final class PluginManagerDialog extends Dialog<Void> {
 
         getDialogPane().setContent(content);
         getDialogPane().getButtonTypes().add(ButtonType.CLOSE);
-
-        DarkThemeHelper.applyTo(this);
+        // story 276 — §5.9 width band. The footer CLOSE button is the
+        // dismiss path, so the redundant header close glyph is retracted
+        // by DawgDialog (§5.9 — "Cancel and Esc are the primary dismiss
+        // paths"); the header keeps this dialog's own SETTINGS graphic
+        // (set above). Flat header / accent primary / tokenized
+        // section-header chrome applied by the DawgDialog super-ctor.
+        sized(DawgDialog.Size.LARGE);
     }
 
     private void browseForJar() {
@@ -194,13 +200,10 @@ public final class PluginManagerDialog extends Dialog<Void> {
     }
 
     private void showError(String message) {
-        Alert alert = new Alert(Alert.AlertType.ERROR);
-        alert.setTitle("Plugin Error");
-        alert.setHeaderText(null);
-        alert.setContentText(message);
-        alert.setGraphic(IconNode.of(DawIcon.ERROR, 32));
-        DarkThemeHelper.applyTo(alert);
-        alert.showAndWait();
+        // story 276 — route through DawgDialog.error(...) so the error
+        // dialog gets the §5.9 flat chrome instead of JavaFX's Alert
+        // (whose header gradient bypasses the author stylesheet).
+        DawgDialog.error("Plugin Error", message).showAndWait();
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/RenderCacheStatsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/RenderCacheStatsDialog.java
@@ -43,6 +43,9 @@ import java.util.Objects;
  * to {@link RenderedTrackCache}, which is fully unit-tested in
  * {@code daw-core}.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up; not a Dialog "
+        + "subclass (static helper that builds a Dialog internally)")
 public final class RenderCacheStatsDialog {
 
     private final Stage stage;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import javafx.geometry.Insets;
@@ -30,7 +31,7 @@ import java.util.Optional;
  *
  * <p>Uses the {@link DawIcon} icon pack for all tab and header graphics.</p>
  */
-public final class SettingsDialog extends Dialog<Void> {
+public final class SettingsDialog extends DawgDialog<Void> {
 
     /**
      * Callback interface invoked after settings are applied.
@@ -155,8 +156,10 @@ public final class SettingsDialog extends Dialog<Void> {
 
         getDialogPane().setContent(tabPane);
         getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
-
-        DarkThemeHelper.applyTo(this);
+        // story 276 — §5.9 width band; flat header / accent primary /
+        // tokenized section-header chrome applied by the DawgDialog
+        // super-constructor. TabPane preserved (Non-Goal).
+        sized(DawgDialog.Size.MEDIUM);
 
         setResultConverter(button -> {
             if (button == ButtonType.APPLY) {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SoundFontBrowserDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SoundFontBrowserDialog.java
@@ -36,6 +36,8 @@ import java.util.logging.Logger;
  * <p>When a preset is selected, a short MIDI phrase is played through
  * the renderer so the user can audition the instrument before confirming.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class SoundFontBrowserDialog extends Dialog<SoundFontAssignment> {
 
     private static final Logger LOG = Logger.getLogger(SoundFontBrowserDialog.class.getName());

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TimeStretchClipDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TimeStretchClipDialog.java
@@ -39,6 +39,9 @@ import java.util.Optional;
  * exercise them without needing a JavaFX scene — the dialog window
  * itself is only constructed inside {@link #showAndWait(Window, Result, double)}.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up; not a Dialog "
+        + "subclass (static helper that builds a Dialog internally)")
 public final class TimeStretchClipDialog {
 
     /** Lower clamp on the stretch ratio surfaced to the user. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/DawgDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/DawgDialog.java
@@ -1,0 +1,479 @@
+package com.benesquivelmusic.daw.app.ui.dialogs;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+import com.benesquivelmusic.daw.app.ui.icons.DawgIcon;
+
+import javafx.beans.InvalidationListener;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.Objects;
+import java.util.ResourceBundle;
+
+/**
+ * Shared dialog skeleton implementing the UI Design Book §5.9
+ * ("Dialog / modal") chrome contract (story 276).
+ *
+ * <p>{@code DawgDialog} is a thin composite wrapper around JavaFX's
+ * {@link Dialog} — <em>not</em> a Control/Skin (Skill §3: a one-off
+ * composite that wraps {@code Dialog<R>} stays a plain wrapper). It
+ * normalises the chrome so individual dialogs cannot drift again:</p>
+ *
+ * <ul>
+ *   <li><strong>Flat {@code -surface-1} header</strong> carrying the
+ *       title as an H1 (18 px / 600, no decoration — §3.2 / §3.4
+ *       elevation 0). The gradient header is gone.</li>
+ *   <li><strong>One-column body</strong> with 24 px padding (§3.3 xl)
+ *       and §3.3 spacing; sections are introduced by tokenized
+ *       label-small headers (§3.2: {@code -text-mute}, 10 px, 600,
+ *       caller passes an already-uppercased string — mirrors the
+ *       inspector convention, not a forked one).</li>
+ *   <li><strong>Footer</strong> with the secondary (text) button on the
+ *       left and the accent-filled primary button on the right
+ *       ({@code .dawg-button.size-default.primary}).</li>
+ *   <li>The header close glyph is <em>secondary</em>: it is dropped when
+ *       a Cancel/secondary button is present (Cancel + Esc are the
+ *       primary dismiss paths, §5.9) and kept only for informational
+ *       dialogs that have no Cancel.</li>
+ * </ul>
+ *
+ * <p>Existing dialogs adopt the chrome by changing
+ * {@code extends Dialog<R>} to {@code extends DawgDialog<R>}; their
+ * <em>contents</em> (forms, tabs, fields) are preserved untouched. The
+ * fluent {@link #sized}/{@link #addSection}/{@link #primary}/{@link
+ * #secondary} API is available for new dialogs and simple
+ * confirmations.</p>
+ *
+ * <h2>JavaFX-specific quirk</h2>
+ *
+ * <p>JavaFX's {@link javafx.scene.control.Alert Alert} paints its own
+ * header gradient and graphic that bypass the {@code .dialog-pane}
+ * author stylesheet. The static {@link #confirm}/{@link #info}/{@link
+ * #warn}/{@link #error} factories therefore build a real
+ * {@code DawgDialog} (never an {@code Alert}) so transient
+ * confirmation / information / error dialogs get the same flat §5.9
+ * chrome as every other dialog.</p>
+ *
+ * @param <R> the dialog result type
+ * @see LegacyDialog
+ */
+public class DawgDialog<R> extends Dialog<R> {
+
+    /** Resource bundle for chrome strings (Skill §14) — {@link Locale#ROOT}. */
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
+
+    /** §3.3 xl — 24 px padding around the dialog body. */
+    private static final double BODY_PADDING = 24;
+    /** §3.3 md — vertical rhythm between sections / section header and body. */
+    private static final double BODY_SPACING = 12;
+    /** §5.9 — the header close glyph is a 16 px secondary icon. */
+    private static final DawgIcon.Size CLOSE_GLYPH_SIZE = DawgIcon.Size.SIZE_16;
+
+    /** Centred-modal widths from UI Design Book §5.9. */
+    public enum Size {
+        /** 480 px — short confirmations. */
+        SMALL(480),
+        /** 640 px — most settings dialogs (default). */
+        MEDIUM(640),
+        /** 800 px — content-heavy dialogs (plugin manager, exports). */
+        LARGE(800);
+
+        private final double px;
+
+        Size(double px) {
+            this.px = px;
+        }
+
+        /** The modal width in pixels. */
+        public double pixels() {
+            return px;
+        }
+    }
+
+    /** Single-column body container; sections are appended in order. */
+    private final VBox body = new VBox(BODY_SPACING);
+
+    private ButtonType primaryType;
+    private ButtonType secondaryType;
+    private Runnable primaryAction;
+    private Runnable secondaryAction;
+
+    /**
+     * The §5.9 secondary close glyph, while installed. Held by reference
+     * so retraction never stomps a domain header graphic a subclass set
+     * via {@link #setGraphic(Node)} itself ({@code null} when no glyph of
+     * ours is currently the header graphic).
+     */
+    private DawgIcon closeGlyph;
+
+    /**
+     * Creates an empty {@code DawgDialog} with the §5.9 chrome applied.
+     * Subclasses set the title via {@link #setTitle(String)} /
+     * {@link #setHeaderText(String)}, populate
+     * {@link DialogPane#setContent(Node)} (or use {@link #addSection}),
+     * and wire {@link ButtonType}s as before — the chrome is already in
+     * place.
+     */
+    public DawgDialog() {
+        body.getStyleClass().add("dawg-dialog-body");
+        body.setPadding(new Insets(BODY_PADDING));
+        applyChrome();
+        // Subclasses populate getButtonTypes() in their constructor body,
+        // which runs AFTER this super-constructor. Re-evaluate the §5.9
+        // close-glyph rule whenever the footer changes so a Cancel/Close
+        // added later still retracts the (now redundant) header glyph.
+        getDialogPane().getButtonTypes().addListener(
+                (InvalidationListener) o -> installCloseGlyphIfAppropriate());
+    }
+
+    // ── Fluent API ───────────────────────────────────────────────────────────
+
+    /**
+     * Sets the modal width to one of the §5.9 sizes (480 / 640 / 800).
+     *
+     * @param size the modal width band; must not be {@code null}
+     * @return this dialog, for chaining
+     */
+    public DawgDialog<R> sized(Size size) {
+        Objects.requireNonNull(size, "size must not be null");
+        getDialogPane().setPrefWidth(size.pixels());
+        return this;
+    }
+
+    /**
+     * Appends a section to the one-column body: a tokenized label-small
+     * header (§3.2 — {@code -text-mute}, 10 px, 600) followed by the
+     * section body. The header text is upper-cased to realise the §3.2
+     * "uppercase" rule the same way the inspector does (JavaFX CSS has
+     * no {@code -fx-text-transform}; tracking is not expressible and is
+     * dropped). The body {@link VBox} is installed as the dialog-pane
+     * content the first time this is called.
+     *
+     * @param header the section header (rendered upper-cased); must not be {@code null}
+     * @param sectionBody the section body node; must not be {@code null}
+     * @return this dialog, for chaining
+     */
+    public DawgDialog<R> addSection(String header, Node sectionBody) {
+        Objects.requireNonNull(header, "header must not be null");
+        Objects.requireNonNull(sectionBody, "sectionBody must not be null");
+        Label headerLabel = new Label(sectionHeaderText(header));
+        headerLabel.getStyleClass().add("dawg-dialog-section-header");
+        body.getChildren().addAll(headerLabel, sectionBody);
+        if (getDialogPane().getContent() != body) {
+            getDialogPane().setContent(body);
+        }
+        return this;
+    }
+
+    /**
+     * Declares the primary (accent-filled) footer action. The button
+     * carries {@code dawg-button size-default primary} and is placed on
+     * the footer's right per §5.9. The {@code action} runs from the
+     * dialog's result converter when the primary button is pressed.
+     *
+     * @param label the button label; must not be {@code null}
+     * @param action the action to run on press, or {@code null} for none
+     * @return this dialog, for chaining
+     */
+    public DawgDialog<R> primary(String label, Runnable action) {
+        Objects.requireNonNull(label, "label must not be null");
+        this.primaryType = new ButtonType(label, ButtonBar.ButtonData.OK_DONE);
+        this.primaryAction = action;
+        rebuildButtons();
+        return this;
+    }
+
+    /**
+     * Declares the secondary (neutral text, no border) footer action,
+     * placed on the footer's left per §5.9. When a secondary button is
+     * present the header close glyph is dropped (Cancel + Esc are the
+     * primary dismiss paths, §5.9).
+     *
+     * @param label the button label; must not be {@code null}
+     * @param action the action to run on press, or {@code null} for none
+     * @return this dialog, for chaining
+     */
+    public DawgDialog<R> secondary(String label, Runnable action) {
+        Objects.requireNonNull(label, "label must not be null");
+        this.secondaryType = new ButtonType(label, ButtonBar.ButtonData.CANCEL_CLOSE);
+        this.secondaryAction = action;
+        rebuildButtons();
+        return this;
+    }
+
+    // ── Chrome ───────────────────────────────────────────────────────────────
+
+    /**
+     * Applies the §5.9 chrome: the dark theme stylesheet + the
+     * {@code dawg-dialog} / header / footer style classes, and a
+     * secondary close glyph for informational dialogs (dropped once a
+     * secondary button is added). Idempotent.
+     */
+    private void applyChrome() {
+        DarkThemeHelper.applyTo(this);
+        DialogPane pane = getDialogPane();
+        addStyleClassOnce(pane, "dawg-dialog");
+        installCloseGlyphIfAppropriate();
+    }
+
+    /**
+     * Applies the §5.9 header close-glyph rule.
+     *
+     * <p>The glyph is a {@link DawgIcon} ({@code x}) whose tint derives
+     * from the resolved CSS {@code -fx-icon-color} of {@code .dawg-dialog}
+     * (project rule: tint glyphs from resolved CSS, never a hard-coded hex
+     * mirror — {@code DawgIcon} reads {@code -fx-icon-color} via its
+     * {@code CssMetaData}, so placing it under the styled dialog-pane is
+     * sufficient and deterministic). It is <em>functional</em>: clicking
+     * it dismisses the dialog (§5.9 — the close glyph is a secondary
+     * dismiss path, with Cancel and Esc primary).</p>
+     *
+     * <p>It is shown only for informational dialogs that have <em>no
+     * footer dismiss button</em>. As soon as the fluent {@code secondary()}
+     * is used or the dialog pane gains any Cancel/Close button, the footer
+     * becomes the dismiss path and the header glyph is retracted (§5.9 —
+     * "Cancel and Esc are the primary dismiss paths"). Retraction only
+     * clears the header graphic when it is still <em>our</em> glyph, so a
+     * domain header graphic a subclass set via {@link #setGraphic(Node)}
+     * is never stomped; conversely the glyph is never installed over a
+     * graphic the subclass already set. Idempotent.</p>
+     */
+    private void installCloseGlyphIfAppropriate() {
+        boolean hasFooterDismissPath = secondaryType != null || paneHasCancelButton();
+        if (hasFooterDismissPath) {
+            if (closeGlyph != null) {
+                if (getGraphic() == closeGlyph) {
+                    setGraphic(null);
+                }
+                closeGlyph = null;
+            }
+            return;
+        }
+        if (closeGlyph != null || getGraphic() != null) {
+            return;
+        }
+        DawgIcon glyph = DawgIcon.of("x", CLOSE_GLYPH_SIZE);
+        glyph.getStyleClass().add("dawg-dialog-close");
+        glyph.setAccessibleText(msg("dialog.close"));
+        glyph.setOnMouseClicked(e -> close());
+        setGraphic(glyph);
+        closeGlyph = glyph;
+    }
+
+    /**
+     * @return {@code true} if the dialog pane carries any
+     *         Cancel/Close-type button ({@link
+     *         javafx.scene.control.ButtonBar.ButtonData#isCancelButton()})
+     *         — i.e. the footer already offers a dismiss path, making the
+     *         header glyph redundant per §5.9.
+     */
+    private boolean paneHasCancelButton() {
+        for (ButtonType bt : getDialogPane().getButtonTypes()) {
+            if (bt.getButtonData() != null && bt.getButtonData().isCancelButton()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Rebuilds the footer button types in §5.9 order (secondary LEFT via
+     * {@link ButtonBar.ButtonData#CANCEL_CLOSE}, primary RIGHT via
+     * {@link ButtonBar.ButtonData#OK_DONE}), tags the rendered buttons
+     * with the unified {@code dawg-button} classes, and installs a
+     * result converter that runs the matching {@link Runnable}.
+     */
+    private void rebuildButtons() {
+        DialogPane pane = getDialogPane();
+        pane.getButtonTypes().clear();
+        if (secondaryType != null) {
+            pane.getButtonTypes().add(secondaryType);
+        }
+        if (primaryType != null) {
+            pane.getButtonTypes().add(primaryType);
+        }
+        styleFooterButton(secondaryType, false);
+        styleFooterButton(primaryType, true);
+        installCloseGlyphIfAppropriate();
+
+        setResultConverter(bt -> {
+            if (bt == primaryType && primaryAction != null) {
+                primaryAction.run();
+            } else if (bt == secondaryType && secondaryAction != null) {
+                secondaryAction.run();
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Tags the rendered footer {@link Button} for {@code buttonType}
+     * with the unified button classes. The primary button carries
+     * {@code dawg-button size-default primary} (accent fill via
+     * {@code .dawg-button.primary}); the secondary carries
+     * {@code dawg-button size-default secondary} (neutral, borderless
+     * text button per §5.9).
+     */
+    private void styleFooterButton(ButtonType buttonType, boolean isPrimary) {
+        if (buttonType == null) {
+            return;
+        }
+        Node node = getDialogPane().lookupButton(buttonType);
+        if (node instanceof Button button) {
+            button.getStyleClass().removeAll(
+                    "primary", "secondary", "dawg-button", "size-default");
+            button.getStyleClass().addAll("dawg-button", "size-default");
+            button.getStyleClass().add(isPrimary ? "primary" : "secondary");
+            button.setDefaultButton(isPrimary);
+        }
+    }
+
+    // ── Static factories — Alert-style transient dialogs ─────────────────────
+
+    /**
+     * Builds a confirmation dialog with the §5.9 chrome (NOT a JavaFX
+     * {@link javafx.scene.control.Alert Alert}, whose header gradient and
+     * graphic bypass the author stylesheet). The result is the pressed
+     * {@link ButtonType} so callers can branch on confirm vs. cancel.
+     *
+     * @param title the localized window/header title
+     * @param message the localized confirmation message
+     * @param confirmLabel the localized primary (confirm) button label
+     * @return a styled confirmation dialog
+     */
+    public static DawgDialog<ButtonType> confirm(String title, String message,
+                                                 String confirmLabel) {
+        DawgDialog<ButtonType> dialog = messageDialog(title, message);
+        ButtonType confirm = new ButtonType(confirmLabel, ButtonBar.ButtonData.OK_DONE);
+        ButtonType cancel = new ButtonType(msg("dialog.cancel"),
+                ButtonBar.ButtonData.CANCEL_CLOSE);
+        dialog.secondaryType = cancel;
+        dialog.primaryType = confirm;
+        dialog.getDialogPane().getButtonTypes().setAll(cancel, confirm);
+        dialog.styleFooterButton(cancel, false);
+        dialog.styleFooterButton(confirm, true);
+        dialog.installCloseGlyphIfAppropriate();
+        dialog.setResultConverter(bt -> bt);
+        return dialog;
+    }
+
+    /**
+     * Builds an informational dialog with the §5.9 chrome. Keeps the
+     * secondary close glyph (no Cancel — informational dialogs dismiss
+     * via the close glyph or {@code OK}).
+     *
+     * @param title the localized window/header title
+     * @param message the localized message
+     * @return a styled informational dialog
+     */
+    public static DawgDialog<ButtonType> info(String title, String message) {
+        return acknowledgeDialog(title, message);
+    }
+
+    /**
+     * Builds a warning dialog with the §5.9 chrome. The chrome is
+     * identical to {@link #info}; the semantic level is conveyed by the
+     * caller-supplied content (§7.2 — one accent, no per-dialog hue).
+     *
+     * @param title the localized window/header title
+     * @param message the localized warning message
+     * @return a styled warning dialog
+     */
+    public static DawgDialog<ButtonType> warn(String title, String message) {
+        return acknowledgeDialog(title, message);
+    }
+
+    /**
+     * Builds an error dialog with the §5.9 chrome. Replaces ad-hoc
+     * {@code new Alert(AlertType.ERROR)} usage so error dialogs get the
+     * same flat header / accent button treatment.
+     *
+     * @param title the localized window/header title
+     * @param message the localized error message
+     * @return a styled error dialog
+     */
+    public static DawgDialog<ButtonType> error(String title, String message) {
+        return acknowledgeDialog(title, message);
+    }
+
+    /**
+     * Single-button acknowledge dialog ({@code OK}) that keeps the
+     * secondary header close glyph (no Cancel present).
+     */
+    private static DawgDialog<ButtonType> acknowledgeDialog(String title, String message) {
+        DawgDialog<ButtonType> dialog = messageDialog(title, message);
+        ButtonType ok = new ButtonType(msg("dialog.ok"), ButtonBar.ButtonData.OK_DONE);
+        dialog.primaryType = ok;
+        dialog.getDialogPane().getButtonTypes().setAll(ok);
+        dialog.styleFooterButton(ok, true);
+        dialog.installCloseGlyphIfAppropriate();
+        dialog.setResultConverter(bt -> bt);
+        return dialog;
+    }
+
+    /** Shared skeleton for the static factories: title + wrapped message body. */
+    private static DawgDialog<ButtonType> messageDialog(String title, String message) {
+        DawgDialog<ButtonType> dialog = new DawgDialog<>();
+        dialog.setTitle(title);
+        dialog.setHeaderText(title);
+        Label content = new Label(message);
+        content.setWrapText(true);
+        content.getStyleClass().add("dawg-dialog-message");
+        VBox box = new VBox(BODY_SPACING, content);
+        box.setPadding(new Insets(BODY_PADDING));
+        box.setAlignment(Pos.TOP_LEFT);
+        box.getStyleClass().add("dawg-dialog-body");
+        dialog.getDialogPane().setContent(box);
+        return dialog;
+    }
+
+    // ── Pure helpers (toolkit-free) ──────────────────────────────────────────
+
+    /**
+     * Resolves a chrome string from the shared {@link ResourceBundle},
+     * falling back to the raw key if absent (mirrors
+     * {@code BrowserPanel#msg(String)} / {@code NotificationPill#msg}).
+     * Package-private so it is unit-testable without a toolkit.
+     *
+     * @param key the message key
+     * @return the localized string, or {@code key} if not found
+     */
+    static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (MissingResourceException e) {
+            return key;
+        }
+    }
+
+    /**
+     * Realises the §3.2 "uppercase" label-small rule the same way the
+     * inspector does — by upper-casing the caller string ({@link
+     * Locale#ROOT}). JavaFX CSS has no {@code -fx-text-transform}; the
+     * +12 % tracking is not expressible and is intentionally dropped.
+     * Package-private + pure so it is unit-testable off-thread.
+     *
+     * @param header the caller-supplied section header
+     * @return the header upper-cased, or {@code ""} if {@code null}
+     */
+    static String sectionHeaderText(String header) {
+        return header == null ? "" : header.toUpperCase(Locale.ROOT);
+    }
+
+    private static void addStyleClassOnce(Node node, String styleClass) {
+        if (!node.getStyleClass().contains(styleClass)) {
+            node.getStyleClass().add(styleClass);
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/LegacyDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/LegacyDialog.java
@@ -1,0 +1,46 @@
+package com.benesquivelmusic.daw.app.ui.dialogs;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Sentinel marker for a {@code *Dialog} class that has <em>not yet</em>
+ * been migrated to {@link DawgDialog} (story 276, UI Design Book §5.9).
+ *
+ * <p>{@code EveryDialogConformsTest} classpath-scans the UI packages and
+ * asserts that every class whose simple name ends in {@code Dialog}
+ * either {@code extends DawgDialog} or carries this annotation. The
+ * annotation makes the not-yet-migrated state <strong>visible</strong>
+ * and prevents drift: a new dialog cannot be added without consciously
+ * either adopting the §5.9 chrome skeleton or recording a TODO here.</p>
+ *
+ * <p>The corrected dialog chrome (flat header, accent primary button,
+ * tokenized section headers) still applies to annotated dialogs for
+ * free, because the legacy {@code .dialog-pane} CSS rules are global;
+ * this annotation only tracks the structural migration to the shared
+ * {@link DawgDialog} skeleton.</p>
+ *
+ * <pre>{@code
+ * @LegacyDialog("migrate to DawgDialog — story 276 follow-up")
+ * public final class FooDialog extends Dialog<Void> { ... }
+ * }</pre>
+ *
+ * @see DawgDialog
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LegacyDialog {
+
+    /**
+     * Mandatory TODO / reason string explaining why the dialog has not
+     * yet been migrated to {@link DawgDialog}, or why it is structurally
+     * exempt (e.g. an {@code Alert}-wrapper static helper).
+     *
+     * @return the migration TODO or exemption rationale, must be non-blank
+     */
+    String value();
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/export/AafExportDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/export/AafExportDialog.java
@@ -40,6 +40,8 @@ import java.util.Objects;
  * {@code AafExportService} in {@code daw-core}; this dialog only builds
  * the request.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class AafExportDialog extends Dialog<AafExportConfig> {
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/export/BundleExportDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/export/BundleExportDialog.java
@@ -50,6 +50,8 @@ import java.util.Objects;
  * {@code BundleExportService} (in {@code daw-core}); this dialog only
  * builds the request.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class BundleExportDialog extends Dialog<DeliverableBundle> {
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemePickerDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemePickerDialog.java
@@ -58,6 +58,8 @@ import java.util.logging.Logger;
  * {@link ThemeRegistry#userThemesDir()} via
  * {@link ThemeRegistry#saveUserTheme(Theme)}.</p>
  */
+@com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
+        "migrate to DawgDialog — story 276 follow-up")
 public final class ThemePickerDialog extends Dialog<Theme> {
 
     private static final Logger LOG = Logger.getLogger(ThemePickerDialog.class.getName());

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -62,3 +62,12 @@ browser.tab.project=Project
 browser.search.placeholder=Search samples and presets…
 browser.audition.play=Audition
 browser.audition.stop=Stop preview
+
+# Dialog chrome (story 276) — UI Design Book §5.9. Shared DawgDialog
+# footer-button / acknowledge strings only. Caller-supplied titles,
+# prompts, and error details stay caller-supplied (already localized at
+# the call site). Section-scoped prefix per the file convention.
+dialog.cancel=Cancel
+dialog.close=Close
+dialog.ok=OK
+dialog.save=Save

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -1306,15 +1306,21 @@
     -fx-padding: 8 16;
 }
 
+/* story 276 / UI Design Book §5.9 / §3.4 — flat dialog header.
+ * The gradient title bar was pure decoration; §3.4 elevation 0 = no
+ * shadow, no gradient. Flatten to -surface-1. Global to .dialog-pane,
+ * so this corrects the chrome of EVERY dialog (migrated or not). */
 .dialog-pane > .header-panel {
-    -fx-background-color: linear-gradient(to bottom, -surface-1, -surface-bg);
+    -fx-background-color: -surface-1;
     -fx-padding: 12 16;
 }
 
+/* story 276 / §5.9 / §3.2 — title is the H1 (18 px / 600, no
+ * decoration). Was 14 px bold. */
 .dialog-pane > .header-panel > .label {
     -fx-text-fill: -text-hi;
-    -fx-font-size: 14px;
-    -fx-font-weight: bold;
+    -fx-font-size: 18px;
+    -fx-font-weight: 600;
 }
 
 .dialog-pane .label {
@@ -1363,19 +1369,26 @@
     -fx-opacity: 0.45;
 }
 
-/* Default / OK button accent — targets both .dawg-button and .button
- * so dialog-pane OK buttons render correctly regardless of whether
- * dawg-button was added. */
+/* story 276 / UI Design Book §5.9 / §3.1 — primary (default) dialog
+ * button is the ACCENT-filled primary action, not green. §3.1: the one
+ * accent is the primary action / selection colour; -ok is success-only
+ * (autosave OK, signal-in-safe-range). Conflating "default button" with
+ * -ok was a category error. Targets both .dawg-button and .button so
+ * dialog-pane OK buttons render correctly regardless of whether
+ * dawg-button was added. Hover STAYS accent (must not fall back to
+ * -surface-3, which would read as non-primary). */
 .dawg-button:default,
 .button:default {
-    -fx-background-color: -surface-3;
-    -fx-border-color: -ok;
-    -fx-text-fill: -ok;
+    -fx-background-color: -accent;
+    -fx-border-color: -accent;
+    -fx-text-fill: -text-on-accent;
 }
 
 .dawg-button:default:hover,
 .button:default:hover {
-    -fx-background-color: -surface-3;
+    -fx-background-color: -accent;
+    -fx-border-color: -accent;
+    -fx-text-fill: -text-on-accent;
 }
 
 /* Cancel button accent. */
@@ -1654,11 +1667,21 @@
     -fx-font-size: 12px;
 }
 
-/* ── Dialog section headers ── */
+/* story 276 / UI Design Book §5.9 / §3.2 / §7.6 — section headers are
+ * labels, not saturated accent. Re-tokenized to label-small, EXACTLY
+ * mirroring the shipped inspector convention (inspector.css:75-79):
+ * -text-mute, 10 px, 600. JavaFX CSS has no -fx-text-transform and no
+ * letter-spacing; "uppercase / +12% tracking" is realised the same way
+ * the inspector does it (callers pass an already-uppercased string;
+ * tracking is dropped). Reuses the existing convention, not a fork.
+ * Two-class form so it beats the `.dialog-pane .label` 12 px rule on
+ * equal specificity + later cascade (same reasoning as
+ * .dawg-dialog-section-header below). */
+.dialog-pane .dialog-section-header,
 .dialog-section-header {
-    -fx-text-fill: -accent;
-    -fx-font-size: 13px;
-    -fx-font-weight: bold;
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10;
+    -fx-font-weight: 600;
 }
 
 /* ── Dialog hint labels ── */
@@ -1673,11 +1696,130 @@
     -fx-font-size: 10px;
 }
 
-/* ── Shortcut category header in Help dialog ── */
-.shortcut-category-header {
-    -fx-text-fill: -accent;
-    -fx-font-weight: bold;
+/* ════════════════════════════════════════════════════════════════════
+ * DawgDialog — shared §5.9 dialog/modal chrome (story 276)
+ * UI Design Book §5.9 (anatomy), §3.2 (typography), §3.3 (spacing),
+ * §3.4 (elevation 0 = flat). The three legacy global .dialog-pane
+ * rules above already correct the chrome of every dialog; these
+ * .dawg-dialog-* rules style the shared DawgDialog skeleton that new
+ * and migrated dialogs build on so the contract cannot drift.
+ *
+ * styles.css is the AUTHOR stylesheet — it cascades AFTER JavaFX's
+ * user-agent modena.css and after component USER_AGENT sheets, so
+ * these rules win by cascade order (the documented project rule;
+ * .dawg-button vs .button is decided by author cascade, not
+ * specificity). New rules are placed in the dialog block so author
+ * cascade is correct.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* §3.4 elevation 0 — flat -surface-1, no shadow, no gradient. */
+.dawg-dialog {
+    -fx-background-color: -surface-1;
+}
+
+/* §5.9 header: flat -surface-1 (matches the global .header-panel fix). */
+.dawg-dialog > .header-panel {
+    -fx-background-color: -surface-1;
+    -fx-padding: 12 16;
+}
+
+/* §3.3 xl — 24 px body padding, one column. */
+.dawg-dialog-body {
+    -fx-background-color: -surface-1;
+    -fx-padding: 24;
+    -fx-spacing: 12;
+}
+
+.dawg-dialog-message {
+    -fx-text-fill: -text-hi;
     -fx-font-size: 12px;
+}
+
+/* §3.2 label-small for section headers — muted, NOT purple per §7.6.
+ * Identical token/size/weight to inspector.css:75-79 and the
+ * re-tokenized .dialog-section-header above (one convention, not a
+ * fork). Callers pass an already-uppercased string; tracking is not
+ * expressible in JavaFX CSS and is dropped.
+ *
+ * Two-class selector (.dawg-dialog descendant) so this matches the
+ * specificity of the global `.dialog-pane .label` (12 px) rule and,
+ * cascading later, wins — a bare `.dawg-dialog-section-header` would
+ * lose to that 2-class descendant rule and render at 12 px. */
+.dawg-dialog .dawg-dialog-section-header,
+.dawg-dialog-section-header {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10;
+    -fx-font-weight: 600;
+}
+
+/* §5.9 footer — buttons right-aligned. */
+.dawg-dialog > .button-bar > .container {
+    -fx-background-color: -surface-bg;
+    -fx-padding: 8 16;
+    -fx-alignment: center-right;
+}
+
+/* §5.9 — the header close glyph is SECONDARY: muted by default,
+ * brightening to -text-hi on hover. DawgIcon resolves its colour from
+ * the CSS -fx-icon-color property (its CssMetaData), so the tint is
+ * derived from resolved CSS, never a hard-coded hex mirror. */
+.dawg-dialog-close {
+    -fx-icon-color: -text-mute;
+    -fx-cursor: hand;
+}
+
+.dawg-dialog-close:hover {
+    -fx-icon-color: -text-hi;
+}
+
+/* §5.9 / §3.1 primary (accent-filled) footer button. The base
+ * .dawg-button:armed/:pressed/:active block (lines ~280) already paints
+ * -accent; .primary makes the accent the RESTING state too and keeps it
+ * through hover/armed/pressed so the primary action never reverts to a
+ * neutral surface (which would read as non-primary). Composes cleanly
+ * with — is not clobbered by — those state rules because both resolve
+ * to the same -accent fill. */
+.dawg-button.primary {
+    -fx-background-color: -accent;
+    -fx-border-color: -accent;
+    -fx-text-fill: -text-on-accent;
+}
+
+.dawg-button.primary:hover,
+.dawg-button.primary:armed,
+.dawg-button.primary:pressed,
+.dawg-button.primary:default {
+    -fx-background-color: -accent;
+    -fx-border-color: -accent;
+    -fx-text-fill: -text-on-accent;
+}
+
+/* §5.9 secondary footer button — neutral TEXT button, no border.
+ * Reuses the existing .dawg-button:cancel neutral treatment intent
+ * (story 264 unified button system) rather than forking a parallel
+ * style: transparent fill + no border + secondary text colour. */
+.dawg-button.secondary {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+    -fx-text-fill: -text;
+}
+
+.dawg-button.secondary:hover {
+    -fx-background-color: -surface-3;
+    -fx-border-color: transparent;
+    -fx-text-fill: -text-hi;
+}
+
+/* story 276 / §7.6 — saturated-section-header veto applies to "any
+ * sibling". HelpDialog's category header is a section-header sibling;
+ * re-tokenized to the same label-small style as .dialog-section-header
+ * (the inspector convention). Two-class form to beat
+ * `.dialog-pane .label` on equal specificity + later cascade. */
+.dialog-pane .shortcut-category-header,
+.shortcut-category-header {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10;
+    -fx-font-weight: 600;
 }
 
 /* ── Track drag-and-drop indicators ── */

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -1680,7 +1680,7 @@
 .dialog-pane .dialog-section-header,
 .dialog-section-header {
     -fx-text-fill: -text-mute;
-    -fx-font-size: 10;
+    -fx-font-size: 10px;
     -fx-font-weight: 600;
 }
 
@@ -1748,7 +1748,7 @@
 .dawg-dialog .dawg-dialog-section-header,
 .dawg-dialog-section-header {
     -fx-text-fill: -text-mute;
-    -fx-font-size: 10;
+    -fx-font-size: 10px;
     -fx-font-weight: 600;
 }
 
@@ -1818,7 +1818,7 @@
 .dialog-pane .shortcut-category-header,
 .shortcut-category-header {
     -fx-text-fill: -text-mute;
-    -fx-font-size: 10;
+    -fx-font-size: 10px;
     -fx-font-weight: 600;
 }
 

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/DialogChromeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/DialogChromeTest.java
@@ -1,0 +1,257 @@
+package com.benesquivelmusic.daw.app.ui.dialogs;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.icons.DawgIcon;
+
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
+import javafx.scene.text.Font;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * §5.9 / §3.2 / §3.4 — the shared {@link DawgDialog} chrome:
+ * <ul>
+ *   <li>a flat (non-gradient, non-image) header background;</li>
+ *   <li>an accent-filled primary footer button;</li>
+ *   <li>a muted, 10 px, non-purple section header (§7.6 veto).</li>
+ * </ul>
+ *
+ * <p>Follows {@code InspectorSectionStylingTest}: resolved values are
+ * extracted out of the FX runnable and asserted on the test thread
+ * (assertions inside an FX runnable are swallowed → false green —
+ * a known project pitfall).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class DialogChromeTest {
+
+    /** Palette-A {@code -accent} (#7C8CFF) is blue-dominant. */
+    private static final double ACCENT_BLUE_DOMINANCE_MIN = 0.20;
+
+    @Test
+    void headerIsFlatPrimaryIsAccentSectionHeaderIsMuted() {
+        Paint[] headerFill = new Paint[1];
+        boolean[] headerHasImage = new boolean[1];
+        Paint[] primaryFill = new Paint[1];
+        Paint[] sectionFill = new Paint[1];
+        double[] sectionFontSize = new double[1];
+
+        runOnFxThread(() -> {
+            DawgDialog<Void> dialog = new DawgDialog<>();
+            dialog.setTitle("Chrome Test");
+            dialog.setHeaderText("Chrome Test");
+            Label sectionBody = new Label("body");
+            dialog.addSection("Scan", sectionBody)
+                  .primary("Save", () -> { })
+                  .secondary("Cancel", () -> { })
+                  .sized(DawgDialog.Size.MEDIUM);
+
+            DialogPane pane = dialog.getDialogPane();
+            Pane root = new Pane(pane);
+            new Scene(root, 720, 480);
+            root.applyCss();
+            root.layout();
+
+            // (a) header panel — must be a flat fill, not a gradient
+            //     or image. The header-panel sub-node is created lazily
+            //     once the dialog has a header.
+            Region header = (Region) pane.lookup(".header-panel");
+            if (header != null) {
+                headerHasImage[0] = !header.getBackground().getImages().isEmpty();
+                headerFill[0] = firstFill(header.getBackground());
+            }
+
+            // (b) primary button — accent-filled region background.
+            Button primary = (Button) pane.lookupButton(
+                    primaryButtonType(pane));
+            primary.applyCss();
+            primaryFill[0] = firstFill(primary.getBackground());
+
+            // (c) section header label — muted, 10 px, not purple.
+            Label sectionHeader = findSectionHeader(pane);
+            sectionFill[0] = sectionHeader.getTextFill();
+            Font f = sectionHeader.getFont();
+            sectionFontSize[0] = f.getSize();
+            return null;
+        });
+
+        // (a) Flat header — no background image, fill is a plain Color
+        //     (not a LinearGradient).
+        assertThat(headerHasImage[0])
+                .as("§3.4 — dialog header must not use a background image")
+                .isFalse();
+        assertThat(headerFill[0])
+                .as("§3.4 — dialog header fill must be a flat Color, not a gradient")
+                .isInstanceOf(Color.class);
+
+        // (b) Primary button resolves to the accent family. Derive the
+        //     judgement from the resolved CSS, never a hard-coded hex:
+        //     the Palette-A accent #7C8CFF is strongly blue-dominant.
+        assertThat(primaryFill[0])
+                .as("primary button background must resolve from CSS")
+                .isInstanceOf(Color.class);
+        Color primary = (Color) primaryFill[0];
+        double primaryBlueDominance =
+                primary.getBlue() - Math.max(primary.getRed(), primary.getGreen());
+        assertThat(primaryBlueDominance)
+                .as("§5.9 / §3.1 — primary button must resolve to the "
+                        + "accent (blue-dominant indigo), not a neutral surface")
+                .isGreaterThan(ACCENT_BLUE_DOMINANCE_MIN);
+
+        // (c) Section header — muted family, 10 px, NOT the saturated
+        //     accent. Reuses InspectorSectionStylingTest's §7.6
+        //     blue-dominance invariant verbatim.
+        assertThat(sectionFontSize[0]).isEqualTo(10.0);
+        assertThat(sectionFill[0]).isInstanceOf(Color.class);
+        Color section = (Color) sectionFill[0];
+        double sectionBlueDominance =
+                section.getBlue() - Math.max(section.getRed(), section.getGreen());
+        assertThat(sectionBlueDominance)
+                .as("§7.6 — section header must not resolve to the "
+                        + "saturated -accent (purple)")
+                .isLessThan(0.10);
+    }
+
+    /**
+     * §5.9 — an informational dialog with no footer dismiss button keeps
+     * the secondary header close glyph, and it is <em>functional</em>
+     * (wired to dismiss; not decorative) and styled
+     * {@code .dawg-dialog-close} so the CSS-resolved tint applies.
+     */
+    @Test
+    void informationalDialogKeepsFunctionalCloseGlyph() {
+        Node[] graphic = new Node[1];
+        boolean[] clickWired = new boolean[1];
+        runOnFxThread(() -> {
+            DawgDialog<ButtonType> dialog = DawgDialog.info("Title", "Message");
+            DialogPane pane = dialog.getDialogPane();
+            new Scene(new Pane(pane), 480, 320);
+            pane.applyCss();
+            graphic[0] = dialog.getGraphic();
+            if (graphic[0] != null) {
+                clickWired[0] = graphic[0].getOnMouseClicked() != null;
+            }
+            return null;
+        });
+
+        assertThat(graphic[0])
+                .as("§5.9 — informational (no footer Cancel) dialog keeps "
+                        + "the header close glyph")
+                .isInstanceOf(DawgIcon.class);
+        assertThat(((Node) graphic[0]).getStyleClass())
+                .as("close glyph must carry .dawg-dialog-close so its tint "
+                        + "resolves from CSS -fx-icon-color")
+                .contains("dawg-dialog-close");
+        assertThat(clickWired[0])
+                .as("§5.9 — the close glyph is a dismiss path, not "
+                        + "decorative: it must have a click handler")
+                .isTrue();
+    }
+
+    /**
+     * §5.9 — when the footer carries a Cancel/Close button it is the
+     * dismiss path; the now-redundant header glyph is retracted. Locks
+     * the extends-only migration case (e.g. ChannelCpuBudgetDialog /
+     * AtmosSessionConfigDialog add APPLY+CANCEL after super()).
+     */
+    @Test
+    void footerCancelRetractsCloseGlyph() {
+        Node[] graphic = new Node[1];
+        runOnFxThread(() -> {
+            DawgDialog<Void> dialog = new DawgDialog<>();
+            dialog.setHeaderText("Has Cancel");
+            dialog.getDialogPane().getButtonTypes()
+                    .setAll(ButtonType.APPLY, ButtonType.CANCEL);
+            new Scene(new Pane(dialog.getDialogPane()), 480, 320);
+            dialog.getDialogPane().applyCss();
+            graphic[0] = dialog.getGraphic();
+            return null;
+        });
+
+        assertThat(graphic[0])
+                .as("§5.9 — a footer Cancel is the dismiss path; the "
+                        + "header close glyph must be retracted")
+                .isNull();
+    }
+
+    /**
+     * Retraction must never stomp a domain header graphic a subclass set
+     * itself via {@code setGraphic(...)} (the AudioSettings / Backup /
+     * Settings pattern: own header icon, then APPLY+CANCEL added).
+     */
+    @Test
+    void subclassHeaderGraphicSurvivesRetraction() {
+        Label domain = new Label("domain-icon");
+        Node[] graphic = new Node[1];
+        runOnFxThread(() -> {
+            DawgDialog<Void> dialog = new DawgDialog<>();
+            dialog.setHeaderText("Own Graphic");
+            dialog.setGraphic(domain);
+            dialog.getDialogPane().getButtonTypes()
+                    .setAll(ButtonType.APPLY, ButtonType.CANCEL);
+            new Scene(new Pane(dialog.getDialogPane()), 480, 320);
+            dialog.getDialogPane().applyCss();
+            graphic[0] = dialog.getGraphic();
+            return null;
+        });
+
+        assertThat(graphic[0])
+                .as("a subclass-set header graphic must survive close-glyph "
+                        + "retraction unstomped")
+                .isSameAs(domain);
+    }
+
+    private static Paint firstFill(Background bg) {
+        if (bg == null) {
+            return null;
+        }
+        for (BackgroundFill fill : bg.getFills()) {
+            if (fill.getFill() != null) {
+                return fill.getFill();
+            }
+        }
+        return null;
+    }
+
+    private static ButtonType primaryButtonType(DialogPane pane) {
+        return pane.getButtonTypes().stream()
+                .filter(bt -> bt.getButtonData()
+                        == javafx.scene.control.ButtonBar.ButtonData.OK_DONE)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no primary button type"));
+    }
+
+    private static Label findSectionHeader(DialogPane pane) {
+        for (var node : pane.lookupAll(".dawg-dialog-section-header")) {
+            if (node instanceof Label label) {
+                return label;
+            }
+        }
+        // Fallback: walk the body VBox directly (lookupAll can miss
+        // un-applied subtrees on some headless pulses).
+        if (pane.getContent() instanceof VBox body) {
+            for (var child : body.getChildren()) {
+                if (child instanceof Label label
+                        && label.getStyleClass().contains("dawg-dialog-section-header")) {
+                    return label;
+                }
+            }
+        }
+        throw new AssertionError("no .dawg-dialog-section-header label found");
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/EveryDialogConformsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/EveryDialogConformsTest.java
@@ -71,8 +71,11 @@ class EveryDialogConformsTest {
                         || Modifier.isAbstract(c.getModifiers())) {
                     continue;
                 }
-                boolean conforms = DawgDialog.class.isAssignableFrom(c)
-                        || c.isAnnotationPresent(LegacyDialog.class);
+                boolean conforms = DawgDialog.class.isAssignableFrom(c);
+                if (!conforms && c.isAnnotationPresent(LegacyDialog.class)) {
+                    LegacyDialog ann = c.getAnnotation(LegacyDialog.class);
+                    conforms = ann.value() != null && !ann.value().isBlank();
+                }
                 if (!conforms) {
                     offenders.add(c.getName());
                 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/EveryDialogConformsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/EveryDialogConformsTest.java
@@ -1,0 +1,201 @@
+package com.benesquivelmusic.daw.app.ui.dialogs;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.module.ModuleReader;
+import java.lang.module.ModuleReference;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Story 276 conformance gate. Classpath/module-scans the UI packages
+ * for every class whose simple name ends in {@code Dialog} and asserts
+ * each either {@code extends DawgDialog} or carries
+ * {@link LegacyDialog}. The annotation makes the not-yet-migrated state
+ * visible and prevents drift — a new dialog cannot be added without
+ * consciously adopting the §5.9 skeleton or recording a TODO.
+ *
+ * <p>The scanner mirrors {@code ProcessorDiscovery}/{@code
+ * ModuleClassScanner} (consumer #7): module layer first (named module),
+ * class-loader walk as the fallback (plain class path); {@code
+ * Class.forName(name, false, cl)} so static initializers do not run
+ * during discovery; both exploded {@code target/classes} dirs and JAR
+ * {@code FileSystem}s handled. No toolkit needed.</p>
+ */
+class EveryDialogConformsTest {
+
+    private static final String[] SCAN_PACKAGES = {
+            "com.benesquivelmusic.daw.app.ui"
+    };
+
+    @Test
+    void everyDialogExtendsDawgDialogOrIsAnnotatedLegacy() {
+        List<String> offenders = new ArrayList<>();
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+
+        for (String pkg : SCAN_PACKAGES) {
+            for (String fqcn : classNamesUnder(pkg)) {
+                Class<?> c;
+                try {
+                    c = Class.forName(fqcn, false, cl);
+                } catch (ClassNotFoundException | NoClassDefFoundError e) {
+                    continue;
+                }
+                if (!c.getSimpleName().endsWith("Dialog")) {
+                    continue;
+                }
+                // Skip the base skeleton itself, the @LegacyDialog
+                // annotation type (its name also ends in "Dialog"), and
+                // any interface.
+                if (c == DawgDialog.class
+                        || c.isAnnotation()
+                        || c.isInterface()
+                        || Modifier.isAbstract(c.getModifiers())) {
+                    continue;
+                }
+                boolean conforms = DawgDialog.class.isAssignableFrom(c)
+                        || c.isAnnotationPresent(LegacyDialog.class);
+                if (!conforms) {
+                    offenders.add(c.getName());
+                }
+            }
+        }
+
+        if (!offenders.isEmpty()) {
+            offenders.sort(Comparator.naturalOrder());
+            fail("Story 276 — every *Dialog class must either "
+                    + "`extends DawgDialog` (adopt the §5.9 chrome "
+                    + "skeleton) or carry @LegacyDialog(\"<TODO>\"). "
+                    + "Non-conforming:\n  "
+                    + String.join("\n  ", offenders)
+                    + "\nAdd `extends DawgDialog<R>` or annotate with "
+                    + "@LegacyDialog and a migration TODO.");
+        }
+    }
+
+    @Test
+    void scannerActuallyFoundDialogs() {
+        // Guard against a silently-empty scan (a broken scanner would
+        // make the conformance test vacuously pass).
+        long count = classNamesUnder(SCAN_PACKAGES[0]).stream()
+                .filter(n -> n.endsWith("Dialog"))
+                .count();
+        if (count < 5) {
+            fail("scanner found only " + count + " *Dialog classes — "
+                    + "expected the full UI dialog set; the classpath/"
+                    + "module scan is likely broken");
+        }
+    }
+
+    // ── scanner (mirrors ProcessorDiscovery / ModuleClassScanner) ────────────
+
+    private static List<String> classNamesUnder(String packagePrefix) {
+        Module module = EveryDialogConformsTest.class.getModule();
+        Set<String> names = new LinkedHashSet<>();
+        if (module.isNamed() && module.getLayer() != null) {
+            collectFromModuleLayer(module, packagePrefix, names);
+        }
+        if (names.isEmpty()) {
+            collectFromClassLoader(packagePrefix, names);
+        }
+        List<String> sorted = new ArrayList<>(names);
+        sorted.sort(Comparator.naturalOrder());
+        return List.copyOf(sorted);
+    }
+
+    private static void collectFromModuleLayer(Module module, String packagePrefix,
+                                               Set<String> out) {
+        String prefixPath = packagePrefix.replace('.', '/') + "/";
+        ModuleLayer layer = module.getLayer();
+        for (var resolved : layer.configuration().modules()) {
+            String name = resolved.name();
+            if (!name.startsWith("daw.")) {
+                continue;
+            }
+            ModuleReference ref = resolved.reference();
+            try (ModuleReader reader = ref.open()) {
+                reader.list()
+                        .filter(r -> r.startsWith(prefixPath) && r.endsWith(".class"))
+                        .filter(r -> !r.endsWith("module-info.class"))
+                        .map(r -> r.substring(0, r.length() - ".class".length())
+                                .replace('/', '.'))
+                        .filter(cn -> cn.indexOf('$') < 0)
+                        .forEach(out::add);
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Failed to read module " + name + " for " + packagePrefix, e);
+            }
+        }
+    }
+
+    private static void collectFromClassLoader(String packagePrefix, Set<String> out) {
+        String resourcePath = packagePrefix.replace('.', '/');
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        try {
+            Enumeration<URL> roots = cl.getResources(resourcePath);
+            while (roots.hasMoreElements()) {
+                collectFromUrl(roots.nextElement(), resourcePath, packagePrefix, out);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Failed to scan class path for " + packagePrefix, e);
+        }
+    }
+
+    private static void collectFromUrl(URL url, String resourcePath,
+                                       String packagePrefix, Set<String> out) {
+        try {
+            URI uri = url.toURI();
+            FileSystem closeable = null;
+            Path root;
+            if ("jar".equals(uri.getScheme())) {
+                closeable = FileSystems.newFileSystem(uri, Map.of());
+                root = closeable.getPath(resourcePath);
+            } else {
+                root = Path.of(uri);
+            }
+            try (Stream<Path> stream = Files.walk(root)) {
+                stream.filter(p -> p.toString().endsWith(".class"))
+                        .forEach(p -> {
+                            StringBuilder rel = new StringBuilder();
+                            Path r = root.relativize(p);
+                            for (int i = 0; i < r.getNameCount(); i++) {
+                                if (i > 0) {
+                                    rel.append('.');
+                                }
+                                rel.append(r.getName(i));
+                            }
+                            String cn = packagePrefix + "."
+                                    + rel.substring(0, rel.length() - ".class".length());
+                            if (cn.indexOf('$') < 0 && !cn.endsWith("module-info")) {
+                                out.add(cn);
+                            }
+                        });
+            } finally {
+                if (closeable != null) {
+                    closeable.close();
+                }
+            }
+        } catch (URISyntaxException | IOException e) {
+            throw new UncheckedIOException(new IOException("Failed to scan " + url, e));
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/LegacyDialogStylesGoneTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/LegacyDialogStylesGoneTest.java
@@ -1,0 +1,190 @@
+package com.benesquivelmusic.daw.app.ui.dialogs;
+
+import com.benesquivelmusic.daw.app.ui.DarkThemeHelper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Story 276 — the three legacy chrome regressions must stay gone in
+ * {@code styles.css} (UI Design Book §5.9):
+ *
+ * <ol>
+ *   <li>no {@code linear-gradient} inside any rule whose selector
+ *       touches {@code .dialog-} (the gradient header);</li>
+ *   <li>no {@code -ok} token (or literal green hex) on any
+ *       {@code .dialog-*} / {@code .button.default} / {@code :default}
+ *       button rule (the green primary button).</li>
+ * </ol>
+ *
+ * <p>Plain JUnit — no toolkit. The stylesheet is loaded as a resource
+ * and scanned with a tiny brace-aware selector&rarr;body splitter.</p>
+ */
+class LegacyDialogStylesGoneTest {
+
+    /** A {selector list, declaration body} pair from the stylesheet. */
+    private record Rule(String selector, String body) { }
+
+    @Test
+    void noGradientScopedToAnyDialogSelector() {
+        List<Rule> rules = parseRules(loadCss());
+        List<String> offenders = new ArrayList<>();
+        for (Rule rule : rules) {
+            if (rule.selector().contains(".dialog-")
+                    && rule.body().toLowerCase(Locale.ROOT).contains("linear-gradient")) {
+                offenders.add(rule.selector().strip());
+            }
+        }
+        assertThat(offenders)
+                .as("§5.9 — no .dialog-* rule may paint a linear-gradient "
+                        + "(flat -surface-1 header). Offending selectors: " + offenders)
+                .isEmpty();
+    }
+
+    @Test
+    void noGreenTokenOnDefaultOrDialogButtonRules() {
+        // Literal green hex guard: Palette-A -ok is #5BD2A0. Also reject
+        // any 3/6-digit hex whose green channel dominates strongly (a
+        // belt-and-braces check against a re-introduced literal green).
+        Pattern okToken = Pattern.compile("(^|[^\\w-])-ok([^\\w-]|$)");
+        List<Rule> rules = parseRules(loadCss());
+        List<String> offenders = new ArrayList<>();
+        for (Rule rule : rules) {
+            String sel = rule.selector();
+            boolean isDialogOrDefaultButton =
+                    sel.contains(".dialog-")
+                            || sel.contains(":default")
+                            || sel.contains(".button.default")
+                            || sel.contains(".dawg-button.default");
+            if (!isDialogOrDefaultButton) {
+                continue;
+            }
+            String body = rule.body();
+            if (okToken.matcher(body).find()) {
+                offenders.add(sel.strip() + "  (uses -ok)");
+            }
+            if (containsGreenHex(body)) {
+                offenders.add(sel.strip() + "  (literal green hex)");
+            }
+        }
+        if (!offenders.isEmpty()) {
+            fail("§5.9 / §3.1 — primary/dialog buttons must be -accent, "
+                    + "never -ok / green. Offenders:\n  "
+                    + String.join("\n  ", offenders));
+        }
+    }
+
+    @Test
+    void primaryButtonResolvesToAccentToken() {
+        // Positive guard: the migrated .button:default rule must paint
+        // -accent. Protects against a future edit that drops the green
+        // but leaves the button neutral (non-primary).
+        List<Rule> rules = parseRules(loadCss());
+        boolean found = rules.stream()
+                .filter(r -> r.selector().contains(":default")
+                        && !r.selector().contains(":hover"))
+                .anyMatch(r -> r.body().contains("-accent"));
+        assertThat(found)
+                .as("§5.9 / §3.1 — the :default (primary) button rule "
+                        + "must fill with -accent")
+                .isTrue();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /** Detects an {@code #rrggbb} / {@code #rgb} whose green strongly dominates. */
+    private static boolean containsGreenHex(String body) {
+        var m = Pattern.compile("#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})").matcher(body);
+        while (m.find()) {
+            String hex = m.group(1);
+            int r;
+            int g;
+            int b;
+            if (hex.length() == 3) {
+                r = Integer.parseInt(hex.substring(0, 1).repeat(2), 16);
+                g = Integer.parseInt(hex.substring(1, 2).repeat(2), 16);
+                b = Integer.parseInt(hex.substring(2, 3).repeat(2), 16);
+            } else {
+                r = Integer.parseInt(hex.substring(0, 2), 16);
+                g = Integer.parseInt(hex.substring(2, 4), 16);
+                b = Integer.parseInt(hex.substring(4, 6), 16);
+            }
+            if (g > r + 40 && g > b + 20) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Minimal brace-aware splitter: comments stripped, then each
+     * top-level {@code selector { body }} block is captured. CSS in this
+     * stylesheet has no nested braces inside rule bodies, so a depth
+     * counter is sufficient and robust.
+     */
+    private static List<Rule> parseRules(String css) {
+        String noComments = css.replaceAll("(?s)/\\*.*?\\*/", "");
+        List<Rule> rules = new ArrayList<>();
+        StringBuilder selector = new StringBuilder();
+        StringBuilder body = new StringBuilder();
+        boolean inBody = false;
+        int depth = 0;
+        for (int i = 0; i < noComments.length(); i++) {
+            char c = noComments.charAt(i);
+            if (c == '{') {
+                depth++;
+                if (depth == 1) {
+                    inBody = true;
+                    continue;
+                }
+            } else if (c == '}') {
+                depth--;
+                if (depth == 0) {
+                    rules.add(new Rule(selector.toString(), body.toString()));
+                    selector.setLength(0);
+                    body.setLength(0);
+                    inBody = false;
+                    continue;
+                }
+            }
+            if (inBody) {
+                body.append(c);
+            } else {
+                selector.append(c);
+            }
+        }
+        return rules;
+    }
+
+    private static String loadCss() {
+        String url = DarkThemeHelper.getStylesheetUrl();
+        try (InputStream in = URI.create(url).toURL().openStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            // Fallback to the classloader resource if the external-form
+            // URL cannot be opened directly.
+            URL res = LegacyDialogStylesGoneTest.class.getResource(
+                    "/com/benesquivelmusic/daw/app/ui/styles.css");
+            if (res == null) {
+                throw new IllegalStateException("styles.css not found on classpath", e);
+            }
+            try (InputStream in = res.openStream()) {
+                return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException e2) {
+                throw new IllegalStateException("failed to read styles.css", e2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Dialog and Modal Chrome: Flat Header, Accent Primary Button, Tokenized Section Headers

## Motivation

Phase 2 of the UI Design Book §6 migration roadmap. Builds on: #260, #261, #263, #264, #265, #266, #272 (the inspector takes over many former dialogs; only true "transient task" dialogs remain).

UI Design Book §5.9 ("Dialog / modal") fixes three problems with current dialog chrome:

1. **Gradient header.** `styles.css:951–953` paints the dialog title bar with a gradient. §3.4's elevation system says shadow is information; gradients on titles are pure decoration. Flatten to `-surface-1`.
2. **Default button is green.** `styles.css:1001–1011` paints the default ("primary") dialog button green. §3.1 says the *one* accent is the primary action / selection colour. Default button changes to `-accent` (Onyx Refined indigo). Green is reserved for `-ok` semantic colour (autosave success, signal-in-safe-range). Conflating "default button" with `-ok` was a category error.
3. **Section headers are purple.** §1.6 / §7.6. Section headers in `.dialog-section-header` use a saturated colour. §5.9 says: `-text-mute`, label-small (10 px, uppercase, +12 % tracking), per §3.2.

UI Design Book §5.9 also tightens the layout contract:
- Centred modal, 480 / 640 / 800 px wide, 24 px padding.
- Header: title (H1 weight 600, no decoration), close glyph (`x` icon, secondary).
- Body: one column unless there is a clear reason for two; sections separated by tokenized section headers.
- Footer: Cancel on the left (text button, no border), primary action on the right (filled `-accent`).

This story upgrades every existing dialog in the codebase — `AudioSettingsDialog`, `BackupSettingsDialog`, `AtmosSessionConfigDialog`, `ChannelCpuBudgetDialog`, `ArchiveSummaryDialog`, the Plugin Manager dialog (when present), Preferences, and any wrappers around `Alert` / `Dialog`. It also adds a shared `DawgDialog` skeleton so future dialogs can't drift again.

## Goals

- Create `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/DawgDialog.java` — a base class (or composable builder) that produces a `Dialog<R>` with the §5.9 chrome:
  - Flat `-surface-1` header containing title (H1) and `x` icon close.
  - 24 px padding around body.
  - Footer with secondary-on-the-left, primary-on-the-right convention.
  - Methods: `sized(SMALL | MEDIUM | LARGE)` (480 / 640 / 800 px wide), `addSection(String header, Node body)`, `primary(String label, Runnable action)`, `secondary(String label, Runnable action)`.
- Add `.dawg-dialog`, `.dawg-dialog-header`, `.dawg-dialog-body`, `.dawg-dialog-footer`, `.dawg-dialog-section-header` rules to `daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css`. Section header rule consumes `-text-mute` and matches §3.2's label-small style.
- **Remove** the gradient from any existing `.dialog-header` rule. Header background = `-surface-1`. (Drop the existing rule at `styles.css:951–953`.)
- **Remove** the green from any existing `.dialog-default-button` / `.button.default` rule. Primary button = `-accent` fill. (Drop the existing rule at `styles.css:1001–1011`.)
- **Remove** the purple from `.dialog-section-header` / `.section-header` / any sibling. Section header colour = `-text-mute`.
- Migrate each existing dialog to extend / consume `DawgDialog`:
  - `AudioSettingsDialog.java`
  - `BackupSettingsDialog.java`
  - `AtmosSessionConfigDialog.java`
  - `ChannelCpuBudgetDialog.java`
  - `ArchiveSummaryDialog.java`
  - Any Plugin Manager / Preferences dialog wrappers
  - Any `Alert.AlertType.CONFIRMATION` / `INFORMATION` / `ERROR` wrapper helpers — wrap to apply the same chrome
  
  The dialog *contents* (forms, fields, controls) are preserved; only the chrome and the primary-button styling change.
- All dialog buttons use `dawg-button.size-default` from story 264. Primary buttons carry the additional `.primary` modifier that resolves to `-accent` fill via the unified button system.
- Drop the close glyph if `cancel-button-on-left` is present (per §5.9: "Close glyph in the header is *secondary* — Cancel and Esc are the primary dismiss paths"). The close glyph stays for *informational* dialogs without a Cancel button; otherwise prefer Cancel.
- Tests:
  - `DialogChromeTest`: build a `DawgDialog` with one section and primary+secondary footer; assert no gradient `-fx-background-image` on the header; assert primary button's background resolves to `-accent`; assert section-header text-fill resolves to `-text-mute`.
  - `LegacyDialogStylesGoneTest`: parse `styles.css`, assert there is no `linear-gradient` declaration scoped to `.dialog-header` (or any `.dialog-*` selector). Assert there is no rule painting `.dialog-default-button` / `.button.default` with a green token (`-ok`) or literal green hex.
  - `EveryDialogConformsTest`: at startup, scan `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/` for classes whose name ends in `Dialog`; for each, assert it either (a) extends `DawgDialog` or (b) is excluded via a sentinel `@LegacyDialog` annotation with a TODO comment. The annotation prevents drift and forces the migration to be visible.

## Non-Goals

- Replacing JavaFX's built-in `Stage`-based modal mechanism — the dialogs continue to use `Dialog<R>` / `Stage`. Only the chrome changes.
- Moving dialog state into the inspector — the inspector is per-selection; dialogs are *transient tasks* (settings, plugin manager, exports). Story 272 is clear about the split.
- Custom titlebar / window decorations on the OS shell — that is an OS-level concern outside the design book's scope.
- Adding tabs to dialogs (`AudioSettingsDialog` currently has multiple panes) — keep existing tab structure; only chrome changes.

## Technical Notes

- JavaFX's `Dialog<R>` provides a `DialogPane` whose `headerText` / `graphic` / `content` / `expandableContent` slots can be configured to match the §5.9 layout. `DawgDialog` wraps a `DialogPane`; consumers don't need to know which JavaFX class is the root.
- For `Alert`-derived dialogs (`Alert.AlertType.CONFIRMATION`, etc.), the wrapper applies the chrome by replacing the `Alert`'s `DialogPane` styling. Document this as a known JavaFX-specific quirk.
- All `DawgDialog` chrome strings ("Cancel", "Close", "OK", default primary labels for confirmation/info/error dialogs) come from the existing `Messages.properties` resource bundle. Caller-supplied content (titles, prompts, error details) is whatever the caller passes in — already localized at the call site. Skill §14.
- Reference: UI Design Book §3.1, §3.2, §3.4, §5.9, §7.6 (saturated-section-header veto — implicit AC).
