### PR TITLE
288-panel-grip-handle-drag-to-detach-and-dock-drop-zone-highlight.md implementation

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.dock.Dockable;
 import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
 import com.benesquivelmusic.daw.app.ui.drag.DragSourceKind;
 import com.benesquivelmusic.daw.app.ui.drag.DragVisualAdvisor;
 import com.benesquivelmusic.daw.app.ui.drag.DropTargetKind;
@@ -189,6 +190,13 @@ public final class BrowserPanel extends VBox implements Dockable {
         Label headerLabel = new Label("BROWSER");
         headerLabel.getStyleClass().add("panel-header");
         headerLabel.setGraphic(IconNode.of(DawIcon.LIBRARY, ICON_SIZE));
+        // Story 288 — dock grip leads the header so the browser can be
+        // detached / re-docked by direct manipulation. The grip's gesture
+        // consumes and uses the dedicated dock DataFormat, so it stays
+        // distinct from the file-tree sample drag (TransferMode.COPY,
+        // putString) wired below.
+        HBox headerRow = new HBox(8, new PanelGripHandle(dockId(), this), headerLabel);
+        headerRow.setAlignment(Pos.CENTER_LEFT);
 
         // ── Persistent search field (story 275, UI Design Book §5.5) ────────
         // SEARCH icon (story 265) as a leading affordance; the text is
@@ -309,7 +317,7 @@ public final class BrowserPanel extends VBox implements Dockable {
             }
         });
 
-        getChildren().addAll(headerLabel, searchBar, tabStrip, contentArea);
+        getChildren().addAll(headerRow, searchBar, tabStrip, contentArea);
 
         selectSection(BrowserSection.FILES);
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/EditorView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/EditorView.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.display.WaveformDisplay;
 import com.benesquivelmusic.daw.app.ui.dock.Dockable;
 import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.core.midi.MidiClip;
@@ -110,7 +111,13 @@ public final class EditorView extends VBox implements Dockable {
         contentArea.getStyleClass().add("content-area");
         VBox.setVgrow(contentArea, Priority.ALWAYS);
 
-        getChildren().addAll(header, toolBar, contentArea);
+        // Story 288 — wrap the bare header label in a row led by the dock
+        // grip so the editor can be detached / re-docked by direct
+        // manipulation like the other dockable panels.
+        HBox headerRow = new HBox(8, new PanelGripHandle(dockId(), this), header);
+        headerRow.setAlignment(Pos.CENTER_LEFT);
+
+        getChildren().addAll(headerRow, toolBar, contentArea);
         setPadding(new Insets(8));
 
         // Enable keyboard events for Delete key

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -111,6 +111,8 @@ public final class MainController {
     @FXML private Label statusBarLabel;
     @FXML private Label arrangementPlaceholder;
     @FXML private Label arrangementPanelHeader;
+    /** Story 288 — timeline-header HBox that hosts the arrangement dock grip. */
+    @FXML private HBox arrangementTimelineHeader;
     @FXML private StackPane arrangementContentPane;
     @FXML private Label tracksPanelHeader;
     @FXML private Label ioRoutingLabel;
@@ -2182,16 +2184,60 @@ public final class MainController {
                 com.benesquivelmusic.daw.app.ui.layout.PanelDetachRequestedEvent.PANEL_DETACH_REQUESTED,
                 e -> {
                     if (dockManager != null) {
-                        dockManager.float_(e.getPanelId(), null);
+                        // Story 288 — honour the grip-gesture drop point when
+                        // present; a null bounds preserves the prior
+                        // remembered/default placement behaviour.
+                        dockManager.float_(e.getPanelId(), e.getBounds());
                     }
                 });
         rootPane.addEventHandler(
                 com.benesquivelmusic.daw.app.ui.layout.PanelDockRequestedEvent.PANEL_DOCK_REQUESTED,
                 e -> {
                     if (dockManager != null) {
-                        dockManager.moveToEnd(e.getPanelId(), e.getTargetZone());
+                        // Story 288 review — reconcile() is the authority on
+                        // each canonical panel's docked home: it re-derives
+                        // placement from the panel id and ignores the recorded
+                        // zone. Recording the geometric drop zone would persist
+                        // a zone the reconciler never honours (and the manifest
+                        // bar, which renders DockEntry.zone, would show it),
+                        // while the panel snaps back to its real home. Coerce
+                        // the re-dock to that home so model and view agree.
+                        DockZone home = dockHomeZone(
+                                e.getPanelId(),
+                                vizDockables.containsKey(e.getPanelId()),
+                                e.getTargetZone());
+                        dockManager.moveToEnd(e.getPanelId(), home);
                     }
                 });
+
+        // ── Story 288 — drop-zone highlight + re-dock gesture. ───────
+        // Bind the dock drop behaviour to the five BorderPane slot
+        // PROPERTIES (not fixed nodes): CENTER is swapped per view, LEFT is
+        // null while the browser is hidden, and the Performance Stage
+        // save/restore replaces whole slots — binding to the property lets
+        // the drop zone follow the live content. Handlers are additive
+        // (addEventHandler), so the existing clip/sample DnD keeps working.
+        com.benesquivelmusic.daw.app.ui.dock.DockDropZones dropZones =
+                new com.benesquivelmusic.daw.app.ui.dock.DockDropZones(rootPane);
+        dropZones.bindSlot(rootPane.topProperty(), DockZone.TOP);
+        dropZones.bindSlot(rootPane.bottomProperty(), DockZone.BOTTOM);
+        dropZones.bindSlot(rootPane.leftProperty(), DockZone.LEFT);
+        dropZones.bindSlot(rootPane.rightProperty(), DockZone.RIGHT);
+        dropZones.bindSlot(rootPane.centerProperty(), DockZone.CENTER);
+
+        // ── Story 288 — mount the arrangement grip in the timeline header.
+        // The arrangement panel lives in FXML (timeline-header HBox); its
+        // grip detaches/re-docks the PANEL_ARRANGEMENT dockable. Size the
+        // floating window from the cached arrangement node when available.
+        if (arrangementTimelineHeader != null) {
+            Region arrangementBounds = viewNavigationController != null
+                    && viewNavigationController.getCachedArrangementNode() instanceof Region r
+                    ? r
+                    : rootPane;
+            arrangementTimelineHeader.getChildren().add(0,
+                    new com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle(
+                            DefaultWorkspaces.PANEL_ARRANGEMENT, arrangementBounds));
+        }
 
         // ── Story 287 — bottom analyzer strip (above the manifest bar). ──
         mountVisualizationDockStrip();
@@ -2208,6 +2254,44 @@ public final class MainController {
                 mountBottomVizPanel(id, e.visible());
             }
         }
+    }
+
+    /**
+     * Resolves the docked home zone for a panel id, mirroring the authority
+     * encoded in {@code MainControllerDockHost.reconcile(...)} — which
+     * re-derives each canonical panel's placement from its id and ignores
+     * the recorded zone.
+     * The drop-zone re-dock gesture (story 288) coerces to this so the
+     * persisted zone, and the manifest bar that renders {@code
+     * DockEntry.zone}, match where the panel actually lands instead of the
+     * arbitrary geometric zone the user happened to release over.
+     *
+     * <p>Telemetry panels home to {@code RIGHT} even though {@code
+     * reconcileTelemetry} ultimately floats them: {@code RIGHT} is still
+     * their nominal/recorded zone, so this keeps the model self-consistent.
+     * Kept in lock-step with {@code reconcile(...)}; pinned by
+     * {@code DockHomeZoneTest}.</p>
+     *
+     * @param panelId         the dragged panel id
+     * @param isVisualization whether {@code panelId} is one of the BOTTOM
+     *                        analyzer adapters ({@code vizDockables})
+     * @param fallback        zone for an unrecognised id (forward-compatible)
+     */
+    static DockZone dockHomeZone(String panelId, boolean isVisualization, DockZone fallback) {
+        if (DefaultWorkspaces.PANEL_BROWSER.equals(panelId)) {
+            return DockZone.LEFT;
+        }
+        if (CENTER_ZONE_PANELS.contains(panelId)) {
+            return DockZone.CENTER;
+        }
+        if (DefaultWorkspaces.PANEL_TELEMETRY.equals(panelId)
+                || DefaultWorkspaces.PANEL_ROOM_3D.equals(panelId)) {
+            return DockZone.RIGHT;
+        }
+        if (isVisualization) {
+            return DockZone.BOTTOM;
+        }
+        return fallback;
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -2211,16 +2211,19 @@ public final class MainController {
                 });
 
         // ── Story 288 — drop-zone highlight + re-dock gesture. ───────
-        // Bind the dock drop behaviour to the five BorderPane slot
-        // PROPERTIES (not fixed nodes): CENTER is swapped per view, LEFT is
-        // null while the browser is hidden, and the Performance Stage
-        // save/restore replaces whole slots — binding to the property lets
-        // the drop zone follow the live content. Handlers are additive
-        // (addEventHandler), so the existing clip/sample DnD keeps working.
+        // Bind the dock drop behaviour for TOP/LEFT/RIGHT/CENTER to the
+        // BorderPane slot PROPERTIES (not fixed nodes): CENTER is swapped per
+        // view, LEFT is null while the browser is hidden, and the Performance
+        // Stage save/restore replaces whole slots — binding to the property
+        // lets the drop zone follow the live content. The BOTTOM slot is the
+        // bottom VBox chrome stack (notification bar, analyzer strip, manifest
+        // bar, status bar), so it is bound to the analyzer strip node below
+        // instead of the whole slot, keeping the status/manifest chrome out of
+        // the BOTTOM hit-region. Handlers are additive (addEventHandler), so
+        // the existing clip/sample DnD keeps working.
         com.benesquivelmusic.daw.app.ui.dock.DockDropZones dropZones =
                 new com.benesquivelmusic.daw.app.ui.dock.DockDropZones(rootPane);
         dropZones.bindSlot(rootPane.topProperty(), DockZone.TOP);
