### PR TITLE
289-introduce-fxdispatcher

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/DawApplication.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/DawApplication.java
@@ -1,6 +1,8 @@
 package com.benesquivelmusic.daw.app;
 
+import com.benesquivelmusic.daw.app.ui.MainController;
 import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.event.DefaultEventBus;
@@ -8,7 +10,6 @@ import com.benesquivelmusic.daw.core.event.EventBusPublisher;
 import com.benesquivelmusic.daw.sdk.event.EventBus;
 
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -56,12 +57,30 @@ public final class DawApplication extends Application {
     public void start(Stage primaryStage) throws IOException {
         loadBundledFonts();
 
+        // Story 289 — the single FX-thread marshalling seam (Control
+        // Synchronization Design Book §2.6, §4.5). Constructed and started
+        // here (we are on the FX thread in start()) BEFORE the bus, because
+        // the bus's ON_UI_THREAD delivery is routed through it: every
+        // off-thread hop onto the FX thread — bus subscribers and the 27
+        // former ad-hoc Platform.runLater sites — now goes through this one
+        // coalescing seam. installDefault publishes it for the awkward
+        // minority of call sites that cannot take a constructor dependency
+        // (the FXML-instantiated MainController, the toolkit-free getDefault()
+        // singletons, short-lived dialogs), mirroring EventBusPublisher.
+        FxDispatcher fxDispatcher = new FxDispatcher();
+        fxDispatcher.start();
+        FxDispatcher.installDefault(fxDispatcher);
+
         // Story 283 — install the application-wide EventBus before any
         // controller is constructed. The UI executor is required because
         // Workshop S3 subscriptions use DispatchMode.ON_UI_THREAD.
         // Sit alongside Theme/Density/Motion managers — same lifecycle.
+        // Story 289 — ON_UI_THREAD delivery now marshals through the
+        // FxDispatcher seam (fxDispatcher::onFx is Executor-compatible and
+        // posts an unconditional Platform.runLater, which the bus's blocking
+        // runAndAwait worker requires) instead of a bare Platform::runLater.
         EventBus bus = DefaultEventBus.builder()
-                .uiExecutor(Platform::runLater)
+                .uiExecutor(fxDispatcher::onFx)
                 .build();
         EventBusPublisher.setDefault(bus);
         primaryStage.addEventHandler(WindowEvent.WINDOW_HIDDEN, _ -> {
@@ -69,11 +88,25 @@ public final class DawApplication extends Application {
             if (EventBusPublisher.getDefault() == bus) {
                 EventBusPublisher.setDefault(null);
             }
+            // Story 289 — stop the pulse timer and clear the seam's channels.
+            fxDispatcher.dispose();
+            if (FxDispatcher.getDefault() == fxDispatcher) {
+                FxDispatcher.installDefault(null);
+            }
         });
 
         FXMLLoader loader = new FXMLLoader(
                 getClass().getResource("ui/main-view.fxml"));
         Parent root = loader.load();
+        // Story 289 — inject the seam into the FXML-instantiated controller
+        // (a no-arg fx:controller cannot be constructor-injected). The
+        // setter is set-once at app init, exactly like the EventBusPublisher
+        // default above; MainController threads it to the collaborators it
+        // builds in initialize().
+        MainController mainController = loader.getController();
+        if (mainController != null) {
+            mainController.setFxDispatcher(fxDispatcher);
+        }
 
         Scene scene = new Scene(root, DEFAULT_WIDTH, DEFAULT_HEIGHT);
         // Story 277 — ThemeManager owns the ordered stylesheet list

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AnimationController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AnimationController.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.app.ui.display.LevelMeterDisplay;
 import com.benesquivelmusic.daw.app.ui.display.SpectrumDisplay;
 import com.benesquivelmusic.daw.app.ui.drag.AnimationProfile;
 import com.benesquivelmusic.daw.app.ui.drag.DragVisualAdvisor;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.core.transport.TransportState;
 
 import javafx.animation.AnimationTimer;
@@ -32,6 +33,10 @@ import java.util.Objects;
  * {@link MainController}. Issue: "Decompose Remaining God-Class
  * Controllers into Focused Services."</p>
  */
+@FxAnimationTimerAllowed("Owns the single per-frame animation timer driving idle "
+        + "visualization, transport glow, and the time ticker "
+        + "(javafx-application-design §6 control-owns-timer); not a cross-thread "
+        + "seam — story 289 sentinel.")
 final class AnimationController {
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ArpeggiatorPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ArpeggiatorPluginView.java
@@ -17,6 +17,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
@@ -34,6 +35,9 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * (scalar primitive writes are safe for the simple fields used here).</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
+@FxAnimationTimerAllowed("Per-frame step-light indicator timer owned by this "
+        + "plugin view (javafx-application-design §6 control-owns-timer); not a "
+        + "cross-thread seam — story 289 sentinel.")
 public final class ArpeggiatorPluginView extends VBox {
 
     /** Number of step lights drawn in the indicator row. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AudioSettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/AudioSettingsDialog.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.sdk.audio.AudioBackendException;
 import com.benesquivelmusic.daw.sdk.audio.AudioDeviceEvent;
 import com.benesquivelmusic.daw.sdk.audio.AudioDeviceInfo;
@@ -964,7 +965,7 @@ public final class AudioSettingsDialog extends DawgDialog<Void> {
         Thread.ofVirtual().name("audio-control-panel").start(() -> {
             try {
                 runnable.run();
-                Platform.runLater(() -> {
+                FxDispatcher.runOnFx(() -> {
                     // Cancel the pending subscription before calling
                     // refreshCapabilities() so it doesn't fire again
                     // when the same refresh has already happened.
@@ -1044,7 +1045,7 @@ public final class AudioSettingsDialog extends DawgDialog<Void> {
                         var ignoredDevice, var ignoredFormat, FormatChangeReason reason)
                         && isCapabilityChanging(reason)) {
                     proxy.cancel();
-                    Platform.runLater(AudioSettingsDialog.this::refreshCapabilities);
+                    FxDispatcher.runOnFx(AudioSettingsDialog.this::refreshCapabilities);
                 }
             }
 
@@ -1267,7 +1268,7 @@ public final class AudioSettingsDialog extends DawgDialog<Void> {
         if (Platform.isFxApplicationThread()) {
             action.run();
         } else {
-            Platform.runLater(action);
+            FxDispatcher.runOnFx(action);
         }
     }
 
@@ -1275,7 +1276,7 @@ public final class AudioSettingsDialog extends DawgDialog<Void> {
         // story 276 — route through DawgDialog.error(...) so the error
         // dialog gets the §5.9 flat chrome instead of JavaFX's Alert
         // (whose header gradient bypasses the author stylesheet).
-        Platform.runLater(() ->
+        FxDispatcher.runOnFx(() ->
                 DawgDialog.error(header, content).showAndWait());
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BackupSettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BackupSettingsDialog.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.persistence.backup.BackupRetentionService;
 import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
 import com.benesquivelmusic.daw.sdk.persistence.BackupRetentionPolicy;
@@ -293,7 +294,7 @@ public final class BackupSettingsDialog extends DawgDialog<BackupRetentionPolicy
         if (Platform.isFxApplicationThread()) {
             apply.run();
         } else {
-            Platform.runLater(apply);
+            FxDispatcher.runOnFx(apply);
         }
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BrowserPanel.java
@@ -8,7 +8,7 @@ import com.benesquivelmusic.daw.app.ui.drag.DragVisualAdvisor;
 import com.benesquivelmusic.daw.app.ui.drag.DropTargetKind;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
-import javafx.application.Platform;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -177,9 +177,32 @@ public final class BrowserPanel extends VBox implements Dockable {
     private DragVisualAdvisor dragVisualAdvisor;
 
     /**
-     * Creates a new browser panel with default width.
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path. May be {@code null} in a pure-unit context (the compatibility
+     * constructor defaults it to {@link FxDispatcher#getDefault()});
+     * {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
+
+    /**
+     * Creates a new browser panel with default width, marshalling off-thread
+     * hops through the {@link FxDispatcher#getDefault() app-scoped default} seam.
      */
     public BrowserPanel() {
+        this(FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates a new browser panel with an explicit FX-thread marshalling seam
+     * (story 289).
+     *
+     * @param fxDispatcher the FX-thread marshalling seam, or {@code null} to use
+     *                     the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public BrowserPanel(FxDispatcher fxDispatcher) {
+        // May be null in a pure-unit context; postFx() falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
         getStyleClass().add("browser-panel");
         setPrefWidth(DEFAULT_WIDTH);
         setMinWidth(MIN_WIDTH);
@@ -421,7 +444,16 @@ public final class BrowserPanel extends VBox implements Dockable {
         measure.run();
         // The button may not be laid out yet on first selection; remeasure
         // once a layout pass has produced a real text width.
-        Platform.runLater(measure);
+        postFx(measure);
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     /**
@@ -500,7 +532,7 @@ public final class BrowserPanel extends VBox implements Dockable {
         // fires on the player's daemon thread, so marshal to the FX
         // thread before touching the scene graph (JavaFX threading rule).
         if (auditioner != null) {
-            auditioner.setOnPlaybackFinished(() -> Platform.runLater(() -> {
+            auditioner.setOnPlaybackFinished(() -> postFx(() -> {
                 auditioningItem = null;
                 refreshListCells();
             }));

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BusCompressorPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/BusCompressorPluginView.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
@@ -32,6 +33,9 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * used by {@link BusCompressorProcessor}).</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
+@FxAnimationTimerAllowed("Per-frame gain-reduction meter timer owned by this "
+        + "plugin view (javafx-application-design §6 control-owns-timer); not a "
+        + "cross-thread seam — story 289 sentinel.")
 public final class BusCompressorPluginView extends VBox {
 
     /** Maximum gain-reduction shown on the meter, in dB (display range: 0 .. -MAX). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClockStatusIndicator.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ClockStatusIndicator.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.sdk.audio.ClockKind;
 import com.benesquivelmusic.daw.sdk.audio.ClockLockEvent;
@@ -268,7 +269,7 @@ public final class ClockStatusIndicator extends Label {
         if (Platform.isFxApplicationThread()) {
             r.run();
         } else {
-            Platform.runLater(r);
+            FxDispatcher.runOnFx(r);
         }
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ConvolutionReverbPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ConvolutionReverbPluginView.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.dsp.reverb.ConvolutionReverbProcessor;
 import com.benesquivelmusic.daw.core.dsp.reverb.ImpulseResponseLibrary;
 import javafx.geometry.Insets;
@@ -90,7 +91,7 @@ public final class ConvolutionReverbPluginView extends VBox {
             if (f != null) {
                 statusLabel.setText("Loading…");
                 processor.loadImpulseResponseFromFileAsync(Path.of(f.getAbsolutePath()))
-                        .whenComplete((_, ex) -> javafx.application.Platform.runLater(() -> {
+                        .whenComplete((_, ex) -> FxDispatcher.runOnFx(() -> {
                             if (ex != null) {
                                 statusLabel.setText("Failed: " + ex.getMessage());
                             } else {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DeEsserPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DeEsserPluginView.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
@@ -34,6 +35,9 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * {@link DeEsserProcessor}).</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
+@FxAnimationTimerAllowed("Per-frame gain-reduction meter timer owned by this "
+        + "plugin view (javafx-application-design §6 control-owns-timer); not a "
+        + "cross-thread seam — story 289 sentinel.")
 public final class DeEsserPluginView extends VBox {
 
     /** Maximum gain-reduction shown on the meter, in dB (display range: 0 .. -MAX). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HistoryPanelController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/HistoryPanelController.java
@@ -1,8 +1,9 @@
 package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
-import com.benesquivelmusic.daw.core.undo.UndoManager;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.core.undo.UndoManager;
 
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
@@ -39,6 +40,14 @@ final class HistoryPanelController {
     private final BorderPane rootPane;
     private final javafx.scene.control.Button historyButton;
     private final Host host;
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path and threaded into every {@link UndoHistoryPanel} this controller
+     * builds. May be {@code null} in a pure-unit context (the compatibility
+     * constructor defaults it to {@link FxDispatcher#getDefault()});
+     * {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
 
     private UndoHistoryPanel undoHistoryPanel;
     private boolean historyPanelVisible;
@@ -46,13 +55,32 @@ final class HistoryPanelController {
     HistoryPanelController(BorderPane rootPane,
                            javafx.scene.control.Button historyButton,
                            Host host) {
+        this(rootPane, historyButton, host, FxDispatcher.getDefault());
+    }
+
+    HistoryPanelController(BorderPane rootPane,
+                           javafx.scene.control.Button historyButton,
+                           Host host,
+                           FxDispatcher fxDispatcher) {
         this.rootPane = rootPane;
         this.historyButton = historyButton;
         this.host = host;
+        // May be null in a pure-unit context; postFx() / UndoHistoryPanel fall
+        // back to the static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     void build() {
-        undoHistoryPanel = new UndoHistoryPanel(host.undoManager());
+        undoHistoryPanel = new UndoHistoryPanel(host.undoManager(), fxDispatcher);
         historyButton.setOnAction(_ -> toggleHistoryPanel());
         LOG.fine("Built undo history panel");
     }
@@ -66,13 +94,13 @@ final class HistoryPanelController {
                 host.updateUndoRedoState();
                 host.refreshArrangementCanvas();
             } else {
-                javafx.application.Platform.runLater(() -> {
+                postFx(() -> {
                     host.updateUndoRedoState();
                     host.refreshArrangementCanvas();
                 });
             }
         });
-        undoHistoryPanel = new UndoHistoryPanel(host.undoManager());
+        undoHistoryPanel = new UndoHistoryPanel(host.undoManager(), fxDispatcher);
         if (historyPanelVisible) {
             rootPane.setRight(undoHistoryPanel);
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/InsertEffectRack.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/InsertEffectRack.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.drag.DragSourceKind;
 import com.benesquivelmusic.daw.app.ui.drag.DragVisualAdvisor;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.mixer.*;
 import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
 import com.benesquivelmusic.daw.core.plugin.ExternalPluginLoader;
@@ -59,6 +60,13 @@ public final class InsertEffectRack extends VBox {
     private final int bufferSize;
     private final UndoManager undoManager;
     private final UndoHistoryListener historyListener;
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path. May be {@code null} in a pure-unit context (the compatibility
+     * constructor defaults it to {@link FxDispatcher#getDefault()});
+     * {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
     private PluginRegistry pluginRegistry;
     private Mixer mixer;
     private Runnable onSlotsChanged;
@@ -89,11 +97,33 @@ public final class InsertEffectRack extends VBox {
      */
     public InsertEffectRack(MixerChannel channel, int audioChannels, double sampleRate,
                             int bufferSize, UndoManager undoManager) {
+        this(channel, audioChannels, sampleRate, bufferSize, undoManager,
+                FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates a new insert-effects rack with an explicit FX-thread marshalling
+     * seam (story 289).
+     *
+     * @param channel       the mixer channel to manage inserts for
+     * @param audioChannels the number of audio channels (e.g., 2 for stereo)
+     * @param sampleRate    the project sample rate in Hz
+     * @param bufferSize    the project buffer size in sample frames
+     * @param undoManager   the undo manager (may be {@code null})
+     * @param fxDispatcher  the FX-thread marshalling seam, or {@code null} to use
+     *                      the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public InsertEffectRack(MixerChannel channel, int audioChannels, double sampleRate,
+                            int bufferSize, UndoManager undoManager,
+                            FxDispatcher fxDispatcher) {
         this.channel = Objects.requireNonNull(channel, "channel must not be null");
         this.audioChannels = audioChannels;
         this.sampleRate = sampleRate;
         this.bufferSize = bufferSize;
         this.undoManager = undoManager;
+        // May be null in a pure-unit context; postFx() falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
 
         setSpacing(2);
         setAlignment(Pos.TOP_CENTER);
@@ -113,13 +143,22 @@ public final class InsertEffectRack extends VBox {
                 if (Platform.isFxApplicationThread()) {
                     rebuildSlots();
                 } else {
-                    Platform.runLater(this::rebuildSlots);
+                    postFx(this::rebuildSlots);
                 }
             };
             undoManager.addHistoryListener(historyListener);
         } else {
             historyListener = null;
         }
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/KeyboardProcessorView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/KeyboardProcessorView.java
@@ -2,6 +2,8 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.midi.KeyboardPreset;
 import com.benesquivelmusic.daw.core.midi.KeyboardProcessor;
 import com.benesquivelmusic.daw.core.midi.VelocityCurve;
@@ -42,6 +44,9 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * names on white keys.</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
+@FxAnimationTimerAllowed("Per-frame MIDI-playback advancement timer owned by "
+        + "this keyboard view (javafx-application-design §6 control-owns-timer); "
+        + "not a cross-thread seam — story 289 sentinel.")
 public final class KeyboardProcessorView extends VBox {
 
     // ── Layout Constants ───────────────────────────────────────────────
@@ -199,7 +204,7 @@ public final class KeyboardProcessorView extends VBox {
             if (Platform.isFxApplicationThread()) {
                 paintKeyboard();
             } else {
-                Platform.runLater(this::paintKeyboard);
+                FxDispatcher.runOnFx(this::paintKeyboard);
             }
         };
         processor.addListener(keyboardListener);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyCalibrationDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyCalibrationDialog.java
@@ -2,11 +2,11 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.sdk.audio.AudioChannelInfo;
 import com.benesquivelmusic.daw.sdk.audio.LatencyCalibration;
 import com.benesquivelmusic.daw.sdk.audio.LatencyCalibration.CalibrationResult;
-import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
@@ -322,11 +322,11 @@ public final class LatencyCalibrationDialog extends Dialog<LatencyCalibrationDia
                 .unstarted(() -> {
                     try {
                         CalibrationResult r = runner.run(input);
-                        Platform.runLater(() -> applyResult(r));
+                        FxDispatcher.runOnFx(() -> applyResult(r));
                     } catch (Exception ex) {
                         final String msg = ex.getMessage() != null ? ex.getMessage()
                                 : ex.getClass().getSimpleName();
-                        Platform.runLater(() -> applyError(msg));
+                        FxDispatcher.runOnFx(() -> applyError(msg));
                     }
                 });
         worker.start();

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyTelemetryPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LatencyTelemetryPanel.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.core.mixer.Mixer;
 import com.benesquivelmusic.daw.fx.GpuPipeline;
 import com.benesquivelmusic.daw.sdk.audio.LatencyTelemetry;
 import com.benesquivelmusic.daw.sdk.audio.LatencyTelemetry.NodeKind;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 
 import javafx.animation.FadeTransition;
@@ -179,7 +180,7 @@ public final class LatencyTelemetryPanel extends BorderPane {
         if (Platform.isFxApplicationThread()) {
             applySnapshot(snapshot, changed);
         } else {
-            Platform.runLater(() -> applySnapshot(snapshot, changed));
+            FxDispatcher.runOnFx(() -> applySnapshot(snapshot, changed));
         }
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LockConflictDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LockConflictDialog.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.persistence.LockConflictHandler;
 import com.benesquivelmusic.daw.core.persistence.LockConflictResolution;
@@ -66,7 +67,7 @@ public final class LockConflictDialog implements LockConflictHandler {
         AtomicReference<LockConflictResolution> result =
                 new AtomicReference<>(DEFAULT_RESOLUTION);
         CountDownLatch latch = new CountDownLatch(1);
-        Platform.runLater(() -> {
+        FxDispatcher.runOnFx(() -> {
             try {
                 result.set(showAndAwait(existingLock, stale));
             } finally {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LockStatusIndicator.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/LockStatusIndicator.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.persistence.LockStatus;
 import com.benesquivelmusic.daw.core.persistence.ProjectLock;
 import com.benesquivelmusic.daw.core.persistence.ProjectLockManager;
@@ -24,7 +25,33 @@ public final class LockStatusIndicator extends Label {
 
     private static final String STYLE_BASE = "-fx-padding: 2 8 2 8; -fx-background-radius: 8;";
 
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path. May be {@code null} in a pure-unit context (the compatibility
+     * constructor defaults it to {@link FxDispatcher#getDefault()});
+     * {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
+
+    /**
+     * Creates an indicator that marshals off-thread updates through the
+     * {@link FxDispatcher#getDefault() app-scoped default} seam.
+     */
     public LockStatusIndicator() {
+        this(FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates an indicator with an explicit FX-thread marshalling seam
+     * (story 289).
+     *
+     * @param fxDispatcher the FX-thread marshalling seam, or {@code null} to use
+     *                     the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public LockStatusIndicator(FxDispatcher fxDispatcher) {
+        // May be null in a pure-unit context; postFx() falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
         getStyleClass().add("lock-status-indicator");
         applyStatus(LockStatus.NONE, null);
     }
@@ -49,8 +76,17 @@ public final class LockStatusIndicator extends Label {
         } else {
             LockStatus s = status;
             ProjectLock l = lock;
-            Platform.runLater(() -> applyStatus(s, l));
+            postFx(() -> applyStatus(s, l));
         }
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     private void applyStatus(LockStatus status, ProjectLock lock) {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1549,7 +1549,7 @@ public final class MainController {
                             mv.refresh();
                         }
                     },
-                    javafx.application.Platform::runLater,
+                    this::postFx,
                     System::nanoTime);
             cpuBudgetEnforcer.performanceEvents().subscribe(trackBudgetUiBinding);
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -11,6 +11,7 @@ import com.benesquivelmusic.daw.app.ui.help.OnboardingTour;
 import com.benesquivelmusic.daw.app.ui.help.QuickHelpBar;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.analysis.InputLevelMonitorRegistry;
 import com.benesquivelmusic.daw.core.audio.AudioBackendFactory;
@@ -338,6 +339,59 @@ public final class MainController {
     /** F1 / Shift+F1 key handler installed on the primary scene. */
     private HelpKeyHandler helpKeyHandler;
 
+    /**
+     * Story 289 — the single FX-thread marshalling seam (Control
+     * Synchronization Design Book §4.5). Injected by {@code DawApplication}
+     * via {@link #setFxDispatcher(FxDispatcher)} immediately after
+     * {@code FXMLLoader.load()} returns, because the {@code fx:controller} is
+     * instantiated by FXML through a no-arg constructor and so cannot be
+     * constructor-injected. {@code DawApplication} installs the same instance
+     * as the {@link FxDispatcher#getDefault() app-scoped default} before the
+     * FXML loads, so {@link #dispatcher()} resolves it even for the brief
+     * window during {@link #initialize()} before the setter has run.
+     */
+    private FxDispatcher fxDispatcher;
+
+    /**
+     * Injects the application's {@link FxDispatcher}. Set once at app init by
+     * the composition root (see {@link #fxDispatcher}); never reassigned at
+     * runtime.
+     *
+     * @param dispatcher the marshalling seam; must not be {@code null}
+     */
+    public void setFxDispatcher(FxDispatcher dispatcher) {
+        this.fxDispatcher = java.util.Objects.requireNonNull(dispatcher, "dispatcher");
+    }
+
+    /**
+     * Resolves the marshalling seam: the injected instance if present,
+     * otherwise the {@link FxDispatcher#getDefault() app-scoped default}. The
+     * fallback keeps the few listeners wired in {@link #initialize()} (which
+     * runs <em>during</em> {@code FXMLLoader.load()}, before the setter) safe
+     * even if they were ever to fire before injection — the production default
+     * is installed before the FXML loads. Returns {@code null} only in a
+     * pure-unit context that installed no dispatcher.
+     *
+     * @return the seam, or {@code null} if none is available
+     */
+    private FxDispatcher dispatcher() {
+        return fxDispatcher != null ? fxDispatcher : FxDispatcher.getDefault();
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the {@link #fxDispatcher
+     * injected seam} when present, else the {@link FxDispatcher#getDefault()
+     * app-scoped default} (and a bare {@code runLater} when neither is
+     * installed). This is the same null-tolerant hop the other UI controllers
+     * use via {@code FxDispatcher.runOnFx(...)}; a listener wired in
+     * {@link #initialize()} that fired before {@link #setFxDispatcher} (or in a
+     * pure-unit context with no dispatcher at all) therefore never dereferences
+     * a null seam, where {@code dispatcher().onFx(...)} would have thrown.
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
+    }
+
     @FXML
     private void initialize() {
         project = new DawProject("Untitled Project", AudioFormat.STUDIO_QUALITY);
@@ -348,7 +402,7 @@ public final class MainController {
                 updateUndoRedoState();
                 refreshArrangementCanvas();
             } else {
-                javafx.application.Platform.runLater(() -> {
+                postFx(() -> {
                     updateUndoRedoState();
                     refreshArrangementCanvas();
                 });
@@ -425,7 +479,8 @@ public final class MainController {
                     @Override public void applyRestoredProject(DawProject restored, String label) {
                         applySnapshotRestoredProject(restored, label);
                     }
-                });
+                },
+                dispatcher());
         toolbarStateStore = new ToolbarStateStore(prefs);
         keyBindingManager = new KeyBindingManager(prefs.node("keybindings"));
 
@@ -699,7 +754,8 @@ public final class MainController {
                                 ? audioEngineController.reportedLatency()
                                 : com.benesquivelmusic.daw.sdk.audio.RoundTripLatency.UNKNOWN;
                     }
-                });
+                },
+                dispatcher());
     }
 
     private void status(String text, DawIcon icon) {
@@ -803,7 +859,8 @@ public final class MainController {
                         }
                     }
                 },
-                new ProjectArchiver());
+                new ProjectArchiver(),
+                dispatcher());
     }
 
     private void handleProjectRebuild(MixerView newMixerView) {
@@ -885,7 +942,7 @@ public final class MainController {
         header.getStyleClass().add("panel-header");
         // No icon-next-to-label per UI Design Book §2.4.
         trackListPanel.getChildren().add(header);
-        MixerView newMixerView = new MixerView(project, undoManager);
+        MixerView newMixerView = new MixerView(project, undoManager, dispatcher());
         handleProjectRebuild(newMixerView);
         if (notificationBar != null && label != null) {
             notificationBar.show(NotificationLevel.INFO,
@@ -992,7 +1049,8 @@ public final class MainController {
                         return inspectorDrawer == null ? null
                                 : inspectorDrawer.getSelectionModel();
                     }
-                });
+                },
+                dispatcher());
     }
 
     private void createTrackStripController() {
@@ -1194,7 +1252,8 @@ public final class MainController {
                     }
                     projectDirty = true;
                 },
-                this::status);
+                this::status,
+                dispatcher());
     }
 
     private void createHistoryPanelController() {
@@ -1207,7 +1266,8 @@ public final class MainController {
                     @Override public boolean isBrowserPanelVisible() { return browserPanelController.isPanelVisible(); }
                     @Override public void hideBrowserPanel() { browserPanelController.toggleBrowserPanel(); }
                     @Override public void updateStatusBar(String text, DawIcon icon) { status(text, icon); }
-                });
+                },
+                dispatcher());
         historyPanelController.build();
     }
 
@@ -1474,7 +1534,7 @@ public final class MainController {
             // degraded badge set on the JavaFX thread.
             NotificationManager toastSink = message -> {
                 if (notificationBar != null) {
-                    javafx.application.Platform.runLater(() -> notificationBar.show(
+                    postFx(() -> notificationBar.show(
                             NotificationLevel.WARNING, message));
                 }
             };
@@ -1571,7 +1631,7 @@ public final class MainController {
     private void initializePluginFaultIsolation() {
         try {
             pluginSupervisor = new PluginInvocationSupervisor();
-            pluginFaultUiController = new PluginFaultUiController(pluginSupervisor, notificationBar);
+            pluginFaultUiController = new PluginFaultUiController(pluginSupervisor, notificationBar, dispatcher());
             // Mixer.setPluginSupervisor both installs the supervisor on every
             // current channel/bus/master AND remembers it so channels added
             // later (new tracks, return buses) inherit it automatically.
@@ -1590,7 +1650,7 @@ public final class MainController {
     }
 
     private void buildBrowserPanel(boolean initiallyVisible) {
-        BrowserPanel browserPanel = new BrowserPanel();
+        BrowserPanel browserPanel = new BrowserPanel(dispatcher());
         // Per-row audition wiring (story 275) — single-channel preview
         // engine from daw.core (com.benesquivelmusic.daw.core.browser).
         browserPanel.setSampleAuditioner(new SamplePreviewAuditioner());
@@ -3204,7 +3264,7 @@ public final class MainController {
                 case CANCELLED -> NotificationLevel.WARNING;
                 default        -> NotificationLevel.INFO;
             };
-            javafx.application.Platform.runLater(() -> {
+            postFx(() -> {
                 if (notificationBar != null) {
                     notificationBar.show(level, msg);
                 }
@@ -3641,7 +3701,7 @@ public final class MainController {
         if (!(parent instanceof HBox bar)) {
             return;
         }
-        lockStatusIndicator = new LockStatusIndicator();
+        lockStatusIndicator = new LockStatusIndicator(dispatcher());
         int idx = bar.getChildren().indexOf(projectInfoLabel);
         bar.getChildren().add(idx + 1, lockStatusIndicator);
         refreshLockStatusIndicator();

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MasteringView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MasteringView.java
@@ -7,6 +7,7 @@ import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.core.mastering.MasteringChain;
 import com.benesquivelmusic.daw.core.mastering.MasteringChainPresets;
 import com.benesquivelmusic.daw.core.mastering.MasteringProcessorFactory;
@@ -48,6 +49,9 @@ import java.util.Objects;
  * <p>Uses existing CSS classes: {@code .content-area}, {@code .panel-header},
  * {@code .mixer-channel}.</p>
  */
+@FxAnimationTimerAllowed("Per-frame loudness/level meter timer owned by this view "
+        + "(javafx-application-design §6 control-owns-timer); not a cross-thread "
+        + "seam — story 289 sentinel.")
 public final class MasteringView extends VBox implements Dockable {
 
     private static final double STAGE_CARD_WIDTH = 140;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MatchEqPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MatchEqPluginView.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.dsp.eq.MatchEqProcessor;
 import com.benesquivelmusic.daw.core.plugin.MatchEqPlugin;
 import com.benesquivelmusic.daw.core.reference.ReferenceTrack;
@@ -222,7 +223,7 @@ public final class MatchEqPluginView extends VBox {
         if (Platform.isFxApplicationThread()) {
             statusLabel.setText(text);
         } else {
-            Platform.runLater(() -> statusLabel.setText(text));
+            FxDispatcher.runOnFx(() -> statusLabel.setText(text));
         }
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MixerView.java
@@ -7,6 +7,7 @@ import com.benesquivelmusic.daw.app.ui.dock.DockZone;
 import com.benesquivelmusic.daw.app.ui.dock.PanelGripHandle;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.analysis.InputLevelMonitor;
 import com.benesquivelmusic.daw.core.analysis.InputLevelMonitorRegistry;
@@ -250,6 +251,14 @@ public final class MixerView extends VBox implements Dockable {
      * mixer channel; null hides the menu entry.
      */
     private java.util.function.Consumer<MixerChannel> onConfigureCpuBudget;
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path and threaded into every {@link InsertEffectRack} this view builds.
+     * May be {@code null} in a pure-unit context (the compatibility
+     * constructors default it to {@link FxDispatcher#getDefault()});
+     * {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
 
     /**
      * Creates a new mixer view bound to the given project.
@@ -267,8 +276,24 @@ public final class MixerView extends VBox implements Dockable {
      * @param undoManager the undo manager for insert effect operations (may be {@code null})
      */
     public MixerView(DawProject project, UndoManager undoManager) {
+        this(project, undoManager, FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates a new mixer view bound to the given project, with undo support
+     * and an explicit FX-thread marshalling seam (story 289).
+     *
+     * @param project      the DAW project to visualize
+     * @param undoManager  the undo manager for insert effect operations (may be {@code null})
+     * @param fxDispatcher the FX-thread marshalling seam, or {@code null} to use
+     *                     the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public MixerView(DawProject project, UndoManager undoManager, FxDispatcher fxDispatcher) {
         this.project = Objects.requireNonNull(project, "project must not be null");
         this.undoManager = undoManager;
+        // May be null in a pure-unit context; postFx() / InsertEffectRack fall
+        // back to the static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
         getStyleClass().add("mixer-panel");
 
         // Refresh solo-safe button rings and "Solo safe" checkmarks after
@@ -280,7 +305,7 @@ public final class MixerView extends VBox implements Dockable {
             if (javafx.application.Platform.isFxApplicationThread()) {
                 runSoloSafeSyncCallbacks();
             } else {
-                javafx.application.Platform.runLater(this::runSoloSafeSyncCallbacks);
+                postFx(this::runSoloSafeSyncCallbacks);
             }
         };
         if (this.undoManager != null) {
@@ -296,7 +321,7 @@ public final class MixerView extends VBox implements Dockable {
             if (javafx.application.Platform.isFxApplicationThread()) {
                 refresh();
             } else {
-                javafx.application.Platform.runLater(this::refresh);
+                postFx(this::refresh);
             }
         };
         project.getChannelLinkManager().addListener(this.channelLinkListener);
@@ -456,7 +481,7 @@ public final class MixerView extends VBox implements Dockable {
                     snapshotsPanel.refresh();
                     syncSlotButtons();
                 } else {
-                    javafx.application.Platform.runLater(() -> {
+                    postFx(() -> {
                         snapshotsPanel.refresh();
                         syncSlotButtons();
                     });
@@ -465,6 +490,17 @@ public final class MixerView extends VBox implements Dockable {
         }
 
         refresh();
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289). Callers
+     * already guard with {@code Platform.isFxApplicationThread()} where an
+     * inline run is wanted; this is only the off-thread hop.
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     // ── Dockable contract (story 285) ────────────────────────────────────────
@@ -1446,7 +1482,7 @@ public final class MixerView extends VBox implements Dockable {
         int channels = project.getFormat().channels();
         double sr = project.getFormat().sampleRate();
         int bs = project.getFormat().bufferSize();
-        InsertEffectRack insertRack = new InsertEffectRack(mixerChannel, channels, sr, bs, undoManager);
+        InsertEffectRack insertRack = new InsertEffectRack(mixerChannel, channels, sr, bs, undoManager, fxDispatcher);
         insertRack.setPluginRegistry(pluginRegistry);
         insertRack.setMixer(project.getMixer());
         insertRack.setDragVisualAdvisor(dragVisualAdvisor);
@@ -1683,7 +1719,7 @@ public final class MixerView extends VBox implements Dockable {
         int channels = project.getFormat().channels();
         double sr = project.getFormat().sampleRate();
         int bs = project.getFormat().bufferSize();
-        InsertEffectRack insertRack = new InsertEffectRack(returnBus, channels, sr, bs, undoManager);
+        InsertEffectRack insertRack = new InsertEffectRack(returnBus, channels, sr, bs, undoManager, fxDispatcher);
         insertRack.setPluginRegistry(pluginRegistry);
         insertRack.setMixer(project.getMixer());
         insertRack.setDragVisualAdvisor(dragVisualAdvisor);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MultibandCompressorPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MultibandCompressorPluginView.java
@@ -20,6 +20,7 @@ import javafx.scene.paint.Color;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
@@ -42,6 +43,9 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * so no locking is required.</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
+@FxAnimationTimerAllowed("Per-frame per-band gain-reduction meter timer owned by "
+        + "this plugin view (javafx-application-design §6 control-owns-timer); "
+        + "not a cross-thread seam — story 289 sentinel.")
 public final class MultibandCompressorPluginView extends VBox {
 
     /** Maximum gain-reduction shown on the per-band meters, in dB. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/NoiseGatePluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/NoiseGatePluginView.java
@@ -15,6 +15,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
@@ -33,6 +34,9 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * {@link NoiseGateProcessor}).</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
+@FxAnimationTimerAllowed("Per-frame input-level meter timer owned by this plugin "
+        + "view (javafx-application-design §6 control-owns-timer); not a "
+        + "cross-thread seam — story 289 sentinel.")
 public final class NoiseGatePluginView extends VBox {
 
     /** Maximum displayed level on the input meter, in dBFS (top of bar). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginFaultLogDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginFaultLogDialog.java
@@ -1,8 +1,8 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.plugin.PluginFault;
 import com.benesquivelmusic.daw.core.plugin.PluginInvocationSupervisor;
-import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
@@ -104,7 +104,7 @@ public final class PluginFaultLogDialog {
 
         @Override
         public void onNext(PluginFault item) {
-            Platform.runLater(() -> rows.addFirst(new FaultRow(item)));
+            FxDispatcher.runOnFx(() -> rows.addFirst(new FaultRow(item)));
         }
 
         @Override

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginFaultUiController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginFaultUiController.java
@@ -1,8 +1,8 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.plugin.PluginFault;
 import com.benesquivelmusic.daw.core.plugin.PluginInvocationSupervisor;
-import javafx.application.Platform;
 
 import java.util.Objects;
 import java.util.concurrent.Flow;
@@ -21,12 +21,51 @@ public final class PluginFaultUiController {
     private final PluginFaultLogDialog dialog;
     private final ToastSubscriber toastSubscriber = new ToastSubscriber();
 
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path. May be {@code null} in a pure-unit context (the compatibility
+     * constructor defaults it to {@link FxDispatcher#getDefault()});
+     * {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
+
+    /**
+     * Creates a controller that marshals fault toasts onto the FX thread
+     * through the {@link FxDispatcher#getDefault() app-scoped default} seam.
+     */
     public PluginFaultUiController(PluginInvocationSupervisor supervisor,
                                    NotificationBar notificationBar) {
+        this(supervisor, notificationBar, FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates a controller with an explicit FX-thread marshalling seam
+     * (story 289).
+     *
+     * @param supervisor      the plugin invocation supervisor whose faults to surface
+     * @param notificationBar the bar that shows fault toasts
+     * @param fxDispatcher    the FX-thread marshalling seam, or {@code null} to use
+     *                        the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public PluginFaultUiController(PluginInvocationSupervisor supervisor,
+                                   NotificationBar notificationBar,
+                                   FxDispatcher fxDispatcher) {
         Objects.requireNonNull(supervisor, "supervisor must not be null");
         this.notificationBar = Objects.requireNonNull(notificationBar, "notificationBar must not be null");
+        // May be null in a pure-unit context; postFx() falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
         this.dialog = new PluginFaultLogDialog(supervisor);
         supervisor.publisher().subscribe(toastSubscriber);
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     /** Opens the fault log dialog (for menu-bar wiring). */
@@ -55,7 +94,7 @@ public final class PluginFaultUiController {
 
         @Override
         public void onNext(PluginFault item) {
-            Platform.runLater(() -> {
+            postFx(() -> {
                 String msg = "Plugin " + item.pluginId() + " was bypassed due to an error — "
                         + "open Plugin Fault Log for details"
                         + (item.quarantined() ? " (quarantined)" : "");

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.audio.AudioClip;
 import com.benesquivelmusic.daw.core.audio.AudioFormat;
@@ -20,7 +21,6 @@ import com.benesquivelmusic.daw.core.track.Track;
 import com.benesquivelmusic.daw.core.undo.UndoManager;
 import com.benesquivelmusic.daw.sdk.session.SessionExportResult;
 import com.benesquivelmusic.daw.sdk.session.SessionImportResult;
-import javafx.application.Platform;
 import javafx.scene.control.*;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
@@ -104,6 +104,14 @@ final class ProjectLifecycleController {
     private final Host host;
     /** Story 189 — engine for {@code .dawz} archive save/restore. */
     private final ProjectArchiver projectArchiver;
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path and threaded into the modeless {@link TaskProgressIndicator}s and
+     * the rebuilt {@link MixerView}. May be {@code null} in a pure-unit context
+     * (the compatibility constructor defaults it to
+     * {@link FxDispatcher#getDefault()}); {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
 
     ProjectLifecycleController(ProjectManager projectManager,
                                SessionInterchangeController sessionInterchangeController,
@@ -114,6 +122,21 @@ final class ProjectLifecycleController {
                                VBox trackListPanel,
                                Host host,
                                ProjectArchiver projectArchiver) {
+        this(projectManager, sessionInterchangeController, notificationBar,
+                statusBarLabel, checkpointLabel, rootPane, trackListPanel, host,
+                projectArchiver, FxDispatcher.getDefault());
+    }
+
+    ProjectLifecycleController(ProjectManager projectManager,
+                               SessionInterchangeController sessionInterchangeController,
+                               NotificationBar notificationBar,
+                               Label statusBarLabel,
+                               Label checkpointLabel,
+                               BorderPane rootPane,
+                               VBox trackListPanel,
+                               Host host,
+                               ProjectArchiver projectArchiver,
+                               FxDispatcher fxDispatcher) {
         this.projectManager = Objects.requireNonNull(projectManager, "projectManager must not be null");
         this.sessionInterchangeController = Objects.requireNonNull(sessionInterchangeController,
                 "sessionInterchangeController must not be null");
@@ -124,6 +147,18 @@ final class ProjectLifecycleController {
         this.trackListPanel = Objects.requireNonNull(trackListPanel, "trackListPanel must not be null");
         this.host = Objects.requireNonNull(host, "host must not be null");
         this.projectArchiver = Objects.requireNonNull(projectArchiver, "projectArchiver must not be null");
+        // May be null in a pure-unit context; postFx() / the leaf views fall
+        // back to the static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     // ── Project action handlers ──────────────────────────────────────────────
@@ -382,7 +417,7 @@ final class ProjectLifecycleController {
         // Progress is surfaced through a modeless TaskProgressIndicator
         // following the same pattern used by TrackFreezeController.
         Window owner = rootPane.getScene().getWindow();
-        TaskProgressIndicator progress = new TaskProgressIndicator(owner, "Archiving project\u2026");
+        TaskProgressIndicator progress = new TaskProgressIndicator(owner, "Archiving project\u2026", fxDispatcher);
         progress.hideCancelButton();
         progress.show();
         progress.update(-1.0, "Writing archive\u2026");
@@ -395,7 +430,7 @@ final class ProjectLifecycleController {
                         ProjectArchiveSummary summary = projectArchiver.saveAsArchive(
                                 current, finalArchivePath);
                         String headline = ArchiveSummaryDialog.formatHeadline(summary);
-                        Platform.runLater(() -> {
+                        postFx(() -> {
                             progress.close();
                             statusBarLabel.setText(headline);
                             statusBarLabel.setGraphic(IconNode.of(DawIcon.UPLOAD, 12));
@@ -408,7 +443,7 @@ final class ProjectLifecycleController {
                                 + " (" + summary.uniqueAssetCount() + " assets, "
                                 + summary.totalAssetBytes() + " bytes)");
                     } catch (IOException | IllegalArgumentException e) {
-                        Platform.runLater(() -> {
+                        postFx(() -> {
                             progress.close();
                             statusBarLabel.setText("Archive failed: " + e.getMessage());
                             statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
@@ -467,10 +502,11 @@ final class ProjectLifecycleController {
         Path destination = parentDir.toPath().resolve(stem + "-" + stamp);
 
         // Run the potentially expensive ZIP extraction on a background
-        // virtual thread. UI updates (load + notification) happen via
-        // Platform.runLater once extraction is complete.
+        // virtual thread. UI updates (load + notification) are marshalled
+        // onto the FX thread via the FxDispatcher seam (story 289) once
+        // extraction is complete.
         Window owner = rootPane.getScene().getWindow();
-        TaskProgressIndicator progress = new TaskProgressIndicator(owner, "Restoring archive\u2026");
+        TaskProgressIndicator progress = new TaskProgressIndicator(owner, "Restoring archive\u2026", fxDispatcher);
         progress.hideCancelButton();
         progress.show();
         progress.update(-1.0, "Extracting archive\u2026");
@@ -497,7 +533,7 @@ final class ProjectLifecycleController {
 
                         // Load the restored project on the FX thread; only
                         // show the success notification if loading succeeded.
-                        Platform.runLater(() -> {
+                        postFx(() -> {
                             progress.close();
                             boolean loaded = loadProjectFromPath(destination);
                             if (loaded) {
@@ -513,7 +549,7 @@ final class ProjectLifecycleController {
                         LOG.info(() -> "Restored archive " + archivePath
                                 + " into " + destination);
                     } catch (IOException e) {
-                        Platform.runLater(() -> {
+                        postFx(() -> {
                             progress.close();
                             statusBarLabel.setText("Restore failed: " + e.getMessage());
                             statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
@@ -775,7 +811,7 @@ final class ProjectLifecycleController {
         header.getStyleClass().add("panel-header");
         // No icon-next-to-label per UI Design Book §2.4.
         trackListPanel.getChildren().add(header);
-        MixerView newMixerView = new MixerView(host.project(), host.undoManager());
+        MixerView newMixerView = new MixerView(host.project(), host.undoManager(), fxDispatcher);
         host.onProjectUIRebuild(newMixerView);
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SnapshotBrowser.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SnapshotBrowser.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.snapshot.SnapshotBrowserService;
 import com.benesquivelmusic.daw.core.snapshot.SnapshotEntry;
 import com.benesquivelmusic.daw.core.snapshot.SnapshotKind;
@@ -78,12 +79,37 @@ public final class SnapshotBrowser extends VBox {
     private Runnable onCreateCheckpoint = () -> {};
 
     /**
-     * Creates a new snapshot browser bound to the given service.
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path. May be {@code null} in a pure-unit context (the compatibility
+     * constructor defaults it to {@link FxDispatcher#getDefault()});
+     * {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
+
+    /**
+     * Creates a new snapshot browser bound to the given service, marshalling
+     * off-thread refreshes through the {@link FxDispatcher#getDefault()
+     * app-scoped default} seam.
      *
      * @param service the snapshot service that supplies entries
      */
     public SnapshotBrowser(SnapshotBrowserService service) {
+        this(service, FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates a new snapshot browser bound to the given service with an
+     * explicit FX-thread marshalling seam (story 289).
+     *
+     * @param service      the snapshot service that supplies entries
+     * @param fxDispatcher the FX-thread marshalling seam, or {@code null} to use
+     *                     the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public SnapshotBrowser(SnapshotBrowserService service, FxDispatcher fxDispatcher) {
         this.service = Objects.requireNonNull(service, "service must not be null");
+        // May be null in a pure-unit context; postFx() falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
 
         getStyleClass().add("browser-panel");
         setPrefWidth(DEFAULT_WIDTH);
@@ -217,8 +243,17 @@ public final class SnapshotBrowser extends VBox {
         if (Platform.isFxApplicationThread()) {
             doRefresh();
         } else {
-            Platform.runLater(this::doRefresh);
+            postFx(this::doRefresh);
         }
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     private void doRefresh() {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SnapshotsController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SnapshotsController.java
@@ -1,5 +1,6 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.persistence.CheckpointManager;
 import com.benesquivelmusic.daw.core.persistence.ProjectDeserializer;
@@ -91,6 +92,14 @@ final class SnapshotsController {
     private final ProjectSerializer serializer = new ProjectSerializer();
     private final ProjectDeserializer deserializer = new ProjectDeserializer();
 
+    /**
+     * The FX-thread marshalling seam (story 289), forwarded to the lazily-built
+     * {@link SnapshotBrowser}. May be {@code null} in a pure-unit context (the
+     * compatibility constructor defaults it to {@link FxDispatcher#getDefault()});
+     * the browser tolerates the null via its own fallback.
+     */
+    private final FxDispatcher fxDispatcher;
+
     /** The last project checkpoint directory registered with the service,
      *  tracked so it can be removed when a different project is opened. */
     private Path lastRegisteredDirectory;
@@ -101,12 +110,23 @@ final class SnapshotsController {
                         CheckpointManager checkpointManager,
                         ProjectManager projectManager,
                         Host host) {
+        this(service, checkpointManager, projectManager, host, FxDispatcher.getDefault());
+    }
+
+    SnapshotsController(SnapshotBrowserService service,
+                        CheckpointManager checkpointManager,
+                        ProjectManager projectManager,
+                        Host host,
+                        FxDispatcher fxDispatcher) {
         this.service = Objects.requireNonNull(service, "service must not be null");
         this.checkpointManager = Objects.requireNonNull(checkpointManager,
                 "checkpointManager must not be null");
         this.projectManager = Objects.requireNonNull(projectManager,
                 "projectManager must not be null");
         this.host = Objects.requireNonNull(host, "host must not be null");
+        // May be null in a pure-unit context; SnapshotBrowser falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
     }
 
     /** Returns the underlying snapshot service (intended for tests). */
@@ -162,7 +182,7 @@ final class SnapshotsController {
     void openBrowser() {
         registerCurrentProjectDirectory();
         if (browserStage == null) {
-            browserView = new SnapshotBrowser(service);
+            browserView = new SnapshotBrowser(service, fxDispatcher);
             browserView.setOnRestore(this::restore);
             browserView.setOnCompare(this::compare);
             browserView.setOnCreateCheckpoint(this::createCheckpoint);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TaskProgressIndicator.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TaskProgressIndicator.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+
 import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -41,6 +43,13 @@ public final class TaskProgressIndicator {
     private final Button cancelButton;
     private volatile Runnable onCancel;
     private volatile boolean cancelled;
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path by the owning controller. May be {@code null} in a pure-unit context
+     * (the compatibility constructor defaults it to
+     * {@link FxDispatcher#getDefault()}); {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
 
     /**
      * Creates a new progress indicator.
@@ -50,6 +59,23 @@ public final class TaskProgressIndicator {
      * @param title the initial window title and headline label
      */
     public TaskProgressIndicator(Window owner, String title) {
+        this(owner, title, FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates a new progress indicator with an explicit FX-thread marshalling
+     * seam (story 289).
+     *
+     * @param owner        the owning window for visual stacking; may be
+     *                     {@code null} for a free-floating indicator
+     * @param title        the initial window title and headline label
+     * @param fxDispatcher the FX-thread marshalling seam, or {@code null} to use
+     *                     the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public TaskProgressIndicator(Window owner, String title, FxDispatcher fxDispatcher) {
+        // May be null in a pure-unit context; postFx() falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
         this.titleLabel = new Label(title);
         this.titleLabel.getStyleClass().add("panel-header");
         this.detailLabel = new Label("");
@@ -101,7 +127,7 @@ public final class TaskProgressIndicator {
         if (Platform.isFxApplicationThread()) {
             r.run();
         } else {
-            Platform.runLater(r);
+            postFx(r);
         }
     }
 
@@ -114,7 +140,7 @@ public final class TaskProgressIndicator {
         if (Platform.isFxApplicationThread()) {
             r.run();
         } else {
-            Platform.runLater(r);
+            postFx(r);
         }
     }
 
@@ -123,7 +149,7 @@ public final class TaskProgressIndicator {
         if (Platform.isFxApplicationThread()) {
             if (!stage.isShowing()) stage.show();
         } else {
-            Platform.runLater(() -> { if (!stage.isShowing()) stage.show(); });
+            postFx(() -> { if (!stage.isShowing()) stage.show(); });
         }
     }
 
@@ -132,7 +158,7 @@ public final class TaskProgressIndicator {
         if (Platform.isFxApplicationThread()) {
             stage.close();
         } else {
-            Platform.runLater(stage::close);
+            postFx(stage::close);
         }
     }
 
@@ -152,7 +178,7 @@ public final class TaskProgressIndicator {
         if (Platform.isFxApplicationThread()) {
             uiUpdate.run();
         } else {
-            Platform.runLater(uiUpdate);
+            postFx(uiUpdate);
         }
         Runnable cb = onCancel;
         if (cb != null) cb.run();
@@ -171,13 +197,24 @@ public final class TaskProgressIndicator {
         if (Platform.isFxApplicationThread()) {
             r.run();
         } else {
-            Platform.runLater(r);
+            postFx(r);
         }
     }
 
     /** Returns {@code true} once {@link #requestCancel()} has been invoked. */
     public boolean isCancelled() {
         return cancelled;
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289). Callers
+     * already guard with {@code Platform.isFxApplicationThread()}; this is only
+     * the off-thread hop.
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     /** Package-private accessor used by tests to verify state without an FX scene. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TrackFreezeController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TrackFreezeController.java
@@ -1,6 +1,7 @@
 package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.mixer.MixerChannel;
 import com.benesquivelmusic.daw.core.project.DawProject;
 import com.benesquivelmusic.daw.core.track.BatchFreezeTracksAction;
@@ -70,6 +71,14 @@ public final class TrackFreezeController {
     private final Runnable onSelectionFreezeChanged;
     private final BiConsumer<String, DawIcon> statusReporter;
     private final Window owner;
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path and threaded into the modeless {@link TaskProgressIndicator}. May be
+     * {@code null} in a pure-unit context (the compatibility constructor
+     * defaults it to {@link FxDispatcher#getDefault()}); {@link #postFx}
+     * tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
 
     /** Per-track-id provenance map for the snowflake tooltip. Thread-safe
      *  because recordFreeze() is called from the virtual worker thread while
@@ -105,12 +114,54 @@ public final class TrackFreezeController {
                                  Consumer<Track> onTrackFreezeChanged,
                                  Runnable onSelectionFreezeChanged,
                                  BiConsumer<String, DawIcon> statusReporter) {
+        this(project, undoManager, owner, onTrackFreezeChanged,
+                onSelectionFreezeChanged, statusReporter, FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates a new controller with an explicit FX-thread marshalling seam
+     * (story 289).
+     *
+     * @param project                  project supplying tracks, mixer,
+     *                                 sample rate and tempo (non-null)
+     * @param undoManager              undo manager to register actions with
+     *                                 (non-null)
+     * @param owner                    owning JavaFX window for the progress
+     *                                 indicator; may be {@code null}
+     * @param onTrackFreezeChanged     single-track freeze-state callback
+     * @param onSelectionFreezeChanged batch freeze/unfreeze callback
+     * @param statusReporter           status-bar reporter (message + icon)
+     * @param fxDispatcher             the FX-thread marshalling seam, or
+     *                                 {@code null} to use the
+     *                                 {@link FxDispatcher#getDefault() default}
+     */
+    public TrackFreezeController(DawProject project,
+                                 UndoManager undoManager,
+                                 Window owner,
+                                 Consumer<Track> onTrackFreezeChanged,
+                                 Runnable onSelectionFreezeChanged,
+                                 BiConsumer<String, DawIcon> statusReporter,
+                                 FxDispatcher fxDispatcher) {
         this.project = Objects.requireNonNull(project, "project must not be null");
         this.undoManager = Objects.requireNonNull(undoManager, "undoManager must not be null");
         this.onTrackFreezeChanged = onTrackFreezeChanged != null ? onTrackFreezeChanged : t -> {};
         this.onSelectionFreezeChanged = onSelectionFreezeChanged != null ? onSelectionFreezeChanged : () -> {};
         this.statusReporter = statusReporter != null ? statusReporter : (m, i) -> {};
         this.owner = owner;
+        // May be null in a pure-unit context; postFx() / TaskProgressIndicator
+        // fall back to the static seam, preserving today's behaviour exactly.
+        this.fxDispatcher = fxDispatcher;
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289). Callers
+     * already guard with {@code Platform.isFxApplicationThread()}; this is only
+     * the off-thread hop.
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     /**
@@ -258,7 +309,8 @@ public final class TrackFreezeController {
      */
     private void runFreezeAsync(List<Track> targets, boolean batch) {
         TaskProgressIndicator progress = new TaskProgressIndicator(
-                owner, batch ? "Freezing " + targets.size() + " tracks…" : "Freezing track…");
+                owner, batch ? "Freezing " + targets.size() + " tracks…" : "Freezing track…",
+                fxDispatcher);
         AtomicBoolean cancelled = new AtomicBoolean(false);
         progress.setOnCancel(() -> cancelled.set(true));
         if (!batch) {
@@ -352,7 +404,7 @@ public final class TrackFreezeController {
                         if (Platform.isFxApplicationThread()) {
                             refresh.run();
                         } else {
-                            Platform.runLater(refresh);
+                            postFx(refresh);
                         }
                     }
                 });
@@ -360,13 +412,14 @@ public final class TrackFreezeController {
 
     /**
      * Reports a status message on the FX thread. Safe to call from any
-     * thread — hops via {@link Platform#runLater} when off the FX thread.
+     * thread — marshals through the {@link FxDispatcher} seam (story 289)
+     * when off the FX thread.
      */
     private void reportStatus(String message, DawIcon icon) {
         if (Platform.isFxApplicationThread()) {
             statusReporter.accept(message, icon);
         } else {
-            Platform.runLater(() -> statusReporter.accept(message, icon));
+            postFx(() -> statusReporter.accept(message, icon));
         }
     }
 
@@ -378,7 +431,7 @@ public final class TrackFreezeController {
      * modified from one thread. If called from the FX thread already,
      * the runnable is executed inline.
      */
-    private static void runOnFxThreadAndWait(Runnable action) {
+    private void runOnFxThreadAndWait(Runnable action) {
         if (Platform.isFxApplicationThread()) {
             action.run();
             return;
@@ -386,7 +439,7 @@ public final class TrackFreezeController {
         Object lock = new Object();
         var done = new AtomicBoolean(false);
         var failure = new java.util.concurrent.atomic.AtomicReference<RuntimeException>();
-        Platform.runLater(() -> {
+        postFx(() -> {
             try {
                 action.run();
             } catch (RuntimeException e) {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransientShaperPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransientShaperPluginView.java
@@ -15,6 +15,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
@@ -30,6 +31,9 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * buffer.</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
+@FxAnimationTimerAllowed("Per-frame input/output/envelope meter timer owned by "
+        + "this plugin view (javafx-application-design §6 control-owns-timer); "
+        + "not a cross-thread seam — story 289 sentinel.")
 public final class TransientShaperPluginView extends VBox {
 
     /** Maximum displayed level on the input/output meters, in dBFS (top of bar). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TransportController.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.audio.AudioClip;
 import com.benesquivelmusic.daw.core.audio.AudioEngine;
@@ -121,6 +122,15 @@ final class TransportController {
     private final Host host;
 
     /**
+     * The FX-thread marshalling seam (story 289). Injected on the production
+     * path by the composition root; {@code null} in a pure-unit context (the
+     * compatibility constructor defaults it to {@link FxDispatcher#getDefault()},
+     * which is unset when {@code DawApplication} never started). {@link #postFx}
+     * tolerates the null and falls back to the static seam.
+     */
+    private final FxDispatcher fxDispatcher;
+
+    /**
      * UI Design Book §2.1 / §7.2 — the {@code :active} pseudo-class is
      * the single source of truth for "this transport button is in the
      * one-accent-at-a-time armed state". Wired here on Play (during
@@ -178,6 +188,25 @@ final class TransportController {
                         Button recordButton,
                         Button loopButton,
                         Host host) {
+        this(project, audioEngine, undoManager, notificationBar, statusLabel,
+                timeDisplay, statusBarLabel, recIndicator, playButton, stopButton,
+                recordButton, loopButton, host, FxDispatcher.getDefault());
+    }
+
+    TransportController(DawProject project,
+                        AudioEngine audioEngine,
+                        UndoManager undoManager,
+                        NotificationBar notificationBar,
+                        Label statusLabel,
+                        Label timeDisplay,
+                        Label statusBarLabel,
+                        Label recIndicator,
+                        Button playButton,
+                        Button stopButton,
+                        Button recordButton,
+                        Button loopButton,
+                        Host host,
+                        FxDispatcher fxDispatcher) {
         this.project = Objects.requireNonNull(project, "project must not be null");
         this.audioEngine = Objects.requireNonNull(audioEngine, "audioEngine must not be null");
         this.undoManager = Objects.requireNonNull(undoManager, "undoManager must not be null");
@@ -191,6 +220,18 @@ final class TransportController {
         this.recordButton = Objects.requireNonNull(recordButton, "recordButton must not be null");
         this.loopButton = Objects.requireNonNull(loopButton, "loopButton must not be null");
         this.host = Objects.requireNonNull(host, "host must not be null");
+        // May be null in a pure-unit context; postFx() falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     // ── Transport action handlers ────────────────────────────────────────────
@@ -717,8 +758,11 @@ final class TransportController {
             recorder.setStartColumnOffset(startColumnOffset);
             recorder.setCountInDurationUs(countInDurationUs);
 
-            // Wire MIDI activity indicator — flash the track strip on each event
-            recorder.addEventListener(_ -> javafx.application.Platform.runLater(
+            // Wire MIDI activity indicator — flash the track strip on each
+            // event. The recorder fires on the MIDI receiver thread, so the
+            // flash is marshalled onto the FX thread through the FxDispatcher
+            // seam (story 289; Control Synchronization Design Book §1.5, §4.5).
+            recorder.addEventListener(_ -> postFx(
                     () -> host.flashMidiActivity(track)));
 
             try {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TruePeakLimiterPluginView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/TruePeakLimiterPluginView.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
 import java.util.Objects;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
 
 /**
@@ -33,6 +34,9 @@ import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
  * used by {@link TruePeakLimiterProcessor}).</p>
  */
 @HardcodedColorAllowed("story 277 follow-up: migrate Canvas/inline paints to resolved -token CSS")
+@FxAnimationTimerAllowed("Per-frame gain-reduction/true-peak meter timer owned by "
+        + "this plugin view (javafx-application-design §6 control-owns-timer); "
+        + "not a cross-thread seam — story 289 sentinel.")
 public final class TruePeakLimiterPluginView extends VBox {
 
     /** Maximum gain-reduction shown on the meter, in dB. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/UndoHistoryPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/UndoHistoryPanel.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.undo.UndoHistoryListener;
 import com.benesquivelmusic.daw.core.undo.UndoManager;
 import com.benesquivelmusic.daw.core.undo.UndoableAction;
@@ -41,6 +42,13 @@ public final class UndoHistoryPanel extends VBox {
     private final ObservableList<String> historyItems;
     private final UndoHistoryListener listener;
     private boolean updating;
+    /**
+     * The FX-thread marshalling seam (story 289), injected on the production
+     * path. May be {@code null} in a pure-unit context (the compatibility
+     * constructor defaults it to {@link FxDispatcher#getDefault()});
+     * {@link #postFx} tolerates the null.
+     */
+    private final FxDispatcher fxDispatcher;
 
     /**
      * Creates a new undo history panel bound to the given {@link UndoManager}.
@@ -48,7 +56,22 @@ public final class UndoHistoryPanel extends VBox {
      * @param undoManager the undo manager whose history to display
      */
     public UndoHistoryPanel(UndoManager undoManager) {
+        this(undoManager, FxDispatcher.getDefault());
+    }
+
+    /**
+     * Creates a new undo history panel with an explicit FX-thread marshalling
+     * seam (story 289).
+     *
+     * @param undoManager  the undo manager whose history to display
+     * @param fxDispatcher the FX-thread marshalling seam, or {@code null} to use
+     *                     the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public UndoHistoryPanel(UndoManager undoManager, FxDispatcher fxDispatcher) {
         this.undoManager = Objects.requireNonNull(undoManager, "undoManager must not be null");
+        // May be null in a pure-unit context; postFx() falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
 
         getStyleClass().add("browser-panel");
         setPrefWidth(DEFAULT_WIDTH);
@@ -83,12 +106,21 @@ public final class UndoHistoryPanel extends VBox {
             if (Platform.isFxApplicationThread()) {
                 refreshHistory();
             } else {
-                Platform.runLater(this::refreshHistory);
+                postFx(this::refreshHistory);
             }
         };
         undoManager.addHistoryListener(listener);
 
         refreshHistory();
+    }
+
+    /**
+     * Posts {@code work} to the FX thread through the injected
+     * {@link FxDispatcher} when present, else the static app-scoped seam — the
+     * null branch reproduces today's behaviour exactly (story 289).
+     */
+    private void postFx(Runnable work) {
+        FxDispatcher.runOnFx(fxDispatcher, work);
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ViewNavigationController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ViewNavigationController.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.event.EventBusPublisher;
 import com.benesquivelmusic.daw.core.project.DawProject;
 import com.benesquivelmusic.daw.core.undo.UndoManager;
@@ -90,6 +91,15 @@ final class ViewNavigationController {
     private final Label statusBarLabel;
     private final ToolbarStateStore toolbarStateStore;
     private final Host host;
+
+    /**
+     * The FX-thread marshalling seam (story 289), forwarded to the
+     * {@link MixerView} this controller builds. May be {@code null} in a
+     * pure-unit context (the compatibility constructor defaults it to
+     * {@link FxDispatcher#getDefault()}); {@code MixerView} tolerates the null
+     * via its own fallback.
+     */
+    private final FxDispatcher fxDispatcher;
 
     // Snap button (top toolbar)
     private final Button snapButton;
@@ -182,11 +192,29 @@ final class ViewNavigationController {
                              boolean initialSnapEnabled,
                              GridResolution initialGridResolution,
                              Host host) {
+        this(rootPane, statusBarLabel, toolbarStateStore, snapButton, initialView,
+                initialEditTool, initialSnapEnabled, initialGridResolution, host,
+                FxDispatcher.getDefault());
+    }
+
+    ViewNavigationController(BorderPane rootPane,
+                             Label statusBarLabel,
+                             ToolbarStateStore toolbarStateStore,
+                             Button snapButton,
+                             DawView initialView,
+                             EditTool initialEditTool,
+                             boolean initialSnapEnabled,
+                             GridResolution initialGridResolution,
+                             Host host,
+                             FxDispatcher fxDispatcher) {
         this.rootPane = Objects.requireNonNull(rootPane, "rootPane must not be null");
         this.statusBarLabel = Objects.requireNonNull(statusBarLabel, "statusBarLabel must not be null");
         this.toolbarStateStore = Objects.requireNonNull(toolbarStateStore, "toolbarStateStore must not be null");
         this.snapButton = Objects.requireNonNull(snapButton, "snapButton must not be null");
         this.host = Objects.requireNonNull(host, "host must not be null");
+        // May be null in a pure-unit context; MixerView falls back to the
+        // static seam, preserving today's behaviour byte-for-byte.
+        this.fxDispatcher = fxDispatcher;
 
         this.activeView = Objects.requireNonNull(initialView, "initialView must not be null");
         this.activeEditTool = Objects.requireNonNull(initialEditTool, "initialEditTool must not be null");
@@ -205,7 +233,7 @@ final class ViewNavigationController {
         viewCache.put(DawView.ARRANGEMENT, rootPane.getCenter());
 
         // Mixer view — real channel-strip mixer panel
-        mixerView = new MixerView(host.project(), host.undoManager());
+        mixerView = new MixerView(host.project(), host.undoManager(), fxDispatcher);
         viewCache.put(DawView.MIXER, mixerView);
 
         // Editor view — MIDI piano-roll / audio waveform editor panel

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/LevelMeterSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/controls/skin/LevelMeterSkin.java
@@ -1,6 +1,7 @@
 package com.benesquivelmusic.daw.app.ui.controls.skin;
 
 import com.benesquivelmusic.daw.app.ui.controls.LevelMeter;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
 
 import javafx.animation.AnimationTimer;
 import javafx.beans.value.ChangeListener;
@@ -51,6 +52,11 @@ import java.util.function.LongSupplier;
  * {@link #tick(long)} so tests can drive it deterministically with
  * synthetic timestamps (no real sleeps).
  */
+@FxAnimationTimerAllowed("Per-frame meter-render loop owned by this skin, gated on "
+        + "scene attachment; relays the control's own lock-free atomic levels to "
+        + "its JavaFX properties (javafx-application-design §6 control-owns-timer). "
+        + "It is not a Platform.runLater cross-thread hop and not the central "
+        + "marshalling seam — story 289 sentinel.")
 public final class LevelMeterSkin extends SkinBase<LevelMeter> {
 
     /** Peak-hold duration in nanoseconds (2 s). */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/density/DensityManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/density/DensityManager.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app.ui.density;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -348,7 +350,7 @@ public final class DensityManager {
             return;
         }
         try {
-            Platform.runLater(r);
+            FxDispatcher.runOnFx(r);
         } catch (IllegalStateException toolkitNotRunning) {
             // No JavaFX toolkit yet / toolkit already shut down (a
             // pure-unit context, or a density change racing application

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/export/RenderQueueView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/export/RenderQueueView.java
@@ -1,8 +1,8 @@
 package com.benesquivelmusic.daw.app.ui.export;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.export.RenderQueue;
 import com.benesquivelmusic.daw.sdk.export.JobProgress;
-import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -66,7 +66,7 @@ public final class RenderQueueView extends VBox {
                 subscription = s;
                 s.request(Long.MAX_VALUE);
             }
-            @Override public void onNext(JobProgress p) { Platform.runLater(() -> applyUpdate(p)); }
+            @Override public void onNext(JobProgress p) { FxDispatcher.runOnFx(() -> applyUpdate(p)); }
             @Override public void onError(Throwable t) { /* ignore */ }
             @Override public void onComplete() { /* ignore */ }
         });

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/inspector/sections/NotificationsSection.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/inspector/sections/NotificationsSection.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.app.ui.NotificationHistoryService;
 import com.benesquivelmusic.daw.app.ui.NotificationPill;
 import com.benesquivelmusic.daw.app.ui.inspector.InspectorDrawer;
 import com.benesquivelmusic.daw.app.ui.inspector.InspectorSection;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 
 import javafx.application.Platform;
 import javafx.geometry.Pos;
@@ -95,7 +96,7 @@ public final class NotificationsSection extends InspectorSection {
             if (Platform.isFxApplicationThread()) {
                 rebuild();
             } else {
-                Platform.runLater(this::rebuild);
+                FxDispatcher.runOnFx(this::rebuild);
             }
         };
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/marshal/FxAnimationTimerAllowed.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/marshal/FxAnimationTimerAllowed.java
@@ -1,0 +1,73 @@
+package com.benesquivelmusic.daw.app.ui.marshal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Sentinel marker for a UI class that legitimately constructs its own
+ * {@link javafx.animation.AnimationTimer} — a per-frame, FX-thread animation
+ * loop a control or plugin view owns — and is therefore <em>not</em> the
+ * cross-thread marshalling seam {@link FxDispatcher} consolidates (story 289;
+ * Control Synchronization Design Book §4.5).
+ *
+ * <p>{@code RunLaterConsolidationTest} scans the {@code
+ * com.benesquivelmusic.daw.app} source tree and asserts that, outside
+ * {@link FxDispatcher}, no source constructs an {@code AnimationTimer} unless it
+ * carries this annotation with a non-blank reason. The annotation makes a
+ * sanctioned timer <strong>visible</strong> and prevents drift: a new class
+ * cannot spin up a frame loop — or, worse, smuggle in a second cross-thread hop
+ * — without consciously recording why its timer is a legitimate
+ * control-owns-its-own-loop case and not a marshalling seam.</p>
+ *
+ * <p>Why a sentinel rather than folding the eleven existing timers into the one
+ * {@code FxDispatcher} pulse? Those are per-frame meter / parameter / glyph
+ * animations each owned by a single control or plugin view
+ * ({@code javafx-application-design} §6: "a control owns its own timer"). They
+ * are not cross-thread seams — none of them hops a non-FX signal onto the FX
+ * thread — and merging them into a shared pulse would change their behaviour
+ * (start/stop lifecycle, per-control framing). Story 289's mandate is a
+ * no-behaviour-change consolidation of the <em>marshalling</em> seam, so these
+ * stay where they are and are tracked here instead of refactored.</p>
+ *
+ * <p>This is the direct sibling of
+ * {@link com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed} (story
+ * 277) and {@link com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog} (story
+ * 276): same pattern (mandatory non-blank {@code value()} reason,
+ * {@code @Documented}, type-targeted), same intent (a green gate that tracks a
+ * sanctioned exception without forcing a risky bulk refactor).</p>
+ *
+ * <p>Retention is {@link RetentionPolicy#SOURCE}: the audit is a source-file
+ * text scan (no module / reflection concerns), so the marker need not survive
+ * compilation. {@link FxDispatcher} itself owns the one legitimate seam timer
+ * and is excluded from the scan by name — it must <em>not</em> carry this
+ * annotation.</p>
+ *
+ * <pre>{@code
+ * @FxAnimationTimerAllowed("Per-frame meter animation owned by this view "
+ *         + "(javafx-application-design §6 control-owns-timer); not a "
+ *         + "cross-thread seam — story 289 sentinel.")
+ * public final class FooMeterView { ... }
+ * }</pre>
+ *
+ * @see com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed
+ * @see com.benesquivelmusic.daw.app.ui.dialogs.LegacyDialog
+ * @see FxDispatcher
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface FxAnimationTimerAllowed {
+
+    /**
+     * Mandatory reason explaining why this class owns its own
+     * {@link javafx.animation.AnimationTimer} and why that timer is a
+     * legitimate per-frame control / view animation loop rather than a
+     * cross-thread marshalling seam.
+     *
+     * @return the rationale; must be non-blank
+     */
+    String value();
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/marshal/FxDispatcher.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/marshal/FxDispatcher.java
@@ -1,0 +1,452 @@
+package com.benesquivelmusic.daw.app.ui.marshal;
+
+import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
+
+import javafx.animation.AnimationTimer;
+import javafx.application.Platform;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * The single marshalling seam between non-JavaFX threads and the JavaFX
+ * Application Thread (Control Synchronization Design Book §2.6, §4.5; story
+ * 289, Stage 1 of the §8 migration path).
+ *
+ * <p>State arrives on the FX thread from at least three other threads: the
+ * MIDI receiver thread, the audio/metering thread, and background virtual
+ * threads doing I/O (archiving, restoring, autosave). Before this seam the UI
+ * layer hopped onto the FX thread from <strong>27 separate files</strong> that
+ * each called {@code Platform.runLater} directly — an independent, un-ordered,
+ * un-coalesced hop with nothing documenting which signals are allowed to
+ * originate off-thread (§1.5). {@code FxDispatcher} replaces all of them: it is
+ * the <em>only</em> place {@code Platform.runLater} (or an
+ * {@link AnimationTimer}) appears in {@code daw-app} (§4.5), enforced by
+ * {@code RunLaterConsolidationTest}.</p>
+ *
+ * <p>The seam exposes the two §4.5 jobs:</p>
+ *
+ * <h2>Discrete — {@link #onFx(Runnable)} / {@link #onFx(Object, Runnable)}</h2>
+ *
+ * <p>{@link #onFx(Runnable)} posts a one-shot runnable to the FX thread. It is
+ * {@link java.util.concurrent.Executor}-compatible by design — {@code
+ * fxDispatcher::onFx} is the {@code Executor} the production
+ * {@link com.benesquivelmusic.daw.sdk.event.EventBus EventBus} uses for
+ * {@link com.benesquivelmusic.daw.sdk.event.DispatchMode#ON_UI_THREAD
+ * ON_UI_THREAD} delivery
+ * ({@code DawApplication}). <strong>It performs an unconditional
+ * {@link Platform#runLater(Runnable)} and never coalesces, drops, or defers a
+ * post indefinitely.</strong> This is a hard contract: the bus's
+ * {@code DefaultEventBus.Sub.runAndAwait} hands the runnable to this executor
+ * and then blocks a daemon worker on a {@code CountDownLatch} until the runnable
+ * has run on the FX thread; a seam that coalesced or dropped it would deadlock
+ * that worker forever. And because {@code Platform.runLater} always enqueues
+ * onto a later turn of the FX event loop — even when called from the FX thread
+ * itself — {@link #onFx(Runnable)} likewise never runs a post inline. Call sites
+ * that want an inline fast-path when they are already on the FX thread test
+ * {@link Platform#isFxApplicationThread()} themselves and hand only the
+ * off-thread case to the seam (as {@code MixerView} does).
+ *
+ * <p>{@link #onFx(Object, Runnable)} adds keyed per-frame coalescing: N posts
+ * with the same {@code key} within one animation pulse collapse to a single
+ * execution of the latest runnable (latest-wins). Use it for a burst of
+ * duplicate discrete updates (a flurry of "refresh undo state" requests, say)
+ * that need to happen once per frame, not N times.</p>
+ *
+ * <h2>Continuous — {@link #openContinuous(Consumer)}</h2>
+ *
+ * <p>A {@link ContinuousChannel} carries a high-frequency value (a meter level,
+ * the playhead during playback) written by the producer with a lock-free,
+ * wait-free {@link ContinuousChannel#publish(Object) publish} that
+ * <strong>never blocks</strong> — safe to call from the {@link RealTimeSafe}
+ * audio thread (§4.1, §4.6, §9). The dispatcher drains the channel once per
+ * frame, keeps the latest value, and invokes the FX-thread consumer with it.
+ * A ~1&nbsp;kHz meter stream therefore becomes ~60 coalesced UI updates/s, and
+ * the audio thread never blocks on the UI (§4.5; {@code research-daw} §3
+ * lock-free audio thread; {@code javafx-application-design} §6 "coalesce per
+ * frame", §11 "the FX thread is sacred — marshal deliberately"). Each channel
+ * is backed by a lock-free, wait-free, single-reader latest-value buffer (a
+ * depth-1 coalescing mailbox; {@code @RealTimeSafe}). See {@link Channel}.</p>
+ *
+ * <h2>Coalescing pulse</h2>
+ *
+ * <p>{@link #start()} creates and starts a single {@link AnimationTimer} (the
+ * only one this seam owns); its {@code handle} body is exactly {@link #pulse()}.
+ * Each pulse runs every pending keyed runnable once then clears the keyed map,
+ * and drains every continuous channel. {@link #onFx(Runnable)} does
+ * <em>not</em> depend on the timer — it goes straight to {@code Platform
+ * .runLater}; the timer only flushes the keyed-coalesce map and the continuous
+ * channels. {@link #dispose()} stops the timer and clears both. Both
+ * {@code start()} and {@code dispose()} are idempotent and must be called on the
+ * FX thread (the {@code AnimationTimer} lifecycle is FX-thread state).</p>
+ *
+ * <h2>Stage-1 scope (story 289)</h2>
+ *
+ * <p>This story builds and fully unit-tests the continuous seam but does
+ * <em>not</em> yet reroute the live playhead / meter polls through it: today
+ * those read state on the FX thread each frame, and inserting a ring-buffer
+ * round-trip would add a frame of latency (a behaviour change), while the real
+ * {@code @RealTimeSafe} audio-thread producer cannot be added without giving
+ * {@code daw-core} a metering tap (an explicit Non-Goal — {@code daw-core} stays
+ * JavaFX-free). The seam exists and is tested; its audio-thread producer is
+ * wired in a later stage when {@code daw-core} gains the metering tap (§4.6,
+ * §5.8).</p>
+ *
+ * <h2>App-scoped default</h2>
+ *
+ * <p>The composition root ({@code DawApplication}) installs one instance via
+ * {@link #installDefault(FxDispatcher)} so the awkward minority of call sites
+ * that cannot take a constructor dependency — the FXML-instantiated
+ * {@code MainController}, the toolkit-free {@code getDefault()} singletons
+ * ({@code ThemeManager}, {@code DensityManager}), and short-lived dialogs — can
+ * reach the one seam through {@link #getDefault()}. This mirrors the blessed
+ * {@code EventBusPublisher} publisher seam (story 283): a single app-scoped
+ * holder set once at startup, with constructor injection preferred wherever the
+ * construction chain makes it natural. Tests install their own instance so they
+ * can drive {@link #onFx(Runnable)} / {@link #pulse()} deterministically.</p>
+ *
+ * <p>This class is thread-safe: {@link #onFx(Runnable)},
+ * {@link #onFx(Object, Runnable)} and {@link ContinuousChannel#publish(Object)}
+ * may be called from any thread; {@link #start()}, {@link #pulse()} and
+ * {@link #dispose()} run on the FX thread.</p>
+ *
+ * @see com.benesquivelmusic.daw.core.event.EventBusPublisher
+ */
+public final class FxDispatcher {
+
+    /**
+     * The application-wide dispatcher installed by the composition root.
+     * {@code volatile} so a hot-swap via {@link #installDefault(FxDispatcher)}
+     * (production startup, or a test installing its own instance) is visible to
+     * every reader without tearing — the same discipline as
+     * {@link com.benesquivelmusic.daw.core.event.EventBusPublisher}.
+     */
+    private static volatile FxDispatcher defaultInstance;
+
+    /**
+     * Latest runnable per coalescing key, run once on the next {@link #pulse()}.
+     * A {@link ConcurrentHashMap} because {@link #onFx(Object, Runnable)} may be
+     * called from any thread while the FX thread drains the map.
+     */
+    private final Map<Object, Runnable> keyedWork = new ConcurrentHashMap<>();
+
+    /** Open continuous channels drained on every {@link #pulse()}. */
+    private final List<Channel<?>> channels = new CopyOnWriteArrayList<>();
+
+    /** The single per-frame coalescing timer; non-null only between
+     *  {@link #start()} and {@link #dispose()}. */
+    private AnimationTimer pulseTimer;
+
+    /** Whether {@link #start()} has run (and {@link #dispose()} has not). */
+    private boolean started;
+
+    /** Creates an unstarted dispatcher. Call {@link #start()} on the FX thread. */
+    public FxDispatcher() {
+        // No FX state is touched until start(): constructable in any thread /
+        // a toolkit-free unit context, like EventBusPublisher's bus reference.
+    }
+
+    // ── app-scoped default (mirrors EventBusPublisher) ───────────────────────
+
+    /**
+     * Installs the application-wide dispatcher. Idempotent; passing
+     * {@code null} clears the default (test teardown / app shutdown). The
+     * caller owns the instance's {@link #start()} / {@link #dispose()}
+     * lifecycle — this only publishes the reference for {@link #getDefault()}.
+     *
+     * @param dispatcher the dispatcher to publish, or {@code null} to clear
+     */
+    public static void installDefault(FxDispatcher dispatcher) {
+        defaultInstance = dispatcher;
+    }
+
+    /**
+     * Returns the application-wide dispatcher installed by the composition
+     * root, or {@code null} when none is installed (a pure-unit context that
+     * never called {@link #installDefault(FxDispatcher)}). Callers that hold a
+     * long-lived reference should capture the returned instance once rather
+     * than re-read on every use (the "capture swappable singleton reference
+     * once" discipline).
+     *
+     * @return the current default dispatcher, or {@code null}
+     */
+    public static FxDispatcher getDefault() {
+        return defaultInstance;
+    }
+
+    /**
+     * Static convenience that posts {@code work} to the FX thread through the
+     * {@link #getDefault() app-scoped default} dispatcher, or — if none is
+     * installed — falls back to a direct {@link Platform#runLater(Runnable)}.
+     *
+     * <p>This is the drop-in for the call sites that cannot take a constructor
+     * dependency on the seam: the {@code getDefault()} singletons
+     * ({@code ThemeManager}, {@code DensityManager}), short-lived dialogs, and
+     * views constructed deep in a chain. It preserves behaviour exactly — the
+     * work always ends in a {@code Platform.runLater} — while keeping
+     * {@code Platform.runLater} confined to this one file (enforced by
+     * {@code RunLaterConsolidationTest}). The fallback matters for unit tests
+     * that start the JavaFX toolkit but not {@code DawApplication}: there the
+     * default is unset, yet a {@code runLater} is still both valid and required,
+     * just as the bare call these sites used previously was.</p>
+     *
+     * <p>Callers that already hold an injected {@code FxDispatcher} should call
+     * the instance {@link #onFx(Runnable)} directly; this static seam is only
+     * for the injection-awkward minority.</p>
+     *
+     * @param work the runnable to execute on the FX thread; must not be
+     *             {@code null}
+     */
+    public static void runOnFx(Runnable work) {
+        runOnFx(null, work);
+    }
+
+    /**
+     * Posts {@code work} to the FX thread, preferring {@code preferred} when it
+     * is non-{@code null} and otherwise falling back to the {@link #getDefault()
+     * app-scoped default} (and, with no dispatcher installed anywhere, a direct
+     * {@link Platform#runLater(Runnable)}).
+     *
+     * <p>This is the single home for the "prefer an injected dispatcher, else
+     * the app-scoped default" resolution that the injection-aware call sites
+     * (e.g. {@code MixerView}, {@code BrowserPanel}, {@code MainController} and
+     * the other controllers) previously each re-implemented as a private
+     * {@code postFx} helper. Those helpers now delegate here, so the rule lives
+     * in one place. Behaviour is identical to the former inlined form: the work
+     * always ends in {@link #onFx(Runnable)} (an unconditional {@code
+     * Platform.runLater}), or in a bare {@code runLater} when no dispatcher is
+     * reachable at all (the pure-unit context).</p>
+     *
+     * @param preferred the call site's injected dispatcher, or {@code null} to
+     *                  use the app-scoped default
+     * @param work      the runnable to execute on the FX thread; must not be
+     *                  {@code null}
+     */
+    public static void runOnFx(FxDispatcher preferred, Runnable work) {
+        Objects.requireNonNull(work, "work must not be null");
+        FxDispatcher target = preferred != null ? preferred : defaultInstance;
+        if (target != null) {
+            target.onFx(work);
+        } else {
+            Platform.runLater(work);
+        }
+    }
+
+    // ── discrete ─────────────────────────────────────────────────────────────
+
+    /**
+     * Posts {@code work} to the JavaFX Application Thread via an unconditional
+     * {@link Platform#runLater(Runnable)}. {@link java.util.concurrent.Executor}-
+     * compatible: this is the {@code Executor} the production
+     * {@link com.benesquivelmusic.daw.sdk.event.EventBus EventBus} uses for
+     * {@link com.benesquivelmusic.daw.sdk.event.DispatchMode#ON_UI_THREAD}
+     * delivery.
+     *
+     * <p>Never coalesces, never drops, and — because {@code Platform.runLater}
+     * always enqueues onto a later turn of the FX event loop — never runs inline
+     * even when called from the FX thread (see the class Javadoc: the bus blocks
+     * a worker until this runnable runs, so the post must not be coalesced or
+     * dropped). This is the single permitted {@code Platform.runLater} call site
+     * in {@code daw-app}.</p>
+     *
+     * @param work the runnable to execute on the FX thread; must not be
+     *             {@code null}
+     */
+    public void onFx(Runnable work) {
+        Objects.requireNonNull(work, "work must not be null");
+        Platform.runLater(work);
+    }
+
+    /**
+     * Posts {@code work} to the FX thread with per-frame coalescing keyed by
+     * {@code key}: only the latest runnable stored under a given key survives
+     * to the next {@link #pulse()}, where it runs exactly once. N same-key posts
+     * within one frame therefore collapse to one execution (latest-wins);
+     * distinct keys each run once.
+     *
+     * <p>Requires {@link #start()} to have been called so the pulse timer is
+     * draining the keyed map; until then the work accumulates and runs on the
+     * first pulse after start. Use this for a burst of duplicate discrete
+     * refreshes that need to happen once per frame, not for work the
+     * {@link com.benesquivelmusic.daw.sdk.event.EventBus EventBus}'s blocking
+     * UI executor relies on (use {@link #onFx(Runnable)} for that).</p>
+     *
+     * @param key  the coalescing key; must not be {@code null}
+     * @param work the runnable to run once per frame under {@code key}; must not
+     *             be {@code null}
+     */
+    public void onFx(Object key, Runnable work) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(work, "work must not be null");
+        keyedWork.put(key, work);
+    }
+
+    // ── continuous ───────────────────────────────────────────────────────────
+
+    /**
+     * A lock-free, single-reader channel carrying a high-frequency value from
+     * a producer thread to an FX-thread consumer, coalesced once per frame.
+     *
+     * @param <T> the value type
+     */
+    public interface ContinuousChannel<T> {
+        /**
+         * Publishes the latest value. Lock-free, wait-free and non-blocking —
+         * safe to call from the {@link RealTimeSafe} audio thread. If the
+         * backing buffer is momentarily full the value is dropped (the next
+         * frame's drain keeps only the latest anyway), so the producer never
+         * blocks on the UI.
+         *
+         * @param value the value to publish; must not be {@code null}
+         */
+        @RealTimeSafe
+        void publish(T value);
+    }
+
+    /**
+     * Opens a continuous channel whose latest published value is delivered to
+     * {@code fxConsumer} on the FX thread at most once per frame. On each
+     * {@link #pulse()} the channel's latest value is taken (and cleared), and —
+     * only if a value was published since the last pulse — {@code fxConsumer} is
+     * invoked with it. The channel stays open until {@link #dispose()}.
+     *
+     * @param fxConsumer the FX-thread consumer of the coalesced latest value;
+     *                   must not be {@code null}
+     * @param <T>        the value type
+     * @return the channel the producer publishes into
+     */
+    public <T> ContinuousChannel<T> openContinuous(Consumer<T> fxConsumer) {
+        Objects.requireNonNull(fxConsumer, "fxConsumer must not be null");
+        Channel<T> channel = new Channel<>(fxConsumer);
+        channels.add(channel);
+        return channel;
+    }
+
+    // ── pulse / lifecycle ────────────────────────────────────────────────────
+
+    /**
+     * Drains the keyed-coalesce map (running each pending keyed runnable once)
+     * then every continuous channel. The owned {@link AnimationTimer}'s {@code
+     * handle} body is exactly this call; it runs on the FX thread.
+     *
+     * <p>Exposed (the enclosing module exports / opens nothing, so this is not a
+     * widened public API) so the story's tests — which must live in the {@code
+     * …app.ui} package for the JavaFX-toolkit extension to work under JPMS, a
+     * different package from this seam — can drive the pulse manually rather
+     * than relying on a live timer.</p>
+     */
+    public void pulse() {
+        // Snapshot-and-clear the keyed map so a runnable that re-posts the same
+        // key schedules for the NEXT pulse, not this one (no starvation, no
+        // ConcurrentModification). Iteration over an entrySet of the live map
+        // would be unsafe against concurrent puts; drain by removing each key.
+        if (!keyedWork.isEmpty()) {
+            for (Object key : keyedWork.keySet()) {
+                Runnable work = keyedWork.remove(key);
+                if (work != null) {
+                    work.run();
+                }
+            }
+        }
+        for (Channel<?> channel : channels) {
+            channel.drain();
+        }
+    }
+
+    /**
+     * Creates and starts the single per-frame {@link AnimationTimer} whose
+     * {@code handle} body is {@link #pulse()}. Idempotent — a second call while
+     * already started is a no-op. Must be called on the FX thread.
+     */
+    public void start() {
+        if (started) {
+            return;
+        }
+        started = true;
+        pulseTimer = new PulseTimer();
+        pulseTimer.start();
+    }
+
+    /**
+     * Stops the pulse timer and clears the keyed map and continuous channels.
+     * Idempotent — safe to call when never started or already disposed. Must be
+     * called on the FX thread.
+     */
+    public void dispose() {
+        started = false;
+        if (pulseTimer != null) {
+            pulseTimer.stop();
+            pulseTimer = null;
+        }
+        keyedWork.clear();
+        channels.clear();
+    }
+
+    /**
+     * The one {@link AnimationTimer} this seam owns. Extracted as a named type
+     * (rather than an anonymous subclass) so {@code RunLaterConsolidationTest}'s
+     * {@code new AnimationTimer} / {@code extends AnimationTimer} scan finds it
+     * only inside {@code FxDispatcher} — the seam's own file is excluded from
+     * that scan by name, so this timer needs no {@code @FxAnimationTimerAllowed}
+     * sentinel (it <em>is</em> the legitimate seam timer §4.5 sanctions).
+     */
+    private final class PulseTimer extends AnimationTimer {
+        @Override
+        public void handle(long now) {
+            pulse();
+        }
+    }
+
+    /**
+     * One continuous channel: a lock-free, wait-free, single-reader
+     * latest-value buffer (a depth-1 coalescing mailbox). The producer
+     * {@link #publish(Object) publishes} the newest value; the FX-thread
+     * {@link #drain()} once per frame takes whatever is there and clears it.
+     *
+     * <p>A depth-1 atomic mailbox is the correct realization of §4.5's
+     * "lock-free single-reader buffer drained once per frame" for a continuous
+     * value whose consumer only ever wants the <em>latest</em>: it coalesces a
+     * full frame's worth of writes (a ~1&nbsp;kHz stream → one value per ~60&nbsp;Hz
+     * frame) into the freshest sample with no allocation and no loss of the
+     * latest. Unlike a bounded ring, it can never deliver a <em>stale</em> value
+     * by dropping the newest write on overflow — "latest always wins" holds
+     * regardless of how far the producer outruns the drain. {@link AtomicReference}
+     * gives single-producer/single-consumer wait-freedom; {@code lazySet} is
+     * sufficient and avoids a full fence, and the producer never blocks on the
+     * consumer (§4.1, §4.6 — safe for the {@link RealTimeSafe} audio thread).</p>
+     *
+     * @param <T> the value type
+     */
+    private static final class Channel<T> implements ContinuousChannel<T> {
+
+        /** Holds the latest published value, or {@code null} when drained / empty. */
+        private final AtomicReference<T> latest = new AtomicReference<>();
+        private final Consumer<T> fxConsumer;
+
+        Channel(Consumer<T> fxConsumer) {
+            this.fxConsumer = fxConsumer;
+        }
+
+        @Override
+        @RealTimeSafe
+        public void publish(T value) {
+            Objects.requireNonNull(value, "value must not be null");
+            // Wait-free latest-wins overwrite: never blocks, never drops the
+            // newest — the audio thread must never block on the UI (§4.1, §4.6).
+            latest.lazySet(value);
+        }
+
+        /** Takes the latest value (if any) and delivers it once on the FX thread. */
+        void drain() {
+            T value = latest.getAndSet(null);
+            if (value != null) {
+                fxConsumer.accept(value);
+            }
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/marshal/FxDispatcher.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/marshal/FxDispatcher.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 import javafx.animation.AnimationTimer;
 import javafx.application.Platform;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -341,15 +342,18 @@ public final class FxDispatcher {
      * than relying on a live timer.</p>
      */
     public void pulse() {
-        // Snapshot-and-clear the keyed map so a runnable that re-posts the same
-        // key schedules for the NEXT pulse, not this one (no starvation, no
-        // ConcurrentModification). Iteration over an entrySet of the live map
-        // would be unsafe against concurrent puts; drain by removing each key.
+        // Snapshot the keyed entries first, then remove each by key AND value, so
+        // work posted while this pulse runs (including a runnable that re-posts
+        // under the same key) stays queued for the NEXT pulse. A weakly
+        // consistent keySet() iterator could otherwise pick up such concurrent
+        // posts and run them in this same pulse nondeterministically, violating
+        // the documented per-frame coalescing contract.
         if (!keyedWork.isEmpty()) {
-            for (Object key : keyedWork.keySet()) {
-                Runnable work = keyedWork.remove(key);
-                if (work != null) {
-                    work.run();
+            List<Map.Entry<Object, Runnable>> snapshot =
+                    new ArrayList<>(keyedWork.entrySet());
+            for (Map.Entry<Object, Runnable> entry : snapshot) {
+                if (keyedWork.remove(entry.getKey(), entry.getValue())) {
+                    entry.getValue().run();
                 }
             }
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/marshal/FxDispatcher.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/marshal/FxDispatcher.java
@@ -298,10 +298,11 @@ public final class FxDispatcher {
     public interface ContinuousChannel<T> {
         /**
          * Publishes the latest value. Lock-free, wait-free and non-blocking —
-         * safe to call from the {@link RealTimeSafe} audio thread. If the
-         * backing buffer is momentarily full the value is dropped (the next
-         * frame's drain keeps only the latest anyway), so the producer never
-         * blocks on the UI.
+         * safe to call from the {@link RealTimeSafe} audio thread. The backing
+         * buffer is a depth-1 latest-wins mailbox: a value published before the
+         * next frame's drain overwrites the previous unconsumed value, so the
+         * newest sample is never lost (an earlier un-drained value is) and the
+         * producer never blocks on the UI.
          *
          * @param value the value to publish; must not be {@code null}
          */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/theme/ThemeManager.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.app.ui.theme;
 
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -496,7 +498,7 @@ public final class ThemeManager {
             return;
         }
         try {
-            Platform.runLater(r);
+            FxDispatcher.runOnFx(r);
         } catch (IllegalStateException toolkitNotRunning) {
             // No JavaFX toolkit yet / toolkit already shut down (a
             // pure-unit context, or a theme change racing application

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BusUiDispatchRoutesThroughDispatcherTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BusUiDispatchRoutesThroughDispatcherTest.java
@@ -1,0 +1,108 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.event.DefaultEventBus;
+import com.benesquivelmusic.daw.sdk.event.DispatchMode;
+import com.benesquivelmusic.daw.sdk.event.EventBus;
+import com.benesquivelmusic.daw.sdk.event.TransportEvent;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 289 — proves the production wiring change: building the
+ * {@link DefaultEventBus} with {@code uiExecutor(fxDispatcher::onFx)} routes
+ * every {@link DispatchMode#ON_UI_THREAD} subscriber through the one
+ * {@link FxDispatcher} marshalling seam, so the handler runs on the JavaFX
+ * Application Thread (Control Synchronization Design Book §4.2, §4.5; mirrors
+ * {@code DawApplication}'s bus build).
+ *
+ * <p>The assertion is made through the bus API plus an FX-thread latch — never
+ * via {@code Event.getSource()} identity (the bus rewrites source on bubble, and
+ * a {@link com.benesquivelmusic.daw.sdk.event.DawEvent DawEvent} is not a JavaFX
+ * {@code Event} anyway). Because the bus's {@code runAndAwait} blocks a worker
+ * until the FX task runs, the dispatcher is started and the FX toolkit is live so
+ * {@code onFx}'s {@code Platform.runLater} actually executes; otherwise that
+ * worker would deadlock.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class BusUiDispatchRoutesThroughDispatcherTest {
+
+    @Test
+    void onUiThreadSubscriberRunsOnTheFxThreadThroughTheDispatcherSeam()
+            throws Exception {
+        FxDispatcher dispatcher = new FxDispatcher();
+        startOnFxAndWait(dispatcher);
+
+        EventBus bus = DefaultEventBus.builder()
+                .uiExecutor(dispatcher::onFx)
+                .build();
+        try {
+            AtomicBoolean ranOnFxThread = new AtomicBoolean(false);
+            AtomicReference<Throwable> thrown = new AtomicReference<>();
+            CountDownLatch handled = new CountDownLatch(1);
+
+            bus.on(TransportEvent.Started.class, DispatchMode.ON_UI_THREAD, _ -> {
+                try {
+                    ranOnFxThread.set(Platform.isFxApplicationThread());
+                } catch (Throwable t) {
+                    thrown.set(t);
+                } finally {
+                    handled.countDown();
+                }
+            });
+
+            // Publish from the test (non-FX) thread; ON_UI_THREAD delivery must
+            // marshal the handler onto the FX thread via dispatcher::onFx.
+            bus.publish(new TransportEvent.Started(0L, Instant.now()));
+
+            assertThat(handled.await(5, TimeUnit.SECONDS))
+                    .as("the ON_UI_THREAD subscriber must run within 5s — a "
+                            + "deadlock here would mean onFx failed to post to a "
+                            + "live FX thread")
+                    .isTrue();
+            if (thrown.get() != null) {
+                throw new AssertionError(thrown.get());
+            }
+            assertThat(ranOnFxThread.get())
+                    .as("the ON_UI_THREAD subscriber must run on the FX thread "
+                            + "through the FxDispatcher seam")
+                    .isTrue();
+        } finally {
+            bus.close();
+            disposeOnFxAndWait(dispatcher);
+        }
+    }
+
+    private static void startOnFxAndWait(FxDispatcher dispatcher) throws InterruptedException {
+        runOnFxAndWait(dispatcher::start);
+    }
+
+    private static void disposeOnFxAndWait(FxDispatcher dispatcher) throws InterruptedException {
+        runOnFxAndWait(dispatcher::dispose);
+    }
+
+    private static void runOnFxAndWait(Runnable action) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX lifecycle action must complete within 5s")
+                .isTrue();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FxDispatcherDrainTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FxDispatcherDrainTest.java
@@ -81,8 +81,9 @@ class FxDispatcherDrainTest {
         AtomicReference<Long> elapsedNanos = new AtomicReference<>();
 
         // A writer thread hammers publish() WITHOUT any concurrent drain: the
-        // SPSC ring is wait-free and drops on full rather than blocking, so even
-        // a million writes against an undrained buffer must return promptly.
+        // depth-1 latest-wins mailbox is wait-free and overwrites the pending
+        // value rather than blocking, so even a million writes against an
+        // undrained buffer must return promptly.
         Thread writer = new Thread(() -> {
             try {
                 long start = System.nanoTime();

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FxDispatcherDrainTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FxDispatcherDrainTest.java
@@ -1,0 +1,168 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 289 — verifies the {@link FxDispatcher} continuous lock-free path
+ * (Control Synchronization Design Book §4.1, §4.5, §4.6): a high-frequency
+ * producer publishes into a single-reader buffer that is drained once per frame,
+ * coalescing a burst into the latest value, and the producer's
+ * {@code publish(...)} <strong>never blocks</strong> — it is wait-free, safe for
+ * the {@code @RealTimeSafe} audio thread.
+ *
+ * <p>No JavaFX toolkit is needed: the drain is driven <em>manually</em> via
+ * {@link FxDispatcher#pulse()} (the story forbids relying on a live
+ * {@code AnimationTimer}), and the consumer is a plain test callback. The
+ * consumer naturally runs on whatever thread calls {@code pulse()} here; in
+ * production {@code pulse()} is the FX thread's {@code AnimationTimer} body.</p>
+ */
+class FxDispatcherDrainTest {
+
+    @Test
+    void manyWritesBetweenTwoDrainsYieldTheLatestCoalescedValue() {
+        FxDispatcher dispatcher = new FxDispatcher();
+        AtomicInteger drains = new AtomicInteger(0);
+        AtomicReference<Integer> lastDelivered = new AtomicReference<>();
+
+        FxDispatcher.ContinuousChannel<Integer> channel =
+                dispatcher.openContinuous(v -> {
+                    drains.incrementAndGet();
+                    lastDelivered.set(v);
+                });
+
+        // Publish a burst, then drain once: the consumer must see only the
+        // latest value, invoked exactly once (the coalescing contract).
+        for (int i = 0; i < 500; i++) {
+            channel.publish(i);
+        }
+        dispatcher.pulse();
+
+        assertThat(drains.get())
+                .as("a burst drained once must deliver exactly one coalesced value")
+                .isEqualTo(1);
+        assertThat(lastDelivered.get())
+                .as("the delivered value must be the latest published")
+                .isEqualTo(499);
+
+        // A second pulse with nothing newly published must not re-deliver.
+        dispatcher.pulse();
+        assertThat(drains.get())
+                .as("an empty drain must not invoke the consumer")
+                .isEqualTo(1);
+
+        // After more writes, the next drain delivers the new latest.
+        channel.publish(1000);
+        channel.publish(1001);
+        dispatcher.pulse();
+        assertThat(drains.get()).isEqualTo(2);
+        assertThat(lastDelivered.get()).isEqualTo(1001);
+    }
+
+    @Test
+    void publishNeverBlocksUnderAConcurrentWriterHammeringTheChannel() throws InterruptedException {
+        FxDispatcher dispatcher = new FxDispatcher();
+        FxDispatcher.ContinuousChannel<Integer> channel =
+                dispatcher.openContinuous(v -> { /* drained on the test thread */ });
+
+        int writeCount = 1_000_000;
+        AtomicReference<Throwable> writerError = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Long> elapsedNanos = new AtomicReference<>();
+
+        // A writer thread hammers publish() WITHOUT any concurrent drain: the
+        // SPSC ring is wait-free and drops on full rather than blocking, so even
+        // a million writes against an undrained buffer must return promptly.
+        Thread writer = new Thread(() -> {
+            try {
+                long start = System.nanoTime();
+                for (int i = 0; i < writeCount; i++) {
+                    channel.publish(i);
+                }
+                elapsedNanos.set(System.nanoTime() - start);
+            } catch (Throwable t) {
+                writerError.set(t);
+            } finally {
+                done.countDown();
+            }
+        }, "fx-dispatcher-drain-test-writer");
+        writer.setDaemon(true);
+        writer.start();
+
+        // If publish() blocked (e.g. waited on a full buffer) this would time
+        // out — proving the producer never blocks on the consumer.
+        boolean finished = done.await(10, TimeUnit.SECONDS);
+        assertThat(finished)
+                .as("a writer hammering publish() must never block — %d wait-free "
+                        + "writes must complete well within the timeout", writeCount)
+                .isTrue();
+        assertThat(writerError.get())
+                .as("the writer must not throw")
+                .isNull();
+        assertThat(elapsedNanos.get())
+                .as("the write burst must complete (non-null elapsed time)")
+                .isNotNull();
+    }
+
+    @Test
+    void concurrentlyDrainingWhileWritingNeverBlocksTheWriter() throws InterruptedException {
+        FxDispatcher dispatcher = new FxDispatcher();
+        List<Integer> delivered = new ArrayList<>();
+        FxDispatcher.ContinuousChannel<Integer> channel =
+                dispatcher.openContinuous(delivered::add);
+
+        int writeCount = 200_000;
+        AtomicReference<Throwable> writerError = new AtomicReference<>();
+        CountDownLatch writerDone = new CountDownLatch(1);
+
+        // SPSC contract: ONE producer thread, ONE consumer (the drain). Here the
+        // writer thread is the single producer and the main thread is the single
+        // consumer draining concurrently — the writer must still never block.
+        Thread writer = new Thread(() -> {
+            try {
+                for (int i = 1; i <= writeCount; i++) {
+                    channel.publish(i);
+                }
+            } catch (Throwable t) {
+                writerError.set(t);
+            } finally {
+                writerDone.countDown();
+            }
+        }, "fx-dispatcher-drain-test-spsc-writer");
+        writer.setDaemon(true);
+        writer.start();
+
+        // Drain repeatedly from this (single consumer) thread while the writer runs.
+        while (writerDone.getCount() > 0) {
+            dispatcher.pulse();
+        }
+
+        assertThat(writerDone.await(10, TimeUnit.SECONDS))
+                .as("the concurrent SPSC writer must finish without blocking")
+                .isTrue();
+        assertThat(writerError.get()).as("the writer must not throw").isNull();
+
+        // The writer is fully done, so the buffer is no longer being written.
+        // A sentinel published now cannot be dropped by a concurrent overflow,
+        // so a final drain must deliver it deterministically — proving the drain
+        // path keeps working after concurrent writes (the coalescing + drop of
+        // intermediate burst values during the run is by design, so we do not
+        // assert which mid-run values were delivered).
+        int sentinel = writeCount + 1;
+        channel.publish(sentinel);
+        dispatcher.pulse();
+        assertThat(delivered)
+                .as("a post-run sentinel must be delivered by the final drain")
+                .contains(sentinel);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FxDispatcherTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FxDispatcherTest.java
@@ -1,0 +1,202 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 289 — verifies the {@link FxDispatcher} discrete marshalling jobs
+ * (Control Synchronization Design Book §4.5): {@code onFx(Runnable)} runs work
+ * on the JavaFX Application Thread, and {@code onFx(key, work)} coalesces N
+ * same-key posts within one pulse into a single execution (latest-wins).
+ *
+ * <p>Assertions that must hold <em>on</em> the FX thread are captured into an
+ * {@link AtomicReference}, the latch is counted down in a {@code finally}, and
+ * the throwable is rethrown on the test thread — a JavaFX headless pitfall is
+ * that an assertion thrown inside a {@code Platform.runLater} body is swallowed,
+ * so a failing assert would otherwise pass green. The coalescing assertions
+ * check an invocation <em>counter</em>, never pixels (per the story).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class FxDispatcherTest {
+
+    private static final long TIMEOUT_SECONDS = 5;
+
+    /** Runs {@code action} on the FX thread and blocks until it completes. */
+    private static void runOnFxAndWait(Runnable action) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("FX action must complete within %ds", TIMEOUT_SECONDS)
+                .isTrue();
+        rethrow(thrown.get());
+    }
+
+    private static void rethrow(Throwable t) {
+        if (t instanceof RuntimeException re) {
+            throw re;
+        }
+        if (t instanceof Error e) {
+            throw e;
+        }
+        if (t != null) {
+            throw new AssertionError(t);
+        }
+    }
+
+    @Test
+    void onFxRunnableRunsWorkOnTheFxThread() throws InterruptedException {
+        FxDispatcher dispatcher = new FxDispatcher();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        AtomicBoolean ran = new AtomicBoolean(false);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Post from the test (non-FX) thread; the work must hop to the FX thread.
+        dispatcher.onFx(() -> {
+            try {
+                // Captured + rethrown on the test thread — an assert thrown here
+                // would otherwise be swallowed and the test would pass green.
+                assertThat(Platform.isFxApplicationThread())
+                        .as("onFx(Runnable) must run work on the FX thread")
+                        .isTrue();
+                ran.set(true);
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("onFx work must run within %ds", TIMEOUT_SECONDS)
+                .isTrue();
+        rethrow(thrown.get());
+        assertThat(ran).as("onFx work must have executed").isTrue();
+    }
+
+    @Test
+    void runOnFxWithPreferredDispatcherRunsWorkOnTheFxThread() throws InterruptedException {
+        // The injection-aware postFx helpers (MixerView, BrowserPanel,
+        // MainController, …) all delegate here; a non-null preferred dispatcher
+        // must be used to hop the work onto the FX thread (and never NPE, the
+        // null-tolerance the per-class helpers relied on).
+        FxDispatcher preferred = new FxDispatcher();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        AtomicBoolean ran = new AtomicBoolean(false);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        FxDispatcher.runOnFx(preferred, () -> {
+            try {
+                assertThat(Platform.isFxApplicationThread())
+                        .as("runOnFx(preferred, work) must run work on the FX thread")
+                        .isTrue();
+                ran.set(true);
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("runOnFx work must run within %ds", TIMEOUT_SECONDS)
+                .isTrue();
+        rethrow(thrown.get());
+        assertThat(ran).as("runOnFx work must have executed").isTrue();
+    }
+
+    @Test
+    void keyedPostsWithinOnePulseCoalesceToASingleLatestRun() throws InterruptedException {
+        FxDispatcher dispatcher = new FxDispatcher();
+        AtomicInteger invocations = new AtomicInteger(0);
+        AtomicInteger lastValueSeen = new AtomicInteger(-1);
+        Object key = new Object();
+        int posts = 50;
+
+        // All puts and the single drain happen on the FX thread in one runnable,
+        // so no pulse can interleave between them: the N same-key posts must
+        // collapse to exactly one execution of the latest runnable.
+        runOnFxAndWait(() -> {
+            for (int i = 0; i < posts; i++) {
+                int value = i;
+                dispatcher.onFx(key, () -> {
+                    invocations.incrementAndGet();
+                    lastValueSeen.set(value);
+                });
+            }
+            dispatcher.pulse();
+        });
+
+        assertThat(invocations.get())
+                .as("%d same-key posts within one pulse must coalesce to one run", posts)
+                .isEqualTo(1);
+        assertThat(lastValueSeen.get())
+                .as("the coalesced run must be the latest-posted runnable")
+                .isEqualTo(posts - 1);
+    }
+
+    @Test
+    void distinctKeysEachRunOncePerPulse() throws InterruptedException {
+        FxDispatcher dispatcher = new FxDispatcher();
+        AtomicInteger runsA = new AtomicInteger(0);
+        AtomicInteger runsB = new AtomicInteger(0);
+        AtomicInteger runsC = new AtomicInteger(0);
+
+        runOnFxAndWait(() -> {
+            // Two posts each for A and B (coalesce to one apiece), one for C.
+            dispatcher.onFx("A", runsA::incrementAndGet);
+            dispatcher.onFx("A", runsA::incrementAndGet);
+            dispatcher.onFx("B", runsB::incrementAndGet);
+            dispatcher.onFx("B", runsB::incrementAndGet);
+            dispatcher.onFx("C", runsC::incrementAndGet);
+            dispatcher.pulse();
+        });
+
+        assertThat(runsA.get()).as("key A runs once").isEqualTo(1);
+        assertThat(runsB.get()).as("key B runs once").isEqualTo(1);
+        assertThat(runsC.get()).as("key C runs once").isEqualTo(1);
+    }
+
+    @Test
+    void keyedWorkDoesNotRunUntilTheNextPulse() throws InterruptedException {
+        FxDispatcher dispatcher = new FxDispatcher();
+        AtomicInteger runs = new AtomicInteger(0);
+
+        runOnFxAndWait(() -> {
+            dispatcher.onFx("k", runs::incrementAndGet);
+            // No pulse yet — the work must be pending, not executed.
+            assertThat(runs.get())
+                    .as("keyed work must not run before a pulse")
+                    .isZero();
+            dispatcher.pulse();
+            assertThat(runs.get())
+                    .as("keyed work runs on the pulse")
+                    .isEqualTo(1);
+            // A second pulse with nothing pending must not re-run it.
+            dispatcher.pulse();
+            assertThat(runs.get())
+                    .as("keyed work runs exactly once, not on every later pulse")
+                    .isEqualTo(1);
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RunLaterConsolidationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RunLaterConsolidationTest.java
@@ -1,0 +1,246 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 289 — guards the §4.5 "one marshalling seam" contract (Control
+ * Synchronization Design Book §2.6, §4.5): after this story, {@code
+ * Platform.runLater} and {@code AnimationTimer} appear only inside
+ * {@link com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher}. Every other
+ * off-thread hop onto the JavaFX Application Thread goes through the dispatcher,
+ * and every legitimate per-frame control timer is explicitly sanctioned with a
+ * {@link com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed}
+ * sentinel carrying a non-blank reason.
+ *
+ * <p>This is the direct sibling of {@code LegacyHardcodedColorAuditTest}
+ * (story 277) and the {@code @LegacyDialog}/{@code @HardcodedColorAllowed}
+ * conformance-sentinel pattern: a green gate that scans the source tree and
+ * prevents drift — a new control cannot reintroduce an ad-hoc {@code
+ * Platform.runLater} or spin up an unsanctioned {@code AnimationTimer}.</p>
+ *
+ * <h3>Scope</h3>
+ *
+ * <p>The scan roots at {@code com.benesquivelmusic.daw.app} (not just {@code
+ * …app.ui}) because the bus-wiring site {@code DawApplication} lives directly in
+ * {@code …app}, and the contract is that <em>no</em> {@code daw-app} source
+ * outside {@code FxDispatcher} references either construct. To stay faithful to
+ * a SOURCE-level scan (both sentinels are {@link
+ * java.lang.annotation.RetentionPolicy#SOURCE}) it strips {@code //} / {@code /*
+ * *\/} comments before matching (so a {@code Platform.runLater} mention in
+ * Javadoc does not false-match), blanks string / text-block literals before the
+ * {@code Platform.runLater} scan, and captures the {@code @FxAnimationTimerAllowed}
+ * {@code value()} literal to assert it is <em>non-blank</em> — exactly the
+ * preprocessing {@code LegacyHardcodedColorAuditTest} performs. {@code
+ * FxDispatcher.java} (which owns the one legitimate seam timer and the two
+ * permitted {@code Platform.runLater} call sites) and the {@code
+ * FxAnimationTimerAllowed.java} annotation type's own source are excluded by
+ * name, exactly as the colour audit skips its annotation type.</p>
+ */
+final class RunLaterConsolidationTest {
+
+    /** {@code Platform.runLater(} — the ad-hoc cross-thread hop this story retires. */
+    private static final Pattern PLATFORM_RUN_LATER =
+            Pattern.compile("\\bPlatform\\s*\\.\\s*runLater\\s*\\(");
+
+    /** {@code new AnimationTimer} / {@code extends AnimationTimer} — a per-frame loop. */
+    private static final Pattern ANIMATION_TIMER =
+            Pattern.compile("\\b(?:new|extends)\\s+AnimationTimer\\b");
+
+    /**
+     * The class-level sentinel <em>with</em> its mandatory {@code value()}
+     * string literal captured (group 1). The audit asserts the captured reason
+     * is non-blank — the SOURCE-scan equivalent of a reflective
+     * {@code ann.value() != null && !ann.value().isBlank()} check. The literal
+     * may be a single string or a {@code "a" + "b"} concatenation; group 1
+     * captures the first segment, which is always non-blank for a real reason.
+     */
+    private static final Pattern ANIMATION_TIMER_SENTINEL = Pattern.compile(
+            "@FxAnimationTimerAllowed\\s*\\(\\s*\"((?:\\\\.|[^\"\\\\])*)\"");
+
+    /**
+     * One Java comment or one string / text-block literal. Alternation order
+     * matters: a literal is matched before {@code //} and {@code /*} so a
+     * delimiter inside a string is not mistaken for a comment, and a quote
+     * inside a comment is consumed as part of the comment.
+     */
+    private static final Pattern COMMENT_OR_STRING = Pattern.compile(
+            "\"\"\"[\\s\\S]*?\"\"\""        // text block
+            + "|\"(?:\\\\.|[^\"\\\\])*\""   // string literal
+            + "|//[^\\n]*"                  // line comment
+            + "|/\\*[\\s\\S]*?\\*/");       // block comment
+
+    /** The seam itself — owns the one timer and the only {@code Platform.runLater} calls. */
+    private static final String DISPATCHER_FILE = "FxDispatcher.java";
+
+    /** The sentinel annotation type, whose own Javadoc necessarily names the
+     *  constructs it guards; excluded exactly as the colour audit skips
+     *  {@code @HardcodedColorAllowed}'s own type. */
+    private static final String ANNOTATION_TYPE_FILE = "FxAnimationTimerAllowed.java";
+
+    @Test
+    void noDawAppSourceOutsideFxDispatcherHopsThreadsOrOwnsAnUnsanctionedTimer()
+            throws IOException {
+        Path appSrcRoot = locateDawAppModule()
+                .resolve("src/main/java/com/benesquivelmusic/daw/app");
+        assertThat(Files.isDirectory(appSrcRoot))
+                .as("daw-app Java sources must live under %s", appSrcRoot)
+                .isTrue();
+
+        List<String> runLaterOffenders = new ArrayList<>();
+        List<String> timerOffenders = new ArrayList<>();
+        List<Path> scanned = new ArrayList<>();
+
+        Files.walkFileTree(appSrcRoot, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                String name = file.getFileName().toString();
+                if (!name.endsWith(".java")
+                        || name.equals(DISPATCHER_FILE)
+                        || name.equals(ANNOTATION_TYPE_FILE)) {
+                    return FileVisitResult.CONTINUE;
+                }
+                scanned.add(file);
+
+                // Strip comments (so a mention in Javadoc does not false-match)
+                // but keep string literals so the real @FxAnimationTimerAllowed("…")
+                // survives for the non-blank check; then blank strings for the
+                // Platform.runLater scan so a mention inside a string is not a
+                // false match.
+                String code = stripComments(
+                        Files.readString(file, StandardCharsets.UTF_8));
+                String relPath = appSrcRoot.relativize(file).toString()
+                        .replace('\\', '/');
+
+                if (PLATFORM_RUN_LATER.matcher(stripStringLiterals(code)).find()) {
+                    runLaterOffenders.add(relPath
+                            + "  — references Platform.runLater (route it through "
+                            + "FxDispatcher instead)");
+                }
+
+                if (ANIMATION_TIMER.matcher(stripStringLiterals(code)).find()) {
+                    Matcher sentinel = ANIMATION_TIMER_SENTINEL.matcher(code);
+                    if (!sentinel.find()) {
+                        timerOffenders.add(relPath
+                                + "  — constructs an AnimationTimer without "
+                                + "@FxAnimationTimerAllowed");
+                    } else if (sentinel.group(1).isBlank()) {
+                        timerOffenders.add(relPath
+                                + "  — @FxAnimationTimerAllowed reason is blank "
+                                + "(the rationale is mandatory)");
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        // Guard against a silently-empty scan (a broken path would make the
+        // audit vacuously pass).
+        assertThat(scanned)
+                .as("the daw-app source scan must visit a non-trivial number of "
+                        + ".java files — an empty scan would make this audit "
+                        + "vacuously pass")
+                .hasSizeGreaterThan(50);
+
+        runLaterOffenders.sort(String::compareTo);
+        assertThat(runLaterOffenders)
+                .as("Story 289 — after the FxDispatcher seam lands, no daw-app "
+                        + "source outside FxDispatcher may reference "
+                        + "Platform.runLater; route every off-thread hop through "
+                        + "fxDispatcher.onFx(...) / FxDispatcher.runOnFx(...). "
+                        + "Offending files:%n  %s",
+                        String.join("\n  ", runLaterOffenders))
+                .isEmpty();
+
+        timerOffenders.sort(String::compareTo);
+        assertThat(timerOffenders)
+                .as("Story 289 — every daw-app source outside FxDispatcher that "
+                        + "constructs an AnimationTimer must carry "
+                        + "@FxAnimationTimerAllowed(\"<reason>\") to record that "
+                        + "its per-frame timer is a legitimate control-owned loop, "
+                        + "not a cross-thread marshalling seam (sibling of story "
+                        + "277's @HardcodedColorAllowed). Offending files:%n  %s",
+                        String.join("\n  ", timerOffenders))
+                .isEmpty();
+    }
+
+    /**
+     * Locate the {@code daw-app} module root. Surefire normally sets the working
+     * directory to the module itself; the fallbacks cover invocations from the
+     * repo root (e.g. {@code mvn -pl daw-app test}). Mirrors
+     * {@code LegacyHardcodedColorAuditTest#locateDawAppModule()}.
+     */
+    private static Path locateDawAppModule() {
+        Path cwd = Paths.get("").toAbsolutePath();
+        if (isDawAppModule(cwd)) {
+            return cwd;
+        }
+        Path child = cwd.resolve("daw-app");
+        if (isDawAppModule(child)) {
+            return child;
+        }
+        Path candidate = cwd.getParent();
+        for (int i = 0; i < 5 && candidate != null; i++) {
+            if (isDawAppModule(candidate)) {
+                return candidate;
+            }
+            Path nested = candidate.resolve("daw-app");
+            if (isDawAppModule(nested)) {
+                return nested;
+            }
+            candidate = candidate.getParent();
+        }
+        return cwd;
+    }
+
+    private static boolean isDawAppModule(Path dir) {
+        return Files.isRegularFile(dir.resolve("pom.xml"))
+                && Files.isDirectory(
+                        dir.resolve("src/main/java/com/benesquivelmusic/daw/app"));
+    }
+
+    // ── source pre-processing (mirrors LegacyHardcodedColorAuditTest) ─────────
+
+    /**
+     * Removes {@code //} and {@code /* *\/} comments while preserving string /
+     * text-block literals (so a real {@code @FxAnimationTimerAllowed("...")}
+     * survives the strip but a {@code Platform.runLater} written inside Javadoc
+     * does not).
+     */
+    private static String stripComments(String source) {
+        Matcher m = COMMENT_OR_STRING.matcher(source);
+        StringBuilder out = new StringBuilder(source.length());
+        while (m.find()) {
+            String token = m.group();
+            // A string / text block (starts with a quote) is code — keep it
+            // verbatim; anything else the alternation matched is a comment and
+            // is replaced with a single space.
+            m.appendReplacement(out, token.charAt(0) == '"'
+                    ? Matcher.quoteReplacement(token) : " ");
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+
+    /** Blanks string / text-block literals out of already comment-free code. */
+    private static String stripStringLiterals(String code) {
+        return code
+                .replaceAll("\"\"\"[\\s\\S]*?\"\"\"", "\"\"")
+                .replaceAll("\"(?:\\\\.|[^\"\\\\])*\"", "\"\"");
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RunLaterConsolidationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RunLaterConsolidationTest.java
@@ -53,9 +53,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 final class RunLaterConsolidationTest {
 
-    /** {@code Platform.runLater(} — the ad-hoc cross-thread hop this story retires. */
+    /**
+     * {@code Platform.runLater(} or {@code Platform::runLater} — the ad-hoc
+     * cross-thread hop this story retires, matched both as a call expression and
+     * as a method reference (the fully qualified {@code
+     * javafx.application.Platform} form is covered too, since {@code \bPlatform}
+     * matches after the package dots).
+     */
     private static final Pattern PLATFORM_RUN_LATER =
-            Pattern.compile("\\bPlatform\\s*\\.\\s*runLater\\s*\\(");
+            Pattern.compile(
+                    "\\bPlatform\\s*(?:\\.\\s*runLater\\s*\\(|::\\s*runLater\\b)");
 
     /** {@code new AnimationTimer} / {@code extends AnimationTimer} — a per-frame loop. */
     private static final Pattern ANIMATION_TIMER =

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RunLaterConsolidationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RunLaterConsolidationTest.java
@@ -59,7 +59,7 @@ final class RunLaterConsolidationTest {
 
     /** {@code new AnimationTimer} / {@code extends AnimationTimer} — a per-frame loop. */
     private static final Pattern ANIMATION_TIMER =
-            Pattern.compile("\\b(?:new|extends)\\s+AnimationTimer\\b");
+            Pattern.compile("\\b(?:new|extends)\\s+(?:javafx\\s*\\.\\s*animation\\s*\\.\\s*)?AnimationTimer\\b");
 
     /**
      * The class-level sentinel <em>with</em> its mandatory {@code value()}


### PR DESCRIPTION
# Introduce the FxDispatcher Marshalling Seam and Route Cross-Surface Updates Through the Existing EventBus (No Behaviour Change)

## Motivation

The Control Synchronization Design Book (`docs/design/CONTROL_SYNCHRONIZATION_DESIGN_BOOK.md`)
diagnoses the user's recurring "the UI feels flaky" complaint as a *missing wiring layer*. Two of its
§1 problem-inventory items are pure threading hazards that can be retired **before** any view-model
work, and this story — Stage 1 of the §8 migration path — does exactly that:

- **§1.5 informal cross-thread `runLater`** — "There are **27 separate files** in the UI package that
  call `Platform.runLater` directly. Each is an independent, un-coordinated hop onto the FX thread.
  Nothing guarantees ordering between them, nothing coalesces a burst of meter updates into one repaint,
  and nothing documents which signals are allowed to originate off-thread." (Verified: 47 occurrences
  across exactly 27 `daw-app` files today — e.g. `MainController` 3, `ProjectLifecycleController` 5,
  `TrackFreezeController` 3, `TaskProgressIndicator` 6.)
- **§1.6 no cascade order** — partly a downstream consequence: when twenty-seven unrelated sites each
  hop threads on their own, "some orders cause visible flicker."

The seam this story adds is already anticipated *in the code*. `DispatchMode.ON_UI_THREAD` is documented
as "every event is re-dispatched through the UI executor (typically `Platform::runLater`) so the
subscriber always runs on the JavaFX Application Thread" (`daw-sdk/.../event/DispatchMode.java`), and
`DefaultEventBus` already takes that UI executor via its builder — `DefaultEventBus.builder().uiExecutor(Executor)`,
documented "typical wiring in JavaFX code is `uiExecutor(Platform::runLater)`" — which production wires
today as the **bare** `DefaultEventBus.builder().uiExecutor(Platform::runLater).build()`
(`daw-app/.../DawApplication.java:63-65`, immediately before `EventBusPublisher.setDefault(bus)` at
`:66`, the story-283 install). Per §4.5 the dispatcher "is the *only* place `Platform.runLater` (or an
`AnimationTimer`) appears."

This story makes the `FxDispatcher` real and routes the existing cross-thread hops through it — with
**no behaviour change** — so every later stage builds on a real, tested marshalling seam.

## Goals

- Add `FxDispatcher` in a new `daw-app/.../ui/marshal/` package as the single seam between non-FX
  threads and the FX thread, with the two §4.5 jobs:
  - **Discrete:** `onFx(Runnable)` posts work to the FX thread, with keyed coalescing so a burst of
    duplicate keyed updates collapses to one run.
  - **Continuous:** drain a lock-free, single-reader buffer once per frame via an `AnimationTimer` the
    dispatcher owns, so a ~1 kHz meter stream becomes ~60 coalesced UI updates/s (meters, playhead).
- Retarget the production `EventBus` `ON_UI_THREAD` delivery through the seam: build the bus as
  `DefaultEventBus.builder().uiExecutor(fxDispatcher::onFx).build()` instead of
  `.uiExecutor(Platform::runLater)` at `DawApplication.java:63-65`, so every `ON_UI_THREAD` subscription
  (story 283 producers + future UI subscribers) marshals through the one coalescing seam rather than a
  bare `runLater`.
- Replace the 27 raw `Platform.runLater` call sites in `daw-app` with `fxDispatcher.onFx(...)`. After
  this story, `Platform.runLater` and `new AnimationTimer` appear **only** inside `FxDispatcher`.
- Route the continuous meter/playhead path through the lock-free buffer the dispatcher drains; the
  `@RealTimeSafe` audio thread writes the buffer and **never blocks** on the UI (§4.1, §4.6, §9). The
  audio thread takes no JavaFX dependency and never subscribes to the bus.
- No behaviour change: every visible flow that worked before works identically; this is consolidation
  only (§8 Stage 1: "behaviour is identical, but the seam now exists").

Tests (operate on properties / buffer state / call routing — never on rasterisation):
- `FxDispatcherTest` — asserts `onFx` runs work on the FX thread; asserts that N keyed duplicate posts
  within one pulse coalesce to a single execution (assert an invocation counter, not pixels).
- `FxDispatcherDrainTest` — asserts the lock-free buffer is single-reader-drained per frame: many writes
  between two manual drains yield the latest coalesced value, and a writer thread never blocks under
  concurrent writes (drive the drain manually rather than relying on a live `AnimationTimer`).
- `BusUiDispatchRoutesThroughDispatcherTest` — builds `DefaultEventBus.builder().uiExecutor(fxDispatcher::onFx).build()`,
  publishes an event with an `ON_UI_THREAD` subscriber, and asserts the handler ran on the FX thread via
  the dispatcher seam (assert through the bus API + an FX-thread latch, never `Event.getSource()`
  identity).
- `RunLaterConsolidationTest` — a source-scan guard (mirrors the `@LegacyDialog`/`@HardcodedColorAllowed`
  conformance-sentinel pattern): asserts no `daw-app` source outside `FxDispatcher` references
  `Platform.runLater` or constructs an `AnimationTimer`; non-empty-scan guard so the test fails if the
  scan matches nothing.

## Non-Goals

- **No view-models.** `TransportVM`, `TrackVM`/`ChannelVM`, `SelectionVM`, `HistoryVM`, `ProjectVM` are
  later stages (stories 290-292). This story adds zero `vm` classes and changes no control bindings.
- **No core notification seam.** The toolkit-neutral `Consumer<ChangeKind>` signal in `daw-core` is
  story 290 — `daw-core` is untouched here and stays JavaFX-free.
- **No new event types.** `SelectionChanged`, `UndoStateChanged`, `ThemeChanged` (§4.2, §7, Appendix A)
  arrive with the stages that need them (story 292). The `DawEvent` `permits` list is unchanged.
- **No re-entrancy-guard deletion.** The five §1.4 flags (`suppressChangeEvents`, `updatingControls`,
  `suppressNotification`, `programmaticDimensionUpdate`, `updating`) are removed in story 293 once
  single-writer view-models exist; they remain in place here.
- No behaviour or visual change, and no god-controller decomposition (stories 293/294).

## Technical Notes

- New: `daw-app/.../ui/marshal/FxDispatcher.java` (+ a small lock-free single-reader ring/exchanger for
  the continuous path). The dispatcher is constructor-injected where the 27 sites live (DI over
  singletons — stories 198/199), so tests can drive `onFx`/drain deterministically.
- Build on the existing bus end-to-end — do **not** invent a parallel bus: `daw-sdk/.../event/EventBus.java`
  (`publish`, `subscribe(Class)`, `on(Class, Consumer)`, `on(Class, DispatchMode, Consumer)`, returning
  `Subscription extends AutoCloseable`), `daw-sdk/.../event/DispatchMode.java` (`ON_UI_THREAD` runs via
  the bus's UI executor), impl `daw-core/.../event/DefaultEventBus.java` (the `Builder.uiExecutor(Executor)`
  seam — toolkit-neutral, takes `java.util.concurrent.Executor`, no JavaFX type), and the publish seam
  `daw-core/.../event/EventBusPublisher.java` (live since story 283; `EventBusPublisher.setDefault(bus)`
  at `DawApplication.java:66`). The only production wiring change is the `uiExecutor` passed at
  `DawApplication.java:63-65`.
- `@RealTimeSafe` is on the audio-thread paths; the audio thread writes the lock-free buffer only, never
  calls into JavaFX, preserving the module boundary and real-time safety (`research-daw` §3 lock-free;
  `dawg-annotations-reflection`).
- Register the `AnimationTimer` once in the constructor and stop it in `dispose()`; never start ad-hoc
  timers elsewhere. There is no `EnumProperty<T>` in JavaFX (not needed here, but flagged for later
  stages — the repo has been bitten by assuming it exists).
- Verified facts: 27 `daw-app` files call `Platform.runLater` (the book's count is correct);
  `DefaultEventBus` is configured via `builder().uiExecutor(...)` (no `Consumer<Runnable>` ctor); the
  live wiring is `DawApplication.java:63-66`.
- Sibling stories: 283 (publishers — the producer half this consumes), 202/203 (sealed `DawEvent` /
  central typed bus), 290 (first VM + core signal), 293 (re-entrancy-guard deletions). See
  `docs/design/CONTROL_SYNCHRONIZATION_DESIGN_BOOK.md` §1.5, §1.6, §4.1, §4.5, §4.6, §8 Stage 1, §9,
  Appendix A.
- SKILL: `javafx-application-design` (§11 threading/marshalling, §6 Canvas, §12 typed events, §15
  anti-patterns), `research-daw` (§3 real-time / lock-free), `dawg-annotations-reflection`
  (`@RealTimeSafe`).
- Build/verify: `mvn -pl daw-app -am test -Dtest=FxDispatcher*,BusUiDispatchRoutesThroughDispatcher*,RunLaterConsolidation* -Dsurefire.failIfNoSpecifiedTests=false`.
