### PR TITLE
277 theme setting onyx studio slate atelier

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/DawApplication.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/DawApplication.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app;
 
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -52,8 +54,12 @@ public final class DawApplication extends Application {
         Parent root = loader.load();
 
         Scene scene = new Scene(root, DEFAULT_WIDTH, DEFAULT_HEIGHT);
-        scene.getStylesheets().add(
-                getClass().getResource("ui/styles.css").toExternalForm());
+        // Story 277 — ThemeManager owns the ordered stylesheet list
+        // (base styles.css + the persisted token-theme overlay) and
+        // re-applies it to the registered scene when the user switches
+        // theme in Preferences, so the whole UI re-themes with no
+        // restart.
+        ThemeManager.getDefault().applyTo(scene);
 
         primaryStage.setTitle(APP_TITLE);
         primaryStage.setScene(scene);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ArpeggiatorPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ArpeggiatorPluginView.java
@@ -17,6 +17,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Compact JavaFX view for the built-in {@link ArpeggiatorPlugin}.
@@ -32,6 +33,7 @@ import java.util.Objects;
  * JavaFX thread; the plugin reads them on its next audio-block call
  * (scalar primitive writes are safe for the simple fields used here).</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class ArpeggiatorPluginView extends VBox {
 
     /** Number of step lights drawn in the indicator row. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ArrangementCanvas.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ArrangementCanvas.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders horizontal track lanes with audio and MIDI clip rectangles
@@ -35,6 +36,7 @@ import java.util.Map;
  * are controlled via the canvas's scroll and zoom parameters and can be
  * coordinated with higher-level navigation components by the caller.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class ArrangementCanvas extends Pane {
 
     // ── Color constants (retained for existing test references) ───────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AutomationLaneRenderer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AutomationLaneRenderer.java
@@ -11,6 +11,7 @@ import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 
 import java.util.List;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders an automation lane's envelope line and breakpoint nodes onto a
@@ -26,6 +27,7 @@ import java.util.List;
  *   <li>A parameter name label at the left edge of the lane</li>
  * </ul>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class AutomationLaneRenderer {
 
     /** Default height in pixels for an automation lane. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AutomationLaneSummaryRenderer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AutomationLaneSummaryRenderer.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders the thin "summary strip" drawn in place of a folded automation
@@ -14,6 +15,7 @@ import javafx.scene.paint.Color;
  * width of the canvas, with the same accent colour as the automation
  * envelope so the eye recognises it as automation data.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class AutomationLaneSummaryRenderer {
 
     /** Fill colour used when the strip indicates folded automation data. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BusCompressorPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BusCompressorPluginView.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the built-in SSL-style {@link BusCompressorProcessor}.
@@ -30,6 +31,7 @@ import java.util.Objects;
  * buffer (scalar writes are naturally thread-safe for the simple primitives
  * used by {@link BusCompressorProcessor}).</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class BusCompressorPluginView extends VBox {
 
     /** Maximum gain-reduction shown on the meter, in dB (display range: 0 .. -MAX). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClipGainEnvelopeRenderer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClipGainEnvelopeRenderer.java
@@ -7,6 +7,7 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 
 import java.util.List;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders a clip's per-clip gain envelope as a second polyline on top of
@@ -25,6 +26,7 @@ import java.util.List;
  * session's {@code samplesPerBeat} (= sample rate &times; 60 / tempo) and
  * the clip's timeline start / source offset.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class ClipGainEnvelopeRenderer {
 
     /** Radius of breakpoint handle circles in pixels. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClipMidiPreviewRenderer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClipMidiPreviewRenderer.java
@@ -6,6 +6,7 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 
 import java.util.List;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders the miniature piano-roll preview inside an arrangement MIDI
@@ -16,6 +17,7 @@ import java.util.List;
  * explicitly so the renderer can be tested with a mock
  * {@link GraphicsContext} and shared between clips.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class ClipMidiPreviewRenderer {
 
     static final Color MIDI_NOTE_COLOR = Color.web("#ffffff", 0.7);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClipOverlayRenderer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClipOverlayRenderer.java
@@ -10,6 +10,7 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders clip rectangles and all clip-level overlays on the arrangement
@@ -23,6 +24,7 @@ import javafx.scene.text.TextAlignment;
  * <p>Stateless utility: positioning, transform, and selection state are
  * passed in explicitly so each call is independently testable.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class ClipOverlayRenderer {
 
     static final Color CLIP_BORDER_COLOR = Color.web("#ffffff", 0.3);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClipWaveformRenderer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClipWaveformRenderer.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders a min/max-summary waveform overview inside the bounds of an
@@ -11,6 +12,7 @@ import javafx.scene.paint.Color;
  * arguments — so it can be reused across clips without retained state
  * and unit-tested with a mock {@link GraphicsContext}.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class ClipWaveformRenderer {
 
     static final Color WAVEFORM_COLOR = Color.web("#ffffff", 0.5);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ConvolutionReverbPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ConvolutionReverbPluginView.java
@@ -19,6 +19,7 @@ import javafx.stage.FileChooser;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the {@link ConvolutionReverbProcessor}.
@@ -35,6 +36,7 @@ import java.util.Objects;
  * <p>All parameter changes are written directly to the processor on the
  * JavaFX application thread.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class ConvolutionReverbPluginView extends VBox {
 
     private final ConvolutionReverbProcessor processor;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DarkThemeHelper.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DarkThemeHelper.java
@@ -23,11 +23,12 @@ import javafx.scene.control.Dialog;
  * {@link ThemeManager#getDefault()} directly. The public method
  * signatures are unchanged.</p>
  *
- * @deprecated use {@link ThemeManager} (via
+ * @deprecated since 0.1.0, scheduled for removal after the 0.2.0
+ *             release cycle — use {@link ThemeManager} (via
  *             {@link ThemeManager#getDefault()}) — this shim only
- *             forwards to it and will be removed after one release cycle.
+ *             forwards to it.
  */
-@Deprecated
+@Deprecated(since = "0.1.0", forRemoval = true)
 public final class DarkThemeHelper {
 
     private DarkThemeHelper() {
@@ -39,9 +40,10 @@ public final class DarkThemeHelper {
      * (Palette-A) stylesheet.
      *
      * @return the base stylesheet URL string
-     * @deprecated use {@link ThemeManager#baseStylesheetUrl()}
+     * @deprecated since 0.1.0, scheduled for removal — use
+     *             {@link ThemeManager#baseStylesheetUrl()}
      */
-    @Deprecated
+    @Deprecated(since = "0.1.0", forRemoval = true)
     public static String getStylesheetUrl() {
         return ThemeManager.getDefault().baseStylesheetUrl();
     }
@@ -51,9 +53,10 @@ public final class DarkThemeHelper {
      * {@link Dialog}'s pane and registers it for live re-theming.
      *
      * @param dialog the dialog to style
-     * @deprecated use {@code ThemeManager.getDefault().applyTo(dialog.getDialogPane())}
+     * @deprecated since 0.1.0, scheduled for removal — use
+     *             {@code ThemeManager.getDefault().applyTo(dialog.getDialogPane())}
      */
-    @Deprecated
+    @Deprecated(since = "0.1.0", forRemoval = true)
     public static void applyTo(Dialog<?> dialog) {
         ThemeManager.getDefault().applyTo(dialog.getDialogPane());
     }
@@ -63,9 +66,10 @@ public final class DarkThemeHelper {
      * {@link Scene} and registers it for live re-theming.
      *
      * @param scene the scene to style
-     * @deprecated use {@code ThemeManager.getDefault().applyTo(scene)}
+     * @deprecated since 0.1.0, scheduled for removal — use
+     *             {@code ThemeManager.getDefault().applyTo(scene)}
      */
-    @Deprecated
+    @Deprecated(since = "0.1.0", forRemoval = true)
     public static void applyTo(Scene scene) {
         ThemeManager.getDefault().applyTo(scene);
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DarkThemeHelper.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DarkThemeHelper.java
@@ -1,81 +1,72 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
 import javafx.scene.Scene;
 import javafx.scene.control.Dialog;
-import javafx.scene.control.DialogPane;
-
-import java.net.URL;
-import java.util.Objects;
 
 /**
- * Utility class for applying the application's dark theme stylesheet
- * consistently to dialogs and standalone windows.
+ * Thin {@code @Deprecated} shim that delegates to {@link ThemeManager}
+ * (story 277, UI Design Book §6 Phase 3).
  *
- * <p>JavaFX dialogs and secondary stages do not automatically inherit the
- * main scene's stylesheets. This helper resolves the shared stylesheet
- * URL once and provides convenience methods to apply it to any
- * {@link Dialog} or {@link Scene}.</p>
+ * <p>Originally this utility only applied the single dark stylesheet.
+ * Phase-3 theming makes {@link ThemeManager} the single source of "the
+ * ordered stylesheet URL list to apply" (base {@code styles.css} + the
+ * active theme overlay). Routing every dialog and standalone-window
+ * call site through {@code ThemeManager.getDefault()} means all of them
+ * — including {@code DawgDialog} and the ~30 legacy dialogs that still
+ * call {@code DarkThemeHelper.applyTo(this)} — re-theme for free when
+ * the user switches theme, with zero churn at the call sites.</p>
+ *
+ * <p>This shim is retained for one release cycle so the existing
+ * callers keep compiling; new code should call
+ * {@link ThemeManager#getDefault()} directly. The public method
+ * signatures are unchanged.</p>
+ *
+ * @deprecated use {@link ThemeManager} (via
+ *             {@link ThemeManager#getDefault()}) — this shim only
+ *             forwards to it and will be removed after one release cycle.
  */
+@Deprecated
 public final class DarkThemeHelper {
-
-    private static final String STYLESHEET_PATH = "styles.css";
-
-    private static volatile String resolvedStylesheetUrl;
 
     private DarkThemeHelper() {
         // utility class
     }
 
     /**
-     * Returns the external-form URL of the application's dark theme
-     * stylesheet, resolving it lazily on first access.
+     * Returns the external-form URL of the application's base
+     * (Palette-A) stylesheet.
      *
-     * @return the stylesheet URL string
-     * @throws IllegalStateException if the stylesheet resource cannot be found
+     * @return the base stylesheet URL string
+     * @deprecated use {@link ThemeManager#baseStylesheetUrl()}
      */
+    @Deprecated
     public static String getStylesheetUrl() {
-        String url = resolvedStylesheetUrl;
-        if (url == null) {
-            URL resource = DarkThemeHelper.class.getResource(STYLESHEET_PATH);
-            Objects.requireNonNull(resource,
-                    "Dark theme stylesheet not found: " + STYLESHEET_PATH);
-            url = resource.toExternalForm();
-            resolvedStylesheetUrl = url;
-        }
-        return url;
+        return ThemeManager.getDefault().baseStylesheetUrl();
     }
 
     /**
-     * Applies the dark theme stylesheet to a {@link Dialog}'s pane.
-     *
-     * <p>This should be called at the end of every dialog constructor
-     * to ensure the dialog inherits the application's dark neon theme.</p>
+     * Applies the active theme (base {@code styles.css} + overlay) to a
+     * {@link Dialog}'s pane and registers it for live re-theming.
      *
      * @param dialog the dialog to style
+     * @deprecated use {@code ThemeManager.getDefault().applyTo(dialog.getDialogPane())}
      */
+    @Deprecated
     public static void applyTo(Dialog<?> dialog) {
-        DialogPane pane = dialog.getDialogPane();
-        String url = getStylesheetUrl();
-        if (!pane.getStylesheets().contains(url)) {
-            pane.getStylesheets().add(url);
-        }
-        if (!pane.getStyleClass().contains("root-pane")) {
-            pane.getStyleClass().add("root-pane");
-        }
+        ThemeManager.getDefault().applyTo(dialog.getDialogPane());
     }
 
     /**
-     * Applies the dark theme stylesheet to a {@link Scene}.
-     *
-     * <p>Use this for standalone floating windows (e.g., spectrum analyzer,
-     * loudness meter) that are not part of the main application scene.</p>
+     * Applies the active theme (base {@code styles.css} + overlay) to a
+     * {@link Scene} and registers it for live re-theming.
      *
      * @param scene the scene to style
+     * @deprecated use {@code ThemeManager.getDefault().applyTo(scene)}
      */
+    @Deprecated
     public static void applyTo(Scene scene) {
-        String url = getStylesheetUrl();
-        if (!scene.getStylesheets().contains(url)) {
-            scene.getStylesheets().add(url);
-        }
+        ThemeManager.getDefault().applyTo(scene);
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DeEsserPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DeEsserPluginView.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the built-in {@link DeEsserProcessor}.
@@ -32,6 +33,7 @@ import java.util.Objects;
  * buffer (scalar writes are safe for the simple primitives used by
  * {@link DeEsserProcessor}).</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class DeEsserPluginView extends VBox {
 
     /** Maximum gain-reduction shown on the meter, in dB (display range: 0 .. -MAX). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ExciterPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ExciterPluginView.java
@@ -13,6 +13,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the built-in {@link ExciterProcessor}.
@@ -30,6 +31,7 @@ import java.util.Objects;
  * application thread; the processor picks them up on its next audio-thread
  * buffer.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class ExciterPluginView extends VBox {
 
     /** Number of harmonic bins sketched in the mini FFT display. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HrtfProfileImportDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HrtfProfileImportDialog.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Modal dialog driving the "Import SOFA…" workflow for personalized HRTF
@@ -49,6 +50,7 @@ import java.util.Optional;
  */
 @com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
         "migrate to DawgDialog — story 276 follow-up")
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class HrtfProfileImportDialog extends Dialog<String> {
 
     private final HrtfImportController controller;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/KeyboardProcessorView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/KeyboardProcessorView.java
@@ -22,6 +22,7 @@ import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX virtual keyboard UI for the {@link KeyboardProcessor} plugin.
@@ -40,6 +41,7 @@ import java.util.Objects;
  * <p>The keyboard visually highlights active (pressed) keys and shows note
  * names on white keys.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class KeyboardProcessorView extends VBox {
 
     // ── Layout Constants ───────────────────────────────────────────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyTelemetryPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyTelemetryPanel.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * UI panel that surfaces plugin and track latency compensation data.
@@ -48,6 +49,7 @@ import java.util.Objects;
  * delivers on its own executor — call {@link #refresh(Mixer)} from the
  * FX thread (or hop to it) to apply a snapshot.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class LatencyTelemetryPanel extends BorderPane {
 
     /** Width of the inline sample-count bar graph, in pixels. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MatchEqPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MatchEqPluginView.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the built-in {@link MatchEqPlugin} / {@link MatchEqProcessor}.
@@ -42,6 +43,7 @@ import java.util.Objects;
  * the JavaFX application thread; the processor picks them up on its next audio
  * buffer (scalar writes are safe for the primitives involved).</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class MatchEqPluginView extends VBox {
 
     /** Plot Y axis range in dB (centered at 0). The curve is clipped to ±DB_RANGE. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MidiEditorView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MidiEditorView.java
@@ -26,6 +26,7 @@ import javafx.scene.paint.Color;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * MIDI piano-roll editor view for detailed note editing.
@@ -35,6 +36,7 @@ import java.util.List;
  * (pointer, pencil, eraser). Supports note add/delete/move/resize with
  * mouse interaction and undo/redo.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class MidiEditorView extends VBox {
 
     private static final int PIANO_ROLL_OCTAVES = 8;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * A mixer view that displays all project tracks as vertical channel strips.
@@ -72,6 +73,7 @@ import java.util.stream.Collectors;
  * <p>Uses existing CSS classes: {@code .mixer-panel}, {@code .mixer-channel},
  * {@code .mixer-channel-name}, {@code .mixer-fader}.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class MixerView extends VBox {
 
     private static final Logger LOG = Logger.getLogger(MixerView.class.getName());

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MultibandCompressorPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MultibandCompressorPluginView.java
@@ -20,6 +20,7 @@ import javafx.scene.paint.Color;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the built-in {@link MultibandCompressorPlugin}.
@@ -40,6 +41,7 @@ import java.util.Objects;
  * gain-reduction snapshot exposed by {@link MultibandCompressorProcessor},
  * so no locking is required.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class MultibandCompressorPluginView extends VBox {
 
     /** Maximum gain-reduction shown on the per-band meters, in dB. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/NoiseGatePluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/NoiseGatePluginView.java
@@ -15,6 +15,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the built-in {@link NoiseGateProcessor}.
@@ -31,6 +32,7 @@ import java.util.Objects;
  * buffer (scalar writes are safe for the simple primitives used by
  * {@link NoiseGateProcessor}).</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class NoiseGatePluginView extends VBox {
 
     /** Maximum displayed level on the input meter, in dBFS (top of bar). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -160,13 +160,14 @@ public final class SettingsDialog extends DawgDialog<Void> {
             @Override
             public ThemeManager.Theme fromString(String string) {
                 // Display-only converter: the combo is non-editable, so
-                // JavaFX never asks the converter to parse user input.
-                // Throwing makes the intent explicit — if the combo is
-                // ever made editable, this surfaces as a clear failure
-                // rather than silently no-op'ing back to the current
-                // value.
-                throw new UnsupportedOperationException(
-                        "Theme combo is display-only; fromString is not supported");
+                // JavaFX should never invoke fromString. Returning the
+                // current value is the safe convention — JavaFX internals
+                // (accessibility queries, type-ahead, selection
+                // restoration on focus loss) may still call fromString
+                // and must not see an exception propagate into the FX
+                // event loop. If the combo is ever made editable, a real
+                // reverse lookup over the items must be added here.
+                return themeCombo.getValue();
             }
         });
 
@@ -302,7 +303,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
         grid.add(header, 0, 0, 2, 1);
         grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label(msg("appearance.theme.label")), 0, 2);
+        grid.add(new Label(msg("appearance.theme.label") + ":"), 0, 2);
         grid.add(themeCombo, 1, 2);
         // Visual separator between the theme chooser (the prominent new
         // affordance) and the UI-scale row keeps the grouping clear —

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -4,7 +4,6 @@ import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
-import javafx.util.StringConverter;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.*;
@@ -14,10 +13,14 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.util.StringConverter;
 
 import java.util.EnumMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.MissingResourceException;
 import java.util.Optional;
+import java.util.ResourceBundle;
 
 /**
  * Modal dialog for configuring application settings.
@@ -55,10 +58,9 @@ public final class SettingsDialog extends DawgDialog<Void> {
     private static final double HEADER_ICON_SIZE = 18;
     private static final double TAB_ICON_SIZE = 14;
 
-    /** Resource bundle for localized strings (Skill §14) — {@link java.util.Locale#ROOT}. */
-    private static final java.util.ResourceBundle MESSAGES =
-            java.util.ResourceBundle.getBundle(
-                    "com.benesquivelmusic.daw.app.i18n.Messages", java.util.Locale.ROOT);
+    /** Resource bundle for localized strings (Skill §14) — {@link Locale#ROOT}. */
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
 
     private final SettingsModel model;
 
@@ -157,6 +159,10 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
             @Override
             public ThemeManager.Theme fromString(String string) {
+                // Non-editable combo: JavaFX never invokes fromString
+                // (the converter is display-only). Returning the current
+                // value is the standard identity idiom — intentional,
+                // not an unimplemented parse.
                 return themeCombo.getValue();
             }
         });
@@ -583,7 +589,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
     private static String msg(String key) {
         try {
             return MESSAGES.getString(key);
-        } catch (java.util.MissingResourceException e) {
+        } catch (MissingResourceException e) {
             return key;
         }
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -58,7 +58,13 @@ public final class SettingsDialog extends DawgDialog<Void> {
     private static final double HEADER_ICON_SIZE = 18;
     private static final double TAB_ICON_SIZE = 14;
 
-    /** Resource bundle for localized strings (Skill §14) — {@link Locale#ROOT}. */
+    /**
+     * Resource bundle for localized strings (Skill §14) — uses
+     * {@link Locale#ROOT} to match the codebase-wide convention (see
+     * {@code BrowserPanel}, {@code MainController}, {@code DawgDialog}).
+     * If/when a locale-aware strategy is adopted it should be changed
+     * globally, not per-class.
+     */
     private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
             "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -160,14 +160,15 @@ public final class SettingsDialog extends DawgDialog<Void> {
             @Override
             public ThemeManager.Theme fromString(String string) {
                 // Display-only converter: the combo is non-editable, so
-                // JavaFX should never invoke fromString. Returning the
-                // current value is the safe convention — JavaFX internals
-                // (accessibility queries, type-ahead, selection
-                // restoration on focus loss) may still call fromString
-                // and must not see an exception propagate into the FX
-                // event loop. If the combo is ever made editable, a real
-                // reverse lookup over the items must be added here.
-                return themeCombo.getValue();
+                // JavaFX should never invoke fromString. Returning
+                // DEFAULT_THEME is the safest fallback — it can never be
+                // null, whereas themeCombo.getValue() could return null if
+                // JavaFX invokes fromString before setValue during early
+                // accessibility queries or a styling pass triggered by
+                // the converter being set. If the combo is ever made
+                // editable, a real reverse lookup over the items must be
+                // added here.
+                return ThemeManager.DEFAULT_THEME;
             }
         });
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -159,11 +159,14 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
             @Override
             public ThemeManager.Theme fromString(String string) {
-                // Non-editable combo: JavaFX never invokes fromString
-                // (the converter is display-only). Returning the current
-                // value is the standard identity idiom — intentional,
-                // not an unimplemented parse.
-                return themeCombo.getValue();
+                // Display-only converter: the combo is non-editable, so
+                // JavaFX never asks the converter to parse user input.
+                // Throwing makes the intent explicit — if the combo is
+                // ever made editable, this surfaces as a clear failure
+                // rather than silently no-op'ing back to the current
+                // value.
+                throw new UnsupportedOperationException(
+                        "Theme combo is display-only; fromString is not supported");
             }
         });
 
@@ -301,9 +304,14 @@ public final class SettingsDialog extends DawgDialog<Void> {
         grid.add(new Separator(), 0, 1, 2, 1);
         grid.add(new Label(msg("appearance.theme.label")), 0, 2);
         grid.add(themeCombo, 1, 2);
-        grid.add(new Label("UI Scale:"), 0, 3);
-        grid.add(uiScaleSlider, 1, 3);
-        grid.add(uiScaleValueLabel, 2, 3);
+        // Visual separator between the theme chooser (the prominent new
+        // affordance) and the UI-scale row keeps the grouping clear —
+        // mirrors the header/separator/fields pattern used elsewhere in
+        // this dialog.
+        grid.add(new Separator(), 0, 3, 2, 1);
+        grid.add(new Label("UI Scale:"), 0, 4);
+        grid.add(uiScaleSlider, 1, 4);
+        grid.add(uiScaleValueLabel, 2, 4);
 
         return grid;
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -3,6 +3,8 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+import javafx.util.StringConverter;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.*;
@@ -53,6 +55,11 @@ public final class SettingsDialog extends DawgDialog<Void> {
     private static final double HEADER_ICON_SIZE = 18;
     private static final double TAB_ICON_SIZE = 14;
 
+    /** Resource bundle for localized strings (Skill §14) — {@link java.util.Locale#ROOT}. */
+    private static final java.util.ResourceBundle MESSAGES =
+            java.util.ResourceBundle.getBundle(
+                    "com.benesquivelmusic.daw.app.i18n.Messages", java.util.Locale.ROOT);
+
     private final SettingsModel model;
 
     // ── Callback ─────────────────────────────────────────────────────────────
@@ -72,6 +79,8 @@ public final class SettingsDialog extends DawgDialog<Void> {
     // ── Appearance tab controls ──────────────────────────────────────────────
     private final Slider uiScaleSlider;
     private final Label uiScaleValueLabel;
+    private final ThemeManager themeManager;
+    private final ComboBox<ThemeManager.Theme> themeCombo;
 
     // ── Plugins tab controls ─────────────────────────────────────────────────
     private final TextField pluginScanPathsField;
@@ -131,6 +140,26 @@ public final class SettingsDialog extends DawgDialog<Void> {
         uiScaleValueLabel.getStyleClass().add("numeric-value");
         uiScaleSlider.valueProperty().addListener((_, _, newVal) ->
                 uiScaleValueLabel.setText(String.format("%.1fx", newVal.doubleValue())));
+
+        // Story 277 — token-theme chooser (UI Design Book §3.1 / §6
+        // Phase 3). Distinct from story 194's WCAG JSON theme registry;
+        // ThemeManager persists under its own preferences key. The combo
+        // shows the three design-book palettes by localized display name.
+        themeManager = ThemeManager.getDefault();
+        themeCombo = new ComboBox<>();
+        themeCombo.getItems().addAll(ThemeManager.Theme.values());
+        themeCombo.setValue(themeManager.getActiveTheme());
+        themeCombo.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(ThemeManager.Theme theme) {
+                return theme == null ? "" : ThemeManager.displayName(theme);
+            }
+
+            @Override
+            public ThemeManager.Theme fromString(String string) {
+                return themeCombo.getValue();
+            }
+        });
 
         Tab appearanceTab = new Tab("Appearance", buildAppearancePane());
         appearanceTab.setGraphic(IconNode.of(DawIcon.MONITOR, TAB_ICON_SIZE));
@@ -264,14 +293,11 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
         grid.add(header, 0, 0, 2, 1);
         grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label("UI Scale:"), 0, 2);
-        grid.add(uiScaleSlider, 1, 2);
-        grid.add(uiScaleValueLabel, 2, 2);
-
-        Label themeNote = new Label("Theme customization coming in a future release.");
-        themeNote.setGraphic(IconNode.of(DawIcon.INFO, 14));
-        themeNote.setStyle("-fx-text-fill: #808080; -fx-font-size: 10px;");
-        grid.add(themeNote, 0, 4, 3, 1);
+        grid.add(new Label(msg("appearance.theme.label")), 0, 2);
+        grid.add(themeCombo, 1, 2);
+        grid.add(new Label("UI Scale:"), 0, 3);
+        grid.add(uiScaleSlider, 1, 3);
+        grid.add(uiScaleValueLabel, 2, 3);
 
         return grid;
     }
@@ -494,6 +520,14 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
         // Appearance
         model.setUiScale(uiScaleSlider.getValue());
+        // Story 277 — apply + persist the token theme. Setting the
+        // active-theme property re-applies the overlay to every
+        // registered scene/dialog-pane (no restart) and persists the
+        // choice under ThemeManager's own preferences key.
+        ThemeManager.Theme selectedTheme = themeCombo.getValue();
+        if (selectedTheme != null) {
+            themeManager.setActiveTheme(selectedTheme);
+        }
 
         // Plugins
         String paths = pluginScanPathsField.getText();
@@ -538,6 +572,20 @@ public final class SettingsDialog extends DawgDialog<Void> {
         grid.setVgap(8);
         grid.setPadding(new Insets(16));
         return grid;
+    }
+
+    /**
+     * Resolves a localized string from the shared {@code Messages}
+     * bundle, falling back to the raw key if absent (mirrors the
+     * {@code DawgDialog#msg} / {@code BrowserPanel#msg} pattern —
+     * Skill §14).
+     */
+    private static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (java.util.MissingResourceException e) {
+            return key;
+        }
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TelemetrySetupPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TelemetrySetupPanel.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.scene.control.*;
 import javafx.scene.layout.*;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Setup panel for configuring room dimensions and wall material
@@ -26,6 +27,7 @@ import javafx.scene.layout.*;
  * consistent with {@link SettingsDialog} and
  * {@link InputPortSelectionDialog}.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class TelemetrySetupPanel extends ScrollPane {
 
     private static final String BACKGROUND_STYLE =

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TimelineRuler.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TimelineRuler.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * A timeline ruler component that displays bar numbers, beat subdivisions
@@ -40,6 +41,7 @@ import java.util.function.Consumer;
  * <p>Click-to-seek: clicking anywhere on the ruler fires the registered
  * seek callback with the corresponding beat position.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class TimelineRuler extends Pane {
 
     /** Default ruler height in pixels. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TrackLaneRenderer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TrackLaneRenderer.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders the alternating track lane backgrounds and separator lines on
@@ -11,6 +12,7 @@ import javafx.scene.paint.Color;
  * cached array) and pass them in, so the renderer remains agnostic to
  * the canvas's automation-lane bookkeeping.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class TrackLaneRenderer {
 
     static final Color LANE_COLOR_EVEN = Color.web("#1c1c2e");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransientShaperPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransientShaperPluginView.java
@@ -15,6 +15,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the built-in {@link TransientShaperProcessor}.
@@ -28,6 +29,7 @@ import java.util.Objects;
  * application thread; the processor picks them up on its next audio-thread
  * buffer.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class TransientShaperPluginView extends VBox {
 
     /** Maximum displayed level on the input/output meters, in dBFS (top of bar). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportOverlayRenderer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportOverlayRenderer.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Renders transport-related full-height overlays on the arrangement
@@ -13,6 +14,7 @@ import javafx.scene.paint.Color;
  * call so the renderer can be exercised with a mock
  * {@link GraphicsContext} in unit tests.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 final class TransportOverlayRenderer {
 
     static final Color PLAYHEAD_COLOR = Color.web("#ff5555");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TruePeakLimiterPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TruePeakLimiterPluginView.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * JavaFX view for the built-in {@link TruePeakLimiterProcessor}.
@@ -31,6 +32,7 @@ import java.util.Objects;
  * buffer (scalar writes are naturally thread-safe for the simple primitives
  * used by {@link TruePeakLimiterProcessor}).</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class TruePeakLimiterPluginView extends VBox {
 
     /** Maximum gain-reduction shown on the meter, in dB. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/VcaStrip.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/VcaStrip.java
@@ -28,6 +28,7 @@ import javafx.scene.paint.Color;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Mixer-strip UI for a single {@link VcaGroup}.
@@ -49,6 +50,7 @@ import java.util.function.Function;
  * <p>The visual layout matches a stripped-down output channel: badge → name
  * field → color swatch → level/fader → mute / solo / delete button row.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class VcaStrip extends VBox {
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Fader.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Fader.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Vertical fader {@link Control} for level / volume parameters.
@@ -69,6 +70,7 @@ import java.util.function.Function;
  *         .showMeter(true).size("mixer").build();
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class Fader extends Control {
 
     /** Stable style class — selectable as {@code .fader} in CSS. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Knob.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Knob.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Rotary knob {@link Control} for bipolar / unipolar parameters
@@ -76,6 +77,7 @@ import java.util.function.Function;
  * {@link CssMetaData} cannot express {@link Function} types, so this is
  * configured from Java only.
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class Knob extends Control {
 
     /** Stable style class — selectable as {@code .knob} in CSS. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeter.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeter.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * A discrete LED-style segment level meter {@link Control}.
@@ -84,6 +85,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *         .build();
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class LevelMeter extends Control {
 
     /** Stable style class — selectable as {@code .level-meter} in CSS. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStrip.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/MixerChannelStrip.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Mixer channel-strip {@link Control} — the complete §5.4 signal-chain
@@ -113,6 +114,7 @@ import java.util.UUID;
  *         .build();
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class MixerChannelStrip extends Control {
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/TrackStrip.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/TrackStrip.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Track strip {@link Control} for the arrangement view's track list (and
@@ -93,6 +94,7 @@ import java.util.UUID;
  *         .build();
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class TrackStrip extends Control {
 
     /** Stable style class — selectable as {@code .track-strip} in CSS. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/TrackStripCell.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/TrackStripCell.java
@@ -6,6 +6,7 @@ import javafx.scene.control.ListCell;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * {@link ListCell} that renders a {@link Track} into a single reusable
@@ -33,6 +34,7 @@ import java.util.Objects;
  * tracks.setCellFactory(lv -> new TrackStripCell());
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public class TrackStripCell extends ListCell<Track> {
 
     private final TrackStrip strip;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/CorrelationDisplay.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/CorrelationDisplay.java
@@ -13,6 +13,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Stereo correlation vectorscope / goniometer display.
@@ -39,6 +40,7 @@ import javafx.scene.text.TextAlignment;
  * mastering-techniques research (§7 — Stereo Imaging), including
  * correlation metering for mono compatibility verification.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class CorrelationDisplay extends Region {
 
     private static final Color BACKGROUND = Color.web("#0d0d1a");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/CorrelationDisplayWindow.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/CorrelationDisplayWindow.java
@@ -8,6 +8,7 @@ import javafx.scene.Scene;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Standalone floating window wrapping a {@link CorrelationDisplay}.
@@ -26,6 +27,7 @@ import javafx.stage.StageStyle;
  * window.updateGoniometer(goniometerData);
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class CorrelationDisplayWindow {
 
     private static final double DEFAULT_WIDTH = 480;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/InputMeterStrip.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/InputMeterStrip.java
@@ -12,6 +12,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Input-signal meter column used for the second mixer-strip meter on armed
@@ -37,6 +38,7 @@ import java.util.Objects;
  * per-frame poll of {@link InputLevelMonitor#snapshot()} happens inside the
  * GpuRenderer, so there is exactly one timer per strip.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class InputMeterStrip extends Region {
 
     private static final double CLIP_LED_HEIGHT = 10.0;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/LevelMeterDisplay.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/LevelMeterDisplay.java
@@ -10,6 +10,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.CycleMethod;
 import javafx.scene.paint.LinearGradient;
 import javafx.scene.paint.Stop;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Animated peak/RMS level meter display with professional ballistics.
@@ -28,6 +29,7 @@ import javafx.scene.paint.Stop;
  * <p>Supports the metering requirements from the mastering-techniques
  * research (§4 — Dynamics Processing, §8 — Loudness Standards).</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class LevelMeterDisplay extends Region {
 
     private static final Color BACKGROUND = Color.web("#0d0d1a");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/LoudnessDisplay.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/LoudnessDisplay.java
@@ -10,6 +10,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * LUFS loudness history display with platform target markers.
@@ -26,6 +27,7 @@ import javafx.scene.text.TextAlignment;
  * <p>Supports the loudness standards from the mastering-techniques
  * research (§8 — Loudness Standards and Metering).</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class LoudnessDisplay extends Region {
 
     private static final Color BACKGROUND = Color.web("#0d0d1a");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/LoudnessDisplayWindow.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/LoudnessDisplayWindow.java
@@ -8,6 +8,7 @@ import javafx.scene.Scene;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Standalone floating window wrapping a {@link LoudnessDisplay}.
@@ -24,6 +25,7 @@ import javafx.stage.StageStyle;
  * window.update(loudnessData);
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class LoudnessDisplayWindow {
 
     private static final double DEFAULT_WIDTH = 480;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/MiniClipIndicator.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/MiniClipIndicator.java
@@ -12,6 +12,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Miniature clip indicator shown in the arrangement-view track header
@@ -29,6 +30,7 @@ import java.util.Objects;
  * per-frame poll, scene-attachment timer gate, and surface lifecycle are
  * delegated to the shared substrate.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class MiniClipIndicator extends Region {
 
     private static final double SIZE = 10.0;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/RoomTelemetryDisplay.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/RoomTelemetryDisplay.java
@@ -15,6 +15,7 @@ import javafx.scene.text.TextAlignment;
 
 import java.util.*;
 import java.util.function.BiConsumer;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Creative, animated 3D room sound wave telemetry visualizer.
@@ -46,6 +47,7 @@ import java.util.function.BiConsumer;
  * {@link GpuCanvas#setAnimated(boolean)}; call {@link #dispose()} when the
  * panel is permanently detached.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class RoomTelemetryDisplay extends Region {
 
     // ── Color palette ──────────────────────────────────────────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/SpatialPannerDisplay.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/SpatialPannerDisplay.java
@@ -15,6 +15,7 @@ import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 
 import java.util.List;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * GpuCanvas-backed 3D spatial panner widget for immersive audio positioning.
@@ -37,6 +38,7 @@ import java.util.List;
  * these interactions to the underlying {@code VbapPanner} or
  * {@code AmbisonicEncoder}.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class SpatialPannerDisplay extends Region {
 
     // ── Color palette ─────────────────────────────────────────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/SpectrumDisplay.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/SpectrumDisplay.java
@@ -13,6 +13,7 @@ import javafx.scene.paint.LinearGradient;
 import javafx.scene.paint.Stop;
 
 import java.util.Arrays;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Real-time animated spectrum analyzer display.
@@ -34,6 +35,7 @@ import java.util.Arrays;
  *   <li>Smooth animated transitions via {@link MeterAnimator}</li>
  * </ul>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class SpectrumDisplay extends Region {
 
     private static final Color BACKGROUND = Color.web("#0d0d1a");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/SpectrumDisplayWindow.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/SpectrumDisplayWindow.java
@@ -19,6 +19,7 @@ import javafx.stage.StageStyle;
 import javafx.util.StringConverter;
 
 import java.util.function.Consumer;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Standalone floating window wrapping a {@link SpectrumDisplay}.
@@ -38,6 +39,7 @@ import java.util.function.Consumer;
  * window.updateSpectrum(spectrumData);
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class SpectrumDisplayWindow {
 
     private static final double DEFAULT_WIDTH = 640;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/TunerDisplay.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/TunerDisplay.java
@@ -10,6 +10,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.TextAlignment;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Chromatic tuner display with note name, octave, frequency, and cents meter.
@@ -31,6 +32,7 @@ import javafx.scene.text.TextAlignment;
  *   <li>Red — beyond ±15 cents (out of tune)</li>
  * </ul>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class TunerDisplay extends Region {
 
     private static final Color BACKGROUND = Color.web("#0d0d1a");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/TunerDisplayWindow.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/TunerDisplayWindow.java
@@ -17,6 +17,7 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
 import java.util.function.Consumer;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Standalone floating window wrapping a {@link TunerDisplay}.
@@ -34,6 +35,7 @@ import java.util.function.Consumer;
  * window.update(tuningResult);
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class TunerDisplayWindow {
 
     private static final double DEFAULT_WIDTH = 480;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/WaveformDisplay.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/WaveformDisplay.java
@@ -6,6 +6,7 @@ import com.benesquivelmusic.daw.sdk.visualization.WaveformData;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * GPU-accelerated waveform visualization component with smooth animations.
@@ -31,6 +32,7 @@ import javafx.scene.paint.Color;
  * integrated against {@link GpuRenderContext#deltaSeconds()} so the cursor
  * speed is correct regardless of frame rate.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class WaveformDisplay extends Region {
 
     private static final Color DEFAULT_PEAK_COLOR = Color.web("#00e5ff");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/help/OnboardingTour.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/help/OnboardingTour.java
@@ -8,6 +8,7 @@ import javafx.scene.paint.Color;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Lightweight, deterministic onboarding tour that walks the user through a
@@ -19,6 +20,7 @@ import java.util.Objects;
  * Persistence of the "first launch" flag is delegated to
  * {@link OnboardingState}.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class OnboardingTour {
 
     /** A single step in the tour. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/icons/DawgIcon.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/icons/DawgIcon.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * The DAW's single iconography entry point.
@@ -79,6 +80,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * single approved family going forward (UI Design Book §3.6); use
  * {@code DawgIcon} for every new icon.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class DawgIcon extends Region {
 
     /** Discrete icon sizes permitted by the design book. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/icons/IconNode.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/icons/IconNode.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Loads SVG icon resources from the DAW icon pack and converts them into
@@ -37,6 +38,7 @@ import java.util.List;
  * button.setGraphic(playIcon);
  * }</pre>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class IconNode {
 
     private static final double DEFAULT_ICON_SIZE = 48.0;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/spatial/AtmosAbView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/spatial/AtmosAbView.java
@@ -28,6 +28,7 @@ import javafx.scene.shape.Rectangle;
 
 import java.util.List;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * UI panel that displays an A/B comparison between the DAW's current Atmos
@@ -56,6 +57,7 @@ import java.util.Objects;
  * has no direct dependency on the audio engine — the embedding controller
  * pumps fresh buffers in whenever the user requests a comparison.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class AtmosAbView extends BorderPane {
 
     /** The single key used to toggle A/B monitoring. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/telemetry/BoundaryResponsePanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/telemetry/BoundaryResponsePanel.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Compact display of the predicted Speaker Boundary Interference
@@ -34,6 +35,7 @@ import java.util.Objects;
  * <p>Computation is performed live by {@link SbirCalculator}; nothing
  * new is persisted alongside the room configuration.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class BoundaryResponsePanel extends VBox {
 
     private static final String LABEL_STYLE =

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/telemetry/RoomModesPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/telemetry/RoomModesPanel.java
@@ -17,6 +17,7 @@ import javafx.scene.text.Font;
 
 import java.util.List;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * Room-modes plot for the
@@ -33,6 +34,7 @@ import java.util.Objects;
  * <p>Computation is performed live by {@link RoomModeCalculator};
  * nothing new is persisted alongside the room configuration.</p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class RoomModesPanel extends VBox {
 
     private static final String EMPTY_STYLE =

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/telemetry/TreatmentSuggestionPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/telemetry/TreatmentSuggestionPanel.java
@@ -30,6 +30,7 @@ import javafx.scene.paint.Color;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
  * UI panel that presents a ranked list of {@link AcousticTreatment}
@@ -47,6 +48,7 @@ import java.util.function.Consumer;
  *         {@link RoomConfiguration} so subsequent analyses account for it.</li>
  * </ul></p>
  */
+@HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
 public final class TreatmentSuggestionPanel extends BorderPane {
 
     private final ObservableList<AcousticTreatment> suggestions =

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/HardcodedColorAllowed.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/HardcodedColorAllowed.java
@@ -1,0 +1,57 @@
+package com.benesquivelmusic.daw.app.ui.theme;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Sentinel marker for a UI class that still constructs colours with a
+ * literal {@code Color.web(...)} / {@code Color.rgb(...)} call instead of
+ * resolving them from a {@code -token} CSS lookup (story 277, UI Design
+ * Book §3.1 / §6 Phase 3).
+ *
+ * <p>{@code LegacyHardcodedColorAuditTest} scans the {@code
+ * com.benesquivelmusic.daw.app.ui} source tree for {@code Color.web(} and
+ * {@code Color.rgb(} calls and asserts that every offending source file
+ * carries this annotation with a non-blank TODO. The annotation makes the
+ * not-yet-tokenized state <strong>visible</strong> and prevents drift: a
+ * new control cannot hard-code a paint without consciously recording why
+ * it is exempt and what the migration is.</p>
+ *
+ * <p>This is the direct sibling of
+ * {@link com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog} (story
+ * 276): same pattern (mandatory non-blank {@code value()} TODO,
+ * {@code @Documented}, type-targeted), same intent (a green gate that
+ * tracks technical debt without forcing a risky bulk refactor). Story
+ * 277's Non-Goals explicitly defer the ~365-call Canvas/inline-paint
+ * tokenization; the audit "tolerates a sentinel {@code
+ * @HardcodedColorAllowed} annotation with a TODO" so the debt is tracked,
+ * not hidden.</p>
+ *
+ * <p>Retention is {@link RetentionPolicy#SOURCE}: the audit is a
+ * source-file text scan (no module/reflection concerns), so the marker
+ * does not need to survive compilation.</p>
+ *
+ * <pre>{@code
+ * @HardcodedColorAllowed("story 277 follow-up: migrate Canvas paints to resolved -token CSS")
+ * public final class FooRenderer { ... }
+ * }</pre>
+ *
+ * @see com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface HardcodedColorAllowed {
+
+    /**
+     * Mandatory TODO / reason string explaining why the class still
+     * hard-codes colour, and what the migration is (or why it is exempt
+     * by design, e.g. it parses arbitrary user-supplied JSON hex).
+     *
+     * @return the migration TODO or exemption rationale, must be non-blank
+     */
+    String value();
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/Theme.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/Theme.java
@@ -19,6 +19,7 @@ import java.util.Objects;
  * themes ship under {@code daw-app/src/main/resources/themes/}, user
  * themes live under {@code ~/.daw/themes/}.</p>
  */
+@HardcodedColorAllowed("story 194 user-supplied JSON theme colour parser/preview - exempt by design; the hex it constructs comes from arbitrary user JSON, not the design-book palette")
 public record Theme(
         String id,
         String name,

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/Theme.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/Theme.java
@@ -19,7 +19,6 @@ import java.util.Objects;
  * themes ship under {@code daw-app/src/main/resources/themes/}, user
  * themes live under {@code ~/.daw/themes/}.</p>
  */
-@HardcodedColorAllowed("story 194 user-supplied JSON theme colour parser/preview - exempt by design; the hex it constructs comes from arbitrary user JSON, not the design-book palette")
 public record Theme(
         String id,
         String name,

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
@@ -154,6 +154,44 @@ public final class ThemeManager {
                 new ThemeManager(Preferences.userNodeForPackage(ThemeManager.class));
     }
 
+    /**
+     * Test-only override for the process-wide default returned by
+     * {@link #getDefault()}. When non-null, {@code getDefault()} returns
+     * this instance instead of the real singleton — isolating tests that
+     * exercise {@code DarkThemeHelper} or {@code SettingsDialog} from
+     * the developer's / CI agent's actual user preferences store.
+     *
+     * <p>Set via {@link #setDefaultForTest(ThemeManager)} and cleared by
+     * passing {@code null}. Not thread-safe — call from a single test
+     * thread before/after the code under test.</p>
+     */
+    private static volatile ThemeManager defaultOverride;
+
+    /**
+     * Overrides the process-wide default instance for testing purposes.
+     * Pass a {@code ThemeManager} backed by an isolated
+     * {@link Preferences} node to prevent test runs from polluting (or
+     * inheriting choices from) the developer's real user preferences.
+     *
+     * <p><strong>Usage:</strong></p>
+     * <pre>{@code
+     * Preferences testNode = Preferences.userRoot().node("myTest_" + nanoTime());
+     * try {
+     *     ThemeManager.setDefaultForTest(new ThemeManager(testNode));
+     *     // … exercise DarkThemeHelper / SettingsDialog …
+     * } finally {
+     *     ThemeManager.setDefaultForTest(null);
+     *     testNode.removeNode();
+     * }
+     * }</pre>
+     *
+     * @param override the test instance, or {@code null} to restore the
+     *                 real singleton
+     */
+    public static void setDefaultForTest(ThemeManager override) {
+        defaultOverride = override;
+    }
+
     private final Preferences prefs;
     private final ObjectProperty<Theme> activeTheme;
 
@@ -207,11 +245,14 @@ public final class ThemeManager {
     }
 
     /**
-     * @return the process-wide default {@code ThemeManager} (persists to
+     * @return the process-wide default {@code ThemeManager} — either the
+     *         test override (if set via {@link #setDefaultForTest}) or
+     *         the real singleton (persists to
      *         {@code Preferences.userNodeForPackage(ThemeManager.class)})
      */
     public static ThemeManager getDefault() {
-        return DefaultHolder.INSTANCE;
+        ThemeManager override = defaultOverride;
+        return override != null ? override : DefaultHolder.INSTANCE;
     }
 
     // ── Active theme ─────────────────────────────────────────────────────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
@@ -186,8 +186,21 @@ public final class ThemeManager {
         this.prefs = Objects.requireNonNull(prefs, "prefs must not be null");
         this.activeTheme = new SimpleObjectProperty<>(this, "activeTheme", restore());
         this.activeTheme.addListener((_, _, newTheme) -> {
-            persist(newTheme);
-            reapplyAll();
+            // Persist FIRST so a backing-store failure can't leave the
+            // property in a state we then propagate to every registered
+            // scene/pane. If persist throws, the in-memory property is
+            // already updated (JavaFX fires change listeners after the
+            // new value is set) but we deliberately propagate the
+            // exception out — callers (Preferences sync, the Settings
+            // dialog Apply handler) can surface it. We still call
+            // reapplyAll() in a finally so an FX failure to log a
+            // persistence error doesn't leave the UI showing the old
+            // theme; this is the lesser of two evils.
+            try {
+                persist(newTheme);
+            } finally {
+                reapplyAll();
+            }
         });
     }
 
@@ -269,18 +282,26 @@ public final class ThemeManager {
      * stylesheet list: base {@code styles.css} first, then the active
      * theme's overlay (if any). Any previously-applied base/overlay
      * entries are removed first so re-application is idempotent and a
-     * stale overlay never lingers.
+     * stale overlay never lingers. The whole replacement is performed
+     * via a single {@link ObservableList#setAll(java.util.Collection)
+     * setAll} call so the JavaFX CSS subsystem sees one change event
+     * (and one re-evaluation pass) rather than a remove-then-add pair —
+     * avoiding a transient frame in which a registered scene is styled
+     * by the base sheet alone before the overlay is re-installed.
      */
     private void applyOrderedSheets(ObservableList<String> target) {
         List<String> ordered = orderedStylesheetUrls();
-        // Remove any of our managed URLs that are present, preserving any
-        // unrelated sheets a caller may have added, then append the
-        // ordered list so the overlay is always last (wins author order).
-        // removeAll() strips every base/overlay URL this manager could
-        // have installed, so the subsequent target.addAll is guaranteed
-        // not to introduce duplicates.
-        target.removeAll(allManagedUrls());
-        target.addAll(ordered);
+        List<String> managed = allManagedUrls();
+        // Build the final list = unrelated existing sheets (in caller's
+        // original order) + our ordered managed list (overlay last).
+        List<String> finalList = new ArrayList<>(target.size() + ordered.size());
+        for (String sheet : target) {
+            if (!managed.contains(sheet)) {
+                finalList.add(sheet);
+            }
+        }
+        finalList.addAll(ordered);
+        target.setAll(finalList);
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
@@ -186,21 +186,23 @@ public final class ThemeManager {
         this.prefs = Objects.requireNonNull(prefs, "prefs must not be null");
         this.activeTheme = new SimpleObjectProperty<>(this, "activeTheme", restore());
         this.activeTheme.addListener((_, _, newTheme) -> {
-            // Persist FIRST so a backing-store failure can't leave the
-            // property in a state we then propagate to every registered
-            // scene/pane. If persist throws, the in-memory property is
-            // already updated (JavaFX fires change listeners after the
-            // new value is set) but we deliberately propagate the
-            // exception out — callers (Preferences sync, the Settings
-            // dialog Apply handler) can surface it. We still call
-            // reapplyAll() in a finally so an FX failure to log a
-            // persistence error doesn't leave the UI showing the old
-            // theme; this is the lesser of two evils.
+            // Persist the new theme, then re-apply to all registered
+            // scenes/panes. If persistence fails (backing-store I/O
+            // error) we log a WARNING and still re-apply so the UI
+            // remains consistent with what the user just chose — they
+            // simply won't get the preference restored on next launch.
+            // Propagating the exception would leave callers (e.g.
+            // SettingsDialog's OK handler) with an unchecked failure
+            // while the UI has already visually switched.
             try {
                 persist(newTheme);
-            } finally {
-                reapplyAll();
+            } catch (RuntimeException ex) {
+                LOG.log(Level.WARNING,
+                        "Failed to persist theme preference; the UI will "
+                                + "switch but the choice may not survive restart",
+                        ex);
             }
+            reapplyAll();
         });
     }
 
@@ -247,6 +249,13 @@ public final class ThemeManager {
      * active theme overlay, overlay last) to {@code scene} and registers
      * it for live re-application on subsequent theme changes. Idempotent.
      *
+     * <p><strong>Threading:</strong> if called from the JavaFX
+     * application thread the sheets are applied synchronously; otherwise
+     * the work is scheduled via {@link Platform#runLater(Runnable)} and
+     * returns immediately. Callers reading
+     * {@code scene.getStylesheets()} from a non-FX thread right after
+     * this method returns may not yet see the updated list.</p>
+     *
      * @param scene the scene to style (must not be {@code null})
      */
     public void applyTo(Scene scene) {
@@ -263,6 +272,13 @@ public final class ThemeManager {
      * ensures the {@code root-pane} style class is present so the
      * {@code .root-pane} token block resolves, and registers the pane
      * for live re-application. Idempotent.
+     *
+     * <p><strong>Threading:</strong> if called from the JavaFX
+     * application thread the sheets are applied synchronously; otherwise
+     * the work is scheduled via {@link Platform#runLater(Runnable)} and
+     * returns immediately. Callers reading
+     * {@code pane.getStylesheets()} from a non-FX thread right after
+     * this method returns may not yet see the updated list.</p>
      *
      * @param pane the dialog pane to style (must not be {@code null})
      */
@@ -288,6 +304,18 @@ public final class ThemeManager {
      * (and one re-evaluation pass) rather than a remove-then-add pair —
      * avoiding a transient frame in which a registered scene is styled
      * by the base sheet alone before the overlay is re-installed.
+     *
+     * <p><strong>Ordering contract:</strong> ThemeManager owns the
+     * <em>tail</em> of the stylesheet list. Unrelated sheets that a
+     * caller appended (e.g. a plugin view or test harness) are preserved
+     * but positioned <em>before</em> the base/overlay pair. This means
+     * the theme overlay always wins the CSS author-order cascade over any
+     * user-appended sheet. If a caller explicitly needs to override a
+     * token after the overlay, it should append its sheet after calling
+     * {@code applyTo} and accept that subsequent theme switches will
+     * re-order it before the managed pair. In the current codebase no
+     * caller layers extra sheets on top of {@code styles.css}, so this
+     * ordering is latent.</p>
      */
     private void applyOrderedSheets(ObservableList<String> target) {
         List<String> ordered = orderedStylesheetUrls();
@@ -332,13 +360,17 @@ public final class ThemeManager {
     }
 
     private void reapplyAll() {
-        // Nothing registered → nothing to re-apply. This keeps the
-        // active-theme property (and therefore persistence) usable in a
-        // toolkit-free unit test that never registers a scene/pane.
-        if (scenes.isEmpty() && dialogPanes.isEmpty()) {
-            return;
-        }
+        // Gate all access to the WeakHashMap-backed sets on the FX
+        // thread — WeakHashMap is not thread-safe and a concurrent GC
+        // sweep (expungeStaleEntries) racing with isEmpty() could throw
+        // ConcurrentModificationException or return an incorrect answer.
+        // If the toolkit is not running (pure-unit context) runOnFx will
+        // silently drop the work — which is fine because there can be no
+        // live scenes/panes to update in that case.
         runOnFx(() -> {
+            if (scenes.isEmpty() && dialogPanes.isEmpty()) {
+                return;
+            }
             // Snapshot the weak sets: copying decouples iteration from a
             // concurrent GC sweep, and List.copyOf rejects nulls (the
             // sets never hold null — registration is null-checked).

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
@@ -140,9 +140,19 @@ public final class ThemeManager {
      * SettingsDialog} consult this so dialogs and the Appearance tab
      * re-theme without threading a {@code ThemeManager} through every
      * call site.
+     *
+     * <p>Lazy-initialized via the initialization-on-demand holder idiom
+     * so that merely loading {@code ThemeManager} (e.g. to read
+     * {@link #PREF_KEY} in a unit test that uses its own isolated
+     * preferences node) does not perform I/O against the developer's /
+     * CI agent's real user preferences store. The holder class loads —
+     * and the default instance constructs — only on the first call to
+     * {@link #getDefault()}.</p>
      */
-    private static final ThemeManager DEFAULT =
-            new ThemeManager(Preferences.userNodeForPackage(ThemeManager.class));
+    private static final class DefaultHolder {
+        static final ThemeManager INSTANCE =
+                new ThemeManager(Preferences.userNodeForPackage(ThemeManager.class));
+    }
 
     private final Preferences prefs;
     private final ObjectProperty<Theme> activeTheme;
@@ -152,7 +162,7 @@ public final class ThemeManager {
      * Held <strong>weakly</strong>: a dismissed dialog's pane (or a
      * closed window's scene) must not be pinned for the JVM lifetime —
      * over a long editing session many transient dialogs come and go,
-     * and {@link #DEFAULT} is a process-lifetime static. GC'd entries
+     * and {@link #getDefault()} is a process-lifetime singleton. GC'd entries
      * simply drop out of the re-theme set. All access is serialized
      * onto the FX thread via {@link #runOnFx}; {@link #reapplyAll()}
      * iterates a snapshot so a concurrent GC sweep cannot disturb it.
@@ -186,7 +196,7 @@ public final class ThemeManager {
      *         {@code Preferences.userNodeForPackage(ThemeManager.class)})
      */
     public static ThemeManager getDefault() {
-        return DEFAULT;
+        return DefaultHolder.INSTANCE;
     }
 
     // ── Active theme ─────────────────────────────────────────────────────────
@@ -266,12 +276,11 @@ public final class ThemeManager {
         // Remove any of our managed URLs that are present, preserving any
         // unrelated sheets a caller may have added, then append the
         // ordered list so the overlay is always last (wins author order).
+        // removeAll() strips every base/overlay URL this manager could
+        // have installed, so the subsequent target.addAll is guaranteed
+        // not to introduce duplicates.
         target.removeAll(allManagedUrls());
-        for (String url : ordered) {
-            if (!target.contains(url)) {
-                target.add(url);
-            }
-        }
+        target.addAll(ordered);
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
@@ -291,7 +291,7 @@ public final class ThemeManager {
      */
     private void applyOrderedSheets(ObservableList<String> target) {
         List<String> ordered = orderedStylesheetUrls();
-        List<String> managed = allManagedUrls();
+        Set<String> managed = Set.copyOf(allManagedUrls());
         // Build the final list = unrelated existing sheets (in caller's
         // original order) + our ordered managed list (overlay last).
         List<String> finalList = new ArrayList<>(target.size() + ordered.size());

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
@@ -9,11 +9,16 @@ import javafx.scene.control.DialogPane;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.prefs.Preferences;
 
 /**
@@ -124,6 +129,9 @@ public final class ThemeManager {
     private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
             "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
 
+    private static final Logger LOG =
+            Logger.getLogger(ThemeManager.class.getName());
+
     /**
      * Process-wide default instance, backed by the same per-package
      * {@link Preferences} node the rest of the UI uses
@@ -139,9 +147,20 @@ public final class ThemeManager {
     private final Preferences prefs;
     private final ObjectProperty<Theme> activeTheme;
 
-    /** Scenes/dialog-panes to re-style when the active theme changes. */
-    private final List<Scene> scenes = new ArrayList<>();
-    private final List<DialogPane> dialogPanes = new ArrayList<>();
+    /**
+     * Scenes / dialog-panes to re-style when the active theme changes.
+     * Held <strong>weakly</strong>: a dismissed dialog's pane (or a
+     * closed window's scene) must not be pinned for the JVM lifetime —
+     * over a long editing session many transient dialogs come and go,
+     * and {@link #DEFAULT} is a process-lifetime static. GC'd entries
+     * simply drop out of the re-theme set. All access is serialized
+     * onto the FX thread via {@link #runOnFx}; {@link #reapplyAll()}
+     * iterates a snapshot so a concurrent GC sweep cannot disturb it.
+     */
+    private final Set<Scene> scenes =
+            Collections.newSetFromMap(new WeakHashMap<>());
+    private final Set<DialogPane> dialogPanes =
+            Collections.newSetFromMap(new WeakHashMap<>());
 
     private volatile String resolvedBaseUrl;
 
@@ -210,9 +229,7 @@ public final class ThemeManager {
     public void applyTo(Scene scene) {
         Objects.requireNonNull(scene, "scene must not be null");
         runOnFx(() -> {
-            if (!scenes.contains(scene)) {
-                scenes.add(scene);
-            }
+            scenes.add(scene); // Set.add is idempotent
             applyOrderedSheets(scene.getStylesheets());
         });
     }
@@ -229,9 +246,7 @@ public final class ThemeManager {
     public void applyTo(DialogPane pane) {
         Objects.requireNonNull(pane, "pane must not be null");
         runOnFx(() -> {
-            if (!dialogPanes.contains(pane)) {
-                dialogPanes.add(pane);
-            }
+            dialogPanes.add(pane); // Set.add is idempotent
             if (!pane.getStyleClass().contains("root-pane")) {
                 pane.getStyleClass().add("root-pane");
             }
@@ -294,10 +309,13 @@ public final class ThemeManager {
             return;
         }
         runOnFx(() -> {
-            for (Scene scene : scenes) {
+            // Snapshot the weak sets: copying decouples iteration from a
+            // concurrent GC sweep, and List.copyOf rejects nulls (the
+            // sets never hold null — registration is null-checked).
+            for (Scene scene : List.copyOf(scenes)) {
                 applyOrderedSheets(scene.getStylesheets());
             }
-            for (DialogPane pane : dialogPanes) {
+            for (DialogPane pane : List.copyOf(dialogPanes)) {
                 applyOrderedSheets(pane.getStylesheets());
             }
         });
@@ -339,9 +357,11 @@ public final class ThemeManager {
         String stored = prefs.get(PREF_KEY, DEFAULT_THEME.name());
         try {
             return Theme.valueOf(stored);
-        } catch (IllegalArgumentException unknownOrNull) {
-            // Unknown / corrupt value persisted by a newer or broken
-            // build — fall back to the design-book default.
+        } catch (IllegalArgumentException unknownValue) {
+            // Unknown / corrupt enum name persisted by a newer or broken
+            // build. (prefs.get with a non-null default never returns
+            // null, so Theme.valueOf only ever throws here for an
+            // unrecognised name.) Fall back to the design-book default.
             return DEFAULT_THEME;
         }
     }
@@ -377,9 +397,15 @@ public final class ThemeManager {
         try {
             Platform.runLater(r);
         } catch (IllegalStateException toolkitNotRunning) {
-            // No JavaFX toolkit (e.g. a pure-unit context). There can be
-            // no live scene/dialog-pane to update, so dropping the
-            // re-apply is correct rather than fatal.
+            // No JavaFX toolkit yet / toolkit already shut down (a
+            // pure-unit context, or a theme change racing application
+            // exit). There can be no live scene/dialog-pane to update,
+            // so dropping the re-apply is correct rather than fatal —
+            // but log at FINE so a genuine post-shutdown failure is not
+            // entirely invisible given the FX-fork-shutdown history.
+            LOG.log(Level.FINE,
+                    "Theme re-apply skipped: no running JavaFX toolkit",
+                    toolkitNotRunning);
         }
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
@@ -1,0 +1,385 @@
+package com.benesquivelmusic.daw.app.ui.theme;
+
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.control.DialogPane;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import java.util.prefs.Preferences;
+
+/**
+ * Phase-3 token-driven theming (UI Design Book §3.1 / §6, story 277).
+ *
+ * <p>The DAW's structural CSS ({@code styles.css}) references every
+ * colour by a semantic {@code -token} lookup, never a literal hex.
+ * Switching theme therefore means nothing more than layering a tiny
+ * stylesheet that re-declares those tokens on top of {@code styles.css};
+ * JavaFX's lookup-colour cascade does the rest and <em>every</em>
+ * Phase-1/2 control re-themes for free with no structural change.</p>
+ *
+ * <p>{@code ThemeManager} is the single source of "the ordered
+ * stylesheet URL list to apply" = base {@code styles.css} +
+ * (optionally) the active theme overlay, overlay last so it wins by
+ * author order. Both the main {@link Scene} and every dialog's own
+ * {@link DialogPane} (dialogs have a separate Scene that the main
+ * scene's sheets do not cascade into) ask {@code ThemeManager} to apply
+ * the same ordered list, so they all re-theme together.</p>
+ *
+ * <h2>Relationship to the WCAG JSON theme system (story 194)</h2>
+ *
+ * <p>This is intentionally <strong>separate</strong> from
+ * {@link ThemeRegistry} / {@link Theme} (story 194). Story 194 is a JSON
+ * theme registry whose job is WCAG contrast validation of user-supplied
+ * palettes; it persists under the {@code appearance.themeId} key. Story
+ * 277 is the token-CSS palette switch — three curated design-book
+ * palettes applied via the lookup-colour cascade — and persists under a
+ * distinct key ({@link #PREF_KEY}) in the <em>same</em>
+ * {@link Preferences} store. The two systems do not share state by
+ * design: one validates arbitrary user colour for accessibility, the
+ * other swaps the three canonical design-book palettes.</p>
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>The active-theme {@link ObjectProperty} and scene/dialog-pane
+ * registration are JavaFX-thread state and must be touched on the FX
+ * application thread (re-application schedules itself via
+ * {@link Platform#runLater} when called off-thread). Persistence and
+ * construction are toolkit-free so {@code ThemeManager} can be
+ * unit-tested without a running toolkit.</p>
+ */
+public final class ThemeManager {
+
+    /**
+     * The token-CSS theme. Each constant carries the classpath resource
+     * of the overlay stylesheet that re-declares the Palette-A tokens
+     * ({@code null} for {@link #ONYX_REFINED}, which <em>is</em> the
+     * Palette-A baseline already in {@code styles.css}) and the
+     * {@code Messages.properties} key for its display name (Skill §14).
+     */
+    public enum Theme {
+
+        /**
+         * Palette A — "Onyx Refined" (default). The baseline palette is
+         * declared directly in {@code styles.css}; no overlay is needed.
+         */
+        ONYX_REFINED(null, "appearance.theme.onyxRefined"),
+
+        /** Palette B — "Studio Slate" (dark, monochrome + warm accent). */
+        STUDIO_SLATE("themes/studio-slate.css", "appearance.theme.studioSlate"),
+
+        /** Palette C — "Atelier" (light, navy accent). */
+        ATELIER("themes/atelier.css", "appearance.theme.atelier");
+
+        private final String overlayResource;
+        private final String displayNameKey;
+
+        Theme(String overlayResource, String displayNameKey) {
+            this.overlayResource = overlayResource;
+            this.displayNameKey = displayNameKey;
+        }
+
+        /**
+         * @return the overlay stylesheet classpath resource (relative to
+         *         the {@code ui} package), or {@code null} for the
+         *         baseline {@link #ONYX_REFINED}
+         */
+        String overlayResource() {
+            return overlayResource;
+        }
+
+        /** @return the {@code Messages.properties} display-name key */
+        public String displayNameKey() {
+            return displayNameKey;
+        }
+    }
+
+    /**
+     * The default active theme for an unknown / missing / unreadable
+     * persisted value — Palette A, the design-book default.
+     */
+    public static final Theme DEFAULT_THEME = Theme.ONYX_REFINED;
+
+    /**
+     * Preferences key under which the active token theme is persisted.
+     *
+     * <p>Deliberately distinct from {@code SettingsModel.KEY_THEME_ID}
+     * ({@code "appearance.themeId"}), which belongs to story 194's JSON
+     * {@link ThemeRegistry}. The two theme systems are separate by
+     * design (see the class Javadoc) and must not share a key.</p>
+     */
+    public static final String PREF_KEY = "appearance.tokenTheme";
+
+    /** Base structural stylesheet — always first in the applied list. */
+    private static final String BASE_STYLESHEET = "styles.css";
+
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
+
+    /**
+     * Process-wide default instance, backed by the same per-package
+     * {@link Preferences} node the rest of the UI uses
+     * ({@code Preferences.userNodeForPackage}). There is no DI container;
+     * {@code DarkThemeHelper} (the deprecated shim) and {@code
+     * SettingsDialog} consult this so dialogs and the Appearance tab
+     * re-theme without threading a {@code ThemeManager} through every
+     * call site.
+     */
+    private static final ThemeManager DEFAULT =
+            new ThemeManager(Preferences.userNodeForPackage(ThemeManager.class));
+
+    private final Preferences prefs;
+    private final ObjectProperty<Theme> activeTheme;
+
+    /** Scenes/dialog-panes to re-style when the active theme changes. */
+    private final List<Scene> scenes = new ArrayList<>();
+    private final List<DialogPane> dialogPanes = new ArrayList<>();
+
+    private volatile String resolvedBaseUrl;
+
+    /**
+     * Creates a {@code ThemeManager} backed by the given preferences
+     * node, restoring the persisted active theme (defaulting to
+     * {@link #DEFAULT_THEME} for a missing/unknown value) and persisting
+     * any subsequent change to the active-theme property.
+     *
+     * @param prefs the backing preferences node (must not be {@code null})
+     */
+    public ThemeManager(Preferences prefs) {
+        this.prefs = Objects.requireNonNull(prefs, "prefs must not be null");
+        this.activeTheme = new SimpleObjectProperty<>(this, "activeTheme", restore());
+        this.activeTheme.addListener((_, _, newTheme) -> {
+            persist(newTheme);
+            reapplyAll();
+        });
+    }
+
+    /**
+     * @return the process-wide default {@code ThemeManager} (persists to
+     *         {@code Preferences.userNodeForPackage(ThemeManager.class)})
+     */
+    public static ThemeManager getDefault() {
+        return DEFAULT;
+    }
+
+    // ── Active theme ─────────────────────────────────────────────────────────
+
+    /**
+     * The active token theme. Setting it persists the choice and
+     * re-applies the new overlay to every registered scene/dialog-pane
+     * (so the UI updates with no restart).
+     *
+     * @return the observable active-theme property
+     */
+    public ObjectProperty<Theme> activeThemeProperty() {
+        return activeTheme;
+    }
+
+    /** @return the current active theme (never {@code null}). */
+    public Theme getActiveTheme() {
+        return activeTheme.get();
+    }
+
+    /**
+     * Sets the active theme. Equivalent to
+     * {@code activeThemeProperty().set(theme)}.
+     *
+     * @param theme the new active theme (must not be {@code null})
+     */
+    public void setActiveTheme(Theme theme) {
+        activeTheme.set(Objects.requireNonNull(theme, "theme must not be null"));
+    }
+
+    // ── Application ──────────────────────────────────────────────────────────
+
+    /**
+     * Applies the ordered stylesheet list (base {@code styles.css} +
+     * active theme overlay, overlay last) to {@code scene} and registers
+     * it for live re-application on subsequent theme changes. Idempotent.
+     *
+     * @param scene the scene to style (must not be {@code null})
+     */
+    public void applyTo(Scene scene) {
+        Objects.requireNonNull(scene, "scene must not be null");
+        runOnFx(() -> {
+            if (!scenes.contains(scene)) {
+                scenes.add(scene);
+            }
+            applyOrderedSheets(scene.getStylesheets());
+        });
+    }
+
+    /**
+     * Applies the ordered stylesheet list to {@code pane} (a dialog's
+     * own pane — its Scene does not inherit the main scene's sheets),
+     * ensures the {@code root-pane} style class is present so the
+     * {@code .root-pane} token block resolves, and registers the pane
+     * for live re-application. Idempotent.
+     *
+     * @param pane the dialog pane to style (must not be {@code null})
+     */
+    public void applyTo(DialogPane pane) {
+        Objects.requireNonNull(pane, "pane must not be null");
+        runOnFx(() -> {
+            if (!dialogPanes.contains(pane)) {
+                dialogPanes.add(pane);
+            }
+            if (!pane.getStyleClass().contains("root-pane")) {
+                pane.getStyleClass().add("root-pane");
+            }
+            applyOrderedSheets(pane.getStylesheets());
+        });
+    }
+
+    /**
+     * Replaces {@code target}'s contents with the canonical ordered
+     * stylesheet list: base {@code styles.css} first, then the active
+     * theme's overlay (if any). Any previously-applied base/overlay
+     * entries are removed first so re-application is idempotent and a
+     * stale overlay never lingers.
+     */
+    private void applyOrderedSheets(ObservableList<String> target) {
+        List<String> ordered = orderedStylesheetUrls();
+        // Remove any of our managed URLs that are present, preserving any
+        // unrelated sheets a caller may have added, then append the
+        // ordered list so the overlay is always last (wins author order).
+        target.removeAll(allManagedUrls());
+        for (String url : ordered) {
+            if (!target.contains(url)) {
+                target.add(url);
+            }
+        }
+    }
+
+    /**
+     * @return the ordered stylesheet URL list for the active theme:
+     *         {@code [styles.css]} for {@link Theme#ONYX_REFINED},
+     *         {@code [styles.css, <overlay>]} otherwise
+     */
+    public List<String> orderedStylesheetUrls() {
+        List<String> urls = new ArrayList<>(2);
+        urls.add(baseStylesheetUrl());
+        String overlay = activeTheme.get().overlayResource();
+        if (overlay != null) {
+            urls.add(resolve(overlay));
+        }
+        return List.copyOf(urls);
+    }
+
+    /** Every URL this manager may have installed (base + all overlays). */
+    private List<String> allManagedUrls() {
+        List<String> all = new ArrayList<>();
+        all.add(baseStylesheetUrl());
+        for (Theme t : Theme.values()) {
+            if (t.overlayResource() != null) {
+                all.add(resolve(t.overlayResource()));
+            }
+        }
+        return all;
+    }
+
+    private void reapplyAll() {
+        // Nothing registered → nothing to re-apply. This keeps the
+        // active-theme property (and therefore persistence) usable in a
+        // toolkit-free unit test that never registers a scene/pane.
+        if (scenes.isEmpty() && dialogPanes.isEmpty()) {
+            return;
+        }
+        runOnFx(() -> {
+            for (Scene scene : scenes) {
+                applyOrderedSheets(scene.getStylesheets());
+            }
+            for (DialogPane pane : dialogPanes) {
+                applyOrderedSheets(pane.getStylesheets());
+            }
+        });
+    }
+
+    // ── Resource resolution (mirrors DarkThemeHelper.getStylesheetUrl) ───────
+
+    /**
+     * @return the external-form URL of the base {@code styles.css},
+     *         resolved lazily and cached (mirrors the
+     *         {@code DarkThemeHelper} resolution it now backs)
+     */
+    public String baseStylesheetUrl() {
+        String url = resolvedBaseUrl;
+        if (url == null) {
+            url = resolve(BASE_STYLESHEET);
+            resolvedBaseUrl = url;
+        }
+        return url;
+    }
+
+    /** Absolute classpath root of the {@code ui} package's resources. */
+    private static final String UI_RESOURCE_ROOT =
+            "/com/benesquivelmusic/daw/app/ui/";
+
+    private static String resolve(String resource) {
+        // The stylesheets live in the `ui` package (the parent of this
+        // `theme` package): `styles.css`, `themes/*.css`. Class.getResource
+        // does NOT normalise a relative `../` segment, so resolve via the
+        // absolute classpath path instead.
+        URL u = ThemeManager.class.getResource(UI_RESOURCE_ROOT + resource);
+        Objects.requireNonNull(u, "Stylesheet resource not found: " + resource);
+        return u.toExternalForm();
+    }
+
+    // ── Persistence (toolkit-free) ───────────────────────────────────────────
+
+    private Theme restore() {
+        String stored = prefs.get(PREF_KEY, DEFAULT_THEME.name());
+        try {
+            return Theme.valueOf(stored);
+        } catch (IllegalArgumentException unknownOrNull) {
+            // Unknown / corrupt value persisted by a newer or broken
+            // build — fall back to the design-book default.
+            return DEFAULT_THEME;
+        }
+    }
+
+    private void persist(Theme theme) {
+        prefs.put(PREF_KEY, theme.name());
+    }
+
+    // ── i18n ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Resolves a theme's localized display name from the shared bundle,
+     * falling back to the raw key if absent (mirrors {@code
+     * DawgDialog#msg} / {@code BrowserPanel#msg}).
+     *
+     * @param theme the theme (must not be {@code null})
+     * @return the localized display name, or the key if not found
+     */
+    public static String displayName(Theme theme) {
+        Objects.requireNonNull(theme, "theme must not be null");
+        try {
+            return MESSAGES.getString(theme.displayNameKey());
+        } catch (MissingResourceException e) {
+            return theme.displayNameKey();
+        }
+    }
+
+    private static void runOnFx(Runnable r) {
+        if (Platform.isFxApplicationThread()) {
+            r.run();
+            return;
+        }
+        try {
+            Platform.runLater(r);
+        } catch (IllegalStateException toolkitNotRunning) {
+            // No JavaFX toolkit (e.g. a pure-unit context). There can be
+            // no live scene/dialog-pane to update, so dropping the
+            // re-apply is correct rather than fatal.
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemePickerDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemePickerDialog.java
@@ -60,6 +60,7 @@ import java.util.logging.Logger;
  */
 @com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog(
         "migrate to DawgDialog — story 276 follow-up")
+@HardcodedColorAllowed("story 194 user-supplied JSON theme colour parser/preview - exempt by design; the hex it constructs comes from arbitrary user JSON, not the design-book palette")
 public final class ThemePickerDialog extends Dialog<Theme> {
 
     private static final Logger LOG = Logger.getLogger(ThemePickerDialog.class.getName());

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -71,3 +71,12 @@ dialog.cancel=Cancel
 dialog.close=Close
 dialog.ok=OK
 dialog.save=Save
+
+# Appearance / token theme (story 277) — UI Design Book §3.1 / §6
+# Phase 3. The three design-book palettes selectable from
+# Preferences > Appearance > Theme. Distinct from story 194's WCAG
+# JSON theme registry. Section-scoped prefix per the file convention.
+appearance.theme.label=Theme:
+appearance.theme.onyxRefined=Onyx Refined
+appearance.theme.studioSlate=Studio Slate
+appearance.theme.atelier=Atelier

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -76,7 +76,7 @@ dialog.save=Save
 # Phase 3. The three design-book palettes selectable from
 # Preferences > Appearance > Theme. Distinct from story 194's WCAG
 # JSON theme registry. Section-scoped prefix per the file convention.
-appearance.theme.label=Theme:
+appearance.theme.label=Theme
 appearance.theme.onyxRefined=Onyx Refined
 appearance.theme.studioSlate=Studio Slate
 appearance.theme.atelier=Atelier

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/themes/atelier.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/themes/atelier.css
@@ -1,0 +1,77 @@
+/*
+ * Atelier — Palette C (UI Design Book §3.1, story 277).
+ *
+ * Phase-3 token theme. This stylesheet re-declares ONLY the lookup
+ * colour tokens that styles.css's Palette A block defines. It carries
+ * NO structural rules — every Phase-1/2 control re-themes for free
+ * because the structural CSS in styles.css references these tokens by
+ * role, never by literal hex.
+ *
+ * It is layered on top of styles.css (loaded last) so its `.root-pane`
+ * lookup-colour re-declarations win the JavaFX lookup-colour cascade.
+ *
+ * A light theme done seriously — warm off-white surfaces, calm navy
+ * accent, for studios that work daylight hours (post, podcast,
+ * mastering rooms with daylight reference monitors).
+ *
+ * This file lives OUTSIDE styles.css so TokenValidationTest (which only
+ * scans styles.css) does not flag these hex values — that is correct and
+ * intended: palette literals belong in palette sheets, never in
+ * structural CSS.
+ */
+
+.root-pane {
+    -surface-bg:      #F4F4F0;
+    -surface-1:       #FFFFFF;
+    -surface-2:       #EDEDE7;
+    -surface-3:       #E3E2DA;
+    /* No per-palette value in §3.1 for surface-overlay; a light theme
+       wants a light-but-distinct modal surface (slightly off the bg so
+       a modal still reads as a separate plane). */
+    -surface-overlay: #FBFBF8;
+
+    -line-soft:       #DEDDD4;
+    -line-strong:     #C4C2B7;
+    -focus-ring:      #244B8C;
+
+    -text-hi:         #15161B;
+    -text:            #3D404A;
+    -text-mute:       #73767F;
+    /* Explicitly declared (story §Goals) — white text on the navy
+       accent. Each theme sheet is self-contained for text-on-accent
+       rather than inheriting Palette A's near-black. */
+    -text-on-accent:  #FFFFFF;
+
+    -accent:          #244B8C;
+    -accent-soft:     rgba(36, 75, 140, 0.14);
+    /* Derived from this palette's accent (Palette A pattern: glow =
+       accent at 0.3 alpha, drop-target = focus-ring at 0.25). */
+    -accent-glow:     rgba(36, 75, 140, 0.30);
+    -drop-target-bg:  rgba(36, 75, 140, 0.25);
+
+    -ok:              #3FA76A;
+    -warn:            #B57A1B;
+    -danger:          #B5273B;
+
+    /* Meter ramp deliberately NOT re-declared. Meters encode signal
+       magnitude (dBFS), not palette identity (UI Design Book §3.1 —
+       "DATA: encode magnitude, not state"). §3.1 gives no per-palette
+       B/C meter values; the Palette-A green→amber→red ramp is a
+       universal signal-level convention that reads correctly on this
+       light surface too. Inheriting it is intentional. */
+
+    /* Elevation tokens softened for a light theme. Palette A's shadows
+       are pure black at 35–55 % opacity — designed for near-black
+       surfaces. On Atelier's #F4F4F0 / #FFFFFF surfaces a 55 %-black
+       modal slab is a visible defect (reads as dirt, not depth), which
+       would fail the story's "every control re-themes correctly" AC.
+       We keep the §3.4 blur/offset geometry identical so the elevation
+       hierarchy (card < hover < popover < modal) is preserved, and
+       lower the alpha substantially so the shadow reads as soft depth
+       on a light ground. This is a scoped correctness measure, not
+       gold-plating. */
+    -elevation-1: dropshadow(gaussian, rgba(0, 0, 0, 0.12), 2, 0, 0, 1);
+    -elevation-2: dropshadow(gaussian, rgba(0, 0, 0, 0.16), 6, 0, 0, 2);
+    -elevation-3: dropshadow(gaussian, rgba(0, 0, 0, 0.20), 16, 0, 0, 6);
+    -elevation-4: dropshadow(gaussian, rgba(0, 0, 0, 0.24), 32, 0, 0, 16);
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/themes/studio-slate.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/themes/studio-slate.css
@@ -1,0 +1,64 @@
+/*
+ * Studio Slate — Palette B (UI Design Book §3.1, story 277).
+ *
+ * Phase-3 token theme. This stylesheet re-declares ONLY the lookup
+ * colour tokens that styles.css's Palette A block defines. It carries
+ * NO structural rules — every Phase-1/2 control re-themes for free
+ * because the structural CSS in styles.css references these tokens by
+ * role, never by literal hex.
+ *
+ * It is layered on top of styles.css (loaded last) so its `.root-pane`
+ * lookup-colour re-declarations win the JavaFX lookup-colour cascade.
+ *
+ * Dark, near-monochrome console aesthetic with a single warm-orange
+ * accent (closest to Pro Tools / Cubase / classic consoles).
+ *
+ * This file lives OUTSIDE styles.css so TokenValidationTest (which only
+ * scans styles.css) does not flag these hex values — that is correct and
+ * intended: palette literals belong in palette sheets, never in
+ * structural CSS.
+ */
+
+.root-pane {
+    -surface-bg:      #101115;
+    -surface-1:       #181A20;
+    -surface-2:       #22252D;
+    -surface-3:       #2C2F38;
+    /* No per-palette value in §3.1 for surface-overlay; derive a
+       slightly-deeper-than-surface-bg modal tone, consistent with
+       Palette A's overlay being darker than its bg. */
+    -surface-overlay: #0C0D10;
+
+    -line-soft:       #262932;
+    -line-strong:     #34384A;
+    -focus-ring:      #FF7A45;
+
+    -text-hi:         #F0F1F4;
+    -text:            #B0B5C0;
+    -text-mute:       #727784;
+    /* Explicitly declared (story §Goals) — near-black, reads on the
+       orange accent. Each theme sheet is self-contained for text-on-
+       accent rather than inheriting Palette A. */
+    -text-on-accent:  #15161B;
+
+    -accent:          #FF7A45;
+    -accent-soft:     rgba(255, 122, 69, 0.14);
+    /* Derived from this palette's accent (Palette A pattern: glow =
+       accent at 0.3 alpha, drop-target = focus-ring at 0.25). */
+    -accent-glow:     rgba(255, 122, 69, 0.30);
+    -drop-target-bg:  rgba(255, 122, 69, 0.25);
+
+    -ok:              #74C28A;
+    -warn:            #E0B764;
+    -danger:          #E26060;
+
+    /* Meter ramp deliberately NOT re-declared. Meters encode signal
+       magnitude (dBFS), not palette identity (UI Design Book §3.1 —
+       "DATA: encode magnitude, not state"). §3.1 gives no per-palette
+       B/C meter values; the Palette-A green→amber→red ramp reads
+       correctly on this dark surface. Inheriting it is intentional. */
+
+    /* Elevation tokens deliberately NOT re-declared. Studio Slate is a
+       dark theme like Palette A; the §3.4 black-translucent slab
+       shadows read correctly on its dark surfaces. */
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/LegacyHardcodedColorAuditTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/LegacyHardcodedColorAuditTest.java
@@ -12,6 +12,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,8 +40,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * dialogs with {@code @LegacyDialog}.</p>
  *
  * <p>The scan is a SOURCE-level filesystem text scan (the annotation is
- * {@link java.lang.annotation.RetentionPolicy#SOURCE}); no toolkit,
- * module, or reflection is involved. Path resolution mirrors
+ * {@link java.lang.annotation.RetentionPolicy#SOURCE}, so {@code
+ * EveryDialogConformsTest}'s reflective {@code !ann.value().isBlank()}
+ * check is unavailable here). To stay faithful to that contract the
+ * scan strips {@code //} / {@code /* *\/} comments before looking for a
+ * hard-coded paint (so a {@code Color.web(...)} mention in Javadoc does
+ * not false-match), blanks string literals before the paint scan, and
+ * captures the annotation's {@code value()} literal to assert it is
+ * <em>non-blank</em>. The annotation type's own source is excluded by
+ * name, exactly as {@code EveryDialogConformsTest} skips the
+ * {@code @LegacyDialog} annotation type. Path resolution mirrors
  * {@code NumericClassAuditTest}.</p>
  */
 final class LegacyHardcodedColorAuditTest {
@@ -49,9 +58,33 @@ final class LegacyHardcodedColorAuditTest {
     private static final Pattern HARDCODED_COLOR =
             Pattern.compile("\\bColor\\.(web|rgb)\\s*\\(");
 
-    /** Class-level sentinel that records the deferral TODO (story 277). */
-    private static final Pattern ANNOTATION =
-            Pattern.compile("@HardcodedColorAllowed\\s*\\(");
+    /**
+     * The class-level sentinel <em>with</em> its mandatory {@code
+     * value()} string literal captured (group 1). The audit asserts the
+     * captured TODO/exemption text is non-blank — the SOURCE-scan
+     * equivalent of {@code EveryDialogConformsTest}'s reflective
+     * {@code ann.value() != null && !ann.value().isBlank()}.
+     */
+    private static final Pattern ANNOTATION_WITH_VALUE = Pattern.compile(
+            "@HardcodedColorAllowed\\s*\\(\\s*\"((?:\\\\.|[^\"\\\\])*)\"");
+
+    /**
+     * One Java comment or one string / text-block literal. Alternation
+     * order matters: a literal is matched before {@code //} and {@code
+     * /*} so a delimiter inside a string is not mistaken for a comment,
+     * and a quote inside a comment is consumed as part of the comment.
+     */
+    private static final Pattern COMMENT_OR_STRING = Pattern.compile(
+            "\"\"\"[\\s\\S]*?\"\"\""        // text block
+            + "|\"(?:\\\\.|[^\"\\\\])*\""   // string literal
+            + "|//[^\\n]*"                  // line comment
+            + "|/\\*[\\s\\S]*?\\*/");       // block comment
+
+    /** {@code daw-app}'s {@code @HardcodedColorAllowed} source — the
+     *  annotation type whose own Javadoc necessarily names the calls it
+     *  guards; excluded exactly as {@code EveryDialogConformsTest} skips
+     *  the {@code @LegacyDialog} annotation type ({@code c.isAnnotation()}). */
+    private static final String ANNOTATION_TYPE_FILE = "HardcodedColorAllowed.java";
 
     @Test
     void everyHardcodedColorSourceCarriesTheSentinelAnnotation() throws IOException {
@@ -67,15 +100,33 @@ final class LegacyHardcodedColorAuditTest {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                     throws IOException {
-                if (!file.getFileName().toString().endsWith(".java")) {
+                String name = file.getFileName().toString();
+                if (!name.endsWith(".java")
+                        || name.equals(ANNOTATION_TYPE_FILE)) {
                     return FileVisitResult.CONTINUE;
                 }
                 scanned.add(file);
-                String source = Files.readString(file, StandardCharsets.UTF_8);
-                if (HARDCODED_COLOR.matcher(source).find()
-                        && !ANNOTATION.matcher(source).find()) {
-                    offenders.add(uiSrcRoot.relativize(file).toString()
-                            .replace('\\', '/'));
+
+                // Strip comments (so a Color.web(...) mention in Javadoc
+                // does not false-match) but keep string literals so the
+                // real @HardcodedColorAllowed("...") survives for the
+                // non-blank check; then blank strings for the paint scan
+                // so a Color.web( inside a string is not a false match.
+                String code = stripComments(
+                        Files.readString(file, StandardCharsets.UTF_8));
+                if (!HARDCODED_COLOR.matcher(stripStringLiterals(code)).find()) {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                String relPath = uiSrcRoot.relativize(file).toString()
+                        .replace('\\', '/');
+                Matcher ann = ANNOTATION_WITH_VALUE.matcher(code);
+                if (!ann.find()) {
+                    offenders.add(relPath + "  — missing @HardcodedColorAllowed");
+                } else if (ann.group(1).isBlank()) {
+                    offenders.add(relPath + "  — @HardcodedColorAllowed value "
+                            + "is blank (the migration TODO / exemption "
+                            + "rationale is mandatory)");
                 }
                 return FileVisitResult.CONTINUE;
             }
@@ -137,5 +188,37 @@ final class LegacyHardcodedColorAuditTest {
         return Files.isRegularFile(dir.resolve("pom.xml"))
                 && Files.isDirectory(
                         dir.resolve("src/main/java/com/benesquivelmusic/daw/app"));
+    }
+
+    // ── source pre-processing ────────────────────────────────────────────────
+
+    /**
+     * Removes {@code //} and {@code /* *\/} comments while preserving
+     * string / text-block literals (so a real {@code
+     * @HardcodedColorAllowed("...")} survives the strip but a {@code
+     * Color.web(...)} written inside Javadoc does not). Mirrors the
+     * DOTALL comment-stripping {@code TokenValidationTest} already does,
+     * generalised to skip over string literals.
+     */
+    private static String stripComments(String source) {
+        Matcher m = COMMENT_OR_STRING.matcher(source);
+        StringBuilder out = new StringBuilder(source.length());
+        while (m.find()) {
+            String token = m.group();
+            // A string / text block (starts with a quote) is code — keep
+            // it verbatim; anything else the alternation matched is a
+            // comment and is replaced with a single space.
+            m.appendReplacement(out, token.charAt(0) == '"'
+                    ? Matcher.quoteReplacement(token) : " ");
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+
+    /** Blanks string / text-block literals out of already comment-free code. */
+    private static String stripStringLiterals(String code) {
+        return code
+                .replaceAll("\"\"\"[\\s\\S]*?\"\"\"", "\"\"")
+                .replaceAll("\"(?:\\\\.|[^\"\\\\])*\"", "\"\"");
     }
 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/LegacyHardcodedColorAuditTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/LegacyHardcodedColorAuditTest.java
@@ -1,0 +1,141 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 277 — guards the Phase-3 token-theming contract (UI Design Book
+ * §3.1 / §6): every control must consume its colours from a
+ * {@code -token} CSS lookup so a theme overlay re-themes it for free.
+ * A {@code Color.web(...)} / {@code Color.rgb(...)} call hard-codes a
+ * paint that no theme overlay can reach.
+ *
+ * <p>This is the direct sibling of {@code EveryDialogConformsTest}
+ * (story 276): a green gate that scans the {@code
+ * com.benesquivelmusic.daw.app.ui} source tree and asserts every file
+ * containing a {@code Color.web(} / {@code Color.rgb(} call carries
+ * {@link com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed}
+ * with a non-blank TODO. The annotation makes the not-yet-tokenized
+ * state visible and prevents drift — a new control cannot hard-code a
+ * paint without consciously recording why and what the migration is.</p>
+ *
+ * <p>Story 277's Non-Goals explicitly defer the bulk Canvas/inline-paint
+ * tokenization; the audit "tolerates a sentinel {@code
+ * @HardcodedColorAllowed} annotation with a TODO" so the debt is
+ * tracked, not hidden, exactly as story 276 tracked the not-yet-migrated
+ * dialogs with {@code @LegacyDialog}.</p>
+ *
+ * <p>The scan is a SOURCE-level filesystem text scan (the annotation is
+ * {@link java.lang.annotation.RetentionPolicy#SOURCE}); no toolkit,
+ * module, or reflection is involved. Path resolution mirrors
+ * {@code NumericClassAuditTest}.</p>
+ */
+final class LegacyHardcodedColorAuditTest {
+
+    /** {@code Color.web(} or {@code Color.rgb(} — the hard-coded paint calls. */
+    private static final Pattern HARDCODED_COLOR =
+            Pattern.compile("\\bColor\\.(web|rgb)\\s*\\(");
+
+    /** Class-level sentinel that records the deferral TODO (story 277). */
+    private static final Pattern ANNOTATION =
+            Pattern.compile("@HardcodedColorAllowed\\s*\\(");
+
+    @Test
+    void everyHardcodedColorSourceCarriesTheSentinelAnnotation() throws IOException {
+        Path uiSrcRoot = locateDawAppModule()
+                .resolve("src/main/java/com/benesquivelmusic/daw/app/ui");
+        assertThat(Files.isDirectory(uiSrcRoot))
+                .as("UI Java sources must live under %s", uiSrcRoot)
+                .isTrue();
+
+        List<String> offenders = new ArrayList<>();
+        List<Path> scanned = new ArrayList<>();
+        Files.walkFileTree(uiSrcRoot, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                if (!file.getFileName().toString().endsWith(".java")) {
+                    return FileVisitResult.CONTINUE;
+                }
+                scanned.add(file);
+                String source = Files.readString(file, StandardCharsets.UTF_8);
+                if (HARDCODED_COLOR.matcher(source).find()
+                        && !ANNOTATION.matcher(source).find()) {
+                    offenders.add(uiSrcRoot.relativize(file).toString()
+                            .replace('\\', '/'));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        // Guard against a silently-empty scan (a broken path would make
+        // the audit vacuously pass).
+        assertThat(scanned)
+                .as("the UI source scan must visit a non-trivial number of "
+                        + ".java files — an empty scan would make this audit "
+                        + "vacuously pass")
+                .hasSizeGreaterThan(50);
+
+        offenders.sort(String::compareTo);
+        assertThat(offenders)
+                .as("Story 277 — every UI source file containing a "
+                        + "Color.web(...) / Color.rgb(...) call must consume "
+                        + "colour from a -token CSS lookup, or carry "
+                        + "@HardcodedColorAllowed(\"<TODO>\") to record the "
+                        + "deferred migration (UI Design Book §3.1 / §6, "
+                        + "sibling of story 276's @LegacyDialog). "
+                        + "Non-conforming files:%n  %s%nAdd the sentinel "
+                        + "annotation with a migration TODO, or tokenize the "
+                        + "paint.",
+                        String.join("\n  ", offenders))
+                .isEmpty();
+    }
+
+    /**
+     * Locate the {@code daw-app} module root. Surefire normally sets the
+     * working directory to the module itself; the fallbacks cover
+     * invocations from the repo root (e.g. {@code mvn -pl daw-app test}).
+     * Mirrors {@code NumericClassAuditTest#locateDawAppModule()}.
+     */
+    private static Path locateDawAppModule() {
+        Path cwd = Paths.get("").toAbsolutePath();
+        if (isDawAppModule(cwd)) {
+            return cwd;
+        }
+        Path child = cwd.resolve("daw-app");
+        if (isDawAppModule(child)) {
+            return child;
+        }
+        Path candidate = cwd.getParent();
+        for (int i = 0; i < 5 && candidate != null; i++) {
+            if (isDawAppModule(candidate)) {
+                return candidate;
+            }
+            Path nested = candidate.resolve("daw-app");
+            if (isDawAppModule(nested)) {
+                return nested;
+            }
+            candidate = candidate.getParent();
+        }
+        return cwd;
+    }
+
+    private static boolean isDawAppModule(Path dir) {
+        return Files.isRegularFile(dir.resolve("pom.xml"))
+                && Files.isDirectory(
+                        dir.resolve("src/main/java/com/benesquivelmusic/daw/app"));
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/LegacyHardcodedColorAuditTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/LegacyHardcodedColorAuditTest.java
@@ -39,6 +39,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  * tracked, not hidden, exactly as story 276 tracked the not-yet-migrated
  * dialogs with {@code @LegacyDialog}.</p>
  *
+ * <h3>Scope justification (why only {@code daw-app/ui}?)</h3>
+ *
+ * <p>This audit intentionally scans only the {@code
+ * com.benesquivelmusic.daw.app.ui} source tree inside the {@code
+ * daw-app} module. Other modules that contribute render code ({@code
+ * daw-fx}, {@code daw-sdk}) operate at a lower layer: they draw to
+ * GPU canvases or render offline buffers where JavaFX CSS tokens are
+ * unreachable by design. Those paints are runtime-computed signal
+ * representations (waveforms, spectra, meter pixels), not UI chrome,
+ * and are not subject to the token theme contract. The audit therefore
+ * does not scan them — broadening the root would generate false
+ * positives without catching any real theming violations.</p>
+ *
  * <p>The scan is a SOURCE-level filesystem text scan (the annotation is
  * {@link java.lang.annotation.RetentionPolicy#SOURCE}, so {@code
  * EveryDialogConformsTest}'s reflective {@code !ann.value().isBlank()}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/TokenValidationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/TokenValidationTest.java
@@ -460,9 +460,19 @@ final class TokenValidationTest {
             // and the assertion below would silently let structural rules
             // slip through. In that case rewrite the strip with a
             // proper brace-balanced parse.
-            String stripped = css
-                    .replaceAll("(?s)/\\*.*?\\*/", " ")
+            String withoutComments = css
+                    .replaceAll("(?s)/\\*.*?\\*/", " ");
+            String stripped = withoutComments
                     .replaceAll("(?s)\\.root-pane\\s*\\{[^}]*\\}", "");
+            // Guard: the strip must have actually removed a non-trivial
+            // rule body. If the regex silently short-circuits (matches
+            // nothing, or an empty body), the before/after lengths will
+            // be suspiciously close. At minimum the .root-pane block
+            // contains all THEME_COLOUR_TOKENS declarations (~20 lines).
+            assertThat(withoutComments.length() - stripped.length())
+                    .as("%s: .root-pane strip removed a non-trivial amount "
+                            + "(sanity check that the regex matched)", resource)
+                    .isGreaterThan(200);
             assertThat(stripped)
                     .as("%s must contain ONLY the .root-pane token block — "
                             + "no structural rules (story 277 / §6 Phase 3)", resource)

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/TokenValidationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/TokenValidationTest.java
@@ -407,6 +407,94 @@ final class TokenValidationTest {
         }
     }
 
+    // ── Story 277 — Phase-3 token-theme overlays ─────────────────────────────
+
+    private static final String STUDIO_SLATE_RESOURCE =
+            "/com/benesquivelmusic/daw/app/ui/themes/studio-slate.css";
+    private static final String ATELIER_RESOURCE =
+            "/com/benesquivelmusic/daw/app/ui/themes/atelier.css";
+
+    /**
+     * The colour tokens every theme overlay must re-declare so it is
+     * self-contained (the {@code -font-*} tokens and the meter ramp are
+     * deliberately inherited from Palette A — see the overlay sheets;
+     * story 277 / UI Design Book §3.1).
+     */
+    private static final List<String> THEME_COLOUR_TOKENS = List.of(
+            "-surface-bg", "-surface-1", "-surface-2", "-surface-3", "-surface-overlay",
+            "-line-soft", "-line-strong", "-focus-ring",
+            "-text-hi", "-text", "-text-mute", "-text-on-accent",
+            "-accent", "-accent-soft",
+            "-ok", "-warn", "-danger");
+
+    /**
+     * Story 277 — each theme overlay re-declares <em>every</em> colour
+     * token (so a control can never resolve a Palette-A colour through a
+     * theme it was not designed for) and carries no structural CSS (only
+     * the single {@code .root-pane} token block).
+     */
+    @Test
+    void themeOverlaysReDeclareEveryColourToken() throws IOException {
+        for (String resource : List.of(STUDIO_SLATE_RESOURCE, ATELIER_RESOURCE)) {
+            String css = loadResource(resource);
+            for (String token : THEME_COLOUR_TOKENS) {
+                assertThat(css)
+                        .as("%s must re-declare colour token '%s' to be self-contained "
+                                + "(story 277 / UI_DESIGN_BOOK.md §3.1)", resource, token)
+                        .contains(token + ":");
+            }
+            // The overlay is a token sheet only: exactly one rule, and
+            // it is `.root-pane` (no structural rules — Phase 3's whole
+            // premise is that no structural CSS changes). Strip comments
+            // (DOTALL) and the single .root-pane block; nothing with a
+            // brace may remain.
+            String stripped = css
+                    .replaceAll("(?s)/\\*.*?\\*/", " ")
+                    .replaceAll("(?s)\\.root-pane\\s*\\{[^}]*\\}", "");
+            assertThat(stripped)
+                    .as("%s must contain ONLY the .root-pane token block — "
+                            + "no structural rules (story 277 / §6 Phase 3)", resource)
+                    .doesNotContain("{");
+        }
+    }
+
+    /**
+     * Story 277 — the Atelier overlay must produce a light theme: it
+     * declares the {@code #F4F4F0} warm-white surface and contains none
+     * of the Palette-A near-black surface literals
+     * ({@code #000000} / {@code #0B0B0E} / {@code #000}). The runtime
+     * counterpart (resolving the actual rendered root background through
+     * the JavaFX lookup cascade) lives in
+     * {@code com.benesquivelmusic.daw.app.ui.theme.ThemeLightnessTest};
+     * this is the toolkit-free static guard.
+     */
+    @Test
+    void atelierOverlayIsLightAndCarriesNoPaletteADarks() throws IOException {
+        String css = loadResource(ATELIER_RESOURCE).toLowerCase(java.util.Locale.ROOT);
+
+        assertThat(css.replaceAll("\\s+", " "))
+                .as("atelier.css must set the #F4F4F0 warm-white surface-bg "
+                        + "(story 277 / UI_DESIGN_BOOK.md §3.1 Palette C)")
+                .contains("-surface-bg: #f4f4f0");
+
+        for (String darkLiteral : List.of("#000000", "#0b0b0e", "#000 ", "#000;")) {
+            assertThat(css)
+                    .as("atelier.css must not reintroduce the Palette-A near-black "
+                            + "surface literal '%s' — the light theme must not render "
+                            + "any panel on the dark default (story 277 AC)", darkLiteral)
+                    .doesNotContain(darkLiteral);
+        }
+    }
+
+    private static String loadResource(String resource) throws IOException {
+        try (InputStream in = TokenValidationTest.class.getResourceAsStream(resource)) {
+            assertThat(in)
+                    .as("%s must be on the test classpath", resource)
+                    .isNotNull();
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
     private static String loadStylesheet() throws IOException {
         try (InputStream in = TokenValidationTest.class.getResourceAsStream(STYLES_CSS_RESOURCE)) {
             assertThat(in)

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/TokenValidationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/TokenValidationTest.java
@@ -424,7 +424,7 @@ final class TokenValidationTest {
             "-surface-bg", "-surface-1", "-surface-2", "-surface-3", "-surface-overlay",
             "-line-soft", "-line-strong", "-focus-ring",
             "-text-hi", "-text", "-text-mute", "-text-on-accent",
-            "-accent", "-accent-soft",
+            "-accent", "-accent-soft", "-accent-glow", "-drop-target-bg",
             "-ok", "-warn", "-danger");
 
     /**

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/TokenValidationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/TokenValidationTest.java
@@ -448,6 +448,18 @@ final class TokenValidationTest {
             // premise is that no structural CSS changes). Strip comments
             // (DOTALL) and the single .root-pane block; nothing with a
             // brace may remain.
+            //
+            // INVARIANT for the `[^}]*` body match below: the .root-pane
+            // rule body must not contain any `}` character. Today the
+            // theme overlays use only paint functions (rgba(), dropshadow())
+            // whose syntax is parenthesis-delimited, so this holds. If a
+            // contributor ever introduces a CSS construct that uses
+            // braces inside the rule body (e.g. a `@supports` block, a
+            // nested rule under future CSS-nesting support, or a
+            // hypothetical region-style {}), this strip will short-circuit
+            // and the assertion below would silently let structural rules
+            // slip through. In that case rewrite the strip with a
+            // proper brace-balanced parse.
             String stripped = css
                     .replaceAll("(?s)/\\*.*?\\*/", " ")
                     .replaceAll("(?s)\\.root-pane\\s*\\{[^}]*\\}", "");
@@ -467,6 +479,19 @@ final class TokenValidationTest {
      * the JavaFX lookup cascade) lives in
      * {@code com.benesquivelmusic.daw.app.ui.theme.ThemeLightnessTest};
      * this is the toolkit-free static guard.
+     *
+     * <p><b>Scope vs. the story's acceptance criterion:</b> the AC asks
+     * that <em>every panel</em> render Atelier's warm-white surface (no
+     * resolved colour resolves to the Palette-A dark). This static check
+     * proves the overlay <em>file</em> does not reintroduce Palette-A
+     * dark literals — a strictly weaker guarantee than a runtime walk of
+     * the scene graph. The runtime root-background probe in
+     * {@code ThemeLightnessTest#atelierRootBackgroundIsLight} is the
+     * canary that a contributor missing a {@code -surface-*} override
+     * would trip; full per-panel resolved-colour assertions are
+     * deferred (would require constructing each Phase-1/2 control in a
+     * real Scene, which is what {@code FxSnapshotTest} already covers
+     * end-to-end for the Palette-A baseline).</p>
      */
     @Test
     void atelierOverlayIsLightAndCarriesNoPaletteADarks() throws IOException {

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeLightnessTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeLightnessTest.java
@@ -1,0 +1,130 @@
+package com.benesquivelmusic.daw.app.ui.theme;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 277 — proof that the Atelier overlay produces a genuinely
+ * <em>light</em> UI. Applies the Atelier theme via {@link ThemeManager}
+ * to a {@code .root-pane} scene (the {@code main-view.fxml} root anchor;
+ * see {@code TokenResolutionSmokeTest} for why the full FXML is not
+ * loaded), runs a CSS pass, and asserts the resolved root background —
+ * {@code .root-pane { -fx-background-color: -surface-bg; }} — has every
+ * RGB channel above {@code 240/255}.
+ *
+ * <p>This is a deliberately blunt canary: a contributor who adds a new
+ * surface token to the Palette-A block but forgets to override it in
+ * {@code atelier.css} would leave that surface dark; the
+ * {@code -surface-bg} root is the single most visible regression point
+ * and it must read as Atelier's {@code #F4F4F0} warm white.</p>
+ *
+ * <p>FX-harness pitfalls honoured: a real {@link Scene}, {@code
+ * applyCss()} + {@code layout()} before reading resolved values, and any
+ * failure captured and rethrown on the test thread.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class ThemeLightnessTest {
+
+    /** 240/255 ≈ 0.941 — "light" threshold from the story's AC. */
+    private static final double LIGHT_THRESHOLD = 240.0 / 255.0;
+
+    @Test
+    void atelierRootBackgroundIsLight() throws Exception {
+        ThemeManager manager = newManager(ThemeManager.Theme.ATELIER);
+
+        Color rootFill = onFxThread(() -> {
+            BorderPane rootPane = new BorderPane();
+            rootPane.getStyleClass().add("root-pane");
+            Scene scene = new Scene(rootPane, 100, 100);
+            manager.applyTo(scene);
+            assertThat(scene.getStylesheets())
+                    .as("Atelier must install base + atelier overlay")
+                    .hasSize(2);
+            rootPane.applyCss();
+            rootPane.layout();
+            Paint fill = rootPane.getBackground().getFills().get(0).getFill();
+            assertThat(fill)
+                    .as(".root-pane background must resolve to a Color")
+                    .isInstanceOf(Color.class);
+            return (Color) fill;
+        });
+
+        assertThat(rootFill.getRed())
+                .as("Atelier root background red channel must be light (> 240/255)")
+                .isGreaterThan(LIGHT_THRESHOLD);
+        assertThat(rootFill.getGreen())
+                .as("Atelier root background green channel must be light (> 240/255)")
+                .isGreaterThan(LIGHT_THRESHOLD);
+        assertThat(rootFill.getBlue())
+                .as("Atelier root background blue channel must be light (> 240/255)")
+                .isGreaterThan(LIGHT_THRESHOLD);
+    }
+
+    @Test
+    void onyxRefinedRootBackgroundStaysDark() throws Exception {
+        // Negative control: the baseline theme must remain the near-black
+        // Palette-A surface — proves the lightness assertion above is the
+        // overlay's doing, not an artefact of the probe.
+        ThemeManager manager = newManager(ThemeManager.Theme.ONYX_REFINED);
+
+        Color rootFill = onFxThread(() -> {
+            BorderPane rootPane = new BorderPane();
+            rootPane.getStyleClass().add("root-pane");
+            Scene scene = new Scene(rootPane, 100, 100);
+            manager.applyTo(scene);
+            rootPane.applyCss();
+            rootPane.layout();
+            return (Color) rootPane.getBackground().getFills().get(0).getFill();
+        });
+
+        assertThat(rootFill.getRed())
+                .as("Onyx Refined root background must stay dark (Palette A #0B0B0E)")
+                .isLessThan(0.1);
+    }
+
+    private static ThemeManager newManager(ThemeManager.Theme theme) {
+        Preferences node = Preferences.userRoot()
+                .node("themeLightnessTest_" + System.nanoTime());
+        ThemeManager m = new ThemeManager(node);
+        m.setActiveTheme(theme);
+        return m;
+    }
+
+    private static <T> T onFxThread(Supplier<T> supplier) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(supplier.get());
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("FX thread did not complete within 5 seconds");
+        }
+        if (err.get() != null) {
+            throw new AssertionError("FX thread action failed", err.get());
+        }
+        return ref.get();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeLightnessTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeLightnessTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +47,9 @@ final class ThemeLightnessTest {
 
     @Test
     void atelierRootBackgroundIsLight() throws Exception {
-        ThemeManager manager = newManager(ThemeManager.Theme.ATELIER);
+        Preferences node = newPrefsNode();
+        try {
+        ThemeManager manager = newManager(node, ThemeManager.Theme.ATELIER);
 
         Color rootFill = onFxThread(() -> {
             BorderPane rootPane = new BorderPane();
@@ -74,6 +77,9 @@ final class ThemeLightnessTest {
         assertThat(rootFill.getBlue())
                 .as("Atelier root background blue channel must be light (> 240/255)")
                 .isGreaterThan(LIGHT_THRESHOLD);
+        } finally {
+            removeQuietly(node);
+        }
     }
 
     @Test
@@ -81,7 +87,9 @@ final class ThemeLightnessTest {
         // Negative control: the baseline theme must remain the near-black
         // Palette-A surface — proves the lightness assertion above is the
         // overlay's doing, not an artefact of the probe.
-        ThemeManager manager = newManager(ThemeManager.Theme.ONYX_REFINED);
+        Preferences node = newPrefsNode();
+        try {
+        ThemeManager manager = newManager(node, ThemeManager.Theme.ONYX_REFINED);
 
         Color rootFill = onFxThread(() -> {
             BorderPane rootPane = new BorderPane();
@@ -96,14 +104,29 @@ final class ThemeLightnessTest {
         assertThat(rootFill.getRed())
                 .as("Onyx Refined root background must stay dark (Palette A #0B0B0E)")
                 .isLessThan(0.1);
+        } finally {
+            removeQuietly(node);
+        }
     }
 
-    private static ThemeManager newManager(ThemeManager.Theme theme) {
-        Preferences node = Preferences.userRoot()
+    private static Preferences newPrefsNode() {
+        return Preferences.userRoot()
                 .node("themeLightnessTest_" + System.nanoTime());
+    }
+
+    private static ThemeManager newManager(Preferences node, ThemeManager.Theme theme) {
         ThemeManager m = new ThemeManager(node);
         m.setActiveTheme(theme);
         return m;
+    }
+
+    private static void removeQuietly(Preferences node) {
+        try {
+            node.removeNode();
+        } catch (BackingStoreException ignored) {
+            // Best-effort cleanup; a failure here only leaves an empty
+            // user-prefs node behind and must not mask test results.
+        }
     }
 
     private static <T> T onFxThread(Supplier<T> supplier) throws Exception {

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemePersistenceTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemePersistenceTest.java
@@ -1,0 +1,69 @@
+package com.benesquivelmusic.daw.app.ui.theme;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 277 — the token theme survives a "restart": set the active
+ * theme, then rebuild {@link ThemeManager} from the <em>same</em>
+ * {@link Preferences} node and assert it deserialises back to the
+ * persisted value.
+ *
+ * <p>This is intentionally a pure unit test — {@link ThemeManager}'s
+ * persistence path is toolkit-free, so no JavaFX is needed. That is a
+ * feature: theme persistence is verifiable without the FX harness.</p>
+ */
+final class ThemePersistenceTest {
+
+    @Test
+    void activeThemeRoundTripsThroughPreferences() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("themePersistenceTest_" + System.nanoTime());
+        try {
+            ThemeManager first = new ThemeManager(node);
+            // Fresh node → design-book default.
+            assertThat(first.getActiveTheme())
+                    .isEqualTo(ThemeManager.DEFAULT_THEME)
+                    .isEqualTo(ThemeManager.Theme.ONYX_REFINED);
+
+            first.setActiveTheme(ThemeManager.Theme.STUDIO_SLATE);
+
+            // Simulate a restart: a brand-new manager over the same node.
+            ThemeManager restarted = new ThemeManager(node);
+            assertThat(restarted.getActiveTheme())
+                    .as("the persisted theme must survive a ThemeManager rebuild")
+                    .isEqualTo(ThemeManager.Theme.STUDIO_SLATE);
+        } finally {
+            node.removeNode();
+        }
+    }
+
+    @Test
+    void unknownPersistedValueFallsBackToDefault() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("themePersistenceTestBad_" + System.nanoTime());
+        try {
+            node.put(ThemeManager.PREF_KEY, "NOT_A_REAL_THEME");
+            ThemeManager mgr = new ThemeManager(node);
+            assertThat(mgr.getActiveTheme())
+                    .as("a corrupt/unknown persisted value must fall back to the default")
+                    .isEqualTo(ThemeManager.DEFAULT_THEME);
+        } finally {
+            node.removeNode();
+        }
+    }
+
+    @Test
+    void persistenceKeyIsDistinctFromStory194ThemeIdKey() {
+        // The two theme systems must not share a preferences key
+        // (ThemeManager = token CSS palette, SettingsModel.KEY_THEME_ID
+        // = story 194 WCAG JSON registry).
+        assertThat(ThemeManager.PREF_KEY)
+                .isEqualTo("appearance.tokenTheme")
+                .isNotEqualTo("appearance.themeId");
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeSwitchSmokeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeSwitchSmokeTest.java
@@ -1,0 +1,158 @@
+package com.benesquivelmusic.daw.app.ui.theme;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+/**
+ * Story 277 — proof that the Studio Slate overlay re-themes the token
+ * cascade. Builds a {@code .root-pane} scene (the same anchor
+ * {@code main-view.fxml} declares — see {@code TokenResolutionSmokeTest}
+ * for why the full FXML is intentionally not loaded: it transitively
+ * spins up an {@code AudioEngine}), has {@link ThemeManager} apply the
+ * Studio Slate overlay, runs a CSS pass, and asserts the resolved
+ * {@code -accent} lookup is Palette B's warm orange {@code #FF7A45} and
+ * <em>not</em> Palette A's indigo {@code #7C8CFF}.
+ *
+ * <p>This exercises the production path exactly: {@code ThemeManager}
+ * builds the ordered {@code [styles.css, studio-slate.css]} list and the
+ * overlay (loaded last) wins the JavaFX lookup-colour cascade. If any
+ * Phase-1/2 control hard-coded a colour instead of consuming a token it
+ * would not re-theme — that regression is caught structurally by
+ * {@code LegacyHardcodedColorAuditTest}; this test proves the cascade
+ * mechanism itself works.</p>
+ *
+ * <p>FX-harness pitfalls honoured: a real {@link Scene}, {@code
+ * applyCss()} + {@code layout()} before reading resolved values, and all
+ * assertions/exceptions captured into an {@link AtomicReference} and
+ * rethrown on the test thread (assertions thrown inside a {@code
+ * runLater} runnable are otherwise swallowed).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class ThemeSwitchSmokeTest {
+
+    private static final Color PALETTE_A_ACCENT = Color.web("#7C8CFF");
+    private static final Color PALETTE_B_ACCENT = Color.web("#FF7A45");
+
+    @Test
+    void studioSlateOverlayRethemesTheAccentToken() throws Exception {
+        ThemeManager manager = newManager(ThemeManager.Theme.STUDIO_SLATE);
+
+        Color accent = onFxThread(() -> {
+            BorderPane rootPane = new BorderPane();
+            rootPane.getStyleClass().add("root-pane");
+
+            Region accentProbe = new Region();
+            accentProbe.setStyle("-fx-background-color: -accent;");
+            rootPane.getChildren().add(accentProbe);
+
+            Scene scene = new Scene(rootPane, 100, 100);
+            // ThemeManager owns the ordered stylesheet list; applying it
+            // to the scene installs [styles.css, studio-slate.css].
+            manager.applyTo(scene);
+            assertThat(scene.getStylesheets())
+                    .as("ThemeManager must install base + overlay, overlay last")
+                    .hasSize(2);
+
+            rootPane.applyCss();
+            rootPane.layout();
+
+            Paint fill = accentProbe.getBackground().getFills().get(0).getFill();
+            assertThat(fill)
+                    .as("-accent must resolve to a Color")
+                    .isInstanceOf(Color.class);
+            return (Color) fill;
+        });
+
+        assertCloseTo(accent, PALETTE_B_ACCENT, "Studio Slate -accent must be #FF7A45");
+        assertThat(distance(accent, PALETTE_A_ACCENT))
+                .as("Studio Slate -accent must NOT still be Palette A's #7C8CFF")
+                .isGreaterThan(0.1);
+    }
+
+    @Test
+    void baselineThemeKeepsPaletteAAccent() throws Exception {
+        ThemeManager manager = newManager(ThemeManager.Theme.ONYX_REFINED);
+
+        Color accent = onFxThread(() -> {
+            BorderPane rootPane = new BorderPane();
+            rootPane.getStyleClass().add("root-pane");
+            Region probe = new Region();
+            probe.setStyle("-fx-background-color: -accent;");
+            rootPane.getChildren().add(probe);
+
+            Scene scene = new Scene(rootPane, 100, 100);
+            manager.applyTo(scene);
+            assertThat(scene.getStylesheets())
+                    .as("ONYX_REFINED is the baseline — only styles.css, no overlay")
+                    .hasSize(1);
+            rootPane.applyCss();
+            rootPane.layout();
+            return (Color) probe.getBackground().getFills().get(0).getFill();
+        });
+
+        assertCloseTo(accent, PALETTE_A_ACCENT, "baseline -accent must be #7C8CFF");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static ThemeManager newManager(ThemeManager.Theme theme) {
+        Preferences node = Preferences.userRoot()
+                .node("themeSwitchSmokeTest_" + System.nanoTime());
+        ThemeManager m = new ThemeManager(node);
+        m.setActiveTheme(theme);
+        return m;
+    }
+
+    private static void assertCloseTo(Color got, Color want, String why) {
+        assertThat(got.getRed()).as(why + " (red)").isCloseTo(want.getRed(), offset(0.01));
+        assertThat(got.getGreen()).as(why + " (green)").isCloseTo(want.getGreen(), offset(0.01));
+        assertThat(got.getBlue()).as(why + " (blue)").isCloseTo(want.getBlue(), offset(0.01));
+    }
+
+    private static double distance(Color a, Color b) {
+        double dr = a.getRed() - b.getRed();
+        double dg = a.getGreen() - b.getGreen();
+        double db = a.getBlue() - b.getBlue();
+        return Math.sqrt(dr * dr + dg * dg + db * db);
+    }
+
+    private static <T> T onFxThread(Supplier<T> supplier) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(supplier.get());
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("FX thread did not complete within 5 seconds");
+        }
+        if (err.get() != null) {
+            throw new AssertionError("FX thread action failed", err.get());
+        }
+        return ref.get();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeSwitchSmokeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeSwitchSmokeTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,7 +56,9 @@ final class ThemeSwitchSmokeTest {
 
     @Test
     void studioSlateOverlayRethemesTheAccentToken() throws Exception {
-        ThemeManager manager = newManager(ThemeManager.Theme.STUDIO_SLATE);
+        Preferences node = newPrefsNode();
+        try {
+        ThemeManager manager = newManager(node, ThemeManager.Theme.STUDIO_SLATE);
 
         Color accent = onFxThread(() -> {
             BorderPane rootPane = new BorderPane();
@@ -87,11 +90,16 @@ final class ThemeSwitchSmokeTest {
         assertThat(distance(accent, PALETTE_A_ACCENT))
                 .as("Studio Slate -accent must NOT still be Palette A's #7C8CFF")
                 .isGreaterThan(0.1);
+        } finally {
+            removeQuietly(node);
+        }
     }
 
     @Test
     void baselineThemeKeepsPaletteAAccent() throws Exception {
-        ThemeManager manager = newManager(ThemeManager.Theme.ONYX_REFINED);
+        Preferences node = newPrefsNode();
+        try {
+        ThemeManager manager = newManager(node, ThemeManager.Theme.ONYX_REFINED);
 
         Color accent = onFxThread(() -> {
             BorderPane rootPane = new BorderPane();
@@ -111,6 +119,9 @@ final class ThemeSwitchSmokeTest {
         });
 
         assertCloseTo(accent, PALETTE_A_ACCENT, "baseline -accent must be #7C8CFF");
+        } finally {
+            removeQuietly(node);
+        }
     }
 
     /** Resolved {@code -accent} and stylesheet count before / after a live switch. */
@@ -130,7 +141,9 @@ final class ThemeSwitchSmokeTest {
     @Test
     void changingThemeRethemesAnAlreadyRegisteredSceneWithNoRestart()
             throws Exception {
-        ThemeManager manager = newManager(ThemeManager.Theme.ONYX_REFINED);
+        Preferences node = newPrefsNode();
+        try {
+        ThemeManager manager = newManager(node, ThemeManager.Theme.ONYX_REFINED);
 
         Switch result = onFxThread(() -> {
             BorderPane rootPane = new BorderPane();
@@ -176,16 +189,31 @@ final class ThemeSwitchSmokeTest {
         assertThat(distance(result.after(), result.before()))
                 .as("the live switch must actually change the resolved accent")
                 .isGreaterThan(0.1);
+        } finally {
+            removeQuietly(node);
+        }
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────
 
-    private static ThemeManager newManager(ThemeManager.Theme theme) {
-        Preferences node = Preferences.userRoot()
+    private static Preferences newPrefsNode() {
+        return Preferences.userRoot()
                 .node("themeSwitchSmokeTest_" + System.nanoTime());
+    }
+
+    private static ThemeManager newManager(Preferences node, ThemeManager.Theme theme) {
         ThemeManager m = new ThemeManager(node);
         m.setActiveTheme(theme);
         return m;
+    }
+
+    private static void removeQuietly(Preferences node) {
+        try {
+            node.removeNode();
+        } catch (BackingStoreException ignored) {
+            // Best-effort cleanup; a failure here only leaves an empty
+            // user-prefs node behind and must not mask test results.
+        }
     }
 
     private static void assertCloseTo(Color got, Color want, String why) {

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeSwitchSmokeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/theme/ThemeSwitchSmokeTest.java
@@ -31,9 +31,11 @@ import static org.assertj.core.api.Assertions.offset;
  * {@code -accent} lookup is Palette B's warm orange {@code #FF7A45} and
  * <em>not</em> Palette A's indigo {@code #7C8CFF}.
  *
- * <p>This exercises the production path exactly: {@code ThemeManager}
- * builds the ordered {@code [styles.css, studio-slate.css]} list and the
- * overlay (loaded last) wins the JavaFX lookup-colour cascade. If any
+ * <p>This exercises the overlay-cascade path exactly (the singleton
+ * wiring through {@code ThemeManager.getDefault()} is deliberately not
+ * shared across the test fork): {@code ThemeManager} builds the ordered
+ * {@code [styles.css, studio-slate.css]} list and the overlay (loaded
+ * last) wins the JavaFX lookup-colour cascade. If any
  * Phase-1/2 control hard-coded a colour instead of consuming a token it
  * would not re-theme — that regression is caught structurally by
  * {@code LegacyHardcodedColorAuditTest}; this test proves the cascade
@@ -109,6 +111,71 @@ final class ThemeSwitchSmokeTest {
         });
 
         assertCloseTo(accent, PALETTE_A_ACCENT, "baseline -accent must be #7C8CFF");
+    }
+
+    /** Resolved {@code -accent} and stylesheet count before / after a live switch. */
+    private record Switch(Color before, Color after,
+                           int sheetsBefore, int sheetsAfter) { }
+
+    /**
+     * Story 277's headline acceptance criterion: changing the theme
+     * re-themes an <em>already-registered</em> scene with no restart and
+     * no second {@code applyTo} call. Registers a scene under Onyx
+     * Refined, asserts the baseline indigo, then flips the active theme
+     * via {@link ThemeManager#setActiveTheme} only — the registered
+     * scene must pick up Studio Slate's orange purely through
+     * {@code reapplyAll()}. Guards the remove-then-append idempotency of
+     * {@code applyOrderedSheets} (no overlay accumulation).
+     */
+    @Test
+    void changingThemeRethemesAnAlreadyRegisteredSceneWithNoRestart()
+            throws Exception {
+        ThemeManager manager = newManager(ThemeManager.Theme.ONYX_REFINED);
+
+        Switch result = onFxThread(() -> {
+            BorderPane rootPane = new BorderPane();
+            rootPane.getStyleClass().add("root-pane");
+            Region accentProbe = new Region();
+            accentProbe.setStyle("-fx-background-color: -accent;");
+            rootPane.getChildren().add(accentProbe);
+
+            Scene scene = new Scene(rootPane, 100, 100);
+            manager.applyTo(scene); // registered once, under Onyx Refined
+            rootPane.applyCss();
+            rootPane.layout();
+            Color before =
+                    (Color) accentProbe.getBackground().getFills().get(0).getFill();
+            int sheetsBefore = scene.getStylesheets().size();
+
+            // The whole no-restart contract: NO second applyTo — just
+            // flip the property. The listener -> reapplyAll() runs
+            // synchronously here (already on the FX thread).
+            manager.setActiveTheme(ThemeManager.Theme.STUDIO_SLATE);
+            rootPane.applyCss();
+            rootPane.layout();
+            Color after =
+                    (Color) accentProbe.getBackground().getFills().get(0).getFill();
+            int sheetsAfter = scene.getStylesheets().size();
+
+            return new Switch(before, after, sheetsBefore, sheetsAfter);
+        });
+
+        assertCloseTo(result.before(), PALETTE_A_ACCENT,
+                "before the switch -accent must be Onyx Refined #7C8CFF");
+        assertThat(result.sheetsBefore())
+                .as("baseline registers only styles.css (no overlay)")
+                .isEqualTo(1);
+
+        assertCloseTo(result.after(), PALETTE_B_ACCENT,
+                "after setActiveTheme the registered scene must re-theme "
+                        + "to Studio Slate #FF7A45 with no restart / no re-applyTo");
+        assertThat(result.sheetsAfter())
+                .as("the overlay is appended (not accumulated): "
+                        + "exactly [styles.css, studio-slate.css]")
+                .isEqualTo(2);
+        assertThat(distance(result.after(), result.before()))
+                .as("the live switch must actually change the resolved accent")
+                .isGreaterThan(0.1);
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
# Theme Setting: Onyx Refined, Studio Slate, and Atelier

## Motivation

Phase 3 of the UI Design Book §6 migration roadmap. Builds on user story: 260 (token contract), and consumes the entire Phase 2 component library so that swapping a theme requires *no* structural CSS changes.

UI Design Book §3.1 specifies three palettes — A "Onyx Refined" (default, set by story 260), B "Studio Slate" (warm-orange single accent, near-monochrome console aesthetic), and C "Atelier" (light, navy accent, daylight-studio target). §6 (migration roadmap) is explicit that Phase 3 validates the Phase 1 token system: "Each theme is a stylesheet that overrides *only* token values. No structural CSS rules need to change."

This story is the proof-of-design: Palettes B and C ship as user-selectable themes, applied by loading a *single* stylesheet that re-declares the lookup colours from story 260. If the Phase 1 / Phase 2 work is correct, every control re-themes for free.

The user-visible target: open Preferences → Appearance → Theme, pick one of the three options, the whole UI updates without restart. Coordinates with story 194 (WCAG-Accessible Color Themes) — story 194 covers contrast validation; this story covers the token-driven theming mechanism. Treat 194 as *adjacent* (do not duplicate); this story focuses on the mechanic, 194 on the contrast guarantees.

## Goals

- Add two new theme stylesheets:
  - `daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/themes/studio-slate.css` — overrides every token declared in the Palette A block (story 260) with the Palette B values from UI Design Book §3.1's table:
    - `-surface-bg: #101115; -surface-1: #181A20; -surface-2: #22252D; -surface-3: #2C2F38;`
    - `-line-soft: #262932; -line-strong: #34384A; -focus-ring: #FF7A45;`
    - `-text-hi: #F0F1F4; -text: #B0B5C0; -text-mute: #727784;`
    - `-text-on-accent: #15161B;` (explicitly declared — near-black, reads on the orange `-accent`; do not let it inherit from Palette A so each theme stylesheet is self-contained.)
    - `-accent: #FF7A45; -accent-soft: rgba(255, 122, 69, 0.14);`
    - `-ok: #74C28A; -warn: #E0B764; -danger: #E26060;`
    - Meter ramp from §3.1.
  - `daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/themes/atelier.css` — Palette C light theme:
    - `-surface-bg: #F4F4F0; -surface-1: #FFFFFF; -surface-2: #EDEDE7; -surface-3: #E3E2DA;`
    - `-line-soft: #DEDDD4; -line-strong: #C4C2B7; -focus-ring: #244B8C;`
    - `-text-hi: #15161B; -text: #3D404A; -text-mute: #73767F;`
    - `-text-on-accent: #FFFFFF;`
    - `-accent: #244B8C; -accent-soft: rgba(36, 75, 140, 0.14);`
    - `-ok: #3FA76A; -warn: #B57A1B; -danger: #B5273B;`
- Add `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java` — a tiny class with:
  - `enum Theme { ONYX_REFINED, STUDIO_SLATE, ATELIER }`
  - `ObjectProperty<Theme> activeThemeProperty()`
  - `applyTo(Scene scene)` — adds the appropriate stylesheet to `scene.getStylesheets()`, removing any prior theme stylesheet first. The `styles.css` (Palette A baseline) always remains loaded; the theme sheet is layered on top via JavaFX's lookup-colour resolution.
  - Persists the user's choice in the existing preferences store.
- Wire `ThemeManager` into a new Preferences section "Appearance → Theme" with the three options. Reuse the dialog chrome from story 276.
- The active theme is restored at startup from the persisted preference.
- Update the existing `DarkThemeHelper` (`daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DarkThemeHelper.java`) to delegate to `ThemeManager`. If its responsibilities are narrow enough (only "apply the dark stylesheet"), deprecate the helper and replace callers with `ThemeManager.applyTo(scene)`. Leave the file as a thin shim with `@Deprecated` annotations for one release cycle.
- Acceptance criteria — every control / panel from Phases 1 and 2 must re-theme for free:
  - Transport bar (story 262), Buttons (story 264), Icons (story 265 — they inherit `-text-hi`), Mono numerics (story 266), LevelMeter (story 267), Knob (story 268), Fader (story 269), TrackStrip (story 270), MixerChannelStrip (story 271), Inspector (story 272), Notification toast (story 273), Status bar (story 274), Browser (story 275), Dialogs (story 276).
  - If *any* of those controls fail to re-theme — i.e., they have a hardcoded colour somewhere — the story is incomplete. The TokenValidationTest from story 260 should already catch this, but extend it to assert "post-load with Atelier theme applied, no resolved colour resolves to the literal `#000000` background (Palette A default) — every panel renders the Atelier `#F4F4F0` warm white".
- Tests:
  - `ThemeSwitchSmokeTest`: load `main-view.fxml` with `styles.css`, apply `studio-slate.css`, walk the scene graph, assert each region's resolved `-accent` lookup is `#FF7A45` and not `#7C8CFF`.
  - `ThemeLightnessTest`: apply `atelier.css`, assert the root pane's background is light (`> 240` for each RGB channel). Useful to catch a contributor missing a `surface-bg` token override in the new sheet.
  - `ThemePersistenceTest`: set theme to Studio Slate, save preferences, simulate restart (rebuild `ThemeManager`), assert active theme deserialises back to Studio Slate.
  - Add `LegacyHardcodedColorAuditTest` that walks the UI module's Java sources for `Color.web(...)` and `Color.rgb(...)` calls outside the `themes/` directory; assert zero matches (controls must consume tokens via CSS, not hardcode colour in Java).

## Non-Goals

- Adding more palettes (high-contrast, sepia, etc.) — out of scope.
- Real-time theme switching with animation — themes swap instantly per §3.5's "Hover / press / selection are instantaneous".
- Per-panel theme overrides — themes are global.
- WCAG contrast validation — that is story 194's domain; this story's tokens are *designed* per the design book but not formally validated. If 194 has landed by the time this story is implemented, run its checker against each theme and adjust if any pair fails.
- Light/dark *automatic* switching based on OS theme — out of scope; the user chooses explicitly.
- Replacing `Color.web("#…")` calls everywhere — only outside `themes/` per `LegacyHardcodedColorAuditTest`. Some plugin views may keep their hex; the audit tolerates a sentinel `@HardcodedColorAllowed` annotation with a TODO.

## Technical Notes

- The token override mechanism is JavaFX's lookup-colour cascade: a child stylesheet that re-declares a lookup colour overrides the parent's. `styles.css` declares the lookups; theme sheets re-declare them. No `@import` or pre-processing is needed.
- `Text-on-accent` differs per palette — for Onyx Refined it's `#0B0B0E` (near-black), for Studio Slate it stays near-black, for Atelier it becomes `#FFFFFF` (white on navy). Verify this token is consumed correctly by every primary button across all themes.
- This story is the user-visible payoff of *all* the Phase 1 / Phase 2 work — three themes, one mechanic, every control re-themes for free.
- Theme display names ("Onyx Refined", "Studio Slate", "Atelier") and the Preferences section label come from the existing `Messages.properties` resource bundle. Skill §14.
- Reference: UI Design Book §3.1, §6.