-        dropZones.bindSlot(rootPane.bottomProperty(), DockZone.BOTTOM);
         dropZones.bindSlot(rootPane.leftProperty(), DockZone.LEFT);
         dropZones.bindSlot(rootPane.rightProperty(), DockZone.RIGHT);
         dropZones.bindSlot(rootPane.centerProperty(), DockZone.CENTER);
@@ -2241,6 +2244,12 @@ public final class MainController {
 
         // ── Story 287 — bottom analyzer strip (above the manifest bar). ──
         mountVisualizationDockStrip();
+        // ── Story 288 — scope the BOTTOM drop zone to the analyzer strip
+        // (the BOTTOM-dock content node), not the whole bottom slot, so the
+        // status bar and dock manifest bar are not dock drop targets.
+        if (vizBottomStrip != null) {
+            dropZones.bindNode(vizBottomStrip, DockZone.BOTTOM);
+        }
         // ── Bottom manifest bar (above the status bar). ─────────────
         mountDockManifestBar();
         // Story 287 — mount the BOTTOM-zone analyzer panels that are

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MasteringView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MasteringView.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.app.ui.display.LevelMeterDisplay;
 import com.benesquivelmusic.daw.app.ui.display.LoudnessDisplay;
 import com.benesquivelmusic.daw.app.ui.dock.Dockable;
 import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.core.mastering.MasteringChain;
@@ -152,7 +153,10 @@ public final class MasteringView extends VBox implements Dockable {
             statusLabel.setText(bypassed ? "Chain bypassed (B) — dry signal" : "Chain active (A) — processed signal");
         });
 
-        HBox headerBar = new HBox(8, headerLabel, headerSpacer, presetSelector, abToggle);
+        // Story 288 — dock grip leads the header bar.
+        HBox headerBar = new HBox(8,
+                new PanelGripHandle(dockId(), this),
+                headerLabel, headerSpacer, presetSelector, abToggle);
         headerBar.setAlignment(Pos.CENTER_LEFT);
         headerBar.setPadding(new Insets(4, 10, 4, 0));
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.app.ui.display.InputMeterStrip;
 import com.benesquivelmusic.daw.app.ui.display.LevelMeterDisplay;
 import com.benesquivelmusic.daw.app.ui.dock.Dockable;
 import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
