### PR TITLE
285-instantiate-dockmanager-and-implement-dockable-in-top-level-panel implementation

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.drag.DragSourceKind;
 import com.benesquivelmusic.daw.app.ui.drag.DragVisualAdvisor;
 import com.benesquivelmusic.daw.app.ui.drag.DropTargetKind;
@@ -73,7 +75,7 @@ import java.util.logging.Logger;
  * row is playing. With no auditioner installed the button is
  * {@code :disabled} (the unified {@code .dawg-button:disabled} rule).</p>
  */
-public final class BrowserPanel extends VBox {
+public final class BrowserPanel extends VBox implements Dockable {
 
     private static final Logger LOG = Logger.getLogger(BrowserPanel.class.getName());
 
@@ -342,6 +344,12 @@ public final class BrowserPanel extends VBox {
         tabIndicators.put(section, indicator);
         return container;
     }
+
+    // ── Dockable contract (story 285) ────────────────────────────────────────
+    @Override public String dockId()            { return DefaultWorkspaces.PANEL_BROWSER; }
+    @Override public String displayName()       { return "Browser"; }
+    @Override public String iconName()          { return "BROWSER"; }
+    @Override public DockZone preferredZone()   { return DockZone.LEFT; }
 
     /**
      * Returns the persistent search/filter text field.

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultWorkspaces.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultWorkspaces.java
@@ -45,6 +45,14 @@ public final class DefaultWorkspaces {
     public static final String PANEL_SPATIAL = "spatial";
     /** Loudness / LUFS metering panel. */
     public static final String PANEL_LOUDNESS = "loudness";
+    /**
+     * Telemetry setup panel (story 285). Constant added so
+     * {@link TelemetrySetupPanel} can advertise a stable {@code dockId};
+     * not added to {@link #panelIds()} because the panel is owned by
+     * {@code TelemetryView} (a plugin view) and is not yet registered as
+     * a top-level dock surface — a future story will elevate it.
+     */
+    public static final String PANEL_TELEMETRY = "telemetry";
 
     private DefaultWorkspaces() { }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultWorkspaces.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultWorkspaces.java
@@ -45,14 +45,6 @@ public final class DefaultWorkspaces {
     public static final String PANEL_SPATIAL = "spatial";
     /** Loudness / LUFS metering panel. */
     public static final String PANEL_LOUDNESS = "loudness";
-    /**
-     * Telemetry setup panel (story 285). Constant added so
-     * {@link TelemetrySetupPanel} can advertise a stable {@code dockId};
-     * not added to {@link #panelIds()} because the panel is owned by
-     * {@code TelemetryView} (a plugin view) and is not yet registered as
-     * a top-level dock surface — a future story will elevate it.
-     */
-    public static final String PANEL_TELEMETRY = "telemetry";
 
     private DefaultWorkspaces() { }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/EditorView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/EditorView.java
@@ -1,6 +1,8 @@
 package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.display.WaveformDisplay;
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.core.midi.MidiClip;
@@ -37,7 +39,7 @@ import java.util.function.Consumer;
  * <p>Uses existing CSS classes: {@code .editor-panel}, {@code .content-area},
  * {@code .panel-header}, {@code .placeholder-label}.</p>
  */
-public final class EditorView extends VBox {
+public final class EditorView extends VBox implements Dockable {
 
     /** The mode the editor is currently operating in. */
     public enum Mode {
@@ -120,6 +122,12 @@ public final class EditorView extends VBox {
             }
         });
     }
+
+    // ── Dockable contract (story 285) ────────────────────────────────────────
+    @Override public String dockId()            { return DefaultWorkspaces.PANEL_EDITOR; }
+    @Override public String displayName()       { return "Editor"; }
+    @Override public String iconName()          { return "EDITOR"; }
+    @Override public DockZone preferredZone()   { return DockZone.CENTER; }
 
     /**
      * Sets the track to edit. If the track is {@code null}, the editor

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1851,7 +1851,27 @@ public final class MainController {
             // If a Stage was previously open for this panel, close it now
             // (panel was re-docked).
             Stage existing = floatingStages.remove(id);
+            boolean wasFloating = existing != null;
             if (existing != null) existing.close();
+            if (wasFloating) {
+                // The panel node is still parented inside the closed stage's
+                // scene. Detach it so it can be re-parented into the main
+                // chrome by the reconcile helpers below.
+                detachFromParent(resolveNode(id));
+                // Force the controller's internal state to diverge from the
+                // desired state so the standard show paths fire. The
+                // controllers' flags (panelVisible / activeView) were never
+                // updated when the panel was floated — they're stale.
+                if (id.equals(DefaultWorkspaces.PANEL_BROWSER)) {
+                    if (browserPanelController != null
+                            && browserPanelController.isPanelVisible()) {
+                        browserPanelController.toggleBrowserPanel();
+                    }
+                } else if (CENTER_ZONE_PANELS.contains(id)
+                        && viewNavigationController != null) {
+                    viewNavigationController.invalidateActiveViewCache();
+                }
+            }
             switch (id) {
                 case DefaultWorkspaces.PANEL_BROWSER -> reconcileBrowser(entry.visible());
                 case DefaultWorkspaces.PANEL_ARRANGEMENT -> reconcileCenterView(
@@ -1863,6 +1883,20 @@ public final class MainController {
                 case DefaultWorkspaces.PANEL_MASTERING -> reconcileCenterView(
                         entry.visible(), DawView.MASTERING);
                 default -> { /* unknown id — forward compatible */ }
+            }
+        }
+
+        private void detachFromParent(Node content) {
+            if (content == null) return;
+            javafx.scene.Parent parent = content.getParent();
+            if (parent instanceof javafx.scene.layout.BorderPane bp) {
+                if (bp.getCenter() == content) bp.setCenter(null);
+                else if (bp.getLeft() == content) bp.setLeft(null);
+                else if (bp.getRight() == content) bp.setRight(null);
+                else if (bp.getTop() == content) bp.setTop(null);
+                else if (bp.getBottom() == content) bp.setBottom(null);
+            } else if (parent instanceof Pane pane) {
+                pane.getChildren().remove(content);
             }
         }
 
@@ -1902,20 +1936,7 @@ public final class MainController {
                 if (rootPane.getScene() != null && rootPane.getScene().getWindow() != null) {
                     stage.initOwner(rootPane.getScene().getWindow());
                 }
-                javafx.scene.Parent parent = content.getParent();
-                // BorderPane extends Pane — test for BorderPane (the rootPane
-                // slot setter case) first so generic Pane removal doesn't
-                // strip a node out of a BorderPane slot without clearing the
-                // setter.
-                if (parent instanceof javafx.scene.layout.BorderPane bp) {
-                    if (bp.getCenter() == content) bp.setCenter(null);
-                    else if (bp.getLeft() == content) bp.setLeft(null);
-                    else if (bp.getRight() == content) bp.setRight(null);
-                    else if (bp.getTop() == content) bp.setTop(null);
-                    else if (bp.getBottom() == content) bp.setBottom(null);
-                } else if (parent instanceof Pane pane) {
-                    pane.getChildren().remove(content);
-                }
+                detachFromParent(content);
                 javafx.scene.Scene scene = new javafx.scene.Scene(
                         content instanceof javafx.scene.Parent p ? p
                                 : new javafx.scene.layout.StackPane(content));
@@ -1925,13 +1946,16 @@ public final class MainController {
                 com.benesquivelmusic.daw.app.ui.theme.ThemeManager.getDefault().applyTo(scene);
                 stage.setScene(scene);
                 // When the user dismisses the floating window via the OS
-                // close button, mark the panel hidden in the dock layout so
-                // the manager doesn't re-open it on the next layout change.
+                // close button, move the panel back to its preferred dock
+                // zone so it isn't trapped in a hidden-floating state.
                 final String idForHandler = panelId;
                 stage.setOnCloseRequest(e -> {
                     floatingStages.remove(idForHandler);
                     if (dockManager != null) {
-                        dockManager.setVisible(idForHandler, false);
+                        DockZone preferred = dockManager.panel(idForHandler)
+                                .map(Dockable::preferredZone)
+                                .orElse(DockZone.CENTER);
+                        dockManager.move(idForHandler, preferred, 0);
                     }
                 });
                 floatingStages.put(panelId, stage);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1805,10 +1805,17 @@ public final class MainController {
             // Active panel — radio-button behaviour: no-op.
             return;
         }
-        // Hide every other CENTER panel before showing the requested one so
-        // reconciliation sees exactly one visible CENTER entry.
-        for (String other : CENTER_ZONE_PANELS) {
-            if (!other.equals(panelId)) dockManager.setVisible(other, false);
+        // Suppress reconciliation while hiding siblings so we don't fire
+        // N × N reconcile passes. Only the final setVisible (which shows
+        // the requested panel) fires onLayoutChanged — a single pass that
+        // reconciles the entire batch atomically.
+        dockHostReconciliationSuppressed = true;
+        try {
+            for (String other : CENTER_ZONE_PANELS) {
+                if (!other.equals(panelId)) dockManager.setVisible(other, false);
+            }
+        } finally {
+            dockHostReconciliationSuppressed = false;
         }
         dockManager.setVisible(panelId, true);
     }
@@ -1957,6 +1964,26 @@ public final class MainController {
                         dockManager.move(idForHandler, preferred, 0);
                     }
                 });
