### PR TITLE
279 reduce motion setting

### DIFF
--- a/daw-app/pom.xml
+++ b/daw-app/pom.xml
@@ -161,10 +161,13 @@
                          enable-native-access flag is repeated here to preserve
                          native access for the daw.core FFM bindings (granted by
                          module name now that daw.core is a named module) and
-                         the headless backend's native code paths. ALL-UNNAMED
-                         is retained for test-only code on the unnamed
-                         classpath. -->
-                    <argLine>--enable-native-access=daw.core,ALL-UNNAMED
+                         the headless backend's native code paths. daw.app is
+                         granted too (story 279): MotionManager's
+                         PlatformMotionHint performs an FFM downcall to
+                         user32!SystemParametersInfoW for OS reduce-motion
+                         detection. ALL-UNNAMED is retained for test-only code
+                         on the unnamed classpath. -->
+                    <argLine>--enable-native-access=daw.core,daw.app,ALL-UNNAMED
                         -Dglass.platform=Headless
                         -Dmonocle.platform=Headless
                         -Dprism.order=sw
@@ -333,6 +336,17 @@
                                 <argument>${project.build.directory}/daw-runtime</argument>
                                 <argument>--module</argument>
                                 <argument>daw.app/com.benesquivelmusic.daw.app.DawLauncher</argument>
+                                <!-- Grant restricted native access to the two
+                                     named modules that perform FFM downcalls:
+                                     daw.core (PortAudio/FluidSynth/CLAP/codec
+                                     bindings) and daw.app (story 279 —
+                                     MotionManager's user32!SystemParametersInfoW
+                                     OS reduce-motion probe). Without this the
+                                     JDK prints a native-access warning per
+                                     module on first downcall; in a future JDK
+                                     the warning becomes a hard error. -->
+                                <argument>--java-options</argument>
+                                <argument>--enable-native-access=daw.core,daw.app</argument>
                                 <argument>--dest</argument>
                                 <argument>${project.build.directory}/dist/app-image</argument>
                                 <!-- Ship the CMake-built native libraries

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/DawApplication.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/DawApplication.java
@@ -1,6 +1,7 @@
 package com.benesquivelmusic.daw.app;
 
 import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 
 import javafx.application.Application;