@@ -388,7 +389,11 @@ public final class MixerView extends VBox implements Dockable {
 
         Region toolbarSpacer = new Region();
         HBox.setHgrow(toolbarSpacer, Priority.ALWAYS);
+        // Story 288 — dock grip leads the header. Its own drag gesture
+        // consumes, so it never collides with the per-channel-strip
+        // (TransferMode.LINK) drag wired in buildChannelStrip(...).
         HBox headerRow = new HBox(8,
+                new PanelGripHandle(dockId(), this),
                 header, toolbarSpacer,
                 slotAButton, slotBButton,
                 snapshotsToggleButton, mixerMenu);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/DockableVisualizationPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/display/DockableVisualizationPanel.java
@@ -2,11 +2,14 @@ package com.benesquivelmusic.daw.app.ui.display;
 
 import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 
 import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
@@ -80,10 +83,16 @@ public final class DockableVisualizationPanel extends VBox implements Dockable {
             header.setGraphic(IconNode.of(icon, 12));
         }
 
+        // Story 288 — dock grip leads the tile header so every analyzer
+        // tile can be detached / re-docked by direct manipulation. dockId
+        // is already assigned above, so reading it here is safe.
+        HBox headerRow = new HBox(6, new PanelGripHandle(dockId(), this), header);
+        headerRow.setAlignment(Pos.CENTER_LEFT);
+
         content.setMinHeight(0);
         VBox.setVgrow(content, Priority.ALWAYS);
 
-        getChildren().addAll(header, content);
+        getChildren().addAll(headerRow, content);
     }
 
     /** Returns the wrapped analyzer display node. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockDropZones.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockDropZones.java
@@ -98,6 +98,27 @@ public final class DockDropZones {
     }
 
     /**
+     * Binds dock drop behaviour to a fixed content node rather than a
+     * {@code BorderPane} slot property. Used for the BOTTOM zone, whose
+     * {@code BorderPane} slot is the bottom {@code VBox} chrome stack
+     * (notification bar, analyzer strip, manifest bar, status bar). Binding
+     * the whole slot would make the status bar and the dock manifest bar
+     * accept dock drops; scoping to the BOTTOM-dock content node (the
+     * analyzer strip) keeps the chrome out of the hit-region.
+     *
+     * @param node the fixed content node that represents the zone (non-null)
+     * @param zone the dock zone this node represents
+     */
+    public void bindNode(Node node, DockZone zone) {
+        Objects.requireNonNull(node, "node must not be null");
+        Objects.requireNonNull(zone, "zone must not be null");
+        if (zone == DockZone.FLOATING) {
+            throw new IllegalArgumentException("FLOATING is not a drop slot");
+        }
+        new SlotBinding(zone).attachTo(node);
+    }
+
+    /**
      * Adds or removes the {@link #DROP_TARGET_ACTIVE_CLASS} highlight on a
      * zone node. Per UI Design Book §7.3 the active state is a background
      * swap to {@code -accent-soft} via this style class — never a border —

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockDropZones.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/DockDropZones.java
@@ -1,0 +1,227 @@
+package com.benesquivelmusic.daw.app.ui.dock;
+
+import com.benesquivelmusic.daw.app.ui.layout.PanelDockRequestedEvent;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.event.EventHandler;
+import javafx.scene.Node;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.Region;
+
+import java.util.Objects;
+
+/**
+ * Installs the dock drop-target behaviour on the five {@code BorderPane}
+ * zone slots of the main window: drag-over highlight, transfer acceptance,
+ * and the {@link PanelDockRequestedEvent} fired on drop. This is the
+ * <em>event producer</em> counterpart to the {@code rootPane} bridge in
+ * {@code MainController.installLayoutManager()} (story 286) — the gesture
+ * surface story 282 promised but 285 / 286 left unwired.
+ *
+ * <h2>Why bind to slot properties, not nodes</h2>
+ *
+ * <p>The main {@code BorderPane}'s slots are not stable nodes: the CENTER
+ * slot is swapped on every view switch ({@code ViewNavigationController
+ * .switchView()} does {@code rootPane.setCenter(target)}), the LEFT slot is
+ * {@code null} while the browser is hidden, and the Performance-Stage
+ * save/restore replaces TOP/LEFT/RIGHT/CENTER wholesale. So
+ * {@link #bindSlot(ObjectProperty, DockZone)} attaches the drop handlers to
+ * whatever {@link Node} currently occupies the slot and re-attaches them
+ * (removing the old handlers first) whenever that node changes. The drop
+ * zone follows the live content automatically.</p>
+ *
+ * <h2>Drag vocabulary isolation</h2>
+ *
+ * <p>Handlers are added with {@code addEventHandler} (never the
+ * {@code setOnDragOver}/{@code setOnDragDropped} setters) so they compose
+ * with the clip/sample DnD handlers already present on the arrangement and
+ * browser nodes (story 248). For a non-dock drag the {@code DRAG_OVER}
+ * handler returns <em>without consuming</em>, leaving the event to reach
+ * the existing handlers; it reacts only when the dragboard carries
+ * {@link PanelGripHandle#DOCK_PANEL_FORMAT}.</p>
+ *
+ * <h2>Testability</h2>
+ *
+ * <p>A {@link DragEvent} with a real {@link Dragboard} cannot be built
+ * headless, so the side-effecting cores take already-extracted values:
+ * {@link #applyHighlight(Region, boolean)} and
+ * {@link #fireDock(DockZone, String)}. The installed handlers are thin
+ * adapters over those.</p>
+ */
+public final class DockDropZones {
+
+    /** Style class toggled on a zone node while a dock drag hovers it. */
+    public static final String DROP_TARGET_ACTIVE_CLASS = "dock-drop-target-active";
+
+    private final Node eventTarget;
+
+    /**
+     * Creates a drop-zone controller that fires dock events on
+     * {@code eventTarget} (the {@code rootPane}, so events bubble to the
+     * MainController bridge).
+     *
+     * @param eventTarget node that {@link PanelDockRequestedEvent}s are
+     *                    fired on (non-null)
+     */
+    public DockDropZones(Node eventTarget) {
+        this.eventTarget = Objects.requireNonNull(eventTarget, "eventTarget must not be null");
+    }
+
+    /**
+     * Binds dock drop behaviour to a {@code BorderPane} slot. The handlers
+     * follow the slot's content: they attach to the node currently in the
+     * slot and re-attach (removing the old handlers) whenever the slot's
+     * node changes. A {@code null} slot value detaches the handlers until a
+     * node is installed again.
+     *
+     * @param slot the {@code BorderPane} slot property
+     *             (e.g. {@code rootPane.centerProperty()})
+     * @param zone the dock zone this slot represents
+     */
+    public void bindSlot(ObjectProperty<Node> slot, DockZone zone) {
+        Objects.requireNonNull(slot, "slot must not be null");
+        Objects.requireNonNull(zone, "zone must not be null");
+        if (zone == DockZone.FLOATING) {
+            throw new IllegalArgumentException("FLOATING is not a drop slot");
+        }
+
+        SlotBinding binding = new SlotBinding(zone);
+        // The SlotBinding stays reachable through the slot's change-listener
+        // below (which captures it), so no separate registry is needed.
+        binding.attachTo(slot.get());
+        slot.addListener((obs, oldNode, newNode) -> {
+            binding.detachFrom(oldNode);
+            binding.attachTo(newNode);
+        });
+    }
+
+    /**
+     * Adds or removes the {@link #DROP_TARGET_ACTIVE_CLASS} highlight on a
+     * zone node. Per UI Design Book §7.3 the active state is a background
+     * swap to {@code -accent-soft} via this style class — never a border —
+     * and it is instantaneous (no fade, per the Reduce-Motion default of
+     * story 279).
+     *
+     * @param zoneNode the node occupying the dock slot
+     * @param active   {@code true} to highlight, {@code false} to clear
+     */
+    void applyHighlight(Region zoneNode, boolean active) {
+        if (zoneNode == null) {
+            return;
+        }
+        if (active) {
+            if (!zoneNode.getStyleClass().contains(DROP_TARGET_ACTIVE_CLASS)) {
+                zoneNode.getStyleClass().add(DROP_TARGET_ACTIVE_CLASS);
+            }
+        } else {
+            zoneNode.getStyleClass().remove(DROP_TARGET_ACTIVE_CLASS);
+        }
+    }
+
+    /**
+     * Fires a {@link PanelDockRequestedEvent} carrying the geometric drop
+     * zone on the configured event target so it bubbles to the MainController
+     * bridge. The bridge coerces the panel to its canonical home zone (the
+     * reconciler ignores arbitrary zones for the fixed-home panels) before
+     * calling {@code DockManager.moveToEnd(...)}.
+     *
+     * @param zone    the dock zone the panel was dropped over
+     * @param panelId the dragged panel's id
+     */
+    void fireDock(DockZone zone, String panelId) {
+        eventTarget.fireEvent(new PanelDockRequestedEvent(panelId, zone));
+    }
+
+    /**
+     * Holds the live handler instances for one bound slot so they can be
+     * removed from the previous node when the slot's content changes, and
+     * tracks the currently bound node so the highlight targets it directly
+     * (rather than {@code DragEvent.getSource()}, which JavaFX rewrites per
+     * node on bubble — {@code feedback_javafx_bubbling_event_test_pitfall.md}).
+     * The highlight is applied only when the slot node is a {@link Region}
+     * (every real {@code BorderPane} child here is one); for the rare
+     * non-{@code Region} node the accept/drop logic still works, only the
+     * background swap is skipped.
+     */
+    private final class SlotBinding {
+        private final DockZone zone;
+        private final EventHandler<DragEvent> overHandler;
+        private final EventHandler<DragEvent> exitedHandler;
+        private final EventHandler<DragEvent> droppedHandler;
+        private Node boundNode;
+
+        SlotBinding(DockZone zone) {
+            this.zone = zone;
+            this.overHandler = this::onDragOver;
+            this.exitedHandler = this::onDragExited;
+            this.droppedHandler = this::onDragDropped;
+        }
+
+        void attachTo(Node node) {
+            if (node == null) {
+                return;
+            }
+            boundNode = node;
+            node.addEventHandler(DragEvent.DRAG_OVER, overHandler);
+            node.addEventHandler(DragEvent.DRAG_EXITED, exitedHandler);
+            node.addEventHandler(DragEvent.DRAG_DROPPED, droppedHandler);
+        }
+
+        void detachFrom(Node node) {
+            if (node == null) {
+                return;
+            }
+            node.removeEventHandler(DragEvent.DRAG_OVER, overHandler);
+            node.removeEventHandler(DragEvent.DRAG_EXITED, exitedHandler);
+            node.removeEventHandler(DragEvent.DRAG_DROPPED, droppedHandler);
+            highlightBoundNode(node, false);
+            if (boundNode == node) {
+                boundNode = null;
+            }
+        }
+
+        private void onDragOver(DragEvent event) {
+            if (!hasDockPayload(event)) {
+                // Not a dock drag — leave it for the existing clip/sample
+                // handlers (do NOT consume).
+                return;
+            }
+            event.acceptTransferModes(TransferMode.MOVE);
+            highlightBoundNode(boundNode, true);
+            event.consume();
+        }
+
+        private void onDragExited(DragEvent event) {
+            highlightBoundNode(boundNode, false);
+        }
+
+        private void onDragDropped(DragEvent event) {
+            if (!hasDockPayload(event)) {
+                return;
+            }
+            Object payload = event.getDragboard().getContent(PanelGripHandle.DOCK_PANEL_FORMAT);
+            String panelId = payload instanceof String s ? s : null;
+            boolean completed = false;
+            if (panelId != null && !panelId.isBlank()) {
+                fireDock(zone, panelId);
+                completed = true;
+            }
+            highlightBoundNode(boundNode, false);
+            event.setDropCompleted(completed);
+            event.consume();
+        }
+
+        private void highlightBoundNode(Node node, boolean active) {
+            if (node instanceof Region region) {
+                applyHighlight(region, active);
+            }
+        }
+
+        private boolean hasDockPayload(DragEvent event) {
+            Dragboard db = event.getDragboard();
+            return db != null && db.hasContent(PanelGripHandle.DOCK_PANEL_FORMAT);
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/PanelGripHandle.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dock/PanelGripHandle.java
@@ -1,0 +1,173 @@
+package com.benesquivelmusic.daw.app.ui.dock;
+
+import com.benesquivelmusic.daw.app.ui.icons.DawgIcon;
+import com.benesquivelmusic.daw.app.ui.layout.PanelDetachRequestedEvent;
+import com.benesquivelmusic.daw.sdk.ui.Rectangle2D;
+
+import javafx.scene.control.Tooltip;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+
+import java.util.Objects;
+
+/**
+ * Reusable {@code ⋮⋮} grip affordance mounted in the chrome of every
+ * dockable panel (UI Design Book §4 Concept D mockup). Dragging the grip
+ * starts a JavaFX drag-and-drop gesture that drives the panel
+ * detach / re-dock flow promised by story 282 but not shipped by stories
+ * 285 / 286 (which delivered only the {@code DockManager} machinery and the
+ * receiving event bridge).
+ *
+ * <p>This is a one-off application layout node, so it is a plain
+ * {@link Region} subclass (an {@link HBox} wrapping a single
+ * {@link DawgIcon}) rather than a {@code Control}/{@code Skin} pair, per
+ * the JavaFX application-design skill (§3 / §16). It contributes one
+ * affordance and one gesture and nothing else.</p>
+ *
+ * <h2>Drag vocabulary</h2>
+ *
+ * <p>The gesture carries the panel id under the dedicated
+ * {@link #DOCK_PANEL_FORMAT} {@link DataFormat}. The dock drop zones
+ * ({@code DockDropZones}) react <em>only</em> to that format, so this
+ * vocabulary stays distinct from the clip/sample drags (story 248's
+ * {@code DragVisualAdvisor} path, which uses {@code putString}) and the
+ * mixer channel-strip drags ({@code VcaStrip.CHANNEL_ID_FORMAT}). The
+ * grip's own {@code setOnDragDetected} consumes the event so it never
+ * collides with a sibling strip gesture.</p>
+ *
+ * <h2>Detach vs. re-dock</h2>
+ *
+ * <ul>
+ *   <li>Released over <em>no</em> accepting target → {@link #completeGesture}
+ *       fires a {@link PanelDetachRequestedEvent} (with drop-point bounds)
+ *       on this node; it bubbles to the {@code rootPane} bridge in
+ *       {@code MainController.installLayoutManager()} which calls
+ *       {@code DockManager.float_(panelId, bounds)}.</li>
+ *   <li>Released over a dock zone → that zone accepts the transfer and fires
+ *       the {@code PanelDockRequestedEvent} itself, so this node does
+ *       nothing on drag-done.</li>
+ * </ul>
+ *
+ * <p>Real drag-and-drop {@code DragEvent}s cannot be synthesised in a
+ * headless test (a {@link Dragboard} is not constructible), so the
+ * side-effecting tail of the gesture is factored into the
+ * {@link #completeGesture(TransferMode, double, double)} seam that tests
+ * invoke directly. The seam is {@code public} only because constructing a
+ * {@code PanelGripHandle} (it builds a {@code DawgIcon} and installs a
+ * {@code Tooltip}) requires the started JavaFX toolkit, which in turn
+ * pins its test into the {@code …app.ui} package — a different package
+ * from this class — by the JPMS {@code @ExtendWith} quirk
+ * ({@code project_extendwith_jpms_test_env.md}). The class itself is
+ * internal to the non-exported {@code daw.app} module, so this widens no
+ * public surface.</p>
+ */
+public final class PanelGripHandle extends HBox {
+
+    /**
+     * Custom drag {@link DataFormat} carrying the dragged panel's id.
+     * Resolved via lookup-or-create because a bare {@code new
+     * DataFormat(mime)} throws {@code IllegalArgumentException} if the mime
+     * type is already registered — which happens in the shared Surefire
+     * test fork the moment a second {@code PanelGripHandle} class is loaded.
+     */
+    public static final DataFormat DOCK_PANEL_FORMAT = resolveFormat();
+
+    private static DataFormat resolveFormat() {
+        DataFormat existing = DataFormat.lookupMimeType("application/x-dawg-dock-panel");
+        return existing != null ? existing : new DataFormat("application/x-dawg-dock-panel");
+    }
+
+    private final String panelId;
+    private final Region boundsSource;
+
+    /**
+     * Creates a grip handle for the panel identified by {@code panelId}.
+     *
+     * @param panelId      stable {@code Dockable#dockId()} of the host panel
+     *                     (non-null, non-blank)
+     * @param boundsSource the panel node whose current width/height sizes
+     *                     the floating window when the panel is detached
+     *                     (non-null; panels pass {@code this})
+     */
+    public PanelGripHandle(String panelId, Region boundsSource) {
+        this.panelId = Objects.requireNonNull(panelId, "panelId must not be null");
+        if (panelId.isBlank()) {
+            throw new IllegalArgumentException("panelId must not be blank");
+        }
+        this.boundsSource = Objects.requireNonNull(boundsSource, "boundsSource must not be null");
+
+        getStyleClass().add("dock-grip");
+        getChildren().add(DawgIcon.of("grip-vertical", DawgIcon.Size.SIZE_16));
+
+        Tooltip.install(this, new Tooltip("Drag to detach or re-dock"));
+        setAccessibleText("Drag handle — detach or re-dock this panel");
+
+        setOnDragDetected(event -> {
+            Dragboard db = startDragAndDrop(TransferMode.MOVE);
+            ClipboardContent content = new ClipboardContent();
+            content.put(DOCK_PANEL_FORMAT, panelId);
+            db.setContent(content);
+            // No explicit drag view: the panel stays put during the gesture
+            // and the platform shows its default move cursor. The drop zones
+            // give the visual feedback (the §7.3 background-swap highlight),
+            // so rasterising a drag image here would add nothing.
+            event.consume();
+        });
+
+        setOnDragDone(event ->
+                completeGesture(event.getTransferMode(), event.getScreenX(), event.getScreenY()));
+    }
+
+    /** Stable {@code Dockable#dockId()} this grip detaches / re-docks. */
+    public String panelId() {
+        return panelId;
+    }
+
+    /**
+     * Side-effecting tail of the drag gesture, extracted as a testable seam
+     * (a real {@code DragEvent} with a {@link Dragboard} cannot be built
+     * headless).
+     *
+     * <p>When {@code transferMode} is {@code null} the drop landed on no
+     * accepting target, so the panel should detach: a
+     * {@link PanelDetachRequestedEvent} is fired on this node (bubbling to
+     * the scene-root bridge) carrying drop-point bounds when they can be
+     * derived. When {@code transferMode} is non-null a dock zone already
+     * accepted the drop and fired the dock event, so this method does
+     * nothing.</p>
+     *
+     * @param transferMode  the completed transfer mode, or {@code null} if
+     *                      the drop was not accepted by any target
+     * @param dropScreenX   screen x of the release point
+     * @param dropScreenY   screen y of the release point
+     */
+    public void completeGesture(TransferMode transferMode, double dropScreenX, double dropScreenY) {
+        if (transferMode != null) {
+            // A dock zone accepted the drop and fired PanelDockRequestedEvent.
+            return;
+        }
+        fireEvent(new PanelDetachRequestedEvent(panelId, detachBounds(dropScreenX, dropScreenY)));
+    }
+
+    /**
+     * Builds the floating-window bounds for a detach, anchored at the drop
+     * point and sized from the host panel's current dimensions. Returns
+     * {@code null} (let {@code DockManager} fall back to remembered/default
+     * bounds) when the panel has no measured size yet or the drop point is
+     * non-finite, so a {@link Rectangle2D} is never constructed with a
+     * negative or NaN extent.
+     */
+    private Rectangle2D detachBounds(double dropScreenX, double dropScreenY) {
+        double w = boundsSource.getWidth();
+        double h = boundsSource.getHeight();
+        if (w <= 0 || h <= 0
+                || !Double.isFinite(dropScreenX) || !Double.isFinite(dropScreenY)) {
+            return null;
+        }
+        return new Rectangle2D(dropScreenX, dropScreenY, w, h);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/layout/PanelDetachRequestedEvent.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/layout/PanelDetachRequestedEvent.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app.ui.layout;
 
+import com.benesquivelmusic.daw.sdk.ui.Rectangle2D;
+
 import javafx.event.Event;
 import javafx.event.EventTarget;
 import javafx.event.EventType;
@@ -17,13 +19,17 @@ import java.util.Objects;
  * standard event dispatch chain"). Mirrors the {@code
  * DetachPluginRequestedEvent} convention from story 281.</p>
  *
- * <p>The event carries the {@code panelId} of the panel being detached.
- * Consumers (typically {@code MainController}) listen for it at the
- * scene-root level and route the request to
+ * <p>The event carries the {@code panelId} of the panel being detached and
+ * an optional drop-point {@link Rectangle2D bounds} (story 288 — the grip
+ * gesture supplies the screen position and panel size of the release point
+ * so the floating {@code Stage} opens where the user let go). Consumers
+ * (typically {@code MainController}) listen for it at the scene-root level
+ * and route the request to
  * {@link com.benesquivelmusic.daw.app.ui.dock.DockManager#float_(String,
- * com.benesquivelmusic.daw.sdk.ui.Rectangle2D)}; the dock layer owns the
- * actual {@code Stage} creation so the event itself is UI-toolkit-light
- * (it only mentions JavaFX through {@code Event}).</p>
+ * com.benesquivelmusic.daw.sdk.ui.Rectangle2D)}; a {@code null} bounds lets
+ * the {@code DockManager} fall back to remembered / default placement. The
+ * dock layer owns the actual {@code Stage} creation so the event itself is
+ * UI-toolkit-light (it only mentions JavaFX through {@code Event}).</p>
  */
 public final class PanelDetachRequestedEvent extends Event {
 
@@ -34,27 +40,53 @@ public final class PanelDetachRequestedEvent extends Event {
             new EventType<>(Event.ANY, "PANEL_DETACH_REQUESTED");
 
     private final String panelId;
+    private final Rectangle2D bounds;
 
-    /** Creates a detach-request event for the given panel id. */
+    /** Creates a detach-request event for the given panel id (no drop bounds). */
     public PanelDetachRequestedEvent(String panelId) {
-        super(PANEL_DETACH_REQUESTED);
-        this.panelId = Objects.requireNonNull(panelId, "panelId must not be null");
-        if (panelId.isBlank()) {
-            throw new IllegalArgumentException("panelId must not be blank");
-        }
+        this(panelId, (Rectangle2D) null);
     }
 
-    /** Creates a detach-request event with an explicit source/target. */
+    /**
+     * Creates a detach-request event for the given panel id carrying the
+     * drop-point {@code bounds} the floating window should open at.
+     *
+     * @param panelId stable {@code Dockable#dockId()} (non-null, non-blank)
+     * @param bounds  drop-point floating bounds, or {@code null} to let the
+     *                {@code DockManager} choose remembered / default bounds
+     */
+    public PanelDetachRequestedEvent(String panelId, Rectangle2D bounds) {
+        super(PANEL_DETACH_REQUESTED);
+        this.panelId = checkPanelId(panelId);
+        this.bounds = bounds;
+    }
+
+    /** Creates a detach-request event with an explicit source/target (no drop bounds). */
     public PanelDetachRequestedEvent(String panelId, Object source, EventTarget target) {
         super(source, target, PANEL_DETACH_REQUESTED);
-        this.panelId = Objects.requireNonNull(panelId, "panelId must not be null");
-        if (panelId.isBlank()) {
-            throw new IllegalArgumentException("panelId must not be blank");
-        }
+        this.panelId = checkPanelId(panelId);
+        this.bounds = null;
     }
 
     /** Stable {@code Dockable#dockId()} of the panel being detached. */
     public String getPanelId() {
         return panelId;
+    }
+
+    /**
+     * Drop-point bounds the floating window should open at, or {@code null}
+     * when no explicit placement was supplied (the {@code DockManager} then
+     * falls back to remembered / default bounds).
+     */
+    public Rectangle2D getBounds() {
+        return bounds;
+    }
+
+    private static String checkPanelId(String id) {
+        Objects.requireNonNull(id, "panelId must not be null");
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("panelId must not be blank");
+        }
+        return id;
     }
 }

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml
@@ -125,7 +125,8 @@
 
                 <!-- Right: Arrangement Timeline Tile -->
                 <VBox styleClass="arrangement-panel">
-                    <HBox styleClass="timeline-header" alignment="CENTER_LEFT" spacing="20">
+                    <HBox fx:id="arrangementTimelineHeader" styleClass="timeline-header"
+                          alignment="CENTER_LEFT" spacing="20">
                         <Label fx:id="arrangementPanelHeader" text="ARRANGEMENT"
                                styleClass="panel-header"/>
                         <!-- Beat markers — .timeline-label keeps the muted

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -1168,6 +1168,28 @@
     -fx-spacing: 8;
 }
 