+                // Propagate user-driven position/size changes back to the
+                // DockManager so workspace captures reflect the actual
+                // window placement (not just the launch bounds).
+                final Stage stageRef = stage;
+                javafx.beans.value.ChangeListener<Number> boundsListener = (obs, oldVal, newVal) -> {
+                    if (dockManager == null) return;
+                    var currentEntry = dockManager.layout().entry(idForHandler).orElse(null);
+                    if (currentEntry == null || currentEntry.zone() != DockZone.FLOATING) return;
+                    com.benesquivelmusic.daw.sdk.ui.Rectangle2D actual =
+                            new com.benesquivelmusic.daw.sdk.ui.Rectangle2D(
+                                    stageRef.getX(), stageRef.getY(),
+                                    stageRef.getWidth(), stageRef.getHeight());
+                    if (!actual.equals(currentEntry.floatingBounds())) {
+                        dockManager.updateFloatingBounds(idForHandler, actual);
+                    }
+                };
+                stage.xProperty().addListener(boundsListener);
+                stage.yProperty().addListener(boundsListener);
+                stage.widthProperty().addListener(boundsListener);
+                stage.heightProperty().addListener(boundsListener);
                 floatingStages.put(panelId, stage);
             }
             stage.setX(b.x());

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -206,6 +206,16 @@ public final class MainController {
     private DockManager dockManager;
     /** Floating windows currently owned by the dock host, keyed by panel id. */
     private final java.util.Map<String, Stage> floatingStages = new java.util.LinkedHashMap<>();
+
+    /**
+     * Panel ids that compete for the CENTER dock zone. Treated as a
+     * single-selection slot by {@link #toggleCenterDockPanel(String)} —
+     * only one is visible at a time while tabbed CENTER targets are
+     * deferred.
+     */
+    private static final java.util.List<String> CENTER_ZONE_PANELS = java.util.List.of(
+            DefaultWorkspaces.PANEL_ARRANGEMENT, DefaultWorkspaces.PANEL_MIXER,
+            DefaultWorkspaces.PANEL_EDITOR, DefaultWorkspaces.PANEL_MASTERING);
     /**
      * Suppresses {@code DockManager.Host.onLayoutChanged} side-effects while
      * the dock manager is being seeded. Without this flag the initial
@@ -1797,9 +1807,7 @@ public final class MainController {
         }
         // Hide every other CENTER panel before showing the requested one so
         // reconciliation sees exactly one visible CENTER entry.
-        for (String other : java.util.List.of(
-                DefaultWorkspaces.PANEL_ARRANGEMENT, DefaultWorkspaces.PANEL_MIXER,
-                DefaultWorkspaces.PANEL_EDITOR, DefaultWorkspaces.PANEL_MASTERING)) {
+        for (String other : CENTER_ZONE_PANELS) {
             if (!other.equals(panelId)) dockManager.setVisible(other, false);
         }
         dockManager.setVisible(panelId, true);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1176,13 +1176,13 @@ public final class MainController {
                     // viewNavigationController / browserPanelController as the
                     // underlying mechanism (not a parallel one).
                     @Override public void onToggleDockMixer() {
-                        if (dockManager != null) dockManager.toggleVisible(DefaultWorkspaces.PANEL_MIXER);
+                        toggleCenterDockPanel(DefaultWorkspaces.PANEL_MIXER);
                     }
                     @Override public void onToggleDockBrowser() {
                         if (dockManager != null) dockManager.toggleVisible(DefaultWorkspaces.PANEL_BROWSER);
                     }
                     @Override public void onToggleDockArrangement() {
-                        if (dockManager != null) dockManager.toggleVisible(DefaultWorkspaces.PANEL_ARRANGEMENT);
+                        toggleCenterDockPanel(DefaultWorkspaces.PANEL_ARRANGEMENT);
                     }
                     @Override public void onMixerToggleAB() {
                         if (viewNavigationController != null
@@ -1758,10 +1758,6 @@ public final class MainController {
         if (browserPanelController != null && browserPanelController.getBrowserPanel() != null) {
             dockManager.register(browserPanelController.getBrowserPanel());
         }
-        // TelemetrySetupPanel implements Dockable as a contract addition; it
-        // is owned by TelemetryView (plugin view) and is not yet registered
-        // as a top-level dock surface — a future story will elevate it.
-
         // Align initial dock visibility with the live chrome before
         // releasing the host's reconciliation guard, so the first
         // toggleVisible() the user invokes reflects the actual seam (e.g.
@@ -1776,6 +1772,37 @@ public final class MainController {
         dockManager.setVisible(DefaultWorkspaces.PANEL_BROWSER,
                 browserPanelController != null && browserPanelController.isPanelVisible());
         dockHostReconciliationSuppressed = false;
+    }
+
+    /**
+     * CENTER zone is a single-selection slot — only one of
+     * {@link DefaultWorkspaces#PANEL_ARRANGEMENT},
+     * {@link DefaultWorkspaces#PANEL_MIXER},
+     * {@link DefaultWorkspaces#PANEL_EDITOR}, or
+     * {@link DefaultWorkspaces#PANEL_MASTERING} can be visible at a time.
+     * Wraps {@link DockManager#toggleVisible(String)} so that toggling a
+     * CENTER panel ON automatically hides any other CENTER panel that was
+     * visible (avoiding order-dependent "last entry wins" reconciliation).
+     * Toggling the active CENTER panel OFF is a no-op (radio-button
+     * behaviour) — the slot has to hold something while the story defers
+     * tabbed CENTER targets.
+     */
+    private void toggleCenterDockPanel(String panelId) {
+        if (dockManager == null) return;
+        DockEntry entry = dockManager.layout().entry(panelId).orElse(null);
+        if (entry == null) return;
+        if (entry.visible()) {
+            // Active panel — radio-button behaviour: no-op.
+            return;
+        }
+        // Hide every other CENTER panel before showing the requested one so
+        // reconciliation sees exactly one visible CENTER entry.
+        for (String other : java.util.List.of(
+                DefaultWorkspaces.PANEL_ARRANGEMENT, DefaultWorkspaces.PANEL_MIXER,
+                DefaultWorkspaces.PANEL_EDITOR, DefaultWorkspaces.PANEL_MASTERING)) {
+            if (!other.equals(panelId)) dockManager.setVisible(other, false);
+        }
+        dockManager.setVisible(panelId, true);
     }
 
     /**
@@ -1843,13 +1870,13 @@ public final class MainController {
             DawView active = viewNavigationController.getActiveView();
             if (wantVisible && active != view) {
                 viewNavigationController.switchView(view);
-            } else if (!wantVisible && active == view && view != DawView.ARRANGEMENT) {
-                // Hide-on-CENTER for a non-arrangement panel: fall back to
-                // arrangement so the dock layout's visible=false matches the
-                // live chrome (the story defers tabbed CENTER targets, so the
-                // slot has to hold *something*).
-                viewNavigationController.switchView(DawView.ARRANGEMENT);
             }
+            // No hide-fallback: CENTER is a single-selection slot (see
+            // {@link MainController#toggleCenterDockPanel}). Hiding a panel
+            // that isn't the active CENTER view is already consistent with
+            // the live chrome; hiding the active one is a no-op (the slot
+            // has to hold something while the story defers tabbed CENTER
+            // targets, so a sibling becoming visible is what changes it).
         }
 
         private void ensureFloating(String panelId, DockEntry entry) {
@@ -1861,18 +1888,44 @@ public final class MainController {
             if (stage == null) {
                 stage = new Stage();
                 stage.setTitle(displayNameFor(panelId));
+                // Own the floating window to the primary stage so it closes
+                // when the app exits (cascaded from MainController's
+                // setOnHidden lifetime cleanup on the primary Stage).
+                if (rootPane.getScene() != null && rootPane.getScene().getWindow() != null) {
+                    stage.initOwner(rootPane.getScene().getWindow());
+                }
                 javafx.scene.Parent parent = content.getParent();
-                if (parent instanceof Pane pane) {
+                // BorderPane extends Pane — test for BorderPane (the rootPane
+                // slot setter case) first so generic Pane removal doesn't
+                // strip a node out of a BorderPane slot without clearing the
+                // setter.
+                if (parent instanceof javafx.scene.layout.BorderPane bp) {
+                    if (bp.getCenter() == content) bp.setCenter(null);
+                    else if (bp.getLeft() == content) bp.setLeft(null);
+                    else if (bp.getRight() == content) bp.setRight(null);
+                    else if (bp.getTop() == content) bp.setTop(null);
+                    else if (bp.getBottom() == content) bp.setBottom(null);
+                } else if (parent instanceof Pane pane) {
                     pane.getChildren().remove(content);
-                } else if (rootPane.getCenter() == content) rootPane.setCenter(null);
-                else if (rootPane.getLeft() == content) rootPane.setLeft(null);
-                else if (rootPane.getRight() == content) rootPane.setRight(null);
-                else if (rootPane.getTop() == content) rootPane.setTop(null);
-                else if (rootPane.getBottom() == content) rootPane.setBottom(null);
+                }
                 javafx.scene.Scene scene = new javafx.scene.Scene(
                         content instanceof javafx.scene.Parent p ? p
                                 : new javafx.scene.layout.StackPane(content));
+                // Apply the active theme + register for live re-theming so
+                // the floating panel inherits root-pane styling instead of
+                // showing the default JavaFX white background.
+                com.benesquivelmusic.daw.app.ui.theme.ThemeManager.getDefault().applyTo(scene);
                 stage.setScene(scene);
+                // When the user dismisses the floating window via the OS
+                // close button, mark the panel hidden in the dock layout so
+                // the manager doesn't re-open it on the next layout change.
+                final String idForHandler = panelId;
+                stage.setOnCloseRequest(e -> {
+                    floatingStages.remove(idForHandler);
+                    if (dockManager != null) {
+                        dockManager.setVisible(idForHandler, false);
+                    }
+                });
                 floatingStages.put(panelId, stage);
             }
             stage.setX(b.x());

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -38,6 +38,11 @@ import com.benesquivelmusic.daw.core.undo.UndoManager;
 import com.benesquivelmusic.daw.sdk.audio.AudioBackend;
 import com.benesquivelmusic.daw.sdk.audio.AudioChannelInfo;
 import com.benesquivelmusic.daw.sdk.audio.DeviceId;
+import com.benesquivelmusic.daw.app.ui.dock.DockEntry;
+import com.benesquivelmusic.daw.app.ui.dock.DockLayout;
+import com.benesquivelmusic.daw.app.ui.dock.DockManager;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 
 import javafx.animation.FadeTransition;
@@ -49,6 +54,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.*;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 import javafx.util.Duration;
@@ -197,7 +203,18 @@ public final class MainController {
     private KeyBindingManager keyBindingManager;
     private CommandPaletteView commandPaletteView;
     private WorkspaceManager workspaceManager;
-    private com.benesquivelmusic.daw.app.ui.dock.DockManager dockManager;
+    private DockManager dockManager;
+    /** Floating windows currently owned by the dock host, keyed by panel id. */
+    private final java.util.Map<String, Stage> floatingStages = new java.util.LinkedHashMap<>();
+    /**
+     * Suppresses {@code DockManager.Host.onLayoutChanged} side-effects while
+     * the dock manager is being seeded. Without this flag the initial
+     * {@code register(mixer)} would fire a layout snapshot saying
+     * "mixer visible in BOTTOM" and the host would call
+     * {@code viewNavigationController.switchView(MIXER)} at startup —
+     * stealing the centre slot from the arrangement view the user persisted.
+     */
+    private boolean dockHostReconciliationSuppressed = true;
     /**
      * Story 190 — Snapshot History Browser. Owns the data-only
      * SnapshotBrowserService and the lazy SnapshotBrowser dialog;
@@ -457,6 +474,14 @@ public final class MainController {
         viewNavigationController.initializeSnapControls();
         viewNavigationController.initializeZoomControls();
         createMenuBar();
+        // Story 285 — instantiate the single application-wide DockManager
+        // and register every top-level Dockable. Must run after both
+        // viewNavigationController.initializeViewNavigation() (mixer/editor/
+        // mastering views exist) and buildBrowserPanel(...) (browser panel
+        // exists), and after createMenuBar() so workspaceManager is live and
+        // captureDockLayoutJson()/applyDockLayoutJson() flow through this
+        // manager.
+        installDockManager();
         selectionModel.setSelectionChangeListener(() -> {
             if (menuBarController != null) menuBarController.syncMenuState();
         });
@@ -1146,31 +1171,18 @@ public final class MainController {
                         }
                     }
                     // ── Dockable panels (F3 / F4 / F5) ────────────────────
-                    // Preserve legacy visible behavior unless the docking
-                    // path is the only available way to service the toggle.
+                    // Story 285 — the dock manager is the single entry point;
+                    // its Host then calls into the legacy
+                    // viewNavigationController / browserPanelController as the
+                    // underlying mechanism (not a parallel one).
                     @Override public void onToggleDockMixer() {
-                        if (viewNavigationController != null) {
-                            viewNavigationController.switchView(DawView.MIXER);
-                        } else if (dockManager != null
-                                && dockManager.layout().contains(DefaultWorkspaces.PANEL_MIXER)) {
-                            dockManager.toggleVisible(DefaultWorkspaces.PANEL_MIXER);
-                        }
+                        if (dockManager != null) dockManager.toggleVisible(DefaultWorkspaces.PANEL_MIXER);
                     }
                     @Override public void onToggleDockBrowser() {
-                        if (browserPanelController != null) {
-                            browserPanelController.toggleBrowserPanel();
-                        } else if (dockManager != null
-                                && dockManager.layout().contains(DefaultWorkspaces.PANEL_BROWSER)) {
-                            dockManager.toggleVisible(DefaultWorkspaces.PANEL_BROWSER);
-                        }
+                        if (dockManager != null) dockManager.toggleVisible(DefaultWorkspaces.PANEL_BROWSER);
                     }
                     @Override public void onToggleDockArrangement() {
-                        if (viewNavigationController != null) {
-                            viewNavigationController.switchView(DawView.ARRANGEMENT);
-                        } else if (dockManager != null
-                                && dockManager.layout().contains(DefaultWorkspaces.PANEL_ARRANGEMENT)) {
-                            dockManager.toggleVisible(DefaultWorkspaces.PANEL_ARRANGEMENT);
-                        }
+                        if (dockManager != null) dockManager.toggleVisible(DefaultWorkspaces.PANEL_ARRANGEMENT);
                     }
                     @Override public void onMixerToggleAB() {
                         if (viewNavigationController != null
@@ -1609,11 +1621,6 @@ public final class MainController {
     }
 
     private void installWorkspacesMenu(javafx.scene.control.MenuBar bar) {
-        // Do not create/register a DockManager until the JavaFX docking
-        // adapter is available to reconcile layout changes back into the
-        // existing panel controllers. Creating it early would make workspace
-        // apply and keyboard actions mutate dock state without updating the
-        // visible UI, effectively bypassing legacy behavior.
         workspaceManager = new WorkspaceManager(buildWorkspaceHost());
         WorkspacesMenu menuBuilder = new WorkspacesMenu(
                 workspaceManager,
@@ -1720,28 +1727,188 @@ public final class MainController {
     }
 
     /**
-     * Registers the well-known top-level panels (arrangement, mixer,
-     * editor, mastering, browser) with the {@link
-     * com.benesquivelmusic.daw.app.ui.dock.DockManager} so workspace
-     * switches can save/restore their dock placement. Each registration
-     * is a lightweight {@link com.benesquivelmusic.daw.app.ui.dock.Dockable}
-     * — a record carrying the stable id, display name, icon, and
-     * preferred zone.
+     * Adapter Dockable for the arrangement view — the cached arrangement
+     * node is owned by {@link ViewNavigationController}'s {@code viewCache}
+     * (a {@code Node}, not a class that can implement {@link Dockable}), so
+     * the contract is supplied here.
      */
-    private void registerDockablePanels(com.benesquivelmusic.daw.app.ui.dock.DockManager dm) {
-        record Panel(String dockId, String displayName, String iconName,
-                     com.benesquivelmusic.daw.app.ui.dock.DockZone preferredZone)
-                implements com.benesquivelmusic.daw.app.ui.dock.Dockable { }
-        dm.register(new Panel(DefaultWorkspaces.PANEL_ARRANGEMENT, "Arrangement",
-                "TIMELINE", com.benesquivelmusic.daw.app.ui.dock.DockZone.CENTER));
-        dm.register(new Panel(DefaultWorkspaces.PANEL_MIXER, "Mixer",
-                "MIXER", com.benesquivelmusic.daw.app.ui.dock.DockZone.BOTTOM));
-        dm.register(new Panel(DefaultWorkspaces.PANEL_EDITOR, "Editor",
-                "EDITOR", com.benesquivelmusic.daw.app.ui.dock.DockZone.CENTER));
-        dm.register(new Panel(DefaultWorkspaces.PANEL_MASTERING, "Mastering",
-                "MASTERING", com.benesquivelmusic.daw.app.ui.dock.DockZone.CENTER));
-        dm.register(new Panel(DefaultWorkspaces.PANEL_BROWSER, "Browser",
-                "BROWSER", com.benesquivelmusic.daw.app.ui.dock.DockZone.LEFT));
+    private record ArrangementDockable() implements Dockable {
+        @Override public String dockId()          { return DefaultWorkspaces.PANEL_ARRANGEMENT; }
+        @Override public String displayName()     { return "Arrangement"; }
+        @Override public String iconName()        { return "TIMELINE"; }
+        @Override public DockZone preferredZone() { return DockZone.CENTER; }
+    }
+
+    /**
+     * Story 285 — instantiates the single application-wide {@link DockManager}
+     * and registers every top-level panel. Called once from
+     * {@link #initialize()} after the menu bar / workspace manager are wired.
+     */
+    private void installDockManager() {
+        dockManager = new DockManager(new MainControllerDockHost());
+        dockManager.register(new ArrangementDockable());
+        if (viewNavigationController != null) {
+            MixerView mixer = viewNavigationController.getMixerView();
+            if (mixer != null) dockManager.register(mixer);
+            EditorView editor = viewNavigationController.getEditorView();
+            if (editor != null) dockManager.register(editor);
+            MasteringView mastering = viewNavigationController.getMasteringView();
+            if (mastering != null) dockManager.register(mastering);
+        }
+        if (browserPanelController != null && browserPanelController.getBrowserPanel() != null) {
+            dockManager.register(browserPanelController.getBrowserPanel());
+        }
+        // TelemetrySetupPanel implements Dockable as a contract addition; it
+        // is owned by TelemetryView (plugin view) and is not yet registered
+        // as a top-level dock surface — a future story will elevate it.
+
+        // Align initial dock visibility with the live chrome before
+        // releasing the host's reconciliation guard, so the first
+        // toggleVisible() the user invokes reflects the actual seam (e.g.
+        // F3 from a hidden mixer flips visible=false → true).
+        DawView active = viewNavigationController == null
+                ? DawView.ARRANGEMENT
+                : viewNavigationController.getActiveView();
+        dockManager.setVisible(DefaultWorkspaces.PANEL_ARRANGEMENT, active == DawView.ARRANGEMENT);
+        dockManager.setVisible(DefaultWorkspaces.PANEL_MIXER, active == DawView.MIXER);
+        dockManager.setVisible(DefaultWorkspaces.PANEL_EDITOR, active == DawView.EDITOR);
+        dockManager.setVisible(DefaultWorkspaces.PANEL_MASTERING, active == DawView.MASTERING);
+        dockManager.setVisible(DefaultWorkspaces.PANEL_BROWSER,
+                browserPanelController != null && browserPanelController.isPanelVisible());
+        dockHostReconciliationSuppressed = false;
+    }
+
+    /**
+     * {@link DockManager.Host} that reconciles dock layout snapshots back
+     * into the existing controllers ({@link BrowserPanelController},
+     * {@link ViewNavigationController}) and a per-panel floating {@link Stage}
+     * registry. Idempotent: an {@code onLayoutChanged} that matches the
+     * current actual state of the chrome is a no-op, so the first fire after
+     * register/applyLayout cannot clobber the FXML-mounted view.
+     */
+    private final class MainControllerDockHost implements DockManager.Host {
+
+        @Override public void onLayoutChanged(DockLayout newLayout) {
+            if (dockHostReconciliationSuppressed) return;
+            for (DockEntry entry : newLayout.entries().values()) {
+                reconcile(entry);
+            }
+        }
+
+        @Override public boolean isScreenAvailableFor(
+                com.benesquivelmusic.daw.sdk.ui.Rectangle2D bounds) {
+            if (bounds == null) return false;
+            javafx.geometry.Rectangle2D fxBounds = new javafx.geometry.Rectangle2D(
+                    bounds.x(), bounds.y(),
+                    Math.max(1, bounds.width()), Math.max(1, bounds.height()));
+            for (Screen screen : Screen.getScreens()) {
+                if (screen.getBounds().intersects(fxBounds)) return true;
+            }
+            return false;
+        }
+
+        private void reconcile(DockEntry entry) {
+            String id = entry.panelId();
+            if (entry.zone() == DockZone.FLOATING) {
+                ensureFloating(id, entry);
+                return;
+            }
+            // If a Stage was previously open for this panel, close it now
+            // (panel was re-docked).
+            Stage existing = floatingStages.remove(id);
+            if (existing != null) existing.close();
+            switch (id) {
+                case DefaultWorkspaces.PANEL_BROWSER -> reconcileBrowser(entry.visible());
+                case DefaultWorkspaces.PANEL_ARRANGEMENT -> reconcileCenterView(
+                        entry.visible(), DawView.ARRANGEMENT);
+                case DefaultWorkspaces.PANEL_MIXER -> reconcileCenterView(
+                        entry.visible(), DawView.MIXER);
+                case DefaultWorkspaces.PANEL_EDITOR -> reconcileCenterView(
+                        entry.visible(), DawView.EDITOR);
+                case DefaultWorkspaces.PANEL_MASTERING -> reconcileCenterView(
+                        entry.visible(), DawView.MASTERING);
+                default -> { /* unknown id — forward compatible */ }
+            }
+        }
+
+        private void reconcileBrowser(boolean wantVisible) {
+            if (browserPanelController == null) return;
+            if (browserPanelController.isPanelVisible() != wantVisible) {
+                browserPanelController.toggleBrowserPanel();
+            }
+        }
+
+        private void reconcileCenterView(boolean wantVisible, DawView view) {
+            if (viewNavigationController == null) return;
+            DawView active = viewNavigationController.getActiveView();
+            if (wantVisible && active != view) {
+                viewNavigationController.switchView(view);
+            } else if (!wantVisible && active == view && view != DawView.ARRANGEMENT) {
+                // Hide-on-CENTER for a non-arrangement panel: fall back to
+                // arrangement so the dock layout's visible=false matches the
+                // live chrome (the story defers tabbed CENTER targets, so the
+                // slot has to hold *something*).
+                viewNavigationController.switchView(DawView.ARRANGEMENT);
+            }
+        }
+
+        private void ensureFloating(String panelId, DockEntry entry) {
+            Node content = resolveNode(panelId);
+            if (content == null) return;
+            com.benesquivelmusic.daw.sdk.ui.Rectangle2D b = entry.floatingBounds();
+            if (b == null) return;
+            Stage stage = floatingStages.get(panelId);
+            if (stage == null) {
+                stage = new Stage();
+                stage.setTitle(displayNameFor(panelId));
+                javafx.scene.Parent parent = content.getParent();
+                if (parent instanceof Pane pane) {
+                    pane.getChildren().remove(content);
+                } else if (rootPane.getCenter() == content) rootPane.setCenter(null);
+                else if (rootPane.getLeft() == content) rootPane.setLeft(null);
+                else if (rootPane.getRight() == content) rootPane.setRight(null);
+                else if (rootPane.getTop() == content) rootPane.setTop(null);
+                else if (rootPane.getBottom() == content) rootPane.setBottom(null);
+                javafx.scene.Scene scene = new javafx.scene.Scene(
+                        content instanceof javafx.scene.Parent p ? p
+                                : new javafx.scene.layout.StackPane(content));
+                stage.setScene(scene);
+                floatingStages.put(panelId, stage);
+            }
+            stage.setX(b.x());
+            stage.setY(b.y());
+            stage.setWidth(b.width());
+            stage.setHeight(b.height());
+            if (entry.visible() && !stage.isShowing()) stage.show();
+            else if (!entry.visible() && stage.isShowing()) stage.hide();
+        }
+
+        private Node resolveNode(String panelId) {
+            return switch (panelId) {
+                case DefaultWorkspaces.PANEL_BROWSER ->
+                        browserPanelController == null ? null
+                                : browserPanelController.getBrowserPanel();
+                case DefaultWorkspaces.PANEL_MIXER ->
+                        viewNavigationController == null ? null
+                                : viewNavigationController.getMixerView();
+                case DefaultWorkspaces.PANEL_EDITOR ->
+                        viewNavigationController == null ? null
+                                : viewNavigationController.getEditorView();
+                case DefaultWorkspaces.PANEL_MASTERING ->
+                        viewNavigationController == null ? null
+                                : viewNavigationController.getMasteringView();
+                case DefaultWorkspaces.PANEL_ARRANGEMENT ->
+                        viewNavigationController == null ? null
+                                : viewNavigationController.getCachedArrangementNode();
+                default -> null;
+            };
+        }
+
+        private String displayNameFor(String panelId) {
+            Dockable d = dockManager == null ? null
+                    : dockManager.panel(panelId).orElse(null);
+            return d == null ? panelId : d.displayName();
+        }
     }
 
     private String promptWorkspaceName() {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1904,6 +1904,13 @@ public final class MainController {
                 else if (bp.getBottom() == content) bp.setBottom(null);
             } else if (parent instanceof Pane pane) {
                 pane.getChildren().remove(content);
+            } else if (parent == null && content instanceof javafx.scene.Parent p
+                    && p.getScene() != null) {
+                // The node is a Scene root (getParent() == null but still held
+                // by Scene.setRoot). Replace it with an empty Group so the node
+                // can be re-parented into the main BorderPane without JavaFX
+                // throwing "already set as root of another scene".
+                p.getScene().setRoot(new javafx.scene.Group());
             }
         }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1950,7 +1950,6 @@ public final class MainController {
                 // zone so it isn't trapped in a hidden-floating state.
                 final String idForHandler = panelId;
                 stage.setOnCloseRequest(e -> {
-                    floatingStages.remove(idForHandler);
                     if (dockManager != null) {
                         DockZone preferred = dockManager.panel(idForHandler)
                                 .map(Dockable::preferredZone)

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MasteringView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MasteringView.java
@@ -2,6 +2,8 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.display.LevelMeterDisplay;
 import com.benesquivelmusic.daw.app.ui.display.LoudnessDisplay;
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.core.mastering.MasteringChain;
@@ -45,7 +47,7 @@ import java.util.Objects;
  * <p>Uses existing CSS classes: {@code .content-area}, {@code .panel-header},
  * {@code .mixer-channel}.</p>
  */
-public final class MasteringView extends VBox {
+public final class MasteringView extends VBox implements Dockable {
 
     private static final double STAGE_CARD_WIDTH = 140;
     private static final double METER_WIDTH = 10;
@@ -190,6 +192,12 @@ public final class MasteringView extends VBox {
             }
         });
     }
+
+    // ── Dockable contract (story 285) ────────────────────────────────────────
+    @Override public String dockId()            { return DefaultWorkspaces.PANEL_MASTERING; }
+    @Override public String displayName()       { return "Mastering"; }
+    @Override public String iconName()          { return "MASTERING"; }
+    @Override public DockZone preferredZone()   { return DockZone.CENTER; }
 
     /**
      * Rebuilds the stage cards from the current mastering chain state.

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java
@@ -2,6 +2,8 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.display.InputMeterStrip;
 import com.benesquivelmusic.daw.app.ui.display.LevelMeterDisplay;
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
@@ -75,7 +77,7 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * {@code .mixer-channel-name}, {@code .mixer-fader}.</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
-public final class MixerView extends VBox {
+public final class MixerView extends VBox implements Dockable {
 
     private static final Logger LOG = Logger.getLogger(MixerView.class.getName());
     /**
@@ -459,6 +461,12 @@ public final class MixerView extends VBox {
 
         refresh();
     }
+
+    // ── Dockable contract (story 285) ────────────────────────────────────────
+    @Override public String dockId()            { return DefaultWorkspaces.PANEL_MIXER; }
+    @Override public String displayName()       { return "Mixer"; }
+    @Override public String iconName()          { return "MIXER"; }
+    @Override public DockZone preferredZone()   { return DockZone.BOTTOM; }
 
     private boolean mainAreaContains(javafx.scene.Node node) {
         return mainArea != null && mainArea.getChildren().contains(node);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TelemetrySetupPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TelemetrySetupPanel.java
@@ -1,7 +1,5 @@
 package com.benesquivelmusic.daw.app.ui;
 
-import com.benesquivelmusic.daw.app.ui.dock.Dockable;
-import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.telemetry.BoundaryResponsePanel;
 import com.benesquivelmusic.daw.app.ui.telemetry.RoomModesPanel;
 import com.benesquivelmusic.daw.core.telemetry.RoomConfiguration;
@@ -30,7 +28,7 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * {@link InputPortSelectionDialog}.</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
-public final class TelemetrySetupPanel extends ScrollPane implements Dockable {
+public final class TelemetrySetupPanel extends ScrollPane {
 
     private static final String BACKGROUND_STYLE =
             "-fx-background-color: #1a1a2e; -fx-background: #1a1a2e;";
@@ -137,11 +135,11 @@ public final class TelemetrySetupPanel extends ScrollPane implements Dockable {
      */
     private boolean autoSizeActive = false;
 
-    // ── Dockable contract (story 285) ────────────────────────────────────────
-    @Override public String dockId()            { return DefaultWorkspaces.PANEL_TELEMETRY; }
-    @Override public String displayName()       { return "Telemetry"; }
-    @Override public String iconName()          { return "TELEMETRY"; }
-    @Override public DockZone preferredZone()   { return DockZone.RIGHT; }
+    // ── Dockable contract deferred ───────────────────────────────────────────
+    // Story 285 — TelemetrySetupPanel is owned by TelemetryView (plugin view)
+    // and is not yet wired as a top-level dock surface, so the Dockable
+    // contract is not published here. A future story can re-add it (and
+    // PANEL_TELEMETRY in DefaultWorkspaces) once there is a consumer.
 
     /**
      * Creates a new telemetry setup panel with sensible defaults.

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TelemetrySetupPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TelemetrySetupPanel.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.telemetry.BoundaryResponsePanel;
 import com.benesquivelmusic.daw.app.ui.telemetry.RoomModesPanel;
 import com.benesquivelmusic.daw.core.telemetry.RoomConfiguration;
@@ -28,7 +30,7 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * {@link InputPortSelectionDialog}.</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
-public final class TelemetrySetupPanel extends ScrollPane {
+public final class TelemetrySetupPanel extends ScrollPane implements Dockable {
 
     private static final String BACKGROUND_STYLE =
             "-fx-background-color: #1a1a2e; -fx-background: #1a1a2e;";
@@ -134,6 +136,12 @@ public final class TelemetrySetupPanel extends ScrollPane {
      * moment the user manually edits a dimension input.
      */
     private boolean autoSizeActive = false;
+
+    // ── Dockable contract (story 285) ────────────────────────────────────────
+    @Override public String dockId()            { return DefaultWorkspaces.PANEL_TELEMETRY; }
+    @Override public String displayName()       { return "Telemetry"; }
+    @Override public String iconName()          { return "TELEMETRY"; }
+    @Override public DockZone preferredZone()   { return DockZone.RIGHT; }
 
     /**
      * Creates a new telemetry setup panel with sensible defaults.

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ViewNavigationController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ViewNavigationController.java
@@ -880,6 +880,27 @@ final class ViewNavigationController {
     }
 
     /**
+     * Returns the mastering view instance.
+     *
+     * @return the mastering view
+     */
+    MasteringView getMasteringView() {
+        return masteringView;
+    }
+
+    /**
+     * Returns the cached arrangement {@link Node} (FXML-mounted
+     * {@code .arrangement-panel}) — story 285 dock host uses this when the
+     * arrangement panel is detached into a floating window.
+     *
+     * @return the arrangement node (may be {@code null} before
+     *         {@link #initializeViewNavigation()} has run)
+     */
+    Node getCachedArrangementNode() {
+        return viewCache.get(DawView.ARRANGEMENT);
+    }
+
+    /**
      * Replaces the mixer view (e.g. after a project reload) and updates the view cache.
      *
      * @param newMixerView the new mixer view instance

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ViewNavigationController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ViewNavigationController.java
@@ -862,6 +862,16 @@ final class ViewNavigationController {
     }
 
     /**
+     * Invalidates the active-view cache so the next {@link #switchView}
+     * call re-attaches the panel node even if it matches the stored active
+     * view. Used by the dock reconciler when a center panel transitions
+     * from FLOATING back to a docked zone.
+     */
+    void invalidateActiveViewCache() {
+        activeView = null;
+    }
+
+    /**
      * Returns the mixer view instance.
      *
      * @return the mixer view

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DockableImplementationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DockableImplementationTest.java
@@ -1,0 +1,120 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.project.DawProject;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 285 — every top-level panel must implement {@link Dockable}
+ * directly (no inner-record adapters) with the contract values the story
+ * specifies. The Dockable methods are pure and inspector-friendly; the
+ * panels still need the JavaFX toolkit because they extend {@code VBox} /
+ * {@code ScrollPane}.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class DockableImplementationTest {
+
+    @Test
+    void mixerViewImplementsDockable() throws Exception {
+        DawProject project = new DawProject("test", AudioFormat.STUDIO_QUALITY);
+        MixerView view = createOnFxThread(() -> new MixerView(project));
+        assertThat(view).isInstanceOf(Dockable.class);
+        Dockable d = view;
+        assertThat(d.dockId()).isEqualTo(DefaultWorkspaces.PANEL_MIXER);
+        assertThat(d.displayName()).isEqualTo("Mixer");
+        assertThat(d.iconName()).isEqualTo("MIXER");
+        assertThat(d.preferredZone()).isEqualTo(DockZone.BOTTOM);
+    }
+
+    @Test
+    void browserPanelImplementsDockable() throws Exception {
+        BrowserPanel view = createOnFxThread(BrowserPanel::new);
+        assertThat(view).isInstanceOf(Dockable.class);
+        Dockable d = view;
+        assertThat(d.dockId()).isEqualTo(DefaultWorkspaces.PANEL_BROWSER);
+        assertThat(d.displayName()).isEqualTo("Browser");
+        assertThat(d.iconName()).isEqualTo("BROWSER");
+        assertThat(d.preferredZone()).isEqualTo(DockZone.LEFT);
+    }
+
+    @Test
+    void editorViewImplementsDockable() throws Exception {
+        EditorView view = createOnFxThread(EditorView::new);
+        assertThat(view).isInstanceOf(Dockable.class);
+        Dockable d = view;
+        assertThat(d.dockId()).isEqualTo(DefaultWorkspaces.PANEL_EDITOR);
+        assertThat(d.displayName()).isEqualTo("Editor");
+        assertThat(d.iconName()).isEqualTo("EDITOR");
+        assertThat(d.preferredZone()).isEqualTo(DockZone.CENTER);
+    }
+
+    @Test
+    void masteringViewImplementsDockable() throws Exception {
+        MasteringView view = createOnFxThread(MasteringView::new);
+        assertThat(view).isInstanceOf(Dockable.class);
+        Dockable d = view;
+        assertThat(d.dockId()).isEqualTo(DefaultWorkspaces.PANEL_MASTERING);
+        assertThat(d.displayName()).isEqualTo("Mastering");
+        assertThat(d.iconName()).isEqualTo("MASTERING");
+        assertThat(d.preferredZone()).isEqualTo(DockZone.CENTER);
+    }
+
+    @Test
+    void telemetrySetupPanelImplementsDockable() throws Exception {
+        TelemetrySetupPanel view = createOnFxThread(TelemetrySetupPanel::new);
+        assertThat(view).isInstanceOf(Dockable.class);
+        Dockable d = view;
+        assertThat(d.dockId()).isEqualTo(DefaultWorkspaces.PANEL_TELEMETRY);
+        assertThat(d.displayName()).isEqualTo("Telemetry");
+        assertThat(d.iconName()).isEqualTo("TELEMETRY");
+        assertThat(d.preferredZone()).isEqualTo(DockZone.RIGHT);
+    }
+
+    @Test
+    void panelTelemetryConstantExists() {
+        // PANEL_TELEMETRY is the story 285 addition; deliberately NOT in
+        // DefaultWorkspaces.panelIds() because TelemetrySetupPanel is owned
+        // by TelemetryView (plugin view), not the top-level chrome.
+        assertThat(DefaultWorkspaces.PANEL_TELEMETRY).isEqualTo("telemetry");
+        assertThat(DefaultWorkspaces.panelIds())
+                .doesNotContain(DefaultWorkspaces.PANEL_TELEMETRY);
+    }
+
+    private interface FxSupplier<T> {
+        T get();
+    }
+
+    private static <T> T createOnFxThread(FxSupplier<T> supplier) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(supplier.get());
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("FX thread did not respond within 5s");
+        }
+        if (err.get() != null) {
+            throw new RuntimeException("Failed to construct on FX thread", err.get());
+        }
+        return ref.get();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DockableImplementationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DockableImplementationTest.java
@@ -71,26 +71,10 @@ class DockableImplementationTest {
         assertThat(d.preferredZone()).isEqualTo(DockZone.CENTER);
     }
 
-    @Test
-    void telemetrySetupPanelImplementsDockable() throws Exception {
-        TelemetrySetupPanel view = createOnFxThread(TelemetrySetupPanel::new);
-        assertThat(view).isInstanceOf(Dockable.class);
-        Dockable d = view;
-        assertThat(d.dockId()).isEqualTo(DefaultWorkspaces.PANEL_TELEMETRY);
-        assertThat(d.displayName()).isEqualTo("Telemetry");
-        assertThat(d.iconName()).isEqualTo("TELEMETRY");
-        assertThat(d.preferredZone()).isEqualTo(DockZone.RIGHT);
-    }
-
-    @Test
-    void panelTelemetryConstantExists() {
-        // PANEL_TELEMETRY is the story 285 addition; deliberately NOT in
-        // DefaultWorkspaces.panelIds() because TelemetrySetupPanel is owned
-        // by TelemetryView (plugin view), not the top-level chrome.
-        assertThat(DefaultWorkspaces.PANEL_TELEMETRY).isEqualTo("telemetry");
-        assertThat(DefaultWorkspaces.panelIds())
-                .doesNotContain(DefaultWorkspaces.PANEL_TELEMETRY);
-    }
+    // TelemetrySetupPanel Dockable contract intentionally deferred — see
+    // TelemetrySetupPanel.java: the panel is owned by TelemetryView (plugin
+    // view) and not yet registered as a top-level dock surface, so the
+    // contract isn't published until there is a consumer.
 
     private interface FxSupplier<T> {
         T get();

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RealPanelDockManagerRegistrationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RealPanelDockManagerRegistrationTest.java
@@ -1,0 +1,158 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.dock.DockLayout;
+import com.benesquivelmusic.daw.app.ui.dock.DockManager;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.app.ui.dock.FloatingWindowStore;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.project.DawProject;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 285 — registers the five top-level panels (now {@code implements
+ * Dockable} directly, not via inner-record adapters) with a real
+ * {@link DockManager} and verifies the layout/toggle contract.
+ *
+ * <p>This is the in-process counterpart to {@code
+ * MainControllerDockManagerInitializedTest} / {@code DockToggleHandlerTest}
+ * from the story brief — both of those require an FXML-loaded
+ * {@code MainController}, which is blocked by the documented
+ * {@code @ExtendWith} JPMS environmental failure in this sandbox. The
+ * registration path itself (story headline AC) is fully exercised here
+ * against the actual panel classes that {@code MainController.installDockManager()}
+ * registers.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class RealPanelDockManagerRegistrationTest {
+
+    private static final class CaptureHost implements DockManager.Host {
+        final List<DockLayout> snapshots = new ArrayList<>();
+        @Override public void onLayoutChanged(DockLayout newLayout) { snapshots.add(newLayout); }
+    }
+
+    @Test
+    void everyRegisteredPanelAppearsInLayout(@TempDir Path tmp) throws Exception {
+        DawProject project = new DawProject("test", AudioFormat.STUDIO_QUALITY);
+        MixerView mixer = createOnFxThread(() -> new MixerView(project));
+        BrowserPanel browser = createOnFxThread(BrowserPanel::new);
+        EditorView editor = createOnFxThread(EditorView::new);
+        MasteringView mastering = createOnFxThread(MasteringView::new);
+
+        CaptureHost host = new CaptureHost();
+        DockManager dm = new DockManager(host, new FloatingWindowStore(tmp.resolve("f.json")));
+
+        // Register every top-level Dockable, matching
+        // MainController.installDockManager().
+        dm.register(new ArrangementDockableFixture());
+        dm.register(mixer);
+        dm.register(editor);
+        dm.register(mastering);
+        dm.register(browser);
+
+        assertThat(dm.layout().contains(DefaultWorkspaces.PANEL_ARRANGEMENT)).isTrue();
+        assertThat(dm.layout().contains(DefaultWorkspaces.PANEL_MIXER)).isTrue();
+        assertThat(dm.layout().contains(DefaultWorkspaces.PANEL_EDITOR)).isTrue();
+        assertThat(dm.layout().contains(DefaultWorkspaces.PANEL_MASTERING)).isTrue();
+        assertThat(dm.layout().contains(DefaultWorkspaces.PANEL_BROWSER)).isTrue();
+
+        // Preferred zones come straight from the panels' own Dockable
+        // implementations — no parallel mapping table.
+        assertThat(dm.layout().entry(DefaultWorkspaces.PANEL_MIXER).orElseThrow().zone())
+                .isEqualTo(DockZone.BOTTOM);
+        assertThat(dm.layout().entry(DefaultWorkspaces.PANEL_BROWSER).orElseThrow().zone())
+                .isEqualTo(DockZone.LEFT);
+        assertThat(dm.layout().entry(DefaultWorkspaces.PANEL_EDITOR).orElseThrow().zone())
+                .isEqualTo(DockZone.CENTER);
+        assertThat(dm.layout().entry(DefaultWorkspaces.PANEL_MASTERING).orElseThrow().zone())
+                .isEqualTo(DockZone.CENTER);
+        assertThat(dm.layout().entry(DefaultWorkspaces.PANEL_ARRANGEMENT).orElseThrow().zone())
+                .isEqualTo(DockZone.CENTER);
+
+        // Every register fires onLayoutChanged at least once — that is the
+        // exact callback MainControllerDockHost uses to reconcile chrome.
+        assertThat(host.snapshots).isNotEmpty();
+    }
+
+    @Test
+    void toggleVisibleFlipsMixerEntry(@TempDir Path tmp) throws Exception {
+        DawProject project = new DawProject("test", AudioFormat.STUDIO_QUALITY);
+        MixerView mixer = createOnFxThread(() -> new MixerView(project));
+        DockManager dm = new DockManager(
+                new CaptureHost(), new FloatingWindowStore(tmp.resolve("f.json")));
+        dm.register(mixer);
+
+        boolean initial = dm.layout().entry(DefaultWorkspaces.PANEL_MIXER).orElseThrow().visible();
+        dm.toggleVisible(DefaultWorkspaces.PANEL_MIXER);
+        boolean after = dm.layout().entry(DefaultWorkspaces.PANEL_MIXER).orElseThrow().visible();
+        assertThat(after).isEqualTo(!initial);
+        dm.toggleVisible(DefaultWorkspaces.PANEL_MIXER);
+        assertThat(dm.layout().entry(DefaultWorkspaces.PANEL_MIXER).orElseThrow().visible())
+                .isEqualTo(initial);
+    }
+
+    @Test
+    void toggleVisibleFlipsBrowserAndArrangement(@TempDir Path tmp) throws Exception {
+        BrowserPanel browser = createOnFxThread(BrowserPanel::new);
+        DockManager dm = new DockManager(
+                new CaptureHost(), new FloatingWindowStore(tmp.resolve("f.json")));
+        dm.register(browser);
+        dm.register(new ArrangementDockableFixture());
+
+        dm.toggleVisible(DefaultWorkspaces.PANEL_BROWSER);
+        dm.toggleVisible(DefaultWorkspaces.PANEL_ARRANGEMENT);
+        // Both flipped from the default visible=true to false.
+        assertThat(dm.layout().entry(DefaultWorkspaces.PANEL_BROWSER).orElseThrow().visible())
+                .isFalse();
+        assertThat(dm.layout().entry(DefaultWorkspaces.PANEL_ARRANGEMENT).orElseThrow().visible())
+                .isFalse();
+    }
+
+    /** Mirrors MainController.ArrangementDockable — separate to avoid touching the inner type. */
+    private record ArrangementDockableFixture() implements Dockable {
+        @Override public String dockId() { return DefaultWorkspaces.PANEL_ARRANGEMENT; }
+        @Override public String displayName() { return "Arrangement"; }
+        @Override public String iconName() { return "TIMELINE"; }
+        @Override public DockZone preferredZone() { return DockZone.CENTER; }
+    }
+
+    private interface FxSupplier<T> {
+        T get();
+    }
+
+    private static <T> T createOnFxThread(FxSupplier<T> supplier) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(supplier.get());
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("FX thread did not respond within 5s");
+        }
+        if (err.get() != null) {
+            throw new RuntimeException("Failed to construct on FX thread", err.get());
+        }
+        return ref.get();
+    }
+}


### PR DESCRIPTION
# Instantiate DockManager in MainController and Make Top-Level Panels Implement Dockable

## Motivation

User story 195 — "Resizable and Detachable Dockable Panels" — calls for every top-level panel (`ArrangementView`, `MixerView`, `BrowserPanel`, `EditorView`, `TelemetrySetupPanel`, `MasteringChainView`, etc.) to implement a `Dockable` interface, register with a `DockManager`, drag between dock zones, and float out to a `Stage`. The core types are implemented and unit-tested:

- `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockManager.java`
- `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/Dockable.java`
- `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockZone.java`
- `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockEntry.java`
- `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockLayout.java`
- `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockLayoutJson.java`
- `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/FloatingWindowStore.java`
- `DockManagerTest`, `WorkspaceDockIntegrationTest` cover register / move / float / persist / monitor-disconnect.

But:

```
$ grep -rn 'new DockManager\b' daw-app/src/main/
(no matches)
$ grep -rn 'implements .*Dockable\|implements Dockable\b' daw-app/src/main/
daw-app/.../MainController.java:1731:   private void registerDockablePanels(...) {
    record Panel(...) implements com.benesquivelmusic.daw.app.ui.dock.Dockable { }
```

Nothing in production instantiates `DockManager`. The one `Dockable` implementation is an inner `record` inside `registerDockablePanels(DockManager dm)` — a method that itself is **never called** (no caller of `registerDockablePanels` exists anywhere in the source tree). `MainController` carries an explicit block-comment at line 1612 — *"Do not create/register a DockManager until the JavaFX docking adapter is available to reconcile layout changes back into the existing panel controllers"* — and the `private com.benesquivelmusic.daw.app.ui.dock.DockManager dockManager;` field at line 200 is read by `onToggleDockMixer` / `onToggleDockBrowser` / `onToggleDockArrangement` (line 1151-1174) only on the `else if (dockManager != null …)` branch, which is forever unreachable because the field is forever null.

Net effect: every "dock" feature shipped by story 195 lives only in tests. `MixerView`, `BrowserPanel`, `EditorView`, `MasteringView`, `ArrangementCanvas`, `TelemetrySetupPanel`, etc. are plain `Region`/`Node` subclasses — none of them implements `Dockable`. The F3 / F4 / F5 keyboard shortcuts fall through to the legacy `viewNavigationController.switchView(...)` / `browserPanelController.toggleBrowserPanel()` path; floating windows for panels do not exist; `WorkspaceManager` (story 193) saves panel show/hide booleans but never restores dock layout because there is no live dock state.

This is also the explicit blocker for user story 282 (Mission Control). `LayoutManager` (story 282) ships its own `Host` bridge (`captureDockLayoutJson` / `applyDockLayoutJson`) intended to flow through `DockManager`, but `LayoutManager` is itself never instantiated in production either — that gap is the subject of a sibling story.

## Goals

- Instantiate the single application-wide `DockManager` in `MainController` once the JavaFX scene graph is mounted. The block-comment at `MainController.java:1611-1616` is the seam: delete the "Do not create/register" caveat and create the manager using a real `DockManager.Host` that wraps the existing `BorderPane` chrome (top / left / right / center / bottom dock zones).
- Implement `Dockable` on each top-level panel as a thin trait rather than inheriting it via an inner record:
  - `MixerView` — `dockId = DefaultWorkspaces.PANEL_MIXER`, `displayName = "Mixer"`, `iconName = "MIXER"`, `preferredZone = DockZone.BOTTOM`.
  - `BrowserPanel` — `PANEL_BROWSER`, `"Browser"`, `"BROWSER"`, `DockZone.LEFT`.
  - `MasteringView` — `PANEL_MASTERING`, `"Mastering"`, `"MASTERING"`, `DockZone.CENTER`.
  - `EditorView` — `PANEL_EDITOR`, `"Editor"`, `"EDITOR"`, `DockZone.CENTER`.
  - `TelemetrySetupPanel` — new id (`PANEL_TELEMETRY` to add to `DefaultWorkspaces`), `"Telemetry"`, `"TELEMETRY"`, `DockZone.RIGHT`.
  - The arrangement view (currently the cached `BorderPane#getCenter()` in `ViewNavigationController#initializeViewNavigation`) — `PANEL_ARRANGEMENT`, `"Arrangement"`, `"TIMELINE"`, `DockZone.CENTER`.
- Delete the orphan `registerDockablePanels(DockManager dm)` private method at `MainController.java:1731-1745`. Replace its single inner `record Panel` with the in-place `Dockable` interface implementations above, then call `dockManager.register(<panel>)` once per panel during initialisation.
- The F3 / F4 / F5 toggle handlers at `MainController.java:1151-1174` lose their `else if (dockManager != null …)` dead branches and become unconditional `dockManager.toggleVisible(<panelId>)` calls; the legacy `viewNavigationController.switchView(...)` / `browserPanelController.toggleBrowserPanel()` path becomes the underlying mechanism the `DockManager.Host` invokes, not a parallel one.
- Wire `WorkspaceManager` (story 193) to the live `DockManager`: when a workspace is applied, the manager's panel-visible / panel-bounds state is restored through `DockManager#applyLayout(DockLayout)` rather than through the existing show/hide booleans. The existing `WorkspaceManager.Host` callback stays, but `MainController`'s implementation now delegates to `DockManager` for layout reconciliation.
- Verify that a panel dragged out to a floating `Stage` and back lands in the same dock zone with the same width / height — the existing `DockManagerTest` covers this in isolation; this story needs an integration test that exercises it through the live `MainController` scene graph.
- Tests:
  - `MainControllerDockManagerInitializedTest` (new): build a `MainController`, force the scene to mount, assert `dockManager != null`, assert `dockManager.layout().contains(PANEL_MIXER)`, `PANEL_BROWSER`, `PANEL_EDITOR`, `PANEL_MASTERING`, `PANEL_ARRANGEMENT`.
  - `DockToggleHandlerTest` (new): trigger `onToggleDockMixer()` via the `DawMenuBarController.Host` callback, assert the mixer's `DockEntry` flips between `visible = true` and `visible = false`. Repeat for browser and arrangement.
  - `DockableImplementationTest` (new): instantiate each of the six top-level panels, assert `instanceof Dockable`, assert `dockId()` / `preferredZone()` match the table above.
  - `WorkspaceAppliesDockLayoutTest` (new): switch from "Tracking" to "Mixing", assert the mixer panel becomes visible and (where the panel-state record carries bounds) sized per the workspace snapshot.

## Non-Goals

- **No Mission Control layout persistence.** `LayoutManager` (story 282) wire-up is a sibling story; this story only ensures `DockManager` itself is reachable from production code. Once `DockManager` is live, `LayoutManager` can subscribe to its layout changes in a follow-on.
- **No floating-plugin-window detach mechanism.** `DetachPluginRequestedEvent` (story 281) currently has no production subscriber; that follow-on is owned by story 282's domain.
- **No new dock zones.** The five existing zones (`TOP` / `LEFT` / `CENTER` / `RIGHT` / `BOTTOM`) are sufficient for this story.
- **No tabbed dock targets.** One panel per dock slot for now; multi-panel tabs in one slot is a future story.
- **No dock-related visual restyle.** Visual polish (drop-zone highlight on drag-over, grip handles, dock-manifest bar at the bottom) is owned by story 282 and the §7.3 background-swap rule.
- **No removal of the existing per-controller show/hide methods** (`browserPanelController.toggleBrowserPanel`, etc.). They become the implementation `DockManager.Host` calls into, not parallel code paths.
- **No virtual-thread / background-thread layout reconciliation.** All dock state mutations stay on the JavaFX application thread (per `DockManager`'s threading contract).

## Technical Notes

- Files: `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java` (delete the block-comment caveat at 1611-1616, instantiate `DockManager` in `installWorkspacesMenu` or a new dedicated `installDockManager()`; delete the orphan `registerDockablePanels`; remove the `dockManager != null` dead branches at 1151-1174), `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java` / `BrowserPanel.java` / `EditorView.java` / `MasteringView.java` / `TelemetrySetupPanel.java` (each implements `Dockable`), `daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DefaultWorkspaces.java` (add `PANEL_TELEMETRY` constant if missing).
- The `DockManager.Host` implementation is the load-bearing piece. It needs to know how to add a `Node` to each of the five `BorderPane` zones, how to remove it, how to swap two panels in the same zone (re-ordering), and how to read the zone bounds for floating-window placement. Today every panel's parent is hard-wired in `MainController#initialize` / `MainView.fxml` — the host implementation centralises that knowledge so the existing controllers don't need to know they're now dockable.
- `MainController.java:200` (`private DockManager dockManager;`) already exists; this story just makes it non-null. No new field is required.
- `registerDockablePanels(DockManager dm)` at `MainController.java:1731-1745` is the canonical contract for what should be wired. Use it as the template, then delete it.
- Reference: user story 195 (Resizable and Detachable Dockable Panels), user story 193 (Customizable Workspace Layouts), user story 282 (Mission Control Dock-and-Float Layout — blocked on this).