@@ -66,6 +67,12 @@ public final class DawApplication extends Application {
         // re-applies it to the registered scene when the user switches
         // density in Preferences, so the UI re-densifies with no restart.
         DensityManager.getDefault().applyTo(scene);
+        // Story 279 — touch MotionManager so its singleton constructs at
+        // startup: this restores the persisted Reduce Motion flag (or, on
+        // first launch, seeds it from the OS-level accessibility hint).
+        // MotionManager is a pure observable flag — controls observe it
+        // directly, so there is no applyTo(scene) call.
+        MotionManager.getDefault();
 
         primaryStage.setTitle(APP_TITLE);
         primaryStage.setScene(scene);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanelController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanelController.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
@@ -108,23 +110,36 @@ public final class BrowserPanelController {
     }
 
     private void showPanel() {
-        browserPanel.setOpacity(0.0);
+        // Panel show is transitional motion — gated by global Reduce
+        // Motion (story 279). With Reduce Motion on the panel appears at
+        // once with no opacity fade.
         rootPane.setRight(browserPanel);
-
-        Timeline timeline = new Timeline(
-                new KeyFrame(ANIMATION_DURATION,
-                        new KeyValue(browserPanel.opacityProperty(), 1.0))
-        );
-        timeline.play();
+        if (MotionManager.getDefault().isAnimationAllowed()) {
+            browserPanel.setOpacity(0.0);
+            Timeline timeline = new Timeline(
+                    new KeyFrame(ANIMATION_DURATION,
+                            new KeyValue(browserPanel.opacityProperty(), 1.0))
+            );
+            timeline.play();
+        } else {
+            browserPanel.setOpacity(1.0);
+        }
     }
 
     private void hidePanel() {
-        Timeline timeline = new Timeline(
-                new KeyFrame(ANIMATION_DURATION,
-                        new KeyValue(browserPanel.opacityProperty(), 0.0))
-        );
-        timeline.setOnFinished(event -> rootPane.setRight(null));
-        timeline.play();
+        // Panel hide is transitional motion — gated by global Reduce
+        // Motion (story 279). With Reduce Motion on the panel is removed
+        // at once with no opacity fade.
+        if (MotionManager.getDefault().isAnimationAllowed()) {
+            Timeline timeline = new Timeline(
+                    new KeyFrame(ANIMATION_DURATION,
+                            new KeyValue(browserPanel.opacityProperty(), 0.0))
+            );
+            timeline.setOnFinished(event -> rootPane.setRight(null));
+            timeline.play();
+        } else {
+            rootPane.setRight(null);
+        }
     }
 
     private void updateButtonActiveState() {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ButtonPressAnimator.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ButtonPressAnimator.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
 import javafx.animation.Interpolator;
 import javafx.animation.ScaleTransition;
 import javafx.scene.control.Button;
@@ -48,11 +50,25 @@ final class ButtonPressAnimator {
         springBack.setToY(1.0);
         springBack.setInterpolator(Interpolator.EASE_OUT);
 
+        // Press feedback is transitional motion (UI Design Book §3.5) —
+        // gated by the global Reduce Motion flag (story 279). When Reduce
+        // Motion is on the click still works, it just does not scale.
         btn.setOnMousePressed(_ -> {
+            if (!MotionManager.getDefault().isAnimationAllowed()) {
+                return;
+            }
             springBack.stop();
             pressDown.playFromStart();
         });
         btn.setOnMouseReleased(_ -> {
+            if (!MotionManager.getDefault().isAnimationAllowed()) {
+                // Ensure the button is never left mid-press if Reduce
+                // Motion was toggled on between press and release.
+                pressDown.stop();
+                btn.setScaleX(1.0);
+                btn.setScaleY(1.0);
+                return;
+            }
             pressDown.stop();
             springBack.playFromStart();
         });

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClockStatusIndicator.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClockStatusIndicator.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.sdk.audio.ClockKind;
 import com.benesquivelmusic.daw.sdk.audio.ClockLockEvent;
 import com.benesquivelmusic.daw.sdk.audio.ClockSource;
@@ -8,6 +9,8 @@ import javafx.animation.Animation;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.util.Duration;
@@ -61,6 +64,16 @@ public final class ClockStatusIndicator extends Label {
     private final NotificationManager notifications;
     private final Runnable recordingPauseHandler;
     private final Timeline flashTimeline;
+    /**
+     * Re-evaluates the badge when global Reduce Motion is toggled (story
+     * 279) so flipping the setting <em>during</em> an active clock-unlock
+     * fault starts/stops the flash pulse immediately. Held as a strong
+     * field and registered on the process-lifetime {@link MotionManager}
+     * singleton via a {@link WeakChangeListener} so the singleton never
+     * pins this badge.
+     */
+    private final ChangeListener<Boolean> reduceMotionListener =
+            (obs, was, now) -> runOnFx(this::refresh);
     private final AtomicReference<ClockSource> activeSource = new AtomicReference<>();
     private final AtomicReference<Flow.Subscription> subscription = new AtomicReference<>();
     private volatile int sampleRate;
@@ -94,6 +107,10 @@ public final class ClockStatusIndicator extends Label {
         this.flashTimeline = new Timeline(
                 new KeyFrame(Duration.seconds(0.5), _ -> toggleFlashStyle()));
         flashTimeline.setCycleCount(Animation.INDEFINITE);
+        // Story 279 — global Reduce Motion suppresses the decorative flash
+        // pulse (see startFlash). React to a live toggle of the setting.
+        MotionManager.getDefault().reduceMotionProperty()
+                .addListener(new WeakChangeListener<>(reduceMotionListener));
     }
 
     /**
@@ -195,6 +212,18 @@ public final class ClockStatusIndicator extends Label {
     }
 
     private void startFlash() {
+        if (!MotionManager.getDefault().isAnimationAllowed()) {
+            // Reduce Motion (story 279) — suppress the 0.5 s pulse. The
+            // unlocked state stays unmistakable without it: refresh() has
+            // already applied the solid red STYLE_UNLOCKED and the
+            // "⚠ … UNLOCKED" text, and the lock-loss event fired the
+            // notification + recording-pause side effects. Only the
+            // decorative motion is dropped — no information is lost.
+            // stopFlash() handles the case where the user enables Reduce
+            // Motion while the pulse is already running.
+            stopFlash();
+            return;
+        }
         if (flashTimeline.getStatus() != Animation.Status.RUNNING) {
             flashTimeline.playFromStart();
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClockStatusIndicator.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClockStatusIndicator.java
@@ -74,6 +74,13 @@ public final class ClockStatusIndicator extends Label {
      */
     private final ChangeListener<Boolean> reduceMotionListener =
             (obs, was, now) -> runOnFx(this::refresh);
+    /**
+     * Captured once at construction so the {@link WeakChangeListener}
+     * registration and {@link #startFlash()} always read the SAME
+     * {@code MotionManager} — a {@code getDefault()} swap mid-life
+     * ({@code setDefaultForTest}) cannot make them diverge.
+     */
+    private final MotionManager motionManager = MotionManager.getDefault();
     private final AtomicReference<ClockSource> activeSource = new AtomicReference<>();
     private final AtomicReference<Flow.Subscription> subscription = new AtomicReference<>();
     private volatile int sampleRate;
@@ -109,7 +116,7 @@ public final class ClockStatusIndicator extends Label {
         flashTimeline.setCycleCount(Animation.INDEFINITE);
         // Story 279 — global Reduce Motion suppresses the decorative flash
         // pulse (see startFlash). React to a live toggle of the setting.
-        MotionManager.getDefault().reduceMotionProperty()
+        motionManager.reduceMotionProperty()
                 .addListener(new WeakChangeListener<>(reduceMotionListener));
     }
 
@@ -212,7 +219,7 @@ public final class ClockStatusIndicator extends Label {
     }
 
     private void startFlash() {
-        if (!MotionManager.getDefault().isAnimationAllowed()) {
+        if (!motionManager.isAnimationAllowed()) {
             // Reduce Motion (story 279) — suppress the 0.5 s pulse. The
             // unlocked state stays unmistakable without it: refresh() has
             // already applied the solid red STYLE_UNLOCKED and the

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HistoryPanelController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HistoryPanelController.java
@@ -2,6 +2,8 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.core.undo.UndoManager;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
@@ -78,20 +80,32 @@ final class HistoryPanelController {
 
     void toggleHistoryPanel() {
         historyPanelVisible = !historyPanelVisible;
+        // Panel show/hide is transitional motion (UI Design Book §3.5) —
+        // gated by global Reduce Motion (story 279). With Reduce Motion on
+        // the panel is shown/removed at once with no opacity fade.
+        boolean animate = MotionManager.getDefault().isAnimationAllowed();
         if (historyPanelVisible) {
             if (host.isBrowserPanelVisible()) {
                 host.hideBrowserPanel();
             }
-            undoHistoryPanel.setOpacity(0.0);
             rootPane.setRight(undoHistoryPanel);
-            new Timeline(new KeyFrame(Duration.millis(250),
-                    new KeyValue(undoHistoryPanel.opacityProperty(), 1.0))).play();
+            if (animate) {
+                undoHistoryPanel.setOpacity(0.0);
+                new Timeline(new KeyFrame(Duration.millis(250),
+                        new KeyValue(undoHistoryPanel.opacityProperty(), 1.0))).play();
+            } else {
+                undoHistoryPanel.setOpacity(1.0);
+            }
             host.updateStatusBar("Undo History panel opened", DawIcon.HISTORY);
         } else {
-            Timeline timeline = new Timeline(new KeyFrame(Duration.millis(250),
-                    new KeyValue(undoHistoryPanel.opacityProperty(), 0.0)));
-            timeline.setOnFinished(_ -> rootPane.setRight(null));
-            timeline.play();
+            if (animate) {
+                Timeline timeline = new Timeline(new KeyFrame(Duration.millis(250),
+                        new KeyValue(undoHistoryPanel.opacityProperty(), 0.0)));
+                timeline.setOnFinished(_ -> rootPane.setRight(null));
+                timeline.play();
+            } else {
+                rootPane.setRight(null);
+            }
             host.updateStatusBar("Undo History panel closed", DawIcon.HISTORY);
         }
         updateHistoryButtonActiveState();

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyTelemetryPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyTelemetryPanel.java
@@ -5,6 +5,8 @@ import com.benesquivelmusic.daw.core.mixer.Mixer;
 import com.benesquivelmusic.daw.fx.GpuPipeline;
 import com.benesquivelmusic.daw.sdk.audio.LatencyTelemetry;
 import com.benesquivelmusic.daw.sdk.audio.LatencyTelemetry.NodeKind;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
 import javafx.animation.FadeTransition;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
@@ -301,6 +303,12 @@ public final class LatencyTelemetryPanel extends BorderPane {
     }
 
     private static void flash(TreeItem<String> item) {
+        // The fade flash is decorative transitional feedback — gated by
+        // global Reduce Motion (story 279). With Reduce Motion on, no
+        // transient graphic is attached at all (nothing to fade).
+        if (!MotionManager.getDefault().isAnimationAllowed()) {
+            return;
+        }
         // JavaFX TreeItem has no opacity — attach a graphic rectangle that fades.
         Rectangle flash = new Rectangle(8, 8, Color.web("#f0c420"));
         item.setGraphic(flash);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -37,6 +37,8 @@ import com.benesquivelmusic.daw.core.undo.UndoManager;
 import com.benesquivelmusic.daw.sdk.audio.AudioBackend;
 import com.benesquivelmusic.daw.sdk.audio.AudioChannelInfo;
 import com.benesquivelmusic.daw.sdk.audio.DeviceId;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
 import javafx.animation.FadeTransition;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
@@ -596,7 +598,10 @@ public final class MainController {
         for (Node child : trackListPanel.getChildren()) {
             if (child.getUserData() == track) {
                 Node armBtn = child.lookup(".track-arm-button");
-                if (armBtn != null) {
+                if (armBtn != null
+                        && MotionManager.getDefault().isAnimationAllowed()) {
+                    // Decorative arm-button flash — transitional motion,
+                    // gated by global Reduce Motion (story 279).
                     FadeTransition flash = new FadeTransition(Duration.millis(120), armBtn);
                     flash.setFromValue(0.4);
                     flash.setToValue(1.0);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/NotificationBar.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/NotificationBar.java
@@ -4,10 +4,16 @@ import javafx.animation.FadeTransition;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
 import javafx.scene.AccessibleRole;
 import javafx.scene.layout.StackPane;
 import javafx.util.Duration;
+
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 
 import java.util.Optional;
 
@@ -44,9 +50,21 @@ public final class NotificationBar extends StackPane {
 
     private final NotificationPill pill = new NotificationPill(true);
 
-    /** Reduce-motion opt-out (story 279 binds this later — mirrors InspectorDrawer). */
-    private final BooleanProperty animated =
-            new SimpleBooleanProperty(this, "animated", true);
+    // ── Animated flag — two-mechanism design (story 279) ──────────────────
+    // localAnimated is the per-control opt-out (set via setAnimated);
+    // `animated` is the read-only COMBINED value (localAnimated AND NOT
+    // global Reduce Motion). dismiss()/showInternal() read isAnimated(),
+    // so the 200 ms show/dismiss FadeTransition collapses to immediate
+    // under Reduce Motion.
+    private final BooleanProperty localAnimated =
+            new SimpleBooleanProperty(this, "localAnimated", true);
+    private final ReadOnlyBooleanWrapper animated =
+            new ReadOnlyBooleanWrapper(this, "animated", true);
+    // Strong field — lives exactly as long as this bar; registered on the
+    // MotionManager singleton via a WeakChangeListener so the singleton
+    // never pins the bar (story 277/278 pattern).
+    private final ChangeListener<Boolean> reduceMotionListener =
+            (obs, was, now) -> recomputeAnimated();
 
     private Timeline dismissTimeline;
     private FadeTransition dismissFade;
@@ -62,6 +80,23 @@ public final class NotificationBar extends StackPane {
 
         pill.installDismiss(this::dismiss);
         getChildren().add(pill);
+
+        // Combined animated = localAnimated AND NOT global Reduce Motion
+        // (story 279). The global listener is weak so the MotionManager
+        // singleton cannot pin this bar.
+        localAnimated.addListener((obs, was, now) -> recomputeAnimated());
+        MotionManager.getDefault().reduceMotionProperty()
+                .addListener(new WeakChangeListener<>(reduceMotionListener));
+        recomputeAnimated();
+    }
+
+    /**
+     * Recomputes the combined {@link #animatedProperty()} value:
+     * {@code localAnimated AND NOT reduceMotion} (story 279).
+     */
+    private void recomputeAnimated() {
+        animated.set(localAnimated.get()
+                && !MotionManager.getDefault().isReduceMotion());
     }
 
     /**
@@ -202,11 +237,29 @@ public final class NotificationBar extends StackPane {
         return pill;
     }
 
-    // ── Reduce-motion (story 279 binds this later) ────────────────────────
+    // ── Reduce-motion (story 279) ─────────────────────────────────────────
 
-    public BooleanProperty animatedProperty() { return animated; }
+    /**
+     * @return the combined {@code animated} property (default
+     *         {@code true}): {@code true} only when this bar's per-control
+     *         flag is set <em>and</em> global Reduce Motion is off. When
+     *         {@code false} the 200 ms show / dismiss fade is skipped.
+     *         Read-only — write the per-control flag via
+     *         {@link #setAnimated(boolean)}.
+     */
+    public ReadOnlyBooleanProperty animatedProperty() {
+        return animated.getReadOnlyProperty();
+    }
+    /** @return the combined animated value (per-control flag AND NOT Reduce Motion). */
     public boolean isAnimated()                { return animated.get(); }
-    public void setAnimated(boolean a)         { animated.set(a); }
+    /**
+     * Sets this bar's per-control animation opt-out flag. The effective
+     * {@link #isAnimated()} value also depends on the global Reduce Motion
+     * setting (story 279).
+     *
+     * @param a whether the bar should animate (per-control flag)
+     */
+    public void setAnimated(boolean a)         { localAnimated.set(a); }
 
     private void showInternal(NotificationLevel level, String message,
                               String actionLabel, Runnable action) {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/NotificationBar.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/NotificationBar.java
@@ -65,6 +65,12 @@ public final class NotificationBar extends StackPane {
     // never pins the bar (story 277/278 pattern).
     private final ChangeListener<Boolean> reduceMotionListener =
             (obs, was, now) -> recomputeAnimated();
+    // Captured once at construction so the WeakChangeListener registration
+    // and recomputeAnimated() always read the SAME MotionManager: a
+    // getDefault() swap mid-life (setDefaultForTest) cannot make them
+    // diverge — the listener firing on instance A while the recompute
+    // reads instance B's flag.
+    private final MotionManager motionManager = MotionManager.getDefault();
 
     private Timeline dismissTimeline;
     private FadeTransition dismissFade;
@@ -85,7 +91,7 @@ public final class NotificationBar extends StackPane {
         // (story 279). The global listener is weak so the MotionManager
         // singleton cannot pin this bar.
         localAnimated.addListener((obs, was, now) -> recomputeAnimated());
-        MotionManager.getDefault().reduceMotionProperty()
+        motionManager.reduceMotionProperty()
                 .addListener(new WeakChangeListener<>(reduceMotionListener));
         recomputeAnimated();
     }
@@ -96,7 +102,7 @@ public final class NotificationBar extends StackPane {
      */
     private void recomputeAnimated() {
         animated.set(localAnimated.get()
-                && !MotionManager.getDefault().isReduceMotion());
+                && !motionManager.isReduceMotion());
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.density.DensityManager;
 import com.benesquivelmusic.daw.app.ui.density.DensityMode;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
@@ -100,6 +101,11 @@ public final class SettingsDialog extends DawgDialog<Void> {
     private final ToggleGroup densityGroup;
     private final Map<DensityMode, RadioButton> densityButtons =
             new EnumMap<>(DensityMode.class);
+    // Story 279 — global Reduce Motion accessibility flag (UI Design Book
+    // §2.7 / §3.5). A single checkbox; MotionManager persists under its
+    // own key and is a pure observable flag (no scene re-apply).
+    private final MotionManager motionManager;
+    private final CheckBox reduceMotionCheck;
 
     // ── Plugins tab controls ─────────────────────────────────────────────────
     private final TextField pluginScanPathsField;
@@ -203,6 +209,16 @@ public final class SettingsDialog extends DawgDialog<Void> {
             rb.setSelected(mode == activeDensity);
             densityButtons.put(mode, rb);
         }
+
+        // Story 279 — Reduce Motion checkbox. MotionManager persists under
+        // its own key; the checkbox reflects the current flag and is
+        // applied in applySettings(). A tooltip restates the WCAG 2.3.3
+        // intent (cut transitions, keep real-time meters).
+        motionManager = MotionManager.getDefault();
+        reduceMotionCheck = new CheckBox(msg("appearance.reduceMotion.label"));
+        reduceMotionCheck.setSelected(motionManager.isReduceMotion());
+        reduceMotionCheck.setTooltip(
+                new Tooltip(msg("appearance.reduceMotion.tooltip")));
 
         Tab appearanceTab = new Tab("Appearance", buildAppearancePane());
         appearanceTab.setGraphic(IconNode.of(DawIcon.MONITOR, TAB_ICON_SIZE));
@@ -362,6 +378,12 @@ public final class SettingsDialog extends DawgDialog<Void> {
                 densityButtons.get(DensityMode.COMFORTABLE),
                 densityButtons.get(DensityMode.TOUCH));
         grid.add(densityBox, 1, 6, 2, 1);
+
+        // Story 279 — Reduce Motion accessibility checkbox. Separator +
+        // the single checkbox on the next row, following the same grid
+        // idiom as the theme / density rows above.
+        grid.add(new Separator(), 0, 7, 2, 1);
+        grid.add(reduceMotionCheck, 1, 8, 2, 1);
 
         return grid;
     }
@@ -602,6 +624,12 @@ public final class SettingsDialog extends DawgDialog<Void> {
                 && selectedDensityToggle.getUserData() instanceof DensityMode mode) {
             densityManager.setActiveDensity(mode);
         }
+        // Story 279 — apply + persist the global Reduce Motion flag.
+        // MotionManager is a pure observable flag: every animatable
+        // control observes reduceMotionProperty() and recomputes its
+        // combined animated state, so the change takes effect with no
+        // restart. The flag persists under MotionManager's own key.
+        motionManager.setReduceMotion(reduceMotionCheck.isSelected());
 
         // Plugins
         String paths = pluginScanPathsField.getText();

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TrackStripController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TrackStripController.java
@@ -18,6 +18,8 @@ import com.benesquivelmusic.daw.core.undo.UndoManager;
 import com.benesquivelmusic.daw.core.undo.UndoableAction;
 import com.benesquivelmusic.daw.sdk.audio.AudioDeviceInfo;
 import com.benesquivelmusic.daw.sdk.audio.NativeAudioBackend;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
 import javafx.animation.FadeTransition;
 import javafx.animation.Interpolator;
 import javafx.animation.ParallelTransition;
@@ -611,15 +613,19 @@ final class TrackStripController {
             trackListPanel.getChildren().add(trackItem);
         }
 
-        // Slide-fade entry animation: item slides in from the left and fades in
-        trackItem.setTranslateX(-24);
-        trackItem.setOpacity(0.0);
-        TranslateTransition slide = new TranslateTransition(Duration.millis(200), trackItem);
-        slide.setToX(0.0);
-        slide.setInterpolator(Interpolator.EASE_OUT);
-        FadeTransition fade = new FadeTransition(Duration.millis(200), trackItem);
-        fade.setToValue(1.0);
-        new ParallelTransition(slide, fade).play();
+        // Slide-fade entry animation — transitional motion, gated by
+        // global Reduce Motion (story 279). With Reduce Motion on the
+        // strip simply appears at its final position/opacity.
+        if (MotionManager.getDefault().isAnimationAllowed()) {
+            trackItem.setTranslateX(-24);
+            trackItem.setOpacity(0.0);
+            TranslateTransition slide = new TranslateTransition(Duration.millis(200), trackItem);
+            slide.setToX(0.0);
+            slide.setInterpolator(Interpolator.EASE_OUT);
+            FadeTransition fade = new FadeTransition(Duration.millis(200), trackItem);
+            fade.setToValue(1.0);
+            new ParallelTransition(slide, fade).play();
+        }
 
         return trackItem;
     }
@@ -1596,6 +1602,14 @@ final class TrackStripController {
      * consistent with the existing track-strip entry animation style.
      */
     private void animateDrop(Node trackItem) {
+        // Drop animation — transitional motion, gated by global Reduce
+        // Motion (story 279). With Reduce Motion on the strip settles at
+        // its final position/opacity at once.
+        if (!MotionManager.getDefault().isAnimationAllowed()) {
+            trackItem.setTranslateY(0.0);
+            trackItem.setOpacity(1.0);
+            return;
+        }
         trackItem.setTranslateY(-8);
         trackItem.setOpacity(0.6);
         TranslateTransition slide = new TranslateTransition(Duration.millis(200), trackItem);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportController.java
@@ -20,6 +20,8 @@ import com.benesquivelmusic.daw.core.undo.UndoManager;
 import com.benesquivelmusic.daw.core.undo.UndoableAction;
 import com.benesquivelmusic.daw.sdk.audio.RoundTripLatency;
 import com.benesquivelmusic.daw.sdk.transport.PreRollPostRoll;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
 import javafx.animation.FadeTransition;
 import javafx.animation.PauseTransition;
 import javafx.css.PseudoClass;
@@ -821,12 +823,18 @@ final class TransportController {
             }
         }
 
-        // Smooth fade-in so the status label change feels polished
-        statusLabel.setOpacity(0.0);
-        FadeTransition fadeIn = new FadeTransition(Duration.millis(200), statusLabel);
-        fadeIn.setFromValue(0.0);
-        fadeIn.setToValue(1.0);
-        fadeIn.play();
+        // Smooth fade-in so the status label change feels polished —
+        // decorative transitional motion, gated by global Reduce Motion
+        // (story 279). With Reduce Motion on the label is shown at once.
+        if (MotionManager.getDefault().isAnimationAllowed()) {
+            statusLabel.setOpacity(0.0);
+            FadeTransition fadeIn = new FadeTransition(Duration.millis(200), statusLabel);
+            fadeIn.setFromValue(0.0);
+            fadeIn.setToValue(1.0);
+            fadeIn.play();
+        } else {
+            statusLabel.setOpacity(1.0);
+        }
 
         // Play is a toggle (UI Design Book §5.1) — it stays enabled while
         // playing so the user can pause. Record stays enabled during

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/VisualizationPanelController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/VisualizationPanelController.java
@@ -4,6 +4,8 @@ import com.benesquivelmusic.daw.app.ui.VisualizationPreferences.DisplayTile;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
@@ -231,29 +233,44 @@ public final class VisualizationPanelController {
     }
 
     private void animateRowVisibility(boolean visible) {
+        // Row show/hide is transitional motion (UI Design Book §3.5) —
+        // gated by global Reduce Motion (story 279). With Reduce Motion on
+        // the row snaps to its final height/opacity with no transition.
+        boolean animate = MotionManager.getDefault().isAnimationAllowed();
         if (visible) {
             vizTileRow.setVisible(true);
             vizTileRow.setManaged(true);
-            vizTileRow.setPrefHeight(0);
-            vizTileRow.setOpacity(0.0);
-
-            Timeline timeline = new Timeline(
-                    new KeyFrame(ANIMATION_DURATION,
-                            new KeyValue(vizTileRow.prefHeightProperty(), DEFAULT_ROW_HEIGHT),
-                            new KeyValue(vizTileRow.opacityProperty(), 1.0))
-            );
-            timeline.play();
+            if (animate) {
+                vizTileRow.setPrefHeight(0);
+                vizTileRow.setOpacity(0.0);
+                Timeline timeline = new Timeline(
+                        new KeyFrame(ANIMATION_DURATION,
+                                new KeyValue(vizTileRow.prefHeightProperty(), DEFAULT_ROW_HEIGHT),
+                                new KeyValue(vizTileRow.opacityProperty(), 1.0))
+                );
+                timeline.play();
+            } else {
+                vizTileRow.setPrefHeight(DEFAULT_ROW_HEIGHT);
+                vizTileRow.setOpacity(1.0);
+            }
         } else {
-            Timeline timeline = new Timeline(
-                    new KeyFrame(ANIMATION_DURATION,
-                            new KeyValue(vizTileRow.prefHeightProperty(), 0),
-                            new KeyValue(vizTileRow.opacityProperty(), 0.0))
-            );
-            timeline.setOnFinished(event -> {
+            if (animate) {
+                Timeline timeline = new Timeline(
+                        new KeyFrame(ANIMATION_DURATION,
+                                new KeyValue(vizTileRow.prefHeightProperty(), 0),
+                                new KeyValue(vizTileRow.opacityProperty(), 0.0))
+                );
+                timeline.setOnFinished(event -> {
+                    vizTileRow.setVisible(false);
+                    vizTileRow.setManaged(false);
+                });
+                timeline.play();
+            } else {
+                vizTileRow.setPrefHeight(0);
+                vizTileRow.setOpacity(0.0);
                 vizTileRow.setVisible(false);
                 vizTileRow.setManaged(false);
-            });
-            timeline.play();
+            }
         }
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Fader.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Fader.java
@@ -5,11 +5,16 @@ import com.benesquivelmusic.daw.app.ui.controls.skin.FaderSkin;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import javafx.css.CssMetaData;
 import javafx.css.StyleConverter;
 import javafx.css.Styleable;
@@ -169,8 +174,21 @@ public final class Fader extends Control {
             };
     private final BooleanProperty showMeter =
             new SimpleBooleanProperty(this, "showMeter", true);
-    private final BooleanProperty animated =
-            new SimpleBooleanProperty(this, "animated", true);
+
+    // ── Animated flag — two-mechanism design (story 279) ──────────────────
+    // localAnimated is the per-control opt-out (set via setAnimated /
+    // builder.animated); `animated` is the read-only COMBINED value
+    // (localAnimated AND NOT global Reduce Motion).
+    private final BooleanProperty localAnimated =
+            new SimpleBooleanProperty(this, "localAnimated", true);
+    private final ReadOnlyBooleanWrapper animated =
+            new ReadOnlyBooleanWrapper(this, "animated", true);
+    // Strong field — lives exactly as long as this control; registered on
+    // the MotionManager singleton via a WeakChangeListener so the
+    // singleton never pins the control (story 277/278 pattern).
+    private final ChangeListener<Boolean> reduceMotionListener =
+            (obs, was, now) -> recomputeAnimated();
+
     private final StringProperty unit =
             new SimpleStringProperty(this, "unit", "dB");
 
@@ -204,6 +222,23 @@ public final class Fader extends Control {
         setAccessibleRoleDescription("Fader");
         setAccessibleText("Fader: " + formatValue());
         setFocusTraversable(true);
+
+        // Combined animated = localAnimated AND NOT global Reduce Motion
+        // (story 279). The global listener is weak so the MotionManager
+        // singleton cannot pin this control.
+        localAnimated.addListener((obs, was, now) -> recomputeAnimated());
+        MotionManager.getDefault().reduceMotionProperty()
+                .addListener(new WeakChangeListener<>(reduceMotionListener));
+        recomputeAnimated();
+    }
+
+    /**
+     * Recomputes the combined {@link #animatedProperty()} value:
+     * {@code localAnimated AND NOT reduceMotion} (story 279).
+     */
+    private void recomputeAnimated() {
+        animated.set(localAnimated.get()
+                && !MotionManager.getDefault().isReduceMotion());
     }
 
     @Override
@@ -343,9 +378,26 @@ public final class Fader extends Control {
 
     // ── animated (Reduce Motion) ──────────────────────────────────────────
 
-    public final BooleanProperty animatedProperty() { return animated; }
+    /**
+     * @return the combined {@code animated} property (default
+     *         {@code true}): {@code true} only when this fader's
+     *         per-control flag is set <em>and</em> global Reduce Motion is
+     *         off (story 279). Read-only — write the per-control flag via
+     *         {@link #setAnimated(boolean)}.
+     */
+    public final ReadOnlyBooleanProperty animatedProperty() {
+        return animated.getReadOnlyProperty();
+    }
+    /** @return the combined animated value (per-control flag AND NOT Reduce Motion). */
     public final boolean isAnimated() { return animated.get(); }
-    public final void setAnimated(boolean v) { animated.set(v); }
+    /**
+     * Sets this fader's per-control animation opt-out flag. The effective
+     * {@link #isAnimated()} value also depends on the global Reduce Motion
+     * setting (story 279).
+     *
+     * @param v whether the fader should animate (per-control flag)
+     */
+    public final void setAnimated(boolean v) { localAnimated.set(v); }
 
     // ── unit / formatter ──────────────────────────────────────────────────
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Fader.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Fader.java
@@ -188,6 +188,12 @@ public final class Fader extends Control {
     // singleton never pins the control (story 277/278 pattern).
     private final ChangeListener<Boolean> reduceMotionListener =
             (obs, was, now) -> recomputeAnimated();
+    // Captured once at construction so the WeakChangeListener registration
+    // and recomputeAnimated() always read the SAME MotionManager: a
+    // getDefault() swap mid-life (setDefaultForTest) cannot make them
+    // diverge — the listener firing on instance A while the recompute
+    // reads instance B's flag.
+    private final MotionManager motionManager = MotionManager.getDefault();
 
     private final StringProperty unit =
             new SimpleStringProperty(this, "unit", "dB");
@@ -227,7 +233,7 @@ public final class Fader extends Control {
         // (story 279). The global listener is weak so the MotionManager
         // singleton cannot pin this control.
         localAnimated.addListener((obs, was, now) -> recomputeAnimated());
-        MotionManager.getDefault().reduceMotionProperty()
+        motionManager.reduceMotionProperty()
                 .addListener(new WeakChangeListener<>(reduceMotionListener));
         recomputeAnimated();
     }
@@ -238,7 +244,7 @@ public final class Fader extends Control {
      */
     private void recomputeAnimated() {
         animated.set(localAnimated.get()
-                && !MotionManager.getDefault().isReduceMotion());
+                && !motionManager.isReduceMotion());
     }
 
     @Override

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Knob.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Knob.java
@@ -5,11 +5,16 @@ import com.benesquivelmusic.daw.app.ui.controls.skin.KnobSkin;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import javafx.css.CssMetaData;
 import javafx.css.StyleConverter;
 import javafx.css.Styleable;
@@ -158,8 +163,20 @@ public final class Knob extends Control {
             new SimpleBooleanProperty(this, "bipolar", false);
     private final StringProperty unit =
             new SimpleStringProperty(this, "unit", "");
-    private final BooleanProperty animated =
-            new SimpleBooleanProperty(this, "animated", true);
+
+    // ── Animated flag — two-mechanism design (story 279) ──────────────────
+    // localAnimated is the per-control opt-out (set via setAnimated /
+    // builder.animated); `animated` is the read-only COMBINED value
+    // (localAnimated AND NOT global Reduce Motion).
+    private final BooleanProperty localAnimated =
+            new SimpleBooleanProperty(this, "localAnimated", true);
+    private final ReadOnlyBooleanWrapper animated =
+            new ReadOnlyBooleanWrapper(this, "animated", true);
+    // Strong field — lives exactly as long as this control; registered on
+    // the MotionManager singleton via a WeakChangeListener so the
+    // singleton never pins the control (story 277/278 pattern).
+    private final ChangeListener<Boolean> reduceMotionListener =
+            (obs, was, now) -> recomputeAnimated();
 
     /** Default formatter: 1-decimal numeric (UI Design Book §5.8). */
     public static final Function<Double, String> DEFAULT_FORMATTER =
@@ -184,6 +201,23 @@ public final class Knob extends Control {
         setAccessibleRoleDescription("Knob");
         setAccessibleText("Knob: " + formatValue());
         setFocusTraversable(true);
+
+        // Combined animated = localAnimated AND NOT global Reduce Motion
+        // (story 279). The global listener is weak so the MotionManager
+        // singleton cannot pin this control.
+        localAnimated.addListener((obs, was, now) -> recomputeAnimated());
+        MotionManager.getDefault().reduceMotionProperty()
+                .addListener(new WeakChangeListener<>(reduceMotionListener));
+        recomputeAnimated();
+    }
+
+    /**
+     * Recomputes the combined {@link #animatedProperty()} value:
+     * {@code localAnimated AND NOT reduceMotion} (story 279).
+     */
+    private void recomputeAnimated() {
+        animated.set(localAnimated.get()
+                && !MotionManager.getDefault().isReduceMotion());
     }
 
     @Override
@@ -250,13 +284,27 @@ public final class Knob extends Control {
     // ── animated (Reduce Motion) ──────────────────────────────────────────
 
     /**
-     * @return the {@code animated} property (default {@code true}). When
-     *         {@code false} the skin's centre-detent spring is suppressed
-     *         (UI Design Book §2.5, story 279 Reduce Motion).
+     * @return the combined {@code animated} property (default
+     *         {@code true}): {@code true} only when this knob's
+     *         per-control flag is set <em>and</em> global Reduce Motion is
+     *         off. When {@code false} the skin's centre-detent spring is
+     *         suppressed (UI Design Book §2.5, story 279 Reduce Motion).
+     *         Read-only — write the per-control flag via
+     *         {@link #setAnimated(boolean)}.
      */
-    public final BooleanProperty animatedProperty() { return animated; }
+    public final ReadOnlyBooleanProperty animatedProperty() {
+        return animated.getReadOnlyProperty();
+    }
+    /** @return the combined animated value (per-control flag AND NOT Reduce Motion). */
     public final boolean isAnimated() { return animated.get(); }
-    public final void setAnimated(boolean v) { animated.set(v); }
+    /**
+     * Sets this knob's per-control animation opt-out flag. The effective
+     * {@link #isAnimated()} value also depends on the global Reduce Motion
+     * setting (story 279).
+     *
+     * @param v whether the knob should animate (per-control flag)
+     */
+    public final void setAnimated(boolean v) { localAnimated.set(v); }
 
     // ── valueFormatter (plain — not styleable) ────────────────────────────
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Knob.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/Knob.java
@@ -177,6 +177,12 @@ public final class Knob extends Control {
     // singleton never pins the control (story 277/278 pattern).
     private final ChangeListener<Boolean> reduceMotionListener =
             (obs, was, now) -> recomputeAnimated();
+    // Captured once at construction so the WeakChangeListener registration
+    // and recomputeAnimated() always read the SAME MotionManager: a
+    // getDefault() swap mid-life (setDefaultForTest) cannot make them
+    // diverge — the listener firing on instance A while the recompute
+    // reads instance B's flag.
+    private final MotionManager motionManager = MotionManager.getDefault();
 
     /** Default formatter: 1-decimal numeric (UI Design Book §5.8). */
     public static final Function<Double, String> DEFAULT_FORMATTER =
@@ -206,7 +212,7 @@ public final class Knob extends Control {
         // (story 279). The global listener is weak so the MotionManager
         // singleton cannot pin this control.
         localAnimated.addListener((obs, was, now) -> recomputeAnimated());
-        MotionManager.getDefault().reduceMotionProperty()
+        motionManager.reduceMotionProperty()
                 .addListener(new WeakChangeListener<>(reduceMotionListener));
         recomputeAnimated();
     }
@@ -217,7 +223,7 @@ public final class Knob extends Control {
      */
     private void recomputeAnimated() {
         animated.set(localAnimated.get()
-                && !MotionManager.getDefault().isReduceMotion());
+                && !motionManager.isReduceMotion());
     }
 
     @Override

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeter.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeter.java
@@ -6,10 +6,15 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import javafx.css.CssMetaData;
 import javafx.css.StyleConverter;
 import javafx.css.Styleable;
@@ -140,8 +145,20 @@ public final class LevelMeter extends Control {
                     return Math.max(MIN_CHANNELS, Math.min(MAX_CHANNELS, v));
                 }
             };
-    private final BooleanProperty animated =
-            new SimpleBooleanProperty(this, "animated", true);
+    // ── Animated flag — two-mechanism design (story 279) ──────────────────
+    // The per-control opt-out flag (set via setAnimated / builder.animated);
+    // unchanged behaviour. The publicly-observable `animated` property is a
+    // read-only COMBINED value: localAnimated AND NOT global Reduce Motion.
+    private final BooleanProperty localAnimated =
+            new SimpleBooleanProperty(this, "localAnimated", true);
+    private final ReadOnlyBooleanWrapper animated =
+            new ReadOnlyBooleanWrapper(this, "animated", true);
+    // Strong field reference so the listener lives exactly as long as this
+    // control; registered on the process-lifetime MotionManager singleton
+    // wrapped in a WeakChangeListener so the singleton never pins the
+    // control (story 277/278 sanctioned weak-listener pattern, story 279).
+    private final ChangeListener<Boolean> reduceMotionListener =
+            (obs, was, now) -> recomputeAnimated();
 
     // ── Lock-free audio → FX relay ────────────────────────────────────────
     // One AtomicLong per double value (NOT AtomicReference<Double> — avoids
@@ -196,6 +213,24 @@ public final class LevelMeter extends Control {
         // role description.
         setAccessibleText("Level meter: no signal");
         setFocusTraversable(false);
+
+        // Combined animated = localAnimated AND NOT global Reduce Motion
+        // (story 279). Recompute when either input changes; the global
+        // listener is weak so the MotionManager singleton cannot pin this
+        // control (the strong reduceMotionListener field dies with it).
+        localAnimated.addListener((obs, was, now) -> recomputeAnimated());
+        MotionManager.getDefault().reduceMotionProperty()
+                .addListener(new WeakChangeListener<>(reduceMotionListener));
+        recomputeAnimated();
+    }
+
+    /**
+     * Recomputes the combined {@link #animatedProperty()} value:
+     * {@code localAnimated AND NOT reduceMotion} (story 279).
+     */
+    private void recomputeAnimated() {
+        animated.set(localAnimated.get()
+                && !MotionManager.getDefault().isReduceMotion());
     }
 
     @Override
@@ -305,26 +340,39 @@ public final class LevelMeter extends Control {
     // ── animated ──────────────────────────────────────────────────────────
 
     /**
-     * @return the animated property (default {@code true}). Currently a
-     *         no-op for this skin — segments are discrete with no smooth
-     *         transitions, so the per-frame timer always runs while
-     *         attached to keep audio-thread {@link #submitLevels} writes
-     *         visible. The flag is kept for API parity with the rest of
-     *         the controls package (story 279 "Reduce Motion") and may be
-     *         honoured here as a throttle in a future story.
+     * @return the combined animated property (default {@code true}):
+     *         {@code true} only when this control's per-control flag is
+     *         set <em>and</em> global Reduce Motion is off (story 279).
+     *         Read-only — write the per-control flag via
+     *         {@link #setAnimated(boolean)}. Currently a no-op for this
+     *         skin: segments are discrete with no smooth transitions, so
+     *         the per-frame timer always runs while attached to keep
+     *         audio-thread {@link #submitLevels} writes visible. The flag
+     *         is kept for API parity with the rest of the controls
+     *         package and the global Reduce Motion setting.
      */
-    public final BooleanProperty animatedProperty() {
-        return animated;
+    public final ReadOnlyBooleanProperty animatedProperty() {
+        return animated.getReadOnlyProperty();
     }
 
-    /** @return whether the meter is animated. */
+    /**
+     * @return whether the meter is animated — the combined value
+     *         ({@code localAnimated AND NOT reduceMotion}, story 279)
+     */
     public final boolean isAnimated() {
         return animated.get();
     }
 
-    /** @param value whether the meter should animate. */
+    /**
+     * Sets this control's per-control animation opt-out flag. The
+     * effective {@link #isAnimated()} value also depends on the global
+     * Reduce Motion setting (story 279) — this writes only the
+     * per-control half of the two-mechanism gate.
+     *
+     * @param value whether the meter should animate (per-control flag)
+     */
     public final void setAnimated(boolean value) {
-        animated.set(value);
+        localAnimated.set(value);
     }
 
     // ── Audio → FX relay (thread-safe ingest) ─────────────────────────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeter.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeter.java
@@ -159,6 +159,12 @@ public final class LevelMeter extends Control {
     // control (story 277/278 sanctioned weak-listener pattern, story 279).
     private final ChangeListener<Boolean> reduceMotionListener =
             (obs, was, now) -> recomputeAnimated();
+    // Captured once at construction so the WeakChangeListener registration
+    // and recomputeAnimated() always read the SAME MotionManager: a
+    // getDefault() swap mid-life (setDefaultForTest) cannot make them
+    // diverge — the listener firing on instance A while the recompute
+    // reads instance B's flag.
+    private final MotionManager motionManager = MotionManager.getDefault();
 
     // ── Lock-free audio → FX relay ────────────────────────────────────────
     // One AtomicLong per double value (NOT AtomicReference<Double> — avoids
@@ -219,7 +225,7 @@ public final class LevelMeter extends Control {
         // listener is weak so the MotionManager singleton cannot pin this
         // control (the strong reduceMotionListener field dies with it).
         localAnimated.addListener((obs, was, now) -> recomputeAnimated());
-        MotionManager.getDefault().reduceMotionProperty()
+        motionManager.reduceMotionProperty()
                 .addListener(new WeakChangeListener<>(reduceMotionListener));
         recomputeAnimated();
     }
@@ -230,7 +236,7 @@ public final class LevelMeter extends Control {
      */
     private void recomputeAnimated() {
         animated.set(localAnimated.get()
-                && !MotionManager.getDefault().isReduceMotion());
+                && !motionManager.isReduceMotion());
     }
 
     @Override

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/inspector/InspectorDrawer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/inspector/InspectorDrawer.java
@@ -12,9 +12,14 @@ import com.benesquivelmusic.daw.app.ui.inspector.sections.TrackSection;
 import com.benesquivelmusic.daw.app.ui.inspector.skin.InspectorDrawerSkin;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import javafx.css.CssMetaData;
 import javafx.css.StyleConverter;
 import javafx.css.Styleable;
@@ -100,9 +105,20 @@ public final class InspectorDrawer extends Control {
     private final BooleanProperty expanded =
             new SimpleBooleanProperty(this, "expanded", true);
 
-    /** Reduce-motion opt-out (story 279). */
-    private final BooleanProperty animated =
-            new SimpleBooleanProperty(this, "animated", true);
+    // ── Animated flag — two-mechanism design (story 279) ──────────────────
+    // localAnimated is the per-control opt-out (set via setAnimated);
+    // `animated` is the read-only COMBINED value (localAnimated AND NOT
+    // global Reduce Motion). The skin reads isAnimated() and so collapses
+    // the 220 ms open/close transition to 0 ms under Reduce Motion.
+    private final BooleanProperty localAnimated =
+            new SimpleBooleanProperty(this, "localAnimated", true);
+    private final ReadOnlyBooleanWrapper animated =
+            new ReadOnlyBooleanWrapper(this, "animated", true);
+    // Strong field — lives exactly as long as this control; registered on
+    // the MotionManager singleton via a WeakChangeListener so the
+    // singleton never pins the control (story 277/278 pattern).
+    private final ChangeListener<Boolean> reduceMotionListener =
+            (obs, was, now) -> recomputeAnimated();
 
     /** Header bar text — typically "Track 01 — Drums" once a track is selected. */
     private final StringProperty headerText =
@@ -172,6 +188,23 @@ public final class InspectorDrawer extends Control {
 
         // Keyboard parity — Esc collapses; Ctrl+I toggles.
         addEventHandler(KeyEvent.KEY_PRESSED, this::handleKey);
+
+        // Combined animated = localAnimated AND NOT global Reduce Motion
+        // (story 279). The global listener is weak so the MotionManager
+        // singleton cannot pin this drawer.
+        localAnimated.addListener((obs, was, now) -> recomputeAnimated());
+        MotionManager.getDefault().reduceMotionProperty()
+                .addListener(new WeakChangeListener<>(reduceMotionListener));
+        recomputeAnimated();
+    }
+
+    /**
+     * Recomputes the combined {@link #animatedProperty()} value:
+     * {@code localAnimated AND NOT reduceMotion} (story 279).
+     */
+    private void recomputeAnimated() {
+        animated.set(localAnimated.get()
+                && !MotionManager.getDefault().isReduceMotion());
     }
 
     private void handleKey(KeyEvent e) {
@@ -272,9 +305,27 @@ public final class InspectorDrawer extends Control {
     public final boolean isExpanded()                    { return expanded.get(); }
     public final void setExpanded(boolean e)             { expanded.set(e); }
 
-    public final BooleanProperty animatedProperty()      { return animated; }
+    /**
+     * @return the combined {@code animated} property (default
+     *         {@code true}): {@code true} only when this drawer's
+     *         per-control flag is set <em>and</em> global Reduce Motion is
+     *         off (story 279). When {@code false} the skin's 220 ms
+     *         open/close transition collapses to {@code 0 ms}. Read-only —
+     *         write the per-control flag via {@link #setAnimated(boolean)}.
+     */
+    public final ReadOnlyBooleanProperty animatedProperty() {
+        return animated.getReadOnlyProperty();
+    }
+    /** @return the combined animated value (per-control flag AND NOT Reduce Motion). */
     public final boolean isAnimated()                    { return animated.get(); }
-    public final void setAnimated(boolean a)             { animated.set(a); }
+    /**
+     * Sets this drawer's per-control animation opt-out flag. The effective
+     * {@link #isAnimated()} value also depends on the global Reduce Motion
+     * setting (story 279).
+     *
+     * @param a whether the drawer should animate (per-control flag)
+     */
+    public final void setAnimated(boolean a)             { localAnimated.set(a); }
 
     public final StringProperty headerTextProperty()     { return headerText; }
     public final String getHeaderText()                  { return headerText.get(); }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/inspector/InspectorDrawer.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/inspector/InspectorDrawer.java
@@ -119,6 +119,12 @@ public final class InspectorDrawer extends Control {
     // singleton never pins the control (story 277/278 pattern).
     private final ChangeListener<Boolean> reduceMotionListener =
             (obs, was, now) -> recomputeAnimated();
+    // Captured once at construction so the WeakChangeListener registration
+    // and recomputeAnimated() always read the SAME MotionManager: a
+    // getDefault() swap mid-life (setDefaultForTest) cannot make them
+    // diverge — the listener firing on instance A while the recompute
+    // reads instance B's flag.
+    private final MotionManager motionManager = MotionManager.getDefault();
 
     /** Header bar text — typically "Track 01 — Drums" once a track is selected. */
     private final StringProperty headerText =
@@ -193,7 +199,7 @@ public final class InspectorDrawer extends Control {
         // (story 279). The global listener is weak so the MotionManager
         // singleton cannot pin this drawer.
         localAnimated.addListener((obs, was, now) -> recomputeAnimated());
-        MotionManager.getDefault().reduceMotionProperty()
+        motionManager.reduceMotionProperty()
                 .addListener(new WeakChangeListener<>(reduceMotionListener));
         recomputeAnimated();
     }
@@ -204,7 +210,7 @@ public final class InspectorDrawer extends Control {
      */
     private void recomputeAnimated() {
         animated.set(localAnimated.get()
-                && !MotionManager.getDefault().isReduceMotion());
+                && !motionManager.isReduceMotion());
     }
 
     private void handleKey(KeyEvent e) {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/MotionManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/MotionManager.java
@@ -1,0 +1,279 @@
+package com.benesquivelmusic.daw.app.ui.motion;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.prefs.Preferences;
+
+/**
+ * Phase-3 global "Reduce Motion" accessibility flag (UI Design Book
+ * §2.7 / §3.5, story 279).
+ *
+ * <h2>The cut/keep rule</h2>
+ *
+ * <p>Reduce Motion cuts <strong>transitional</strong> motion — panel
+ * show/hide, tab and modal in/out, press/hover feedback, dismissal fades
+ * — to {@code 0 ms}, while leaving <strong>real-time-information</strong>
+ * motion completely untouched. Real-time motion is not "animation": it
+ * <em>is</em> the information. The exempt surfaces are the level-meter
+ * signal rendering, the spectrum analyser / correlation meter /
+ * goniometer / oscilloscope scopes, the waveform display while playback
+ * advances, the {@code ArrangementCanvas} playhead, and any future
+ * analogue-style VU needle ballistics. A future code review can apply
+ * the cut/keep decision from this one paragraph without re-reading the
+ * design book: <em>if it conveys live data, keep it; if it is a
+ * transition between two static states, cut it.</em></p>
+ *
+ * <h2>Two-mechanism design</h2>
+ *
+ * <p>Per-control animation has two independent gates (UI Design Book
+ * §2.7). Each animatable control keeps its own {@code animatedProperty()}
+ * (the per-control opt-out — e.g. a test or a specific layout disabling
+ * one control's motion), <em>and</em> this manager provides the global
+ * Reduce Motion toggle. The effective per-control animation is
+ * {@code localFlag AND NOT reduceMotion}: either gate can suppress
+ * motion, and the per-control {@code setAnimated(...)} API keeps working
+ * unchanged. This manager is therefore a pure observable flag — controls
+ * observe {@link #reduceMotionProperty()} directly and recompute their
+ * combined animated state; nothing here applies CSS or stylesheets.</p>
+ *
+ * <h2>Scope notes</h2>
+ *
+ * <p>{@code TrackStrip} and {@code MixerChannelStrip} have no decorative
+ * motion today (their hover background swap is already instantaneous per
+ * §3.5), so — unlike the five controls that do own an
+ * {@code animatedProperty()} ({@code LevelMeter}, {@code Knob},
+ * {@code Fader}, {@code InspectorDrawer}, {@code NotificationBar}) — they
+ * deliberately have <em>no</em> animated property to gate. Adding one
+ * would be gold-plating against a non-existent transition.</p>
+ *
+ * <h2>Relationship to the theme / density / WCAG systems</h2>
+ *
+ * <p>Reduce Motion persists under its own key ({@link #PREF_KEY} =
+ * {@code "appearance.reduceMotion"}), deliberately distinct from
+ * {@code ThemeManager.PREF_KEY} ({@code "appearance.tokenTheme"}, story
+ * 277), {@code DensityManager.PREF_KEY} ({@code "appearance.density"},
+ * story 278) and {@code SettingsModel.KEY_THEME_ID}
+ * ({@code "appearance.themeId"}, story 194's WCAG JSON registry). Those
+ * are four separate systems and must not share a key (pinned by
+ * {@code MotionManagerPersistenceTest}). It is also a {@code boolean}
+ * key, not an enum-name {@code String} like the theme/density keys.</p>
+ *
+ * <h2>OS-hint seeding</h2>
+ *
+ * <p>On the very first launch — when no in-app preference has yet been
+ * persisted — the initial flag is seeded from the OS-level Reduce Motion
+ * preference via {@link OsMotionHint} (Windows {@code SystemParametersInfo},
+ * Linux {@code gsettings}; macOS is not reliably detectable and seeds to
+ * the {@code false} default). Once the user has saved a choice the stored
+ * value always wins over the OS hint.</p>
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>{@link #reduceMotionProperty()} is a JavaFX property and should be
+ * read/written on the FX application thread once a toolkit is running.
+ * Persistence and construction are toolkit-free so {@code MotionManager}
+ * can be unit-tested without a running toolkit (mirrors
+ * {@code ThemeManager} / {@code DensityManager}).</p>
+ */
+public final class MotionManager {
+
+    /**
+     * Preferences key under which the Reduce Motion flag is persisted.
+     *
+     * <p>Deliberately distinct from {@code ThemeManager.PREF_KEY}
+     * ({@code "appearance.tokenTheme"}), {@code DensityManager.PREF_KEY}
+     * ({@code "appearance.density"}) and {@code SettingsModel.KEY_THEME_ID}
+     * ({@code "appearance.themeId"}). Reduce Motion, the token theme, the
+     * density profile and the WCAG JSON registry are four separate
+     * systems and must not share a key (pinned by
+     * {@code MotionManagerPersistenceTest}). Unlike the theme/density
+     * keys (which store an enum name) this key stores a {@code boolean}.</p>
+     */
+    public static final String PREF_KEY = "appearance.reduceMotion";
+
+    /**
+     * The default Reduce Motion value for a missing OS hint — motion
+     * allowed (transitions play). Reduce Motion is opt-in.
+     */
+    public static final boolean DEFAULT_REDUCE_MOTION = false;
+
+    private static final Logger LOG =
+            Logger.getLogger(MotionManager.class.getName());
+
+    /**
+     * Process-wide default instance, backed by the same per-package
+     * {@link Preferences} node the rest of the UI uses. Lazy-initialized
+     * via the initialization-on-demand holder idiom so merely loading
+     * {@code MotionManager} (e.g. to read {@link #PREF_KEY} in a unit test
+     * using its own isolated node) performs no I/O against the real user
+     * preferences store and runs no OS probe (mirrors {@code ThemeManager}
+     * / {@code DensityManager}).
+     */
+    private static final class DefaultHolder {
+        static final MotionManager INSTANCE =
+                new MotionManager(Preferences.userNodeForPackage(MotionManager.class));
+    }
+
+    /**
+     * Test-only override for the process-wide default returned by
+     * {@link #getDefault()}. When non-null, {@code getDefault()} returns
+     * this instance instead of the real singleton — isolating tests that
+     * exercise controls / {@code SettingsDialog} from the developer's / CI
+     * agent's actual user preferences store.
+     *
+     * <p>Set via {@link #setDefaultForTest(MotionManager)} and cleared by
+     * passing {@code null}. Not thread-safe — call from a single test
+     * thread before/after the code under test (mirrors
+     * {@code ThemeManager.setDefaultForTest} /
+     * {@code DensityManager.setDefaultForTest}).</p>
+     */
+    private static volatile MotionManager defaultOverride;
+
+    /**
+     * Overrides the process-wide default instance for testing purposes.
+     * Pass a {@code MotionManager} backed by an isolated
+     * {@link Preferences} node to prevent test runs from polluting (or
+     * inheriting choices from) the developer's real user preferences.
+     *
+     * @param override the test instance, or {@code null} to restore the
+     *                 real singleton
+     */
+    public static void setDefaultForTest(MotionManager override) {
+        defaultOverride = override;
+    }
+
+    private final Preferences prefs;
+    private final BooleanProperty reduceMotion;
+
+    /**
+     * Creates a {@code MotionManager} backed by the given preferences
+     * node using the real platform OS-hint detector
+     * ({@link PlatformMotionHint}). Equivalent to
+     * {@code MotionManager(prefs, new PlatformMotionHint())}.
+     *
+     * @param prefs the backing preferences node (must not be {@code null})
+     */
+    public MotionManager(Preferences prefs) {
+        this(prefs, new PlatformMotionHint());
+    }
+
+    /**
+     * Creates a {@code MotionManager} backed by the given preferences node
+     * and OS-hint seam, restoring the persisted Reduce Motion flag (or, on
+     * first launch, seeding it from {@code osHint}) and persisting any
+     * subsequent change.
+     *
+     * <p>The {@code osHint} parameter is the mockable seam exercised by
+     * {@code OsHintDetectionTest}; production code uses the
+     * {@link #MotionManager(Preferences)} constructor, which supplies the
+     * real {@link PlatformMotionHint}.</p>
+     *
+     * @param prefs   the backing preferences node (must not be {@code null})
+     * @param osHint  the OS-hint detector (must not be {@code null})
+     */
+    public MotionManager(Preferences prefs, OsMotionHint osHint) {
+        this.prefs = Objects.requireNonNull(prefs, "prefs must not be null");
+        Objects.requireNonNull(osHint, "osHint must not be null");
+        this.reduceMotion =
+                new SimpleBooleanProperty(this, "reduceMotion", restore(osHint));
+        this.reduceMotion.addListener((_, _, now) -> {
+            // Persist the new value. If persistence fails (backing-store
+            // I/O error) we log a WARNING and do NOT propagate — the
+            // in-memory flag is already updated so the UI is consistent
+            // with what the user just chose; the choice simply may not
+            // survive restart (mirrors ThemeManager / DensityManager).
+            try {
+                persist(now);
+            } catch (RuntimeException ex) {
+                LOG.log(Level.WARNING,
+                        "Failed to persist reduce-motion preference; the "
+                                + "setting will apply but may not survive restart",
+                        ex);
+            }
+        });
+    }
+
+    /**
+     * @return the process-wide default {@code MotionManager} — either the
+     *         test override (if set via {@link #setDefaultForTest}) or the
+     *         real singleton (persists to
+     *         {@code Preferences.userNodeForPackage(MotionManager.class)})
+     */
+    public static MotionManager getDefault() {
+        MotionManager override = defaultOverride;
+        return override != null ? override : DefaultHolder.INSTANCE;
+    }
+
+    // ── Reduce-motion flag ───────────────────────────────────────────────────
+
+    /**
+     * The global Reduce Motion flag. {@code true} = transitions are cut
+     * to {@code 0 ms}; real-time motion is unaffected (see the class
+     * Javadoc cut/keep rule). Setting it persists the choice.
+     *
+     * <p>Animatable controls observe this property directly to recompute
+     * their combined {@code animated} state — there is no scene re-apply,
+     * because Reduce Motion is a pure flag, not a CSS class.</p>
+     *
+     * @return the observable Reduce Motion property
+     */
+    public BooleanProperty reduceMotionProperty() {
+        return reduceMotion;
+    }
+
+    /** @return whether Reduce Motion is currently enabled. */
+    public boolean isReduceMotion() {
+        return reduceMotion.get();
+    }
+
+    /**
+     * Sets the Reduce Motion flag. Equivalent to
+     * {@code reduceMotionProperty().set(value)}.
+     *
+     * @param value {@code true} to cut transitions to {@code 0 ms}
+     */
+    public void setReduceMotion(boolean value) {
+        reduceMotion.set(value);
+    }
+
+    /**
+     * Convenience inverse of {@link #isReduceMotion()} for non-control
+     * gating sites that wrap a transition in
+     * {@code if (MotionManager.getDefault().isAnimationAllowed())}.
+     *
+     * @return {@code true} when transitional animation is allowed
+     *         (Reduce Motion off), {@code false} when it should be cut
+     */
+    public boolean isAnimationAllowed() {
+        return !reduceMotion.get();
+    }
+
+    // ── Persistence (toolkit-free) ───────────────────────────────────────────
+
+    /**
+     * Restores the persisted flag. If the key is <em>present</em> the
+     * stored boolean wins. If it is <em>absent</em> (first launch) the
+     * value is seeded from the OS hint, falling back to
+     * {@link #DEFAULT_REDUCE_MOTION} when the OS preference cannot be
+     * determined.
+     */
+    private boolean restore(OsMotionHint osHint) {
+        // prefs.get(key, null) == null distinguishes "key absent" from a
+        // persisted "false" — getBoolean cannot make that distinction.
+        boolean keyPresent = prefs.get(PREF_KEY, null) != null;
+        if (keyPresent) {
+            return prefs.getBoolean(PREF_KEY, DEFAULT_REDUCE_MOTION);
+        }
+        Optional<Boolean> hint = osHint.reduceMotionPreferred();
+        return hint.orElse(DEFAULT_REDUCE_MOTION);
+    }
+
+    private void persist(boolean value) {
+        prefs.putBoolean(PREF_KEY, value);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/OsMotionHint.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/OsMotionHint.java
@@ -1,0 +1,40 @@
+package com.benesquivelmusic.daw.app.ui.motion;
+
+import java.util.Optional;
+
+/**
+ * A mockable seam for detecting the operating system's "reduce motion"
+ * accessibility preference (story 279).
+ *
+ * <p>{@link MotionManager} seeds its initial {@code reduceMotion} value
+ * from this hint when no in-app preference has been persisted yet (the
+ * very first launch). The seam exists so {@code OsHintDetectionTest} can
+ * inject a deterministic mock instead of probing the real platform — the
+ * production constructor uses {@link PlatformMotionHint}, the test
+ * constructor accepts any {@code OsMotionHint}.</p>
+ *
+ * <p>The result is an {@link Optional}: {@code Optional.empty()} means
+ * the OS preference could <em>not</em> be determined (an unsupported
+ * platform, a detection error, or — on macOS — the absence of an
+ * Objective-C runtime call path). A present value is the OS's actual
+ * choice: {@code true} = the user has asked the OS to reduce motion,
+ * {@code false} = motion is allowed.</p>
+ */
+@FunctionalInterface
+public interface OsMotionHint {
+
+    /**
+     * Detects the OS-level reduce-motion preference.
+     *
+     * <p>Implementations must never throw — any detection failure is
+     * reported as {@link Optional#empty()} rather than an exception, so
+     * {@link MotionManager} construction can never be broken by a
+     * platform probe.</p>
+     *
+     * @return {@code Optional.of(true)} if the OS requests reduced
+     *         motion, {@code Optional.of(false)} if motion is allowed,
+     *         or {@code Optional.empty()} if the preference cannot be
+     *         determined on this platform
+     */
+    Optional<Boolean> reduceMotionPreferred();
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/PlatformMotionHint.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/PlatformMotionHint.java
@@ -145,14 +145,15 @@ final class PlatformMotionHint implements OsMotionHint {
                     "org.gnome.desktop.interface", "enable-animations")
                     .redirectErrorStream(true)
                     .start();
+            if (!process.waitFor(LINUX_PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                process.waitFor(500, TimeUnit.MILLISECONDS);
+                return Optional.empty();
+            }
             String output;
             try (var in = process.getInputStream()) {
                 output = new String(in.readAllBytes()).trim()
                         .toLowerCase(Locale.ROOT);
-            }
-            if (!process.waitFor(LINUX_PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                process.destroyForcibly();
-                return Optional.empty();
             }
             if (output.contains("true")) {
                 // animations enabled → reduceMotion = false.

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/PlatformMotionHint.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/PlatformMotionHint.java
@@ -1,0 +1,172 @@
+package com.benesquivelmusic.daw.app.ui.motion;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The production {@link OsMotionHint} — a best-effort, per-platform
+ * detector for the operating system's "reduce motion" accessibility
+ * preference (story 279).
+ *
+ * <p>Detection is intentionally tolerant: every probe is wrapped so that
+ * <em>any</em> failure (an unsupported platform, a missing native
+ * library, a process-spawn error, a {@link Throwable} of any kind)
+ * collapses to {@link Optional#empty()}. {@link MotionManager} then falls
+ * back to {@code false} (motion allowed). A failure to detect the OS hint
+ * must never break application startup.</p>
+ *
+ * <h2>Per-platform strategy</h2>
+ *
+ * <ul>
+ *   <li><strong>Windows</strong> (the project's primary target) — a
+ *       Foreign Function &amp; Memory API (FFM) downcall to
+ *       {@code user32!SystemParametersInfoW} with
+ *       {@code SPI_GETCLIENTAREAANIMATION}. The native call writes a
+ *       {@code BOOL} into a caller-allocated 4-byte buffer:
+ *       <em>non-zero</em> means client-area animations are <em>enabled</em>
+ *       (so {@code reduceMotion = false}); <em>zero</em> means animations
+ *       are off (so {@code reduceMotion = true}).</li>
+ *   <li><strong>macOS</strong> — the equivalent preference
+ *       ({@code NSWorkspace.accessibilityDisplayShouldReduceMotion}) is
+ *       not reliably reachable without an Objective-C runtime message
+ *       send, which this project does not currently bridge. macOS
+ *       therefore returns {@link Optional#empty()}; the in-app setting
+ *       still works, it simply is not OS-seeded on first launch. This is
+ *       a documented, accepted limitation (story 279).</li>
+ *   <li><strong>Linux</strong> — a best-effort {@code gsettings} process
+ *       call reading {@code org.gnome.desktop.interface enable-animations}.
+ *       Any failure (no GNOME, no {@code gsettings} binary, a timeout) is
+ *       swallowed to {@link Optional#empty()}.</li>
+ * </ul>
+ */
+final class PlatformMotionHint implements OsMotionHint {
+
+    private static final Logger LOG =
+            Logger.getLogger(PlatformMotionHint.class.getName());
+
+    /**
+     * {@code SPI_GETCLIENTAREAANIMATION} — the {@code SystemParametersInfo}
+     * action that reports whether animation effects associated with
+     * user-interface client areas are enabled (Win32 {@code winuser.h}).
+     */
+    private static final int SPI_GETCLIENTAREAANIMATION = 0x1042;
+
+    /** Bounded wait for the Linux {@code gsettings} probe. */
+    private static final long LINUX_PROBE_TIMEOUT_SECONDS = 2;
+
+    @Override
+    public Optional<Boolean> reduceMotionPreferred() {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        try {
+            if (os.contains("win")) {
+                return detectWindows();
+            }
+            if (os.contains("mac") || os.contains("darwin")) {
+                // Not reliably detectable without an Objective-C runtime
+                // message send — documented limitation (class Javadoc).
+                return Optional.empty();
+            }
+            return detectLinux();
+        } catch (Throwable t) {
+            // Detection must never break MotionManager construction.
+            LOG.log(Level.FINE,
+                    "OS reduce-motion hint detection failed; defaulting to undetected",
+                    t);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Windows: FFM downcall to
+     * {@code SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION, 0, &BOOL, 0)}.
+     *
+     * @return {@code Optional.of(true)} if client-area animations are
+     *         disabled (reduce motion on), {@code Optional.of(false)} if
+     *         they are enabled, or {@link Optional#empty()} on any failure
+     */
+    private static Optional<Boolean> detectWindows() {
+        try (Arena arena = Arena.ofConfined()) {
+            Linker linker = Linker.nativeLinker();
+            SymbolLookup user32 = SymbolLookup.libraryLookup("user32", arena);
+            MemorySegment fn = user32.find("SystemParametersInfoW").orElse(null);
+            if (fn == null) {
+                return Optional.empty();
+            }
+            // BOOL SystemParametersInfoW(UINT uiAction, UINT uiParam,
+            //                            PVOID pvParam, UINT fWinIni)
+            MethodHandle handle = linker.downcallHandle(fn, FunctionDescriptor.of(
+                    ValueLayout.JAVA_INT,    // BOOL return
+                    ValueLayout.JAVA_INT,    // UINT  uiAction
+                    ValueLayout.JAVA_INT,    // UINT  uiParam
+                    ValueLayout.ADDRESS,     // PVOID pvParam
+                    ValueLayout.JAVA_INT));  // UINT  fWinIni
+
+            // pvParam receives a BOOL (a 4-byte int).
+            MemorySegment out = arena.allocate(ValueLayout.JAVA_INT);
+            int ok = (int) handle.invoke(
+                    SPI_GETCLIENTAREAANIMATION, 0, out, 0);
+            if (ok == 0) {
+                // The call itself failed — treat as undetected.
+                return Optional.empty();
+            }
+            int animationsEnabled = out.get(ValueLayout.JAVA_INT, 0);
+            // animations enabled (non-zero) → reduceMotion = false.
+            return Optional.of(animationsEnabled == 0);
+        } catch (Throwable t) {
+            LOG.log(Level.FINE,
+                    "Windows SystemParametersInfo reduce-motion probe failed", t);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Linux: best-effort {@code gsettings} read of
+     * {@code org.gnome.desktop.interface enable-animations}. Tolerates any
+     * failure silently.
+     *
+     * @return {@code Optional.of(true)} if animations are disabled,
+     *         {@code Optional.of(false)} if enabled, or
+     *         {@link Optional#empty()} on any failure
+     */
+    private static Optional<Boolean> detectLinux() {
+        try {
+            Process process = new ProcessBuilder(
+                    "gsettings", "get",
+                    "org.gnome.desktop.interface", "enable-animations")
+                    .redirectErrorStream(true)
+                    .start();
+            String output;
+            try (var in = process.getInputStream()) {
+                output = new String(in.readAllBytes()).trim()
+                        .toLowerCase(Locale.ROOT);
+            }
+            if (!process.waitFor(LINUX_PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                return Optional.empty();
+            }
+            if (output.contains("true")) {
+                // animations enabled → reduceMotion = false.
+                return Optional.of(false);
+            }
+            if (output.contains("false")) {
+                // animations disabled → reduceMotion = true.
+                return Optional.of(true);
+            }
+            return Optional.empty();
+        } catch (Exception e) {
+            LOG.log(Level.FINE,
+                    "Linux gsettings reduce-motion probe failed", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -87,3 +87,9 @@ appearance.density.label=Density
 appearance.density.compact=Compact
 appearance.density.comfortable=Comfortable
 appearance.density.touch=Touch
+
+# Reduce Motion (story 279) — UI Design Book §2.7 / §3.5. A global
+# accessibility flag that cuts every UI transition to 0 ms while leaving
+# real-time meters, scopes and the playhead untouched (WCAG 2.3.3).
+appearance.reduceMotion.label=Reduce Motion
+appearance.reduceMotion.tooltip=Cut UI transitions (panel, drawer and notification animations) to zero. Real-time meters, scopes and the playhead are unaffected.

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/KnobReducedMotionTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/KnobReducedMotionTest.java
@@ -2,12 +2,20 @@ package com.benesquivelmusic.daw.app.ui.controls;
 
 import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
 import com.benesquivelmusic.daw.app.ui.controls.skin.KnobSkin;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.motion.OsMotionHint;
 
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 
 import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,9 +24,38 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Reduce Motion (story 279): with {@link Knob#isAnimated()} {@code false},
  * the {@code 0} / Ctrl+click reset snaps without instantiating a
  * transition timeline.
+ *
+ * <p>The {@code animated(true)} case asserts the detent timeline <em>does</em>
+ * run — which depends on the combined gate ({@code localAnimated AND NOT
+ * global Reduce Motion}). A deterministic {@link MotionManager} (Reduce
+ * Motion off, OS hint stubbed to "undetected") is installed for the class
+ * so the result does not depend on the host's OS-level animation setting
+ * (e.g. Windows "Show animations").</p>
  */
 @ExtendWith(JavaFxToolkitExtension.class)
 class KnobReducedMotionTest {
+
+    /** An OS hint reporting "undetected" — isolates the test from the real OS. */
+    private static final OsMotionHint NO_HINT = Optional::empty;
+
+    private static Preferences motionNode;
+
+    @BeforeAll
+    static void installDeterministicMotionManager() {
+        motionNode = Preferences.userRoot()
+                .node("knobReducedMotionTest_" + System.nanoTime());
+        MotionManager motion = new MotionManager(motionNode, NO_HINT);
+        motion.setReduceMotion(false);
+        MotionManager.setDefaultForTest(motion);
+    }
+
+    @AfterAll
+    static void clearDeterministicMotionManager() throws BackingStoreException {
+        MotionManager.setDefaultForTest(null);
+        if (motionNode != null) {
+            motionNode.removeNode();
+        }
+    }
 
     @Test
     void resetWithAnimatedFalseSnapsAndCreatesNoTimeline() {

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeterBuilderTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeterBuilderTest.java
@@ -1,11 +1,19 @@
 package com.benesquivelmusic.daw.app.ui.controls;
 
 import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.motion.OsMotionHint;
 
 import javafx.geometry.Orientation;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 
 import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,9 +22,37 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 /**
  * The fluent {@link LevelMeter.Builder} and the no-arg constructor are two
  * equivalent, independently usable construction paths.
+ *
+ * <p>The default-{@code isAnimated()} assertion is the combined gate
+ * ({@code localAnimated AND NOT global Reduce Motion}, story 279); a
+ * deterministic {@link MotionManager} (Reduce Motion off, OS hint stubbed)
+ * is installed for the class so it does not depend on the host's OS-level
+ * animation setting.</p>
  */
 @ExtendWith(JavaFxToolkitExtension.class)
 class LevelMeterBuilderTest {
+
+    /** An OS hint reporting "undetected" — isolates the test from the real OS. */
+    private static final OsMotionHint NO_HINT = Optional::empty;
+
+    private static Preferences motionNode;
+
+    @BeforeAll
+    static void installDeterministicMotionManager() {
+        motionNode = Preferences.userRoot()
+                .node("levelMeterBuilderTest_" + System.nanoTime());
+        MotionManager motion = new MotionManager(motionNode, NO_HINT);
+        motion.setReduceMotion(false);
+        MotionManager.setDefaultForTest(motion);
+    }
+
+    @AfterAll
+    static void clearDeterministicMotionManager() throws BackingStoreException {
+        MotionManager.setDefaultForTest(null);
+        if (motionNode != null) {
+            motionNode.removeNode();
+        }
+    }
 
     @Test
     void builderConfiguresChannelsOrientationAndSizeClass() {

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeterTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/controls/LevelMeterTest.java
@@ -2,18 +2,25 @@ package com.benesquivelmusic.daw.app.ui.controls;
 
 import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
 import com.benesquivelmusic.daw.app.ui.controls.skin.LevelMeterSkin;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.motion.OsMotionHint;
 
 import javafx.geometry.Orientation;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 
 import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,9 +29,37 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Core behaviour of {@link LevelMeter}: defaults, property accessors, the
  * audio→FX relay, the CssMetaData contract, and the draw-model seams
  * exercised under a live {@link Scene}.
+ *
+ * <p>{@code defaultsAreSane} asserts the default {@code isAnimated()} — the
+ * combined gate ({@code localAnimated AND NOT global Reduce Motion}, story
+ * 279). A deterministic {@link MotionManager} (Reduce Motion off, OS hint
+ * stubbed to "undetected") is installed for the class so the result does
+ * not depend on the host's OS-level animation setting.</p>
  */
 @ExtendWith(JavaFxToolkitExtension.class)
 class LevelMeterTest {
+
+    /** An OS hint reporting "undetected" — isolates the test from the real OS. */
+    private static final OsMotionHint NO_HINT = Optional::empty;
+
+    private static Preferences motionNode;
+
+    @BeforeAll
+    static void installDeterministicMotionManager() {
+        motionNode = Preferences.userRoot()
+                .node("levelMeterTest_" + System.nanoTime());
+        MotionManager motion = new MotionManager(motionNode, NO_HINT);
+        motion.setReduceMotion(false);
+        MotionManager.setDefaultForTest(motion);
+    }
+
+    @AfterAll
+    static void clearDeterministicMotionManager() throws BackingStoreException {
+        MotionManager.setDefaultForTest(null);
+        if (motionNode != null) {
+            motionNode.removeNode();
+        }
+    }
 
     /** Meters created by helpers; disposed in {@link #cleanup()} to stop
      *  every attached {@link javafx.animation.AnimationTimer} so timers

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/MotionManagerPersistenceTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/MotionManagerPersistenceTest.java
@@ -1,0 +1,98 @@
+package com.benesquivelmusic.daw.app.ui.motion;
+
+import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 279 — the global Reduce Motion flag survives a "restart": set the
+ * flag, then rebuild {@link MotionManager} from the <em>same</em>
+ * {@link Preferences} node and assert it deserialises back to the
+ * persisted value.
+ *
+ * <p>Intentionally a pure unit test — {@link MotionManager}'s persistence
+ * path is toolkit-free, so no JavaFX is needed (mirrors
+ * {@code DensityPersistenceTest}). That is a feature: Reduce Motion
+ * persistence is verifiable without the FX harness.</p>
+ */
+final class MotionManagerPersistenceTest {
+
+    /** An OS hint that always reports "undetected" — isolates the test from the real OS. */
+    private static final OsMotionHint NO_HINT = Optional::empty;
+
+    @Test
+    void freshNodeDefaultsToMotionAllowed() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("motionPersistenceTest_" + System.nanoTime());
+        try {
+            MotionManager mgr = new MotionManager(node, NO_HINT);
+            assertThat(mgr.isReduceMotion())
+                    .as("a fresh node with no OS hint must default to motion allowed")
+                    .isEqualTo(MotionManager.DEFAULT_REDUCE_MOTION)
+                    .isFalse();
+        } finally {
+            node.removeNode();
+        }
+    }
+
+    @Test
+    void reduceMotionRoundTripsThroughPreferences() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("motionPersistenceTestRT_" + System.nanoTime());
+        try {
+            MotionManager first = new MotionManager(node, NO_HINT);
+            first.setReduceMotion(true);
+
+            // Simulate a restart: a brand-new manager over the same node.
+            MotionManager restarted = new MotionManager(node, NO_HINT);
+            assertThat(restarted.isReduceMotion())
+                    .as("the persisted Reduce Motion flag must survive a rebuild")
+                    .isTrue();
+        } finally {
+            node.removeNode();
+        }
+    }
+
+    @Test
+    void persistedFalseAlsoSurvivesRestart() throws BackingStoreException {
+        // A persisted `false` must round-trip too — the restore() path
+        // distinguishes "key present, value false" from "key absent".
+        Preferences node = Preferences.userRoot()
+                .node("motionPersistenceTestFalse_" + System.nanoTime());
+        try {
+            MotionManager first = new MotionManager(node, NO_HINT);
+            first.setReduceMotion(true);
+            first.setReduceMotion(false);
+
+            // Even with an OS hint that says "reduce motion", the
+            // persisted explicit `false` wins after a restart.
+            MotionManager restarted =
+                    new MotionManager(node, () -> Optional.of(true));
+            assertThat(restarted.isReduceMotion())
+                    .as("a persisted explicit false must override the OS hint")
+                    .isFalse();
+        } finally {
+            node.removeNode();
+        }
+    }
+
+    @Test
+    void persistenceKeyIsDistinctFromThemeAndDensityKeys() {
+        // Reduce Motion, the token theme (story 277), the density profile
+        // (story 278) and the WCAG JSON registry (story 194) are four
+        // separate systems and must not share a preferences key (mirrors
+        // DensityPersistenceTest's analogous distinctness assertion).
+        assertThat(MotionManager.PREF_KEY)
+                .isEqualTo("appearance.reduceMotion")
+                .isNotEqualTo(ThemeManager.PREF_KEY)       // "appearance.tokenTheme"
+                .isNotEqualTo(DensityManager.PREF_KEY)     // "appearance.density"
+                .isNotEqualTo("appearance.themeId");        // SettingsModel.KEY_THEME_ID
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/OsHintDetectionTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/OsHintDetectionTest.java
@@ -1,0 +1,84 @@
+package com.benesquivelmusic.daw.app.ui.motion;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 279 — on first launch (no persisted preference) {@link MotionManager}
+ * seeds its initial Reduce Motion flag from the OS-level accessibility
+ * hint via the injectable {@link OsMotionHint} seam.
+ *
+ * <p>Pure unit test — the {@code MotionManager(Preferences, OsMotionHint)}
+ * constructor lets the test inject a deterministic mock hint instead of
+ * probing the real platform, so no JavaFX and no native call is needed.</p>
+ */
+final class OsHintDetectionTest {
+
+    @Test
+    void hintTrueSeedsReduceMotionOn() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("osHintTestTrue_" + System.nanoTime());
+        try {
+            MotionManager mgr = new MotionManager(node, () -> Optional.of(true));
+            assertThat(mgr.isReduceMotion())
+                    .as("an OS hint of true on a fresh node must seed Reduce Motion on")
+                    .isTrue();
+        } finally {
+            node.removeNode();
+        }
+    }
+
+    @Test
+    void hintFalseSeedsReduceMotionOff() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("osHintTestFalse_" + System.nanoTime());
+        try {
+            MotionManager mgr = new MotionManager(node, () -> Optional.of(false));
+            assertThat(mgr.isReduceMotion())
+                    .as("an OS hint of false on a fresh node must seed Reduce Motion off")
+                    .isFalse();
+        } finally {
+            node.removeNode();
+        }
+    }
+
+    @Test
+    void undetectedHintFallsBackToTheDefault() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("osHintTestEmpty_" + System.nanoTime());
+        try {
+            // Optional.empty() = OS preference could not be determined
+            // (e.g. macOS, or a detection failure) → fall back to default.
+            MotionManager mgr = new MotionManager(node, Optional::empty);
+            assertThat(mgr.isReduceMotion())
+                    .as("an undetected OS hint must fall back to the design default")
+                    .isEqualTo(MotionManager.DEFAULT_REDUCE_MOTION)
+                    .isFalse();
+        } finally {
+            node.removeNode();
+        }
+    }
+
+    @Test
+    void persistedValuePresentOverridesTheOsHint() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("osHintTestOverride_" + System.nanoTime());
+        try {
+            // A value is already persisted (the user has saved a choice):
+            // the stored boolean must win over the OS hint, even when the
+            // hint disagrees.
+            node.putBoolean(MotionManager.PREF_KEY, false);
+            MotionManager mgr = new MotionManager(node, () -> Optional.of(true));
+            assertThat(mgr.isReduceMotion())
+                    .as("a present persisted value must override the OS hint")
+                    .isFalse();
+        } finally {
+            node.removeNode();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/PlatformMotionHintTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/PlatformMotionHintTest.java
@@ -1,0 +1,65 @@
+package com.benesquivelmusic.daw.app.ui.motion;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Story 279 — exercises the <em>real</em> {@link PlatformMotionHint} probe,
+ * the FFM downcall that {@code OsHintDetectionTest}'s mocked seam never
+ * touches.
+ *
+ * <p>Two layers of coverage:</p>
+ * <ul>
+ *   <li>A Windows-only test that drives the genuine
+ *       {@code user32!SystemParametersInfoW} downcall and asserts a
+ *       <em>present</em> result — the call must succeed on the project's
+ *       primary platform. The boolean value itself is intentionally
+ *       <em>not</em> asserted: it depends on the developer's / CI agent's
+ *       actual OS accessibility setting, which the test must not assume.</li>
+ *   <li>A platform-agnostic test that pins the {@link OsMotionHint}
+ *       never-throws contract on whatever OS the suite runs on.</li>
+ * </ul>
+ */
+final class PlatformMotionHintTest {
+
+    /**
+     * On Windows, {@code SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION,
+     * …)} is a stable Win32 call that succeeds on every supported Windows
+     * version, so the probe must return a present {@link Optional}. The
+     * contained boolean mirrors the machine's real "show animations"
+     * setting and is deliberately left unasserted.
+     */
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void windowsProbeReturnsAPresentResult() {
+        Optional<Boolean> hint = new PlatformMotionHint().reduceMotionPreferred();
+        assertThat(hint)
+                .as("the Windows SystemParametersInfo downcall must succeed "
+                        + "and yield a determinate reduce-motion preference")
+                .isPresent();
+    }
+
+    /**
+     * The {@link OsMotionHint} contract forbids throwing: every probe
+     * failure must collapse to {@link Optional#empty()}. This holds on any
+     * platform — including the ones where the probe legitimately returns
+     * empty (macOS, a non-GNOME Linux) — so it is not OS-gated.
+     */
+    @Test
+    void probeNeverThrowsAndNeverReturnsNull() {
+        PlatformMotionHint hint = new PlatformMotionHint();
+        assertThatCode(hint::reduceMotionPreferred)
+                .as("OsMotionHint implementations must never throw — a probe "
+                        + "failure is reported as Optional.empty()")
+                .doesNotThrowAnyException();
+        assertThat(hint.reduceMotionPreferred())
+                .as("the probe must return a non-null Optional")
+                .isNotNull();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/ReduceMotionFlagAppliedTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/ReduceMotionFlagAppliedTest.java
@@ -1,0 +1,87 @@
+package com.benesquivelmusic.daw.app.ui.motion;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.inspector.InspectorDrawer;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Story 279 — with global Reduce Motion enabled, an {@link InspectorDrawer}
+ * that has <em>not</em> had its per-control flag touched still collapses
+ * <strong>instantly</strong>: the 220 ms open/close transition is cut to
+ * {@code 0 ms} by the global gate, so the control width reaches its final
+ * value within a single layout pulse.
+ *
+ * <p>This proves the two-mechanism gate: the drawer keeps its default
+ * {@code localAnimated = true}, and only the global {@code MotionManager}
+ * Reduce Motion flag suppresses the transition. (Contrast
+ * {@code InspectorDrawerCollapseTest}, which suppresses via the
+ * per-control {@code setAnimated(false)} call.)</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class ReduceMotionFlagAppliedTest {
+
+    /** An OS hint reporting "undetected" — isolates the test from the real OS. */
+    private static final OsMotionHint NO_HINT = Optional::empty;
+
+    @Test
+    void reduceMotionCollapsesTheDrawerWithinOnePulse() throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("reduceMotionAppliedTest_" + System.nanoTime());
+        try {
+            MotionManager motion = new MotionManager(node, NO_HINT);
+            motion.setReduceMotion(true);
+            MotionManager.setDefaultForTest(motion);
+
+            double[] widths = new double[2];
+            runOnFxThread(() -> {
+                // The drawer reads MotionManager.getDefault() at
+                // construction, so the test instance must be installed
+                // first (done above).
+                InspectorDrawer drawer = new InspectorDrawer();
+                // Deliberately DO NOT call setAnimated(...) — the
+                // per-control flag stays true; only the global Reduce
+                // Motion flag is in play here.
+                assertThat(drawer.isAnimated())
+                        .as("global Reduce Motion must gate isAnimated() to false")
+                        .isFalse();
+                drawer.setExpanded(true);
+                Pane root = new Pane(drawer);
+                new Scene(root, 600, 400);
+                root.applyCss();
+                root.layout();
+                widths[0] = drawer.getWidth();
+                drawer.setExpanded(false);
+                root.applyCss();
+                root.layout();
+                widths[1] = drawer.getWidth();
+                return null;
+            });
+
+            // Expanded width is 240 px; collapsed is 24 px. With the
+            // transition cut to 0 ms the collapse completes in the same
+            // pulse — no Timeline interpolation leaves it mid-travel.
+            assertThat(widths[0])
+                    .as("expanded width")
+                    .isCloseTo(240.0, within(1.0));
+            assertThat(widths[1])
+                    .as("collapsed width reached within one pulse under Reduce Motion")
+                    .isCloseTo(24.0, within(1.0));
+        } finally {
+            MotionManager.setDefaultForTest(null);
+            node.removeNode();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/ReducedMotionMeterPreservedTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/motion/ReducedMotionMeterPreservedTest.java
@@ -1,0 +1,125 @@
+package com.benesquivelmusic.daw.app.ui.motion;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.LevelMeter;
+import com.benesquivelmusic.daw.app.ui.controls.skin.LevelMeterSkin;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 279 — the real-time exemption: with global Reduce Motion enabled,
+ * a {@link LevelMeter}'s continuous signal-level rendering is <strong>not
+ * gated</strong>. The meter is <em>information</em>, not animation; its
+ * per-frame relay must keep advancing frame-by-frame regardless of Reduce
+ * Motion (UI Design Book §3.5, MotionManager class Javadoc cut/keep rule).
+ *
+ * <p>This is the counterpart to {@code ReduceMotionFlagAppliedTest} (which
+ * proves a <em>transition</em> is cut): here we prove a <em>real-time</em>
+ * surface is preserved. The meter's combined {@code isAnimated()} reads
+ * {@code false} under Reduce Motion — but {@code LevelMeterSkin}'s
+ * continuous pump runs whenever the control is attached, independent of
+ * that flag, so peak values still track the audio feed.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class ReducedMotionMeterPreservedTest {
+
+    /** An OS hint reporting "undetected" — isolates the test from the real OS. */
+    private static final OsMotionHint NO_HINT = Optional::empty;
+
+    @Test
+    void meterStillAdvancesFrameByFrameUnderReduceMotion()
+            throws BackingStoreException {
+        Preferences node = Preferences.userRoot()
+                .node("reduceMotionMeterTest_" + System.nanoTime());
+        try {
+            MotionManager motion = new MotionManager(node, NO_HINT);
+            motion.setReduceMotion(true);
+            MotionManager.setDefaultForTest(motion);
+
+            LevelMeter meter = runOnFxThread(LevelMeter::new);
+            try {
+                // Attach the meter to a Scene so the skin's continuous
+                // per-frame pump is live (mirrors LevelMeterTest.attach).
+                LevelMeterSkin skin = runOnFxThread(() -> {
+                    StackPane root = new StackPane(meter);
+                    new Scene(root, 80, 240);
+                    root.applyCss();
+                    root.layout();
+                    return (LevelMeterSkin) meter.getSkin();
+                });
+
+                // Sanity: global Reduce Motion gates the combined flag.
+                runOnFxThread(() -> {
+                    assertThat(meter.isAnimated())
+                            .as("global Reduce Motion gates the meter's combined "
+                                    + "animated flag to false")
+                            .isFalse();
+                    return null;
+                });
+
+                // Drive peakDb from -infinity up to -3 dBFS over a 200 ms
+                // ramp of synthetic frames. After each frame the relayed
+                // peak property must have advanced — proving the real-time
+                // pump is NOT gated by Reduce Motion.
+                int frames = 20;
+                long startNanos = 1_000_000_000L;
+                long frameStepNanos = 10_000_000L; // 10 ms → 200 ms total
+                double targetDb = -3.0;
+                double[] observed = new double[frames];
+
+                for (int i = 0; i < frames; i++) {
+                    final int frame = i;
+                    runOnFxThread(() -> {
+                        // Ramp: frame 0 starts near the noise floor and
+                        // climbs linearly to the target.
+                        double db = -120.0
+                                + (targetDb + 120.0) * (frame + 1) / frames;
+                        meter.submitLevels(db, db);
+                        skin.pumpOnce(startNanos + frame * frameStepNanos);
+                        observed[frame] = meter.getPeakDb();
+                        return null;
+                    });
+                }
+
+                // Every frame must show a strictly higher peak than the
+                // previous one — the meter advanced continuously.
+                for (int i = 1; i < frames; i++) {
+                    assertThat(observed[i])
+                            .as("meter peak must advance at frame %d "
+                                    + "(real-time rendering is exempt from "
+                                    + "Reduce Motion)", i)
+                            .isGreaterThan(observed[i - 1]);
+                }
+                // And the final frame reached the target.
+                assertThat(observed[frames - 1])
+                        .as("meter reaches the ramp target under Reduce Motion")
+                        .isEqualTo(targetDb);
+            } finally {
+                runOnFxThread(() -> {
+                    if (meter.getSkin() != null) {
+                        meter.setSkin(null);
+                    }
+                    if (meter.getParent()
+                            instanceof javafx.scene.layout.Pane pane) {
+                        pane.getChildren().remove(meter);
+                    }
+                    return null;
+                });
+            }
+        } finally {
+            MotionManager.setDefaultForTest(null);
+            node.removeNode();
+        }
+    }
+}


### PR DESCRIPTION
# Reduce Motion Setting: Cut Transitions to Zero, Preserve Real-Time Meters

## Motivation

Phase 3 of the UI Design Book §6 migration roadmap. Builds on: #267 (LevelMeter `animatedProperty`), #268 (Knob `animatedProperty`), #269 (Fader `animatedProperty`), #272 (Inspector drawer transition), #273 (Notification toast dismissal animation), every other Phase 2 control.

UI Design Book §2.7 ("Motion is functional, not decorative") and §3.5 ("Motion") together specify the motion system:

- 150–250 ms with `EASE_OUT` for state changes (panel show/hide, tab switch, modal in/out).
- Continuous motion (meters, scopes) is real-time, not "animated".
- Hover / press / selection are *instantaneous*.
- Every animation is opt-out via a boolean `animatedProperty()` on each animatable control, **plus a global Reduce Motion toggle in Settings.**

§3.5 also makes the contract explicit: "Reduce Motion (settings flag) cuts every transition to 0 ms while leaving real-time meters alone."

This story:
1. Adds the global Reduce Motion preference.
2. Threads it into every control's `animatedProperty()` (introduced in Phase 2 stories).
3. Documents the invariant that real-time meters, scopes, and the playhead are *not* affected.

This is an accessibility-critical feature. WCAG 2.1 success criterion 2.3.3 (Animation from Interactions, AAA) recommends users be able to disable non-essential animation; this matches the OS-level "Reduce Motion" preference on macOS, Windows, and many Linux desktops.

## Goals

- Add `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/motion/MotionManager.java`:
  - `BooleanProperty reduceMotionProperty()` (default `false`, restored from preferences).
  - `boolean isAnimationAllowed()` — returns `!reduceMotionProperty().get()`. Convenience for control authors.
  - Persists via the existing preferences store.
- Wire `MotionManager.reduceMotionProperty()` into every Phase 2 control's `animatedProperty()` via property binding at construction time:
  - `LevelMeter` (story 267): `animatedProperty().bind(MotionManager.reduceMotionProperty().not())`. Note: the meter's *continuous* paint loop is *not* gated by this — only its peak-hold fall-off animation (which is decorative) is. The real-time peak display continues regardless.
  - `Knob` (story 268): the centre-detent click animation is suppressed; value changes are instantaneous regardless of source.
  - `Fader` (story 269): same — fader has no decorative animation today, so the binding is a contract for future motion (e.g. an automation-driven motorised fader effect, if ever added).
  - `TrackStrip` (story 270): no decorative motion today; hover background swap is already instantaneous per §3.5.
  - `MixerChannelStrip` (story 271): same.
  - `InspectorDrawer` (story 272): the 220 ms `EASE_OUT` open/close transition collapses to 0 ms.
  - `NotificationBar` (story 273): the 200 ms dismissal `EASE_OUT` collapses to 0 ms.
- Audit and gate every other transition / `Timeline` / `FadeTransition` / `TranslateTransition` instantiated in `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/`. Each gated either by `if (motionManager.isAnimationAllowed())` or by binding the transition's `cycleDurationProperty` so it resolves to `Duration.ZERO` when Reduce Motion is on.
- Real-time-motion exemption — these are *not* affected by Reduce Motion:
  - Level meter signal-level rendering (continuous, real-time — the meter is *information*, not animation).
  - Spectrum analyser, correlation meter, goniometer, oscilloscope (story 023, 028).
  - Waveform display while playback advances.
  - Playhead movement in the arrangement view (`ArrangementCanvas`).
  - VU needle ballistics for any future analogue-style meter.
  
  Document this invariant in `MotionManager.java`'s class Javadoc.
- Wire the setting into Preferences → Appearance → Reduce Motion (uses dialog chrome from story 276; same panel as Theme story 277 / Density story 278). One checkbox.
- On startup, detect the OS-level Reduce Motion hint when available and default the preference to match. (macOS: `NSWorkspace.shared.accessibilityDisplayShouldReduceMotion`; Windows 10/11: SystemParametersInfo SPI_GETCLIENTAREAANIMATION; Linux: best-effort via GTK settings if accessible. If not detectable, default false.) Document any non-detectable cases.
- Tests:
  - `ReduceMotionFlagAppliedTest`: enable Reduce Motion, instantiate `InspectorDrawer`, toggle `expandedProperty`, assert the transition completes in ≤ 1 pulse (i.e. instantly).
  - `ReducedMotionMeterPreservedTest`: enable Reduce Motion, instantiate `LevelMeter`, drive `peakDb` from `-∞` to `-3` via a 200 ms ramp, assert the meter visually animates (the rendered top segment moves frame-by-frame). The real-time meter is *not* gated.
  - `OsHintDetectionTest`: mock the OS hint, assert `MotionManager.reduceMotionProperty()` initial value matches the hint.
  - `MotionManagerPersistenceTest`: enable Reduce Motion, simulate restart, assert flag is restored.

## Non-Goals

- Per-animation overrides (a "reduce only modal animations" setting). One global flag.
- Animating the *transition* between motion modes. Switching is itself instantaneous.
- Replacing the OS-level animation preferences with an in-app setting — the in-app setting is independent but starts seeded from the OS hint.
- Building a generalised animation registry that auto-discovers transitions — explicit gating in each control is cleaner and is the established pattern.

## Technical Notes

- The §3.5 contract makes the cut/keep decision easy: anything *real-time-information* is kept; anything *transitional* is cut. The MotionManager Javadoc should restate this rule in one paragraph so future code reviews can apply it without re-reading the design book.
- For OS-hint detection, prefer a small platform-specific helper class with FFM downcalls (the project already uses FFM extensively per the user's memory). For Linux, attempt the GSettings key `org.gnome.desktop.interface gtk-enable-animations` via a process call; tolerate failure silently.
- The Preferences label ("Reduce Motion") and any tooltip / help text come from the existing `Messages.properties` resource bundle. Skill §14.
- Reference: UI Design Book §2.7, §3.5, §6.