+/* ── Dock grip handle + drop-zone highlight (story 288) ── */
+/* The grip (⋮⋮ grip-vertical glyph) is the drag affordance on every
+ * dockable panel's chrome. Muted by default, brightening on hover, with a
+ * hand cursor — mirrors the track-strip-drag-handle convention. */
+.dock-grip {
+    -fx-cursor: hand;
+    -fx-padding: 0 4 0 0;
+    -fx-alignment: center;
+}
+.dock-grip .dawg-icon {
+    -fx-icon-color: -text-mute;
+}
+.dock-grip:hover .dawg-icon {
+    -fx-icon-color: -text-hi;
+}
+/* §7.3: an active drop target is a BACKGROUND SWAP to -accent-soft, never
+ * a border. Instantaneous (no fade) per the Reduce-Motion default
+ * (story 279). */
+.dock-drop-target-active {
+    -fx-background-color: -accent-soft;
+}
+
 .viz-tile {
     -fx-background-color: -surface-1;
     -fx-background-radius: 6;

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DockHomeZoneTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DockHomeZoneTest.java
@@ -1,0 +1,76 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link MainController#dockHomeZone(String, boolean, DockZone)}, the
+ * story-288 review fix that coerces a drop-zone re-dock to each canonical
+ * panel's docked home rather than the arbitrary zone the user released over.
+ *
+ * <p>Before the fix, dropping the browser grip on (say) the RIGHT zone wrote
+ * {@code zone=RIGHT} into the layout model — which {@code reconcile()}
+ * ignores (snapping the browser back to LEFT) and which the manifest bar
+ * then renders, persisting a zone the panel never occupies. These cases lock
+ * the mapping to {@code reconcile()}'s authority. Pure logic, so no JavaFX
+ * toolkit is required.</p>
+ */
+class DockHomeZoneTest {
+
+    @Test
+    void browserAlwaysHomesLeftRegardlessOfDropZone() {
+        // The headline regression: a browser dropped on RIGHT must not record RIGHT.
+        assertThat(MainController.dockHomeZone(
+                DefaultWorkspaces.PANEL_BROWSER, false, DockZone.RIGHT))
+                .isEqualTo(DockZone.LEFT);
+        assertThat(MainController.dockHomeZone(
+                DefaultWorkspaces.PANEL_BROWSER, false, DockZone.BOTTOM))
+                .isEqualTo(DockZone.LEFT);
+    }
+
+    @Test
+    void centerViewsHomeCenterEvenWhenPreferredZoneDisagrees() {
+        // MixerView.preferredZone() returns BOTTOM, but reconcile() homes the
+        // mixer to CENTER — so preferredZone() is NOT the authority here.
+        assertThat(MainController.dockHomeZone(
+                DefaultWorkspaces.PANEL_MIXER, false, DockZone.BOTTOM))
+                .isEqualTo(DockZone.CENTER);
+        assertThat(MainController.dockHomeZone(
+                DefaultWorkspaces.PANEL_ARRANGEMENT, false, DockZone.TOP))
+                .isEqualTo(DockZone.CENTER);
+        assertThat(MainController.dockHomeZone(
+                DefaultWorkspaces.PANEL_EDITOR, false, DockZone.LEFT))
+                .isEqualTo(DockZone.CENTER);
+        assertThat(MainController.dockHomeZone(
+                DefaultWorkspaces.PANEL_MASTERING, false, DockZone.RIGHT))
+                .isEqualTo(DockZone.CENTER);
+    }
+
+    @Test
+    void telemetryPanelsHomeRight() {
+        assertThat(MainController.dockHomeZone(
+                DefaultWorkspaces.PANEL_TELEMETRY, false, DockZone.LEFT))
+                .isEqualTo(DockZone.RIGHT);
+        assertThat(MainController.dockHomeZone(
+                DefaultWorkspaces.PANEL_ROOM_3D, false, DockZone.CENTER))
+                .isEqualTo(DockZone.RIGHT);
+    }
+
+    @Test
+    void visualizationPanelsHomeBottom() {
+        // Viz adapters are identified by the isVisualization flag, not a
+        // fixed id constant; any such id homes to the BOTTOM analyzer strip.
+        assertThat(MainController.dockHomeZone("viz-spectrum", true, DockZone.RIGHT))
+                .isEqualTo(DockZone.BOTTOM);
+    }
+
+    @Test
+    void unknownPanelFallsBackToTheDropZone() {
+        // Forward-compatible: an unrecognised, non-viz id keeps the dropped zone.
+        assertThat(MainController.dockHomeZone("future-panel", false, DockZone.TOP))
+                .isEqualTo(DockZone.TOP);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/GripHandlePresentOnAllPanelsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/GripHandlePresentOnAllPanelsTest.java
@@ -1,0 +1,125 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.display.DockableVisualizationPanel;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
+import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.project.DawProject;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.layout.Region;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 288 — {@code GripHandlePresentOnAllPanelsTest}. Every self-owned
+ * {@code Dockable} panel must expose a {@link PanelGripHandle} in its
+ * chrome so the user can detach / re-dock it by direct manipulation.
+ *
+ * <p>The panels extend {@code VBox} and build {@code DawgIcon}s /
+ * {@code Tooltip}s, so they need the started toolkit and the {@code
+ * …app.ui} package ({@code project_extendwith_jpms_test_env.md}); they are
+ * constructed on the FX thread, mirroring {@code DockableImplementationTest}.
+ * The presence check is a manual recursive {@code getChildrenUnmodifiable()}
+ * walk — a CSS {@code lookup(".dock-grip")} would need a {@code Scene}
+ * ({@code feedback_javafx_headless_test_pitfalls.md}).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class GripHandlePresentOnAllPanelsTest {
+
+    @Test
+    void mixerViewHasGripHandle() throws Exception {
+        DawProject project = new DawProject("test", AudioFormat.STUDIO_QUALITY);
+        Region view = createOnFxThread(() -> new MixerView(project));
+        assertHasGrip(view);
+    }
+
+    @Test
+    void browserPanelHasGripHandle() throws Exception {
+        Region view = createOnFxThread(BrowserPanel::new);
+        assertHasGrip(view);
+    }
+
+    @Test
+    void editorViewHasGripHandle() throws Exception {
+        Region view = createOnFxThread(EditorView::new);
+        assertHasGrip(view);
+    }
+
+    @Test
+    void masteringViewHasGripHandle() throws Exception {
+        Region view = createOnFxThread(MasteringView::new);
+        assertHasGrip(view);
+    }
+
+    @Test
+    void dockableVisualizationPanelHasGripHandle() throws Exception {
+        Region view = createOnFxThread(() -> new DockableVisualizationPanel(
+                DefaultWorkspaces.PANEL_SPECTRUM,
+                "Spectrum",
+                "SPECTRUM",
+                DockZone.BOTTOM,
+                DawIcon.WAVEFORM,
+                null,
+                new Region())); // dummy analyzer content
+        assertHasGrip(view);
+    }
+
+    /** Asserts at least one descendant of {@code root} is a grip handle. */
+    private static void assertHasGrip(Region root) {
+        assertThat(containsGrip(root))
+                .as("panel chrome exposes a PanelGripHandle")
+                .isTrue();
+    }
+
+    /** Headless-safe recursive node-tree walk (no Scene, no CSS lookup). */
+    private static boolean containsGrip(Node node) {
+        if (node instanceof PanelGripHandle) {
+            return true;
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                if (containsGrip(child)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private interface FxSupplier<T> {
+        T get();
+    }
+
+    private static <T> T createOnFxThread(FxSupplier<T> supplier) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(supplier.get());
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("FX thread did not respond within 5s");
+        }
+        if (err.get() != null) {
+            throw new RuntimeException("Failed to construct on FX thread", err.get());
+        }
+        return ref.get();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/PanelGripFiresDetachEventTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/PanelGripFiresDetachEventTest.java
@@ -1,0 +1,112 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
+import com.benesquivelmusic.daw.app.ui.layout.PanelDetachRequestedEvent;
+
+import javafx.application.Platform;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 288 — {@code PanelGripFiresDetachEventTest}. A {@link
+ * PanelGripHandle} dropped on no accepting target (transfer mode {@code
+ * null}) must fire a {@link PanelDetachRequestedEvent} carrying the panel
+ * id and the drop-point bounds, so it bubbles to the {@code MainController}
+ * detach bridge.
+ *
+ * <p>A real drag-and-drop {@code DragEvent} (with a {@code Dragboard})
+ * cannot be synthesised headless, so the test invokes the package-private
+ * {@link PanelGripHandle#completeGesture} seam directly — the same code
+ * {@code setOnDragDone} runs. The assertion reads the event payload via a
+ * parent {@code addEventFilter}, never {@code Event.getSource()} identity
+ * (JavaFX rewrites the source per node on bubble —
+ * {@code feedback_javafx_bubbling_event_test_pitfall.md}).</p>
+ *
+ * <p>Runs on the FX toolkit (and in the {@code …app.ui} package) because
+ * constructing a {@code PanelGripHandle} builds a {@code DawgIcon} and
+ * installs a {@code Tooltip} — both are FX scene nodes
+ * ({@code project_extendwith_jpms_test_env.md}).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class PanelGripFiresDetachEventTest {
+
+    private <T> T onFx(java.util.function.Supplier<T> body) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<RuntimeException> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(body.get());
+            } catch (RuntimeException e) {
+                err.set(e);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS)).as("FX task completed").isTrue();
+        if (err.get() != null) {
+            throw err.get();
+        }
+        return ref.get();
+    }
+
+    @Test
+    void detachGestureFiresDetachEventWithDropBounds() throws Exception {
+        AtomicReference<PanelDetachRequestedEvent> captured = new AtomicReference<>();
+
+        PanelDetachRequestedEvent event = onFx(() -> {
+            Region boundsSource = new Region();
+            boundsSource.resize(420, 300); // give the panel a measured size
+            PanelGripHandle grip = new PanelGripHandle("mixer", boundsSource);
+
+            // Parent filters on the event PAYLOAD (not getSource()).
+            StackPane parent = new StackPane(grip);
+            parent.addEventFilter(
+                    PanelDetachRequestedEvent.PANEL_DETACH_REQUESTED, captured::set);
+
+            // Drop on no accepting target → transferMode == null.
+            grip.completeGesture(null, 640, 480);
+            return captured.get();
+        });
+
+        assertThat(event).as("detach event was fired and bubbled to the parent").isNotNull();
+        assertThat(event.getPanelId()).isEqualTo("mixer");
+        assertThat(event.getBounds()).as("drop-point bounds were carried").isNotNull();
+        assertThat(event.getBounds().x()).isEqualTo(640.0);
+        assertThat(event.getBounds().y()).isEqualTo(480.0);
+        assertThat(event.getBounds().width()).isEqualTo(420.0);
+        assertThat(event.getBounds().height()).isEqualTo(300.0);
+    }
+
+    @Test
+    void acceptedDropDoesNotFireDetachEvent() throws Exception {
+        // When a dock zone accepts the drop (non-null transfer mode), the
+        // grip must NOT fire a detach event — the zone fires the dock event.
+        AtomicReference<PanelDetachRequestedEvent> captured = new AtomicReference<>();
+
+        onFx(() -> {
+            Region boundsSource = new Region();
+            boundsSource.resize(420, 300);
+            PanelGripHandle grip = new PanelGripHandle("mixer", boundsSource);
+            StackPane parent = new StackPane(grip);
+            parent.addEventFilter(
+                    PanelDetachRequestedEvent.PANEL_DETACH_REQUESTED, captured::set);
+
+            grip.completeGesture(javafx.scene.input.TransferMode.MOVE, 640, 480);
+            return null;
+        });
+
+        assertThat(captured.get())
+                .as("an accepted drop fires no detach event")
+                .isNull();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dock/DockDropZonesBindNodeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dock/DockDropZonesBindNodeTest.java
@@ -1,0 +1,50 @@
+package com.benesquivelmusic.daw.app.ui.dock;
+
+import javafx.scene.Group;
+import javafx.scene.layout.HBox;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Story 288 review — {@code DockDropZones.bindNode(...)} scopes the BOTTOM
+ * drop zone to a fixed content node (the analyzer strip) instead of the
+ * whole bottom {@code VBox} slot, so the status bar and dock manifest bar
+ * are not dock drop targets. This pins the new seam's contract: it rejects
+ * a null node and the {@code FLOATING} pseudo-zone, and installs the dock
+ * drag handlers on the supplied node.
+ *
+ * <p>Headless-safe: only attaches handlers and inspects validation — no
+ * skin, Tooltip, or rasterisation
+ * ({@code feedback_javafx_headless_test_pitfalls.md}).</p>
+ */
+class DockDropZonesBindNodeTest {
+
+    @Test
+    void bindNodeRejectsNullNode() {
+        DockDropZones zones = new DockDropZones(new Group());
+        assertThatNullPointerException()
+                .isThrownBy(() -> zones.bindNode(null, DockZone.BOTTOM));
+    }
+
+    @Test
+    void bindNodeRejectsFloatingZone() {
+        DockDropZones zones = new DockDropZones(new Group());
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> zones.bindNode(new HBox(), DockZone.FLOATING));
+    }
+
+    @Test
+    void bindNodeAttachesToTheSuppliedNode() {
+        DockDropZones zones = new DockDropZones(new Group());
+        HBox strip = new HBox();
+        zones.bindNode(strip, DockZone.BOTTOM);
+        // The active highlight class is only ever added by the installed
+        // drag handlers, so a freshly-bound node starts clean.
+        assertThat(strip.getStyleClass())
+                .doesNotContain(DockDropZones.DROP_TARGET_ACTIVE_CLASS);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dock/DropZoneFiresDockEventTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dock/DropZoneFiresDockEventTest.java
@@ -1,0 +1,67 @@
+package com.benesquivelmusic.daw.app.ui.dock;
+
+import com.benesquivelmusic.daw.app.ui.layout.PanelDockRequestedEvent;
+
+import javafx.scene.Group;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 288 — {@code DropZoneFiresDockEventTest}. Dropping a dock-carrying
+ * drag on a zone must fire a {@link PanelDockRequestedEvent} on the
+ * configured event target with the dragged panel id and the zone.
+ *
+ * <p>A real {@code DragEvent}/{@code Dragboard} cannot be built headless,
+ * so the test drives the extracted {@link DockDropZones#fireDock(DockZone,
+ * String)} core — the same call the installed {@code DRAG_DROPPED} handler
+ * makes after pulling the panel id off the dragboard. The event-target is a
+ * parent node whose {@code addEventFilter} captures the payload (never
+ * {@code Event.getSource()} identity, which JavaFX rewrites on bubble —
+ * {@code feedback_javafx_bubbling_event_test_pitfall.md}).</p>
+ *
+ * <p>Lives in {@code …ui.dock} (same package as the package-private seam)
+ * and needs no started toolkit: it constructs only a bare {@link Group}
+ * and fires an event — no skin, Tooltip, or rasterisation
+ * ({@code feedback_javafx_headless_test_pitfalls.md}).</p>
+ */
+class DropZoneFiresDockEventTest {
+
+    @Test
+    void fireDockDispatchesDockEventWithPanelIdAndZone() {
+        AtomicReference<PanelDockRequestedEvent> captured = new AtomicReference<>();
+
+        // Event target = a parent that filters on the event payload.
+        Group eventTarget = new Group();
+        eventTarget.addEventFilter(
+                PanelDockRequestedEvent.PANEL_DOCK_REQUESTED, captured::set);
+
+        DockDropZones zones = new DockDropZones(eventTarget);
+        zones.fireDock(DockZone.LEFT, "mixer");
+
+        PanelDockRequestedEvent event = captured.get();
+        assertThat(event).as("dock event was fired on the target").isNotNull();
+        assertThat(event.getPanelId()).isEqualTo("mixer");
+        assertThat(event.getTargetZone()).isEqualTo(DockZone.LEFT);
+    }
+
+    @Test
+    void fireDockHonoursEachZone() {
+        for (DockZone zone : new DockZone[] {
+                DockZone.TOP, DockZone.BOTTOM, DockZone.LEFT, DockZone.RIGHT, DockZone.CENTER}) {
+            AtomicReference<PanelDockRequestedEvent> captured = new AtomicReference<>();
+            Group eventTarget = new Group();
+            eventTarget.addEventFilter(
+                    PanelDockRequestedEvent.PANEL_DOCK_REQUESTED, captured::set);
+
+            new DockDropZones(eventTarget).fireDock(zone, "browser");
+
+            assertThat(captured.get()).isNotNull();
+            assertThat(captured.get().getTargetZone()).isEqualTo(zone);
+            assertThat(captured.get().getPanelId()).isEqualTo("browser");
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dock/DropZoneHighlightTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dock/DropZoneHighlightTest.java
@@ -1,0 +1,65 @@
+package com.benesquivelmusic.daw.app.ui.dock;
+
+import javafx.scene.Group;
+import javafx.scene.layout.Region;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 288 — {@code DropZoneHighlightTest}. A dock drag-over adds the
+ * {@code dock-drop-target-active} style class to the hovered zone; a
+ * drag-exit (or drop) removes it. Per UI Design Book §7.3 the active state
+ * is a background swap via this style class (mapped to {@code -accent-soft}
+ * in {@code styles.css}), never a border, and is instantaneous (no fade,
+ * per the Reduce-Motion default of story 279).
+ *
+ * <p>The test drives the extracted {@link DockDropZones#applyHighlight(
+ * Region, boolean)} core (the installed {@code DRAG_OVER}/{@code
+ * DRAG_EXITED} handlers call it). It is pure style-class manipulation —
+ * headless-safe, no rasterisation
+ * ({@code feedback_javafx_headless_test_pitfalls.md}) — and needs no
+ * started toolkit.</p>
+ */
+class DropZoneHighlightTest {
+
+    @Test
+    void applyHighlightTogglesActiveStyleClass() {
+        DockDropZones zones = new DockDropZones(new Group());
+        Region zone = new Region();
+
+        assertThat(zone.getStyleClass())
+                .doesNotContain(DockDropZones.DROP_TARGET_ACTIVE_CLASS);
+
+        zones.applyHighlight(zone, true);
+        assertThat(zone.getStyleClass())
+                .as("highlight adds the active class")
+                .contains(DockDropZones.DROP_TARGET_ACTIVE_CLASS);
+
+        zones.applyHighlight(zone, false);
+        assertThat(zone.getStyleClass())
+                .as("clearing removes the active class")
+                .doesNotContain(DockDropZones.DROP_TARGET_ACTIVE_CLASS);
+    }
+
+    @Test
+    void applyHighlightIsIdempotent() {
+        DockDropZones zones = new DockDropZones(new Group());
+        Region zone = new Region();
+
+        zones.applyHighlight(zone, true);
+        zones.applyHighlight(zone, true); // second activate must not duplicate
+
+        assertThat(zone.getStyleClass().stream()
+                .filter(DockDropZones.DROP_TARGET_ACTIVE_CLASS::equals)
+                .count())
+                .as("the active class appears at most once")
+                .isEqualTo(1L);
+
+        zones.applyHighlight(zone, false);
+        zones.applyHighlight(zone, false); // second clear is a harmless no-op
+        assertThat(zone.getStyleClass())
+                .doesNotContain(DockDropZones.DROP_TARGET_ACTIVE_CLASS);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/layout/DetachEventCarriesDropBoundsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/layout/DetachEventCarriesDropBoundsTest.java
@@ -1,0 +1,84 @@
+package com.benesquivelmusic.daw.app.ui.layout;
+
+import com.benesquivelmusic.daw.app.ui.dock.DockLayout;
+import com.benesquivelmusic.daw.app.ui.dock.DockManager;
+import com.benesquivelmusic.daw.app.ui.dock.DockZone;
+import com.benesquivelmusic.daw.app.ui.dock.Dockable;
+import com.benesquivelmusic.daw.app.ui.dock.FloatingWindowStore;
+import com.benesquivelmusic.daw.sdk.ui.Rectangle2D;
+
+import javafx.event.EventHandler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 288 — {@code DetachEventCarriesDropBoundsTest}. The detach bridge
+ * now honours a non-null drop-point {@link Rectangle2D} on the
+ * {@link PanelDetachRequestedEvent} (it previously always passed
+ * {@code null}), so the floating window opens where the user released the
+ * grip drag.
+ *
+ * <p>Mirrors {@code PanelDetachEventBridgeTest}'s substitution exactly —
+ * the FXML-loaded {@code MainController} hangs in tests
+ * ({@code feedback_maincontroller_test_substitute.md}), so this exercises
+ * the same one-liner the controller installs
+ * ({@code e -> dm.float_(e.getPanelId(), e.getBounds())}) against a real
+ * {@link DockManager}.</p>
+ */
+class DetachEventCarriesDropBoundsTest {
+
+    private record TestPanel(String dockId, String displayName, DockZone preferredZone)
+            implements Dockable {
+        @Override public String iconName() { return "ICON"; }
+    }
+
+    private static final class SilentHost implements DockManager.Host {
+        @Override public void onLayoutChanged(DockLayout newLayout) { /* no-op */ }
+    }
+
+    @Test
+    void detachBridgeHonoursDropBounds(@TempDir Path tmp) {
+        DockManager dm = new DockManager(new SilentHost(),
+                new FloatingWindowStore(tmp.resolve("f.json")));
+        dm.register(new TestPanel("mixer", "Mixer", DockZone.BOTTOM));
+
+        // The exact one-liner MainController.installLayoutManager() now
+        // installs (story 288 — getBounds() replaces the prior null).
+        EventHandler<PanelDetachRequestedEvent> handler =
+                e -> dm.float_(e.getPanelId(), e.getBounds());
+
+        Rectangle2D dropBounds = new Rectangle2D(10, 20, 300, 400);
+        handler.handle(new PanelDetachRequestedEvent("mixer", dropBounds));
+
+        var entry = dm.layout().entry("mixer").orElseThrow();
+        assertThat(entry.zone()).isEqualTo(DockZone.FLOATING);
+        assertThat(entry.floatingBounds())
+                .as("floating window opens at the drop-point bounds")
+                .isEqualTo(dropBounds);
+    }
+
+    @Test
+    void nullBoundsStillFallsBackToDefault(@TempDir Path tmp) {
+        // Backward-compatibility: a null-bounds detach (e.g. a menu-driven
+        // float) keeps the prior remembered/default placement behaviour.
+        DockManager dm = new DockManager(new SilentHost(),
+                new FloatingWindowStore(tmp.resolve("f.json")));
+        dm.register(new TestPanel("mixer", "Mixer", DockZone.BOTTOM));
+
+        EventHandler<PanelDetachRequestedEvent> handler =
+                e -> dm.float_(e.getPanelId(), e.getBounds());
+
+        handler.handle(new PanelDetachRequestedEvent("mixer")); // null bounds
+
+        var entry = dm.layout().entry("mixer").orElseThrow();
+        assertThat(entry.zone()).isEqualTo(DockZone.FLOATING);
+        assertThat(entry.floatingBounds())
+                .as("DockManager supplies fallback bounds when none given")
+                .isNotNull();
+    }
+}


### PR DESCRIPTION
# Panel Grip-Handle Drag-to-Detach and Dock Drop-Zone Highlight

## Motivation

User story 282 — "Mission Control: Dock-and-Float Layout with Per-Project Persistence" — specifies two user-gesture surfaces that stories 285 and 286 did **not** deliver:

> **Detach behaviour:**
> - Every panel grows a grip handle (the §4 mockup shows `⋮⋮`). Drag the grip → detach to a floating window (uses 195's mechanism if available).
> - Float-to-dock by dragging the floating window back over a dock target; dock targets light up with `-accent-soft` overlay per the §7.3 "use background swap, not border" rule.
> — `docs/user-stories/282-mission-control-dock-and-float-layout.md:48-50`

Story 286 created the typed events `PanelDetachRequestedEvent` and `PanelDockRequestedEvent` and wired **receiving** bridge handlers in `MainController` that translate them into `DockManager.float_(...)` / `DockManager.moveToEnd(...)`:

```java
// MainController.java:1875-1888 (story 286)
rootPane.addEventHandler(PanelDetachRequestedEvent.PANEL_DETACH_REQUESTED, e -> {
    if (dockManager != null) dockManager.float_(e.getPanelId(), null);
});
rootPane.addEventHandler(PanelDockRequestedEvent.PANEL_DOCK_REQUESTED, e -> {
    if (dockManager != null) dockManager.moveToEnd(e.getPanelId(), e.getTargetZone());
});
```

But **nothing in production ever fires those events** — they are constructed only in test code:

```
$ grep -rn 'new PanelDetachRequestedEvent\|new PanelDockRequestedEvent' daw-app/src/
daw-app/.../PanelDetachRequestedEvent.java:39:    public PanelDetachRequestedEvent(String panelId) {
daw-app/.../PanelDetachRequestedEvent.java:48:    public PanelDetachRequestedEvent(String panelId, Object source, EventTarget target) {
daw-app/.../PanelDockRequestedEvent.java:39:    public PanelDockRequestedEvent(String panelId, DockZone targetZone) {
daw-app/.../PanelDockRequestedEvent.java:46:    public PanelDockRequestedEvent(String panelId, DockZone targetZone, ...) {
daw-app/src/test/.../PanelDetachEventBridgeTest.java:52:   handler.handle(new PanelDetachRequestedEvent("mixer"));
daw-app/src/test/.../PanelDetachEventBridgeTest.java:74:   handler.handle(new PanelDockRequestedEvent("mixer", DockZone.BOTTOM));
daw-app/src/test/.../ArrangementAsDockablePanelTest.java:73:   PanelDetachRequestedEvent detach = new PanelDetachRequestedEvent("arrangement");
daw-app/src/test/.../ArrangementAsDockablePanelTest.java:78:   PanelDockRequestedEvent dock = new PanelDockRequestedEvent("arrangement", DockZone.CENTER);
```

The only constructor call sites are the two constructors themselves plus four lines in `PanelDetachEventBridgeTest` and `ArrangementAsDockablePanelTest`. There is no grip handle on any dockable panel and no drag gesture that publishes either event:

```
$ grep -rn 'setOnDragDetected\|dock-grip\|⋮⋮\|drop-zone\|DropZone' daw-app/src/main/java/.../ui/dock/
(no matches)
```

The only `⋮⋮` glyph in the entire source tree is on `TrackStripSkin` (`daw-app/.../controls/skin/TrackStripSkin.java:37`) — that is the *track-reorder* handle from story 270, unrelated to panel docking. No dockable **panel** (`MixerView`, `BrowserPanel`, `EditorView`, `MasteringView`, the arrangement, or any visualisation panel) has a docking grip handle, a `setOnDragDetected` handler, or a drop-zone highlight on drag-over.

Net effect: the detach/redock *machinery* is live (the `DockManager.float_` / `move` API works, the receiving bridge works, the floating-`Stage` registry in `MainControllerDockHost.ensureFloating(...)` at `MainController.java:2167` works), but a user has **no way to invoke it by direct manipulation**. Panels can only be floated programmatically or via a future menu. The grip-handle drag and the drop-zone highlight — two explicit 282 Goals — are the missing user-facing surface. Neither appears in the Goals or Non-Goals of story 285 or 286 (286 carved out the *event consumer* wire-up but not the *event producer* gesture), and neither is on any deferral list in `GAP_AUDIT_NOTES.md`.

## Goals

- **Grip handle on every dockable panel.** Add a small drag affordance (the §4 mockup `⋮⋮`, rendered as a Lucide SVG glyph per story 265) to the chrome of each registered `Dockable` panel — `MixerView`, `BrowserPanel`, `EditorView`, `MasteringView`, the arrangement view, and (after story 287) the visualisation panels. Factor the handle into one reusable node (e.g. `daw-app/.../dock/PanelGripHandle.java`) so each panel does not re-implement the gesture. The handle reads its panel id from the host `Dockable#dockId()`.
- **Drag the grip → detach.** Install `setOnDragDetected` on the grip that starts a JavaFX drag-and-drop gesture carrying the panel id (a `ClipboardContent` with a custom `DataFormat`, e.g. `application/x-dawg-dock-panel`). When the drag ends over empty space / outside a dock target, fire `new PanelDetachRequestedEvent(panelId)` on the panel node so it bubbles to the `rootPane` handler installed at `MainController.java:1875-1881`, which already calls `dockManager.float_(panelId, bounds)`. Pass the drop-point bounds (not `null`) so the floating `Stage` opens where the user released the drag — extend the existing handler to honour a non-null `bounds` from the event (today it passes `null`; add a `bounds` accessor to `PanelDetachRequestedEvent` or compute bounds in the handler from the drop screen coordinates).
- **Drop-zone highlight on drag-over.** While a panel drag is in progress, each of the five dock zones (`TOP` / `BOTTOM` / `LEFT` / `RIGHT` / `CENTER`) shows a hover highlight when the pointer is over it. Per UI Design Book §7.3 and 282's explicit AC, the highlight is a **background swap** to `-accent-soft`, **not** a border. Implement via `setOnDragOver` / `setOnDragExited` on each zone region of the main `BorderPane`, toggling a `dock-drop-target-active` style class that maps to `-fx-background-color: -accent-soft;` in `styles.css`. `setOnDragOver` must `acceptTransferModes(TransferMode.MOVE)` only when the drag carries the dock `DataFormat`.
- **Drop on a zone → re-dock.** When the drag is released over a dock zone, fire `new PanelDockRequestedEvent(panelId, targetZone)` so it bubbles to the `rootPane` handler at `MainController.java:1882-1888`, which already calls `dockManager.moveToEnd(panelId, targetZone)`. Clear all drop-zone highlights on `setOnDragDone`.
- **Drag a floating window back onto a dock target → re-dock.** For a panel already floating in its own `Stage` (created by `MainControllerDockHost.ensureFloating`, `MainController.java:2167-2219`), dragging its grip back over a main-window dock zone fires the same `PanelDockRequestedEvent`. The existing `ensureFloating` already re-docks on OS-close (`stage.setOnCloseRequest`, `MainController.java:2195-2202`); this adds the drag-back path.
- **Respect Reduce Motion.** The drop-zone highlight is an instantaneous background swap (no fade) — consistent with the `MotionManager` Reduce-Motion default (story 279). No animated dock/undock transition (282 Non-Goal: "Animating dock / undock transitions — instant per Reduce Motion rules").
- Tests:
  - `PanelGripFiresDetachEventTest` (new): construct a panel with a `PanelGripHandle`, simulate a drag-detected → drag-released-outside gesture (or invoke the handle's gesture-completion hook directly), assert a `PanelDetachRequestedEvent` with the correct `panelId` is dispatched. Verify through a `rootPane.addEventFilter` on the event payload, **not** via `Event.getSource()` identity (per `feedback_javafx_bubbling_event_test_pitfall.md`).
  - `DropZoneFiresDockEventTest` (new): simulate a drag carrying the dock `DataFormat` released over the `LEFT` zone region, assert a `PanelDockRequestedEvent(panelId, DockZone.LEFT)` is dispatched.
  - `DropZoneHighlightTest` (new): fire a synthetic `DragEvent.DRAG_OVER` carrying the dock `DataFormat` onto a zone region, assert it gains the `dock-drop-target-active` style class; fire `DRAG_EXITED`, assert the class is removed. (Headless-safe — operates on style classes, not rasterisation; see `feedback_javafx_headless_test_pitfalls.md`.)
  - `GripHandlePresentOnAllPanelsTest` (new): instantiate each registered dockable panel, assert each exposes a `PanelGripHandle` (e.g. a node with style class `dock-grip`) in its chrome.
  - `DetachEventCarriesDropBoundsTest` (new): fire a `PanelDetachRequestedEvent` with non-null bounds through the live `rootPane` bridge, assert `dockManager.layout().entry(panelId).floatingBounds()` equals the supplied bounds (proves the handler now honours drop-point placement rather than `null`).

## Non-Goals

- **No new `DockManager` API.** `float_`, `move`, `moveToEnd`, `updateFloatingBounds` (`daw-app/.../dock/DockManager.java:133-188`) are sufficient. This story only adds the *gesture* that drives them.
- **No tabbed dock targets.** Dropping a panel onto a zone that already holds a panel follows the existing single-panel-per-slot behaviour (CENTER stays single-selection per `MainController.toggleCenterDockPanel`, `MainController.java:2029-2050`); multi-panel tabbing in one slot remains a future story (same cap as 285/286).
- **No change to the receiving bridge's target resolution beyond drop-bounds.** The `rootPane` handlers at `MainController.java:1875-1888` already translate the events into dock operations; the only handler change is honouring a non-null `bounds` on detach.
- **No floating-plugin-window detach.** `DetachPluginRequestedEvent` (story 281) is a separate, deliberately-deferred stub (`GAP_AUDIT_NOTES.md` "held off" section); its consumer is the focused-plugin story's domain. This story handles *panel* detach (`PanelDetachRequestedEvent`), not *plugin* detach.
- **No animated transitions.** Instant per Reduce Motion (story 279, 282 Non-Goal).
- **No multi-monitor auto-placement.** The floating `Stage` opens at the drop point; it is not auto-relocated to another monitor (282 Non-Goal).
- **No grip handle on non-dockable child controls.** The track-reorder `⋮⋮` on `TrackStripSkin` (story 270) is unrelated and unchanged.

## Technical Notes

- Files: new `daw-app/.../dock/PanelGripHandle.java` (the reusable grip + `setOnDragDetected` gesture), `daw-app/.../MainController.java` (add `setOnDragOver` / `setOnDragExited` / `setOnDragDropped` on the five `BorderPane` zone regions; extend the detach bridge at 1875-1881 to honour drop bounds; mount the grip handle on each panel's chrome), `daw-app/.../MixerView.java` / `BrowserPanel.java` / `EditorView.java` / `MasteringView.java` (host the grip in their headers), `styles.css` (the `.dock-drop-target-active { -fx-background-color: -accent-soft; }` rule), and possibly `PanelDetachRequestedEvent.java` (add a `Rectangle2D bounds` field/accessor for drop-point placement).
- The drag payload is a JavaFX drag-and-drop `Dragboard` with a custom `DataFormat` (e.g. `new DataFormat("application/x-dawg-dock-panel")`) whose string content is the panel id. `setOnDragOver` accepts the transfer only when `db.hasContent(DOCK_PANEL_FORMAT)`, so the dock drop zones do not react to clip/sample drags (which use the existing `DragVisualAdvisor` path from story 248 — keep the two drag vocabularies distinct).
- `-accent-soft` is the established drop-target token (it is the exact token 282 names for this purpose, line 50; the same token used for dock-target overlays in the §7.3 background-swap rule). Verify it exists in the Onyx-Refined token set (`styles.css`, story 260) — if absent, add it as a low-alpha derivative of `-accent` rather than a raw hex (per `feedback_control_css_role_token_forwarding.md` / `feedback_ui_design_philosophy.md`: tokens not hex).
- Drop-bounds derivation: `DragEvent.getScreenX()/getScreenY()` give the release point; build a `com.benesquivelmusic.daw.sdk.ui.Rectangle2D` with the panel's current width/height anchored at the drop point for the floating-`Stage` placement.
- The bottom `VBox` ordering (manifest bar above status bar, plus any BOTTOM-zone visualisation panel from story 287) means the BOTTOM drop zone's hit-region is the BOTTOM dock content area, not the manifest bar itself — scope the `setOnDragOver` to the correct region node.
- Event-test pitfall: JavaFX rewrites `Event.getSource()` on each node during bubbling, so assert on the event payload via a parent `addEventFilter`, never on `getSource()` identity (`feedback_javafx_bubbling_event_test_pitfall.md`).
- Reference: user story 282 (Mission Control — the source of these goals, lines 48-50), user story 285 (DockManager wire-up — the `float_`/`move` API and floating-`Stage` registry), user story 286 (LayoutManager wire-up — created the receiving event bridge this story finally drives), user story 279 (Reduce Motion — instant highlight), user story 265 (Lucide icons — the `⋮⋮` grip glyph), user story 248 (`DragVisualAdvisor` — the *other* drag vocabulary to keep distinct), UI Design Book §4 Concept D and §7.3 (background-swap drop-target rule).
