### PR TITLE
292-selectionvm-historyvm-projectvm-and-the-ordered-full-load-cascade implementation.

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/HistoryControlBinder.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/HistoryControlBinder.java
@@ -1,0 +1,142 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import com.benesquivelmusic.daw.app.ui.vm.command.HistoryCommand;
+import com.benesquivelmusic.daw.app.ui.vm.command.RedoCommand;
+import com.benesquivelmusic.daw.app.ui.vm.command.UndoCommand;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.scene.control.ButtonBase;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.Tooltip;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Binds the undo/redo controls — toolbar buttons and Edit-menu items — to a
+ * {@link HistoryVM} and routes their gestures to {@link HistoryCommand}s (Control
+ * Synchronization Design Book §6.9, §4.4; story 292). It replaces the hand-pushed
+ * {@code MainController.updateUndoRedoState()} that poked both surfaces from one
+ * place (§1.2): each control now <em>binds</em> the VM instead.
+ *
+ * <ul>
+ *   <li>A control's {@code disable} state is a pure function of the VM
+ *       ({@code !canUndo} / {@code !canRedo}) — the button greys out and the menu
+ *       item disables automatically, no poke required.</li>
+ *   <li>A menu item's text and a button's tooltip follow the VM's next-undo /
+ *       next-redo label (e.g. "Undo Add Track").</li>
+ *   <li>A click raises a {@link UndoCommand} / {@link RedoCommand} through the
+ *       shared {@link Consumer}&lt;{@link HistoryCommand}&gt; sink (§2.8 — the
+ *       same intent as {@code Ctrl+Z} and the menu), never a write-back.</li>
+ * </ul>
+ *
+ * <p>{@link #dispose()} removes every binding and handler so no leak survives the
+ * control's lifetime ({@code javafx-application-design} §3/§4).</p>
+ */
+public final class HistoryControlBinder {
+
+    private final HistoryVM vm;
+    private final Consumer<HistoryCommand> commandSink;
+    private final List<Runnable> disposers = new ArrayList<>();
+
+    /**
+     * Creates a binder over {@code vm} that emits commands into {@code commandSink}.
+     *
+     * @param vm          the history view-model the controls observe; must not be {@code null}
+     * @param commandSink where control gestures are dispatched; must not be {@code null}
+     * @throws NullPointerException if either argument is {@code null}
+     */
+    public HistoryControlBinder(HistoryVM vm, Consumer<HistoryCommand> commandSink) {
+        this.vm = Objects.requireNonNull(vm, "vm must not be null");
+        this.commandSink = Objects.requireNonNull(commandSink, "commandSink must not be null");
+    }
+
+    /**
+     * Binds an Undo button: {@code disable} follows {@code !canUndo}, its tooltip
+     * follows the next-undo label, and a click raises {@link UndoCommand}.
+     *
+     * @param undo the undo button; must not be {@code null}
+     */
+    public void bindUndoButton(ButtonBase undo) {
+        bindButton(undo, vm.canUndoProperty(), vm.undoLabelProperty(), "Undo", new UndoCommand());
+    }
+
+    /**
+     * Binds a Redo button: {@code disable} follows {@code !canRedo}, its tooltip
+     * follows the next-redo label, and a click raises {@link RedoCommand}.
+     *
+     * @param redo the redo button; must not be {@code null}
+     */
+    public void bindRedoButton(ButtonBase redo) {
+        bindButton(redo, vm.canRedoProperty(), vm.redoLabelProperty(), "Redo", new RedoCommand());
+    }
+
+    /**
+     * Binds an Undo menu item: {@code disable} follows {@code !canUndo}, its text
+     * follows the next-undo label ("Undo" / "Undo &lt;description&gt;"), and a click
+     * raises {@link UndoCommand}.
+     *
+     * @param undo the Edit &rarr; Undo menu item; must not be {@code null}
+     */
+    public void bindUndoMenuItem(MenuItem undo) {
+        bindMenuItem(undo, vm.canUndoProperty(), vm.undoLabelProperty(), "Undo", new UndoCommand());
+    }
+
+    /**
+     * Binds a Redo menu item: {@code disable} follows {@code !canRedo}, its text
+     * follows the next-redo label, and a click raises {@link RedoCommand}.
+     *
+     * @param redo the Edit &rarr; Redo menu item; must not be {@code null}
+     */
+    public void bindRedoMenuItem(MenuItem redo) {
+        bindMenuItem(redo, vm.canRedoProperty(), vm.redoLabelProperty(), "Redo", new RedoCommand());
+    }
+
+    private void bindButton(ButtonBase button, ReadOnlyBooleanProperty available,
+                            ReadOnlyStringProperty label, String verb, HistoryCommand command) {
+        Objects.requireNonNull(button, "button must not be null");
+        button.disableProperty().bind(available.not());
+        Tooltip tip = new Tooltip();
+        tip.textProperty().bind(Bindings.createStringBinding(
+                () -> labelText(verb, label.get()), label));
+        button.setTooltip(tip);
+        button.setOnAction(_ -> commandSink.accept(command));
+        disposers.add(() -> {
+            button.disableProperty().unbind();
+            tip.textProperty().unbind();
+            button.setTooltip(null);
+            button.setOnAction(null);
+        });
+    }
+
+    private void bindMenuItem(MenuItem item, ReadOnlyBooleanProperty available,
+                              ReadOnlyStringProperty label, String verb, HistoryCommand command) {
+        Objects.requireNonNull(item, "item must not be null");
+        item.disableProperty().bind(available.not());
+        item.textProperty().bind(Bindings.createStringBinding(
+                () -> labelText(verb, label.get()), label));
+        item.setOnAction(_ -> commandSink.accept(command));
+        disposers.add(() -> {
+            item.disableProperty().unbind();
+            item.textProperty().unbind();
+            item.setOnAction(null);
+        });
+    }
+
+    /** "{@code Undo}" when there is no description, else "{@code Undo <description>}". */
+    private static String labelText(String verb, String description) {
+        return description == null || description.isEmpty() ? verb : verb + " " + description;
+    }
+
+    /** Removes every binding and handler installed by this binder. Idempotent. */
+    public void dispose() {
+        for (Runnable d : disposers) {
+            d.run();
+        }
+        disposers.clear();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/HistoryVM.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/HistoryVM.java
@@ -1,0 +1,158 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.undo.UndoHistoryListener;
+import com.benesquivelmusic.daw.core.undo.UndoManager;
+
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+
+import java.util.Objects;
+
+/**
+ * The observable view-model mirror of the {@link UndoManager} — Stage 4 of the
+ * §8 migration path (Control Synchronization Design Book §3.3, §5.6, §6.9;
+ * story 292). {@code HistoryVM} projects the four facts the undo/redo UI binds
+ * to: {@link #canUndoProperty() canUndo}, {@link #canRedoProperty() canRedo},
+ * and the next {@link #undoLabelProperty() undo} / {@link #redoLabelProperty()
+ * redo} labels. It replaces the hand-pushed
+ * {@code MainController.updateUndoRedoState()} (§1.2): the Edit menu and the
+ * toolbar buttons bind these properties instead of being poked from nine call
+ * sites.
+ *
+ * <p>It is the <strong>single writer</strong> of its properties (§2.4): the
+ * wrappers are private and only the exposed {@code ReadOnly*Property} views are
+ * handed to controls.</p>
+ *
+ * <h2>The seam it observes</h2>
+ *
+ * <p>{@link UndoManager} predates the {@code Consumer<ChangeKind>} seam used by
+ * {@code Track}/{@code Transport}/{@code DawProject}; it exposes the older
+ * {@link UndoHistoryListener} (a {@code void historyChanged(UndoManager)} callback
+ * removed via {@link UndoManager#removeHistoryListener(UndoHistoryListener)}).
+ * {@code HistoryVM} registers one and, on every history change (execute / undo /
+ * redo / clear), re-reads {@code canUndo}/{@code canRedo}/{@code undoDescription}/
+ * {@code redoDescription} and republishes — the same projection discipline as the
+ * other VMs. It does <em>not</em> publish the {@code UiEvent.UndoStateChanged}
+ * bus event; that is the command handler's ANNOUNCE step
+ * ({@code CoreHistoryIntentHandler}), mirroring stories 290/291 where the VM is a
+ * pure projection and the handler announces.</p>
+ *
+ * <h2>Per-load lifetime</h2>
+ *
+ * <p>The application installs a fresh {@link UndoManager} on every project load,
+ * so a {@code HistoryVM} is bound to a single manager captured at construction
+ * (the "capture the swappable reference once" discipline) and is disposed +
+ * rebuilt by the full-load cascade (§5.7). {@link #dispose()} removes the
+ * listener so a stale {@code HistoryVM} does not leak on the abandoned manager.</p>
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>A history change may originate off the FX thread; every property write is
+ * marshalled onto the FX thread through {@link FxDispatcher#onFx(Runnable)}
+ * (§4.5). The initial seed in the constructor runs on the constructing thread
+ * (no control is bound yet).</p>
+ */
+public final class HistoryVM {
+
+    private final UndoManager undoManager;
+    private final FxDispatcher dispatcher;
+
+    private final ReadOnlyBooleanWrapper canUndo =
+            new ReadOnlyBooleanWrapper(this, "canUndo");
+    private final ReadOnlyBooleanWrapper canRedo =
+            new ReadOnlyBooleanWrapper(this, "canRedo");
+    private final ReadOnlyStringWrapper undoLabel =
+            new ReadOnlyStringWrapper(this, "undoLabel");
+    private final ReadOnlyStringWrapper redoLabel =
+            new ReadOnlyStringWrapper(this, "redoLabel");
+
+    /** Held so {@link #dispose()} can unregister it from the manager. */
+    private final UndoHistoryListener listener;
+
+    private boolean disposed;
+
+    /**
+     * Creates a view-model bound to {@code undoManager}, marshalling all property
+     * writes through {@code dispatcher}.
+     *
+     * @param undoManager the authoritative undo manager to mirror; must not be {@code null}
+     * @param dispatcher  the marshalling seam (story 289); must not be {@code null}
+     * @throws NullPointerException if either argument is {@code null}
+     */
+    public HistoryVM(UndoManager undoManager, FxDispatcher dispatcher) {
+        this.undoManager = Objects.requireNonNull(undoManager, "undoManager must not be null");
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
+
+        // Seed directly (nothing is bound yet) so a control binding shows the
+        // correct state before the first history change arrives.
+        republish();
+
+        this.listener = _ -> dispatcher.onFx(this::republish);
+        undoManager.addHistoryListener(listener);
+    }
+
+    /** Re-reads every fact from the manager and writes the properties (sole writer). */
+    private void republish() {
+        canUndo.set(undoManager.canUndo());
+        canRedo.set(undoManager.canRedo());
+        undoLabel.set(undoManager.undoDescription());
+        redoLabel.set(undoManager.redoDescription());
+    }
+
+    // ── Read-only property views (the VM is the sole writer) ──────────────────
+
+    /** Whether an undo is available. Read-only; bound by the undo button's {@code disable} and the Edit menu. */
+    public ReadOnlyBooleanProperty canUndoProperty() {
+        return canUndo.getReadOnlyProperty();
+    }
+
+    /** Returns whether an undo is available. */
+    public boolean canUndo() {
+        return canUndo.get();
+    }
+
+    /** Whether a redo is available. Read-only; bound by the redo button's {@code disable} and the Edit menu. */
+    public ReadOnlyBooleanProperty canRedoProperty() {
+        return canRedo.getReadOnlyProperty();
+    }
+
+    /** Returns whether a redo is available. */
+    public boolean canRedo() {
+        return canRedo.get();
+    }
+
+    /** The description of the next undo (empty when none). Read-only; bound by the menu label / tooltip. */
+    public ReadOnlyStringProperty undoLabelProperty() {
+        return undoLabel.getReadOnlyProperty();
+    }
+
+    /** Returns the description of the next undo, or {@code ""} when none. */
+    public String getUndoLabel() {
+        return undoLabel.get();
+    }
+
+    /** The description of the next redo (empty when none). Read-only; bound by the menu label / tooltip. */
+    public ReadOnlyStringProperty redoLabelProperty() {
+        return redoLabel.getReadOnlyProperty();
+    }
+
+    /** Returns the description of the next redo, or {@code ""} when none. */
+    public String getRedoLabel() {
+        return redoLabel.get();
+    }
+
+    /**
+     * Removes the history listener so nothing leaks on the (soon-to-be-abandoned)
+     * undo manager. Idempotent — a second call is a no-op.
+     */
+    public void dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        undoManager.removeHistoryListener(listener);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/ProjectLoadCascade.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/ProjectLoadCascade.java
@@ -1,0 +1,148 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The <strong>ordered full-load cascade</strong> — the §1.6 flicker fix
+ * (Control Synchronization Design Book §5.7; story 292). When a project is
+ * loaded, many surfaces must update; doing it in "whatever order the load
+ * handler happens to make" briefly renders a half-built world (the mixer shows
+ * zero channels, the playhead clamps against an unknown length). This class
+ * replaces that ad-hoc sequence with a <strong>single declared phase order</strong>
+ * that a test can assert (§1.6: "the order is a named constant/enum so it can be
+ * asserted").
+ *
+ * <h2>The declared order</h2>
+ *
+ * <p>{@link Phase} <em>is</em> the §5.7 sequence, and {@link #run()} executes the
+ * phases strictly in {@link Phase#values() enum order}:</p>
+ * <ol>
+ *   <li>{@link Phase#TEAR_DOWN} — dispose the old VMs + view subscriptions.</li>
+ *   <li>{@link Phase#BUILD_VMS} — build the model-derived VMs in order
+ *       (ProjectVM → TrackVMs → ChannelVMs → TransportVM → HistoryVM).</li>
+ *   <li>{@link Phase#REBUILD_VIEWS} — rebuild structural views (track lanes ▸
+ *       mixer strips ▸ inserts/racks).</li>
+ *   <li>{@link Phase#BIND_CONTINUOUS} — bind the continuous views (playhead,
+ *       meters, time/tempo display).</li>
+ *   <li>{@link Phase#RESTORE_SELECTION} — restore + clamp the selection to the
+ *       new project's bounds ({@link SelectionVM#clampTo(ProjectVM)}).</li>
+ *   <li>{@link Phase#ANNOUNCE} — announce {@code ProjectLoaded} last (status bar,
+ *       lock indicator, checkpoint, window title, recents).</li>
+ * </ol>
+ *
+ * <p>Running {@code BUILD_VMS} before {@code REBUILD_VIEWS} is what guarantees
+ * the mixer never renders zero channels and the playhead never clamps against an
+ * unknown length (§5.7).</p>
+ *
+ * <h2>The work per phase is injected</h2>
+ *
+ * <p>This class owns the <em>order</em>, not the per-phase work: each phase's
+ * step is supplied as a {@link Runnable} (a phase with no step is a no-op slot
+ * that still runs in sequence). That keeps the cascade a small, fully testable
+ * unit — a test injects recording / clamp steps and asserts {@link
+ * #executedPhases()} equals the declared order and that the selection clamp ran
+ * in step&nbsp;5 — while the live composition root (story 293, the god-controller
+ * retirement) supplies the real VM-rebuild, view-rebuild, continuous-bind, and
+ * announce steps. Story 292 builds and proves the ordered seam; story 293 wires
+ * the real steps into the project-open path that today fires the imperative
+ * refreshers directly.</p>
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>{@link #run()} touches view-models and views, so it must be called on the
+ * FX thread. It may be run again for each subsequent load; each run records a
+ * fresh {@link #executedPhases()}.</p>
+ */
+public final class ProjectLoadCascade {
+
+    /**
+     * The fixed inter-surface phase order of the full-load cascade (§5.7). The
+     * declaration order of these constants <em>is</em> the contract — {@link
+     * #run()} iterates {@link #values()} — so reordering them reorders the
+     * cascade, and a test pins the sequence.
+     */
+    public enum Phase {
+        /** Dispose the old project's VMs and view subscriptions (remove listeners, §4). */
+        TEAR_DOWN,
+        /** Build the model-derived VMs in order: ProjectVM → TrackVMs → ChannelVMs → TransportVM → HistoryVM. */
+        BUILD_VMS,
+        /** Rebuild structural views in order: track lanes ▸ mixer strips ▸ inserts/racks. */
+        REBUILD_VIEWS,
+        /** Bind the continuous views: playhead, meters, time/tempo display. */
+        BIND_CONTINUOUS,
+        /** Restore + clamp the selection (and viewport) to the new project's bounds. */
+        RESTORE_SELECTION,
+        /** Announce {@code ProjectLoaded} last: status bar, lock indicator, checkpoint, window title, recents. */
+        ANNOUNCE
+    }
+
+    private final EnumMap<Phase, Runnable> steps;
+    private final List<Phase> executed = new ArrayList<>();
+
+    private ProjectLoadCascade(EnumMap<Phase, Runnable> steps) {
+        this.steps = steps;
+    }
+
+    /** Returns a builder for assembling the per-phase steps. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Runs the cascade: executes each {@link Phase}'s step (if any) strictly in
+     * {@link Phase#values() declared order}, recording each completed phase. A
+     * re-run first clears the previous {@link #executedPhases()}. Must be called
+     * on the FX thread.
+     */
+    public void run() {
+        executed.clear();
+        for (Phase phase : Phase.values()) {
+            Runnable step = steps.get(phase);
+            if (step != null) {
+                step.run();
+            }
+            executed.add(phase);
+        }
+    }
+
+    /**
+     * Returns the phases executed by the most recent {@link #run()}, in execution
+     * order — i.e. exactly {@link Phase#values()} after a complete run. Exposed so
+     * a test can assert the declared order without relying on render timing
+     * (§1.6).
+     *
+     * @return an immutable snapshot of the executed phases
+     */
+    public List<Phase> executedPhases() {
+        return List.copyOf(executed);
+    }
+
+    /** Builder that collects one {@link Runnable} step per {@link Phase}. */
+    public static final class Builder {
+        private final EnumMap<Phase, Runnable> steps = new EnumMap<>(Phase.class);
+
+        /**
+         * Registers the step to run for {@code phase}, replacing any previous step
+         * for the same phase.
+         *
+         * @param phase the phase the step belongs to; must not be {@code null}
+         * @param step  the work to run in that phase; must not be {@code null}
+         * @return this builder
+         * @throws NullPointerException if either argument is {@code null}
+         */
+        public Builder on(Phase phase, Runnable step) {
+            steps.put(
+                    Objects.requireNonNull(phase, "phase must not be null"),
+                    Objects.requireNonNull(step, "step must not be null"));
+            return this;
+        }
+
+        /** Builds the cascade with the collected steps (any unset phase is a no-op slot). */
+        public ProjectLoadCascade build() {
+            return new ProjectLoadCascade(new EnumMap<>(steps));
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/ProjectVM.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/ProjectVM.java
@@ -95,10 +95,12 @@ public final class ProjectVM {
         this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
 
         // Seed every property with the current state so a control binding shows
-        // the correct value before the first signal arrives.
+        // the correct value before the first signal arrives. getTracks() is a
+        // *live* unmodifiable view, so snapshot it (as the TRACKS branch does)
+        // in case the project is still being populated on another thread.
         name.set(project.getName());
         dirty.set(project.isDirty());
-        tracksBacking.setAll(project.getTracks());
+        tracksBacking.setAll(List.copyOf(project.getTracks()));
 
         this.unregister = project.addChangeListener(this::onCoreChange);
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/ProjectVM.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/ProjectVM.java
@@ -1,0 +1,199 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.project.DawProject;
+import com.benesquivelmusic.daw.core.project.DawProject.ChangeKind;
+import com.benesquivelmusic.daw.core.track.Track;
+
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * The observable view-model mirror of a {@link DawProject} — Stage 4 of the §8
+ * migration path (Control Synchronization Design Book §3.1, §3.2, §3.3, §4.3;
+ * story 292). {@code ProjectVM} projects the three project-level facts the UI
+ * binds to — the {@link #nameProperty() name}, the single
+ * {@link #dirtyProperty() dirty} bit (§1.2's "one dirty bit"), and the
+ * observable {@link #getTracks() track list} (§5.7) — plus a forward-declared
+ * {@link #checkpointProperty() checkpoint} label.
+ *
+ * <p>{@code ProjectVM} is the adapter that lets the JavaFX-free core be observed
+ * without putting {@code javafx.beans.*} into {@code daw-core} (§2.5, §3.2, §9).
+ * It registers the core's toolkit-neutral
+ * {@link DawProject#addChangeListener(Consumer) change signal} and, on each
+ * {@link ChangeKind}, re-reads the affected slice and republishes it as a
+ * read-only JavaFX {@code Property}. It is the <strong>single writer</strong> of
+ * its properties (§2.4): the wrappers are private and only the exposed
+ * {@code ReadOnly*Property} / unmodifiable {@code ObservableList} views are
+ * handed to controls, so a control can bind but never write back — the
+ * feedback-guard smell of §1.4 cannot arise.</p>
+ *
+ * <h2>The single dirty bit (§1.2, §7)</h2>
+ *
+ * <p>{@link #dirtyProperty()} is "the one dirty bit": the window title and the
+ * autosave HUD bind it instead of each call site having to remember a
+ * {@code markProjectDirty()} poke. The core fires {@link ChangeKind#DIRTY} only
+ * on a genuine transition (an idempotent {@code markDirty} on an already-dirty
+ * project announces nothing), so the property tracks {@link DawProject#isDirty()}
+ * exactly.</p>
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>The core signal may fire on any thread; every property write is marshalled
+ * onto the FX thread through the story-289 {@link FxDispatcher#onFx(Runnable)}
+ * (§4.5). {@code ProjectVM} carries no continuous (per-frame) value, so it opens
+ * no {@link FxDispatcher.ContinuousDoubleChannel}.</p>
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <p>The constructor registers the core signal and seeds every property with the
+ * current project state. {@link #dispose()} unregisters the signal so no listener
+ * leaks ({@code javafx-application-design} §3/§4/§11). The full-load cascade
+ * (§5.7, {@code ProjectLoadCascade}) disposes the old {@code ProjectVM} and
+ * builds a fresh one bound to the newly-loaded project.</p>
+ */
+public final class ProjectVM {
+
+    private final DawProject project;
+    private final FxDispatcher dispatcher;
+
+    private final ReadOnlyStringWrapper name =
+            new ReadOnlyStringWrapper(this, "name");
+    private final ReadOnlyBooleanWrapper dirty =
+            new ReadOnlyBooleanWrapper(this, "dirty");
+    private final ReadOnlyStringWrapper checkpoint =
+            new ReadOnlyStringWrapper(this, "checkpoint", "");
+
+    /** Backing list mutated only by {@link #onCoreChange(ChangeKind)} on the FX thread. */
+    private final ObservableList<Track> tracksBacking = FXCollections.observableArrayList();
+    private final ObservableList<Track> tracks =
+            FXCollections.unmodifiableObservableList(tracksBacking);
+
+    /** Removal token returned by {@link DawProject#addChangeListener(Consumer)}. */
+    private final Runnable unregister;
+
+    private boolean disposed;
+
+    /**
+     * Creates a view-model bound to {@code project}, marshalling all property
+     * writes through {@code dispatcher}.
+     *
+     * @param project    the authoritative project to mirror; must not be {@code null}
+     * @param dispatcher the marshalling seam (story 289); must not be {@code null}
+     * @throws NullPointerException if either argument is {@code null}
+     */
+    public ProjectVM(DawProject project, FxDispatcher dispatcher) {
+        this.project = Objects.requireNonNull(project, "project must not be null");
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
+
+        // Seed every property with the current state so a control binding shows
+        // the correct value before the first signal arrives.
+        name.set(project.getName());
+        dirty.set(project.isDirty());
+        tracksBacking.setAll(project.getTracks());
+
+        this.unregister = project.addChangeListener(this::onCoreChange);
+    }
+
+    /**
+     * Handles a core change signal. Runs on whatever thread mutated the project;
+     * routes each affected slice onto the FX thread (§4.5).
+     */
+    private void onCoreChange(ChangeKind kind) {
+        switch (kind) {
+            case NAME -> dispatcher.onFx(() -> name.set(project.getName()));
+            case DIRTY -> dispatcher.onFx(() -> dirty.set(project.isDirty()));
+            case TRACKS -> {
+                // Snapshot on the signaling (mutating) thread, not on the FX thread:
+                // the signal may fire off the FX thread (e.g. a background project
+                // load), and DawProject.getTracks() is a *live* unmodifiable view.
+                // Reading it later inside setAll() on the FX thread while the loader
+                // thread is still adding tracks would throw a
+                // ConcurrentModificationException; copy once here and hand the
+                // immutable snapshot across the thread boundary.
+                List<Track> snapshot = List.copyOf(project.getTracks());
+                dispatcher.onFx(() -> tracksBacking.setAll(snapshot));
+            }
+        }
+    }
+
+    // ── Read-only property views (the VM is the sole writer) ──────────────────
+
+    /** The project name. Read-only; bound by the window title and status bar. */
+    public ReadOnlyStringProperty nameProperty() {
+        return name.getReadOnlyProperty();
+    }
+
+    /** Returns the current project name. */
+    public String getName() {
+        return name.get();
+    }
+
+    /**
+     * The single dirty bit (§1.2, §7). Read-only; bound by the window title and
+     * the autosave HUD.
+     */
+    public ReadOnlyBooleanProperty dirtyProperty() {
+        return dirty.getReadOnlyProperty();
+    }
+
+    /** Returns whether the project has unsaved changes. */
+    public boolean isDirty() {
+        return dirty.get();
+    }
+
+    /**
+     * The checkpoint label. Read-only; bound by the session-status strip.
+     *
+     * <p><strong>Forward-declared</strong> (seeded {@code ""}): {@link DawProject}
+     * owns no checkpoint field today — the checkpoint fact lives in
+     * {@code CheckpointManager} and is part of the Project Manager surface, whose
+     * migration is deferred (the session-status strip is stories 295&ndash;299).
+     * The property exists now so the status strip can bind it without a later API
+     * break; its producer is wired when that surface migrates (mirrors the
+     * forward-declared {@code ChannelVM.meterLevel} of story 291).</p>
+     */
+    public ReadOnlyStringProperty checkpointProperty() {
+        return checkpoint.getReadOnlyProperty();
+    }
+
+    /** Returns the current checkpoint label (empty until the Project Manager surface migrates). */
+    public String getCheckpoint() {
+        return checkpoint.get();
+    }
+
+    /**
+     * The observable, read-only track list in project order (§5.7). Bound by the
+     * arrangement canvas and the mixer to know the set and order of tracks; the
+     * per-track {@code TrackVM}/{@code ChannelVM} pairs are built separately by
+     * {@link TrackChannelRegistry}. Mutated only by this VM on the FX thread, so
+     * a bound view never observes a torn update.
+     *
+     * @return an unmodifiable observable view of the project's tracks
+     */
+    public ObservableList<Track> getTracks() {
+        return tracks;
+    }
+
+    /**
+     * Unregisters the core change signal so nothing leaks (story 292 AC:
+     * "{@code dispose()} unregisters and closes any subscription — no leaked
+     * listeners"). Idempotent — a second call is a no-op. After disposal the VM
+     * receives no further signals; its properties retain their last values.
+     */
+    public void dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        unregister.run();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/SelectionVM.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/SelectionVM.java
@@ -1,0 +1,192 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import com.benesquivelmusic.daw.app.ui.EditTool;
+import com.benesquivelmusic.daw.core.track.Track;
+
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+
+import java.util.Objects;
+
+/**
+ * The observable view-model of the UI <strong>selection</strong> — Stage 4 of
+ * the §8 migration path (Control Synchronization Design Book §3.3, §5.5;
+ * story 292). {@code SelectionVM} drives the inspector target, the canvas
+ * highlight, the mixer focus, and the menu-enablement policy; controls raise
+ * {@code SelectionCommand}s that flow through {@code CoreSelectionIntentHandler},
+ * which mutates this VM and announces {@code UiEvent.SelectionChanged}.
+ *
+ * <h2>UI-authoritative — no core mirror, no dispatcher</h2>
+ *
+ * <p>Unlike {@code ProjectVM}/{@code TrackVM}/{@code TransportVM} (which mirror a
+ * {@code daw-core} model through a change signal), the selection is owned by the
+ * UI (§3.3): there is no core to observe, so {@code SelectionVM} <em>is</em> the
+ * authoritative model. It is mutated only by user gestures on the FX thread (a
+ * click, a menu item, a keyboard shortcut — all converging on a
+ * {@code SelectionCommand}, §2.8), so its writer methods set the properties
+ * synchronously on the calling FX thread and it needs no {@link
+ * com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher FxDispatcher}. It remains
+ * the <strong>single writer</strong> of its properties (§2.4): the wrappers are
+ * private and only the {@code ReadOnly*Property} views are exposed.</p>
+ *
+ * <h2>Lifetime — restored, not rebuilt</h2>
+ *
+ * <p>Because the selection is UI state, the full-load cascade (§5.7) does
+ * <em>not</em> dispose and rebuild {@code SelectionVM} the way it does the
+ * model-derived VMs; instead it <strong>restores and clamps</strong> the
+ * selection to the new project's bounds in step 5 ({@link #clampTo(ProjectVM)}).
+ * A selected track that no longer exists in the loaded project is cleared so no
+ * surface binds a stale target.</p>
+ */
+public final class SelectionVM {
+
+    private final ReadOnlyObjectWrapper<Track> selectedTrack =
+            new ReadOnlyObjectWrapper<>(this, "selectedTrack");
+    private final ReadOnlyObjectWrapper<Object> selectedClip =
+            new ReadOnlyObjectWrapper<>(this, "selectedClip");
+    private final ReadOnlyObjectWrapper<Object> selectedDevice =
+            new ReadOnlyObjectWrapper<>(this, "selectedDevice");
+    private final ReadOnlyObjectWrapper<EditTool> tool =
+            new ReadOnlyObjectWrapper<>(this, "tool", EditTool.POINTER);
+
+    /** Creates an empty selection with the default {@link EditTool#POINTER} tool. */
+    public SelectionVM() {
+        // No upstream listener — selection is UI-authoritative.
+    }
+
+    // ── Writer methods (single-writer command-path entry; FX-thread) ──────────
+    //
+    // Views never call these — they bind the read-only properties and emit a
+    // SelectionCommand. The command handler (CoreSelectionIntentHandler) is the
+    // sole caller, after its VALIDATE gate, and it announces SelectionChanged.
+
+    /**
+     * Selects {@code track} as the focused track. Single-writer entry on the FX
+     * thread; do not call from a view (bind {@link #selectedTrackProperty()} and
+     * emit a {@code SelectTrackCommand} instead).
+     *
+     * @param track the track to select; must not be {@code null} (use {@link #clear()} to deselect)
+     * @throws NullPointerException if {@code track} is {@code null}
+     */
+    public void selectTrack(Track track) {
+        selectedTrack.set(Objects.requireNonNull(track, "track must not be null"));
+    }
+
+    /**
+     * Selects {@code clip} as the focused clip.
+     *
+     * @param clip the clip to select; must not be {@code null}
+     * @throws NullPointerException if {@code clip} is {@code null}
+     */
+    public void selectClip(Object clip) {
+        selectedClip.set(Objects.requireNonNull(clip, "clip must not be null"));
+    }
+
+    /**
+     * Selects {@code device} (an insert / plugin) as the focused device.
+     *
+     * @param device the device to select; must not be {@code null}
+     * @throws NullPointerException if {@code device} is {@code null}
+     */
+    public void selectDevice(Object device) {
+        selectedDevice.set(Objects.requireNonNull(device, "device must not be null"));
+    }
+
+    /**
+     * Sets the active edit tool. Unlike the selected entities, the tool is a
+     * continuous UI mode the toolbar / cursor / canvas <em>bind</em> directly
+     * (§2.7), so a tool change is not announced as a discrete
+     * {@code SelectionChanged} bus event (a distinct {@code ToolChanged} event is
+     * deferred — §5.5; this story scopes {@code UiEvent} to {@code SelectionChanged}
+     * and {@code UndoStateChanged}).
+     *
+     * @param tool the new edit tool; must not be {@code null}
+     * @throws NullPointerException if {@code tool} is {@code null}
+     */
+    public void setTool(EditTool tool) {
+        this.tool.set(Objects.requireNonNull(tool, "tool must not be null"));
+    }
+
+    /** Clears the selected track, clip, and device (the edit tool is unchanged). */
+    public void clear() {
+        selectedTrack.set(null);
+        selectedClip.set(null);
+        selectedDevice.set(null);
+    }
+
+    /**
+     * Restores-and-clamps the selection to {@code project}'s bounds — step 5 of
+     * the full-load cascade (§5.7). A selected track that is not part of the
+     * loaded project is cleared, so no surface binds a target that no longer
+     * exists.
+     *
+     * <p>Only the track selection is clamped here: the clip / device selections
+     * are intentionally typed {@code Object} (the clip layer — {@code AudioClip} /
+     * {@code MidiClip} — has no shared supertype, and a "device" is an insert /
+     * plugin), and clamping them needs the clip-editor / plugin surfaces that
+     * migrate in story 294, so it is deferred with them.</p>
+     *
+     * @param project the newly-loaded project whose tracks bound the selection;
+     *                must not be {@code null}
+     * @throws NullPointerException if {@code project} is {@code null}
+     */
+    public void clampTo(ProjectVM project) {
+        Objects.requireNonNull(project, "project must not be null");
+        Track current = selectedTrack.get();
+        if (current != null && !project.getTracks().contains(current)) {
+            selectedTrack.set(null);
+        }
+    }
+
+    // ── Read-only property views (the VM is the sole writer) ──────────────────
+
+    /** The focused track, or {@code null}. Read-only; bound by the inspector, canvas highlight, mixer focus. */
+    public ReadOnlyObjectProperty<Track> selectedTrackProperty() {
+        return selectedTrack.getReadOnlyProperty();
+    }
+
+    /** Returns the focused track, or {@code null}. */
+    public Track getSelectedTrack() {
+        return selectedTrack.get();
+    }
+
+    /** The focused clip, or {@code null}. Read-only; bound by the inspector and clip editor. */
+    public ReadOnlyObjectProperty<Object> selectedClipProperty() {
+        return selectedClip.getReadOnlyProperty();
+    }
+
+    /** Returns the focused clip, or {@code null}. */
+    public Object getSelectedClip() {
+        return selectedClip.get();
+    }
+
+    /** The focused device (insert / plugin), or {@code null}. Read-only; bound by the inspector and plugin chain. */
+    public ReadOnlyObjectProperty<Object> selectedDeviceProperty() {
+        return selectedDevice.getReadOnlyProperty();
+    }
+
+    /** Returns the focused device, or {@code null}. */
+    public Object getSelectedDevice() {
+        return selectedDevice.get();
+    }
+
+    /** The active edit tool (never {@code null}). Read-only; bound by the toolbar, cursor, canvas mode. */
+    public ReadOnlyObjectProperty<EditTool> toolProperty() {
+        return tool.getReadOnlyProperty();
+    }
+
+    /** Returns the active edit tool. */
+    public EditTool getTool() {
+        return tool.get();
+    }
+
+    /**
+     * No-op disposer kept for lifecycle symmetry with the model-derived VMs that
+     * the cascade/host disposes uniformly: {@code SelectionVM} registers no
+     * upstream listener (it is UI-authoritative, §3.3), so there is nothing to
+     * release.
+     */
+    public void dispose() {
+        // Nothing to release — see Javadoc.
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/ClearSelectionCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/ClearSelectionCommand.java
@@ -1,0 +1,14 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+/**
+ * Intent to clear the current selection — track, clip, and device (§5.5). The
+ * edit tool is unaffected. Raised by an Escape / "deselect" gesture or by the
+ * cascade when clamping a selection that no longer fits the loaded project.
+ */
+public record ClearSelectionCommand() implements SelectionCommand {
+
+    @Override
+    public void execute(SelectionIntentHandler handler) {
+        handler.clear();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/CoreHistoryIntentHandler.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/CoreHistoryIntentHandler.java
@@ -1,0 +1,66 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+import com.benesquivelmusic.daw.core.event.EventBusPublisher;
+import com.benesquivelmusic.daw.core.undo.UndoManager;
+import com.benesquivelmusic.daw.sdk.event.UiEvent;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * The production {@link HistoryIntentHandler}: it wraps the {@link UndoManager}
+ * mutation path and runs the universal cascade for each history intent (Control
+ * Synchronization Design Book §5.1, §5.6; story 292).
+ *
+ * <p>For every intent the handler runs, in order:</p>
+ * <ol>
+ *   <li><strong>VALIDATE</strong> — proceed only when an undo/redo is actually
+ *       available, so an intent with nothing to do neither mutates nor
+ *       announces.</li>
+ *   <li><strong>MUTATE</strong> — call {@link UndoManager#undo()} /
+ *       {@link UndoManager#redo()}. That fires the manager's history listener, so
+ *       {@code HistoryVM} re-reads and republishes its properties (the toolbar
+ *       buttons and Edit menu update as bound subscribers; this handler touches
+ *       no {@code Property}).</li>
+ *   <li><strong>ANNOUNCE</strong> — publish {@link UiEvent.UndoStateChanged} on
+ *       the bus via {@link EventBusPublisher} so unrelated surfaces (e.g. the
+ *       menu-enablement policy) react. This is "the command-history mutation
+ *       publishes {@code UndoStateChanged}" (§6.9); {@code HistoryVM} itself does
+ *       not publish (it is a pure projection, mirroring stories 290/291).</li>
+ * </ol>
+ *
+ * <p>The application installs a fresh {@link UndoManager} per project load, so the
+ * full-load cascade (§5.7) builds a new handler bound to the new manager.</p>
+ */
+public final class CoreHistoryIntentHandler implements HistoryIntentHandler {
+
+    private final UndoManager undoManager;
+
+    /**
+     * Creates a handler bound to {@code undoManager}.
+     *
+     * @param undoManager the authoritative undo manager to mutate; must not be {@code null}
+     * @throws NullPointerException if {@code undoManager} is {@code null}
+     */
+    public CoreHistoryIntentHandler(UndoManager undoManager) {
+        this.undoManager = Objects.requireNonNull(undoManager, "undoManager must not be null");
+    }
+
+    @Override
+    public void undo() {
+        if (!undoManager.canUndo()) {
+            return; // VALIDATE: nothing to undo — no-op
+        }
+        undoManager.undo();
+        EventBusPublisher.publish(new UiEvent.UndoStateChanged(Instant.now()));
+    }
+
+    @Override
+    public void redo() {
+        if (!undoManager.canRedo()) {
+            return; // VALIDATE: nothing to redo — no-op
+        }
+        undoManager.redo();
+        EventBusPublisher.publish(new UiEvent.UndoStateChanged(Instant.now()));
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/CoreSelectionIntentHandler.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/CoreSelectionIntentHandler.java
@@ -1,0 +1,108 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+import com.benesquivelmusic.daw.app.ui.EditTool;
+import com.benesquivelmusic.daw.app.ui.vm.SelectionVM;
+import com.benesquivelmusic.daw.core.event.EventBusPublisher;
+import com.benesquivelmusic.daw.core.track.Track;
+import com.benesquivelmusic.daw.sdk.event.UiEvent;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * The production {@link SelectionIntentHandler}: it owns the {@link SelectionVM}
+ * write and the {@code SelectionChanged} announce, running the universal cascade
+ * for each selection intent (Control Synchronization Design Book §5.1, §5.5;
+ * story 292).
+ *
+ * <p>For every intent the handler runs, in order:</p>
+ * <ol>
+ *   <li><strong>VALIDATE</strong> — an idempotent gate: if the selection already
+ *       matches the request, neither mutate nor announce.</li>
+ *   <li><strong>MUTATE</strong> — write the {@link SelectionVM} (the
+ *       UI-authoritative selection model — there is no {@code daw-core} model for
+ *       selection, §3.3).</li>
+ *   <li><strong>ANNOUNCE</strong> — publish {@link UiEvent.SelectionChanged} on
+ *       the bus via {@link EventBusPublisher} so unrelated surfaces (inspector,
+ *       menu-enablement policy, canvas highlight, mixer focus) re-read the VM.</li>
+ * </ol>
+ *
+ * <p>{@link #setTool(EditTool)} is the exception: the edit tool is a continuous UI
+ * mode bound directly by the toolbar / cursor / canvas (§2.7), so it mutates the
+ * VM but announces no discrete event (a distinct {@code ToolChanged} event is
+ * deferred — §5.5; this story scopes {@code UiEvent} to {@code SelectionChanged}
+ * and {@code UndoStateChanged}).</p>
+ *
+ * <p>Mirrors stories 290/291: the VM is a pure projection of UI state and this
+ * handler is the single writer + announcer the commands target. All methods run
+ * on the FX thread (selection gestures originate there).</p>
+ */
+public final class CoreSelectionIntentHandler implements SelectionIntentHandler {
+
+    private final SelectionVM selectionVM;
+
+    /**
+     * Creates a handler bound to {@code selectionVM}.
+     *
+     * @param selectionVM the UI-authoritative selection model to write; must not be {@code null}
+     * @throws NullPointerException if {@code selectionVM} is {@code null}
+     */
+    public CoreSelectionIntentHandler(SelectionVM selectionVM) {
+        this.selectionVM = Objects.requireNonNull(selectionVM, "selectionVM must not be null");
+    }
+
+    @Override
+    public void selectTrack(Track track) {
+        Objects.requireNonNull(track, "track must not be null");
+        if (Objects.equals(selectionVM.getSelectedTrack(), track)) {
+            return; // VALIDATE: already selected — no-op
+        }
+        selectionVM.selectTrack(track);
+        announceSelectionChanged();
+    }
+
+    @Override
+    public void selectClip(Object clip) {
+        Objects.requireNonNull(clip, "clip must not be null");
+        if (Objects.equals(selectionVM.getSelectedClip(), clip)) {
+            return;
+        }
+        selectionVM.selectClip(clip);
+        announceSelectionChanged();
+    }
+
+    @Override
+    public void selectDevice(Object device) {
+        Objects.requireNonNull(device, "device must not be null");
+        if (Objects.equals(selectionVM.getSelectedDevice(), device)) {
+            return;
+        }
+        selectionVM.selectDevice(device);
+        announceSelectionChanged();
+    }
+
+    @Override
+    public void setTool(EditTool tool) {
+        Objects.requireNonNull(tool, "tool must not be null");
+        if (selectionVM.getTool() == tool) {
+            return; // VALIDATE: already active — no-op
+        }
+        // MUTATE only — the tool is bound directly (§2.7), so no SelectionChanged.
+        selectionVM.setTool(tool);
+    }
+
+    @Override
+    public void clear() {
+        if (selectionVM.getSelectedTrack() == null
+                && selectionVM.getSelectedClip() == null
+                && selectionVM.getSelectedDevice() == null) {
+            return; // VALIDATE: already empty — no-op
+        }
+        selectionVM.clear();
+        announceSelectionChanged();
+    }
+
+    private void announceSelectionChanged() {
+        EventBusPublisher.publish(new UiEvent.SelectionChanged(Instant.now()));
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/HistoryCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/HistoryCommand.java
@@ -1,0 +1,23 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+/**
+ * An undo/redo intent raised by a toolbar button, an Edit-menu item, or a
+ * keyboard shortcut — the three of which converge on the <em>same</em> command
+ * (§2.8). Commands are thin, immutable wrappers; they delegate to a
+ * {@link HistoryIntentHandler} that owns the {@code UndoManager} mutation and the
+ * {@code UndoStateChanged} announce (§2.2 "intent flows up").
+ *
+ * <p>The hierarchy is {@code sealed} so both history intents are enumerated at
+ * compile time (Control Synchronization Design Book §5.6 undo/redo, §6.9).</p>
+ */
+public sealed interface HistoryCommand
+        permits UndoCommand,
+                RedoCommand {
+
+    /**
+     * Runs this intent against the given handler.
+     *
+     * @param handler the handler that owns the undo/redo mutation path; must not be {@code null}
+     */
+    void execute(HistoryIntentHandler handler);
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/HistoryIntentHandler.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/HistoryIntentHandler.java
@@ -1,0 +1,23 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+/**
+ * The intent seam a {@link HistoryCommand} flows into — the up-going half of
+ * "state flows down, intent flows up" (Control Synchronization Design Book §2.2,
+ * §5.6). A command never touches the {@code UndoManager} directly; it asks the
+ * handler to run the undo/redo.
+ *
+ * <p>The production implementation ({@link CoreHistoryIntentHandler}) runs the
+ * §5.1 cascade per intent: VALIDATE (only when an undo/redo is actually
+ * available) → MUTATE ({@code UndoManager.undo()/redo()}, which fires the manager's
+ * history listener so {@code HistoryVM} republishes) → ANNOUNCE (publish
+ * {@code UiEvent.UndoStateChanged} on the bus). Tests substitute a recording fake
+ * to assert that a gesture issues the right command.</p>
+ */
+public interface HistoryIntentHandler {
+
+    /** Undoes the most recent action (§5.6 "Undo"). */
+    void undo();
+
+    /** Redoes the most recently undone action (§5.6 "Redo"). */
+    void redo();
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/RedoCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/RedoCommand.java
@@ -1,0 +1,14 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+/**
+ * Intent to redo the most recently undone action (§5.6). Raised by the redo
+ * toolbar button, the Edit &rarr; Redo menu item, and {@code Ctrl+Y} /
+ * {@code Ctrl+Shift+Z}.
+ */
+public record RedoCommand() implements HistoryCommand {
+
+    @Override
+    public void execute(HistoryIntentHandler handler) {
+        handler.redo();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectClipCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectClipCommand.java
@@ -1,0 +1,24 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+import java.util.Objects;
+
+/**
+ * Intent to select {@code clip} as the focused clip (§5.5). The clip is typed
+ * {@code Object} because the clip layer ({@code AudioClip} / {@code MidiClip})
+ * has no shared supertype; the clip-editor surface that consumes it migrates in
+ * story 294.
+ *
+ * @param clip the clip to select; must not be {@code null}
+ */
+public record SelectClipCommand(Object clip) implements SelectionCommand {
+
+    /** @throws NullPointerException if {@code clip} is {@code null} */
+    public SelectClipCommand {
+        Objects.requireNonNull(clip, "clip must not be null");
+    }
+
+    @Override
+    public void execute(SelectionIntentHandler handler) {
+        handler.selectClip(clip);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectDeviceCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectDeviceCommand.java
@@ -1,0 +1,23 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+import java.util.Objects;
+
+/**
+ * Intent to select {@code device} (an insert / plugin) as the focused device
+ * (§5.5). The device is typed {@code Object} because the plugin-chain surface
+ * that consumes it migrates in story 294.
+ *
+ * @param device the device to select; must not be {@code null}
+ */
+public record SelectDeviceCommand(Object device) implements SelectionCommand {
+
+    /** @throws NullPointerException if {@code device} is {@code null} */
+    public SelectDeviceCommand {
+        Objects.requireNonNull(device, "device must not be null");
+    }
+
+    @Override
+    public void execute(SelectionIntentHandler handler) {
+        handler.selectDevice(device);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectTrackCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectTrackCommand.java
@@ -1,0 +1,26 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+import com.benesquivelmusic.daw.core.track.Track;
+
+import java.util.Objects;
+
+/**
+ * Intent to select {@code track} as the focused track (§5.5). Raised by a click
+ * on a track lane or mixer strip, by the keyboard, or by the cascade restoring
+ * selection on load.
+ *
+ * @param track the track to select; must not be {@code null} (use
+ *              {@link ClearSelectionCommand} to deselect)
+ */
+public record SelectTrackCommand(Track track) implements SelectionCommand {
+
+    /** @throws NullPointerException if {@code track} is {@code null} */
+    public SelectTrackCommand {
+        Objects.requireNonNull(track, "track must not be null");
+    }
+
+    @Override
+    public void execute(SelectionIntentHandler handler) {
+        handler.selectTrack(track);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectionCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectionCommand.java
@@ -1,0 +1,28 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+/**
+ * A selection intent raised by a control, menu item, or keyboard shortcut — the
+ * three of which converge on the <em>same</em> command (§2.8). Commands are thin,
+ * immutable wrappers carrying only the intent's data; they perform no mutation
+ * themselves but delegate to a {@link SelectionIntentHandler} that owns the
+ * {@code SelectionVM} write + the {@code SelectionChanged} announce (§2.2 "intent
+ * flows up").
+ *
+ * <p>The hierarchy is {@code sealed} so every selection intent is enumerated at
+ * compile time (Control Synchronization Design Book §5.5 selection &amp;
+ * edit-tool intents).</p>
+ */
+public sealed interface SelectionCommand
+        permits SelectTrackCommand,
+                SelectClipCommand,
+                SelectDeviceCommand,
+                SetToolCommand,
+                ClearSelectionCommand {
+
+    /**
+     * Runs this intent against the given handler.
+     *
+     * @param handler the handler that owns the selection mutation path; must not be {@code null}
+     */
+    void execute(SelectionIntentHandler handler);
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectionIntentHandler.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectionIntentHandler.java
@@ -1,0 +1,51 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+import com.benesquivelmusic.daw.app.ui.EditTool;
+import com.benesquivelmusic.daw.core.track.Track;
+
+/**
+ * The intent seam a {@link SelectionCommand} flows into — the up-going half of
+ * "state flows down, intent flows up" (Control Synchronization Design Book §2.2,
+ * §3.4, §5.5). A command never writes the selection directly; it asks the handler
+ * to run the corresponding mutation.
+ *
+ * <p>The production implementation ({@link CoreSelectionIntentHandler}) runs the
+ * §5.1 cascade per intent: VALIDATE (an idempotent gate) → MUTATE (write the
+ * {@code SelectionVM}, the UI-authoritative selection model) → ANNOUNCE (publish
+ * {@code UiEvent.SelectionChanged} on the bus, except for a tool change, which is
+ * bound directly per §2.7). Tests substitute a recording fake to assert that a
+ * gesture issues the right command.</p>
+ */
+public interface SelectionIntentHandler {
+
+    /**
+     * Selects a track as the focused track (§5.5 "Select clip(s)/track(s)").
+     *
+     * @param track the track to select
+     */
+    void selectTrack(Track track);
+
+    /**
+     * Selects a clip as the focused clip (§5.5).
+     *
+     * @param clip the clip to select
+     */
+    void selectClip(Object clip);
+
+    /**
+     * Selects a device (insert / plugin) as the focused device (§5.5).
+     *
+     * @param device the device to select
+     */
+    void selectDevice(Object device);
+
+    /**
+     * Changes the active edit tool (§5.5 "Change edit tool").
+     *
+     * @param tool the edit tool to activate
+     */
+    void setTool(EditTool tool);
+
+    /** Clears the track / clip / device selection (the edit tool is unchanged). */
+    void clear();
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SetToolCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/SetToolCommand.java
@@ -1,0 +1,26 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+import com.benesquivelmusic.daw.app.ui.EditTool;
+
+import java.util.Objects;
+
+/**
+ * Intent to change the active edit tool (§5.5). Raised by the toolbar tool
+ * buttons and the tool keyboard shortcuts. The tool is a continuous UI mode the
+ * toolbar / cursor / canvas bind directly (§2.7), so — unlike the selection
+ * commands — applying it does not announce a {@code SelectionChanged} bus event.
+ *
+ * @param tool the edit tool to activate; must not be {@code null}
+ */
+public record SetToolCommand(EditTool tool) implements SelectionCommand {
+
+    /** @throws NullPointerException if {@code tool} is {@code null} */
+    public SetToolCommand {
+        Objects.requireNonNull(tool, "tool must not be null");
+    }
+
+    @Override
+    public void execute(SelectionIntentHandler handler) {
+        handler.setTool(tool);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/UndoCommand.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/vm/command/UndoCommand.java
@@ -1,0 +1,13 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+/**
+ * Intent to undo the most recent action (§5.6). Raised by the undo toolbar
+ * button, the Edit &rarr; Undo menu item, and {@code Ctrl+Z}.
+ */
+public record UndoCommand() implements HistoryCommand {
+
+    @Override
+    public void execute(HistoryIntentHandler handler) {
+        handler.undo();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/HistoryVMTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/HistoryVMTest.java
@@ -1,0 +1,213 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.undo.UndoManager;
+import com.benesquivelmusic.daw.core.undo.UndoableAction;
+
+import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 292 — verifies {@link HistoryVM}: the read-only projection of the
+ * {@link UndoManager} the undo/redo controls bind to (Control Synchronization
+ * Design Book §3.3, §5.6, §6.9). The VM seeds synchronously at construction but
+ * marshals every later history change through {@link FxDispatcher#onFx(Runnable)},
+ * so a mutation is observed only after {@link #flushFx()} drains the FX queue;
+ * property values are then read through a {@link #callOnFx(FxCallable)} capture,
+ * never asserted on the FX thread.
+ *
+ * <p>{@link HistoryVM#dispose()} removes the manager's listener so a stale VM does
+ * not leak on the abandoned (per-load) manager.</p>
+ */
+class HistoryVMTest {
+
+    private static final long TIMEOUT_SECONDS = 5;
+
+    @BeforeAll
+    static void initToolkit() throws InterruptedException {
+        FxTestSupport.startToolkit();
+    }
+
+    @Test
+    void seedsFromEmptyManager() {
+        UndoManager manager = new UndoManager();
+        FxDispatcher dispatcher = new FxDispatcher();
+        HistoryVM vm = new HistoryVM(manager, dispatcher);
+        try {
+            // Seeded synchronously in the constructor — no flush needed.
+            assertThat(vm.canUndo()).as("empty manager: nothing to undo").isFalse();
+            assertThat(vm.canRedo()).as("empty manager: nothing to redo").isFalse();
+            assertThat(vm.getUndoLabel()).as("empty manager: blank undo label").isEmpty();
+            assertThat(vm.getRedoLabel()).as("empty manager: blank redo label").isEmpty();
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void canUndoAndLabelFollowExecute() throws InterruptedException {
+        UndoManager manager = new UndoManager();
+        FxDispatcher dispatcher = new FxDispatcher();
+        HistoryVM vm = new HistoryVM(manager, dispatcher);
+        try {
+            runOnFx(() -> manager.execute(new FakeAction("Add Track")));
+            flushFx(); // drain the dispatcher.onFx the history listener posted
+
+            HistorySnapshot snapshot = snapshotOf(vm);
+            assertThat(snapshot.canUndo())
+                    .as("an executed action becomes undoable").isTrue();
+            assertThat(snapshot.undoLabel())
+                    .as("the undo label follows the action description")
+                    .isEqualTo("Add Track");
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void redoFollowsUndo() throws InterruptedException {
+        UndoManager manager = new UndoManager();
+        FxDispatcher dispatcher = new FxDispatcher();
+        HistoryVM vm = new HistoryVM(manager, dispatcher);
+        try {
+            runOnFx(() -> manager.execute(new FakeAction("Add Track")));
+            flushFx();
+            runOnFx(manager::undo);
+            flushFx();
+
+            HistorySnapshot snapshot = snapshotOf(vm);
+            assertThat(snapshot.canUndo())
+                    .as("after undoing the only action, nothing is left to undo").isFalse();
+            assertThat(snapshot.canRedo())
+                    .as("the undone action becomes redoable").isTrue();
+            assertThat(snapshot.redoLabel())
+                    .as("the redo label follows the undone action's description")
+                    .isEqualTo("Add Track");
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void disposeStopsUpdates() throws InterruptedException {
+        UndoManager manager = new UndoManager();
+        FxDispatcher dispatcher = new FxDispatcher();
+        HistoryVM vm = new HistoryVM(manager, dispatcher);
+
+        // Seeded empty, then disposed BEFORE any mutation — the listener is gone.
+        vm.dispose();
+
+        runOnFx(() -> manager.execute(new FakeAction("Add Track")));
+        flushFx();
+
+        assertThat(snapshotOf(vm).canUndo())
+                .as("after dispose() the VM no longer tracks the manager")
+                .isFalse();
+    }
+
+    @Test
+    void canUndoPropertyIsReadOnly() {
+        UndoManager manager = new UndoManager();
+        FxDispatcher dispatcher = new FxDispatcher();
+        HistoryVM vm = new HistoryVM(manager, dispatcher);
+        try {
+            assertThat(vm.canUndoProperty()).isInstanceOf(ReadOnlyBooleanProperty.class);
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    /** Reads the four projected facts off the FX thread into an off-thread holder. */
+    private static HistorySnapshot snapshotOf(HistoryVM vm) throws InterruptedException {
+        return callOnFx(() -> new HistorySnapshot(
+                vm.canUndo(), vm.canRedo(), vm.getUndoLabel(), vm.getRedoLabel()));
+    }
+
+    private record HistorySnapshot(boolean canUndo, boolean canRedo,
+                                   String undoLabel, String redoLabel) {
+    }
+
+    /** A minimal undoable action whose {@link #description()} drives the VM labels. */
+    private static final class FakeAction implements UndoableAction {
+        private final String description;
+
+        FakeAction(String description) {
+            this.description = description;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+
+        @Override
+        public void execute() {
+            // no model mutation needed for a projection test
+        }
+
+        @Override
+        public void undo() {
+            // no model mutation needed for a projection test
+        }
+    }
+
+    // ── FX-thread helpers ──────────────────────────────────────────────────────
+
+    /** Posts a barrier onto the FX thread and blocks until it (and every earlier {@code onFx}) has run. */
+    private static void flushFx() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(latch::countDown);
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("FX queue must flush within %ds", TIMEOUT_SECONDS).isTrue();
+    }
+
+    private static void runOnFx(Runnable work) throws InterruptedException {
+        callOnFx(() -> {
+            work.run();
+            return null;
+        });
+    }
+
+    private static <T> T callOnFx(FxCallable<T> work) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<T> result = new AtomicReference<>();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Platform.runLater(() -> {
+            try {
+                result.set(work.call());
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+        Throwable t = thrown.get();
+        if (t instanceof RuntimeException re) {
+            throw re;
+        }
+        if (t instanceof Error e) {
+            throw e;
+        }
+        if (t != null) {
+            throw new AssertionError("FX work threw a checked exception", t);
+        }
+        return result.get();
+    }
+
+    @FunctionalInterface
+    private interface FxCallable<T> {
+        T call();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/ProjectLoadCascadeOrderTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/ProjectLoadCascadeOrderTest.java
@@ -1,0 +1,174 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.vm.ProjectLoadCascade.Phase;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.project.DawProject;
+import com.benesquivelmusic.daw.core.track.Track;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 292 — verifies {@link ProjectLoadCascade}: the §1.6 flicker fix that
+ * replaces an ad-hoc load sequence with a single declared {@link Phase} order a
+ * test can pin (Control Synchronization Design Book §5.7). The ordering proofs are
+ * pure (no toolkit), and the step-5 clamp proof drives a real
+ * {@link SelectionVM#clampTo(ProjectVM)} on the FX thread.
+ */
+class ProjectLoadCascadeOrderTest {
+
+    private static final long TIMEOUT_SECONDS = 5;
+
+    @BeforeAll
+    static void initToolkit() throws InterruptedException {
+        // Needed only by clampsSelectionInStep5; harmless for the pure-order tests.
+        FxTestSupport.startToolkit();
+    }
+
+    @Test
+    void runsPhasesInDeclaredOrder() {
+        List<Phase> recorded = new ArrayList<>();
+        ProjectLoadCascade.Builder builder = ProjectLoadCascade.builder();
+        for (Phase phase : Phase.values()) {
+            builder.on(phase, () -> recorded.add(phase));
+        }
+        ProjectLoadCascade cascade = builder.build();
+
+        cascade.run();
+
+        List<Phase> expected = List.of(
+                Phase.TEAR_DOWN, Phase.BUILD_VMS, Phase.REBUILD_VIEWS,
+                Phase.BIND_CONTINUOUS, Phase.RESTORE_SELECTION, Phase.ANNOUNCE);
+        assertThat(recorded)
+                .as("each phase's injected step runs in the declared order")
+                .containsExactlyElementsOf(expected);
+        assertThat(cascade.executedPhases())
+                .as("executedPhases() mirrors the declared order")
+                .containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    void buildVmsRunsBeforeRebuildViews() {
+        AtomicBoolean vmsBuilt = new AtomicBoolean(false);
+        AtomicBoolean observedBuiltBeforeViews = new AtomicBoolean(false);
+
+        ProjectLoadCascade cascade = ProjectLoadCascade.builder()
+                .on(Phase.BUILD_VMS, () -> vmsBuilt.set(true))
+                .on(Phase.REBUILD_VIEWS, () -> observedBuiltBeforeViews.set(vmsBuilt.get()))
+                .build();
+
+        cascade.run();
+
+        assertThat(observedBuiltBeforeViews.get())
+                .as("REBUILD_VIEWS observes the VMs already built — the anti-flicker guarantee")
+                .isTrue();
+    }
+
+    @Test
+    void missingPhaseStepStillRecorded() {
+        ProjectLoadCascade cascade = ProjectLoadCascade.builder()
+                .on(Phase.TEAR_DOWN, () -> { })
+                .on(Phase.ANNOUNCE, () -> { })
+                .build();
+
+        cascade.run();
+
+        assertThat(cascade.executedPhases())
+                .as("a phase with no step is still a sequenced no-op slot")
+                .containsExactly(
+                        Phase.TEAR_DOWN, Phase.BUILD_VMS, Phase.REBUILD_VIEWS,
+                        Phase.BIND_CONTINUOUS, Phase.RESTORE_SELECTION, Phase.ANNOUNCE);
+    }
+
+    @Test
+    void clampsSelectionInStep5() throws InterruptedException {
+        SelectionVM selection = new SelectionVM();
+        AtomicReference<ProjectVM> newVmRef = new AtomicReference<>();
+        try {
+            // trackA belongs to p1; the freshly-loaded p2 never contains it.
+            DawProject p1 = new DawProject("P1", AudioFormat.CD_QUALITY);
+            Track trackA = p1.createAudioTrack("A");
+            DawProject p2 = new DawProject("P2", AudioFormat.CD_QUALITY);
+
+            // Run the cascade on FX (SelectionVM/ProjectVM construction), capturing
+            // both the post-clamp selection and the executed phases into holders so
+            // every assertion happens on the calling thread.
+            ClampOutcome outcome = callOnFx(() -> {
+                ProjectVM newVm = new ProjectVM(p2, new FxDispatcher());
+                newVmRef.set(newVm);
+                selection.selectTrack(trackA);
+
+                ProjectLoadCascade cascade = ProjectLoadCascade.builder()
+                        .on(Phase.RESTORE_SELECTION, () -> selection.clampTo(newVm))
+                        .build();
+                cascade.run();
+                return new ClampOutcome(selection.getSelectedTrack(), cascade.executedPhases());
+            });
+
+            assertThat(outcome.selectedTrack())
+                    .as("step 5 clears a selection absent from the newly-loaded project")
+                    .isNull();
+            assertThat(outcome.executedPhases().indexOf(Phase.RESTORE_SELECTION))
+                    .as("RESTORE_SELECTION runs before ANNOUNCE")
+                    .isLessThan(outcome.executedPhases().indexOf(Phase.ANNOUNCE));
+        } finally {
+            ProjectVM newVm = newVmRef.get();
+            if (newVm != null) {
+                callOnFx(() -> {
+                    newVm.dispose();
+                    return null;
+                });
+            }
+            selection.dispose();
+        }
+    }
+
+    private record ClampOutcome(Track selectedTrack, List<Phase> executedPhases) {
+    }
+
+    // ── FX-thread helper (capture into a holder, assert on the caller) ──────────
+
+    private static <T> T callOnFx(FxCallable<T> work) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<T> result = new AtomicReference<>();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Platform.runLater(() -> {
+            try {
+                result.set(work.call());
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+        Throwable t = thrown.get();
+        if (t instanceof RuntimeException re) {
+            throw re;
+        }
+        if (t instanceof Error e) {
+            throw e;
+        }
+        if (t != null) {
+            throw new AssertionError("FX work threw a checked exception", t);
+        }
+        return result.get();
+    }
+
+    @FunctionalInterface
+    private interface FxCallable<T> {
+        T call();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/ProjectVMTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/ProjectVMTest.java
@@ -1,0 +1,219 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.project.DawProject;
+import com.benesquivelmusic.daw.core.track.Track;
+
+import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyStringProperty;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story 292 — verifies {@link ProjectVM}: the read-only projection of a
+ * {@link DawProject} the project-level UI binds to (Control Synchronization
+ * Design Book §3.1, §3.2, §3.3, §4.3). The VM seeds synchronously at construction
+ * but marshals every later core signal through {@link FxDispatcher#onFx(Runnable)},
+ * so a mutation is observed only after {@link #flushFx()}; values are read through
+ * a {@link #callOnFx(FxCallable)} capture, never asserted on the FX thread. The VM
+ * is constructed on the FX thread because its constructor seeds the backing
+ * {@code ObservableList}.
+ */
+class ProjectVMTest {
+
+    private static final long TIMEOUT_SECONDS = 5;
+
+    @BeforeAll
+    static void initToolkit() throws InterruptedException {
+        FxTestSupport.startToolkit();
+    }
+
+    @Test
+    void seedsFromProject() throws InterruptedException {
+        DawProject project = new DawProject("Song", AudioFormat.CD_QUALITY);
+        ProjectVM vm = constructOnFx(project);
+        try {
+            ProjectSnapshot snapshot = snapshotOf(vm);
+            assertThat(snapshot.name()).as("name seeds from the project").isEqualTo("Song");
+            assertThat(snapshot.dirty()).as("a fresh project is clean").isFalse();
+            assertThat(snapshot.tracks()).as("a fresh project has no tracks").isEmpty();
+        } finally {
+            disposeOnFx(vm);
+        }
+    }
+
+    @Test
+    void nameFollowsSetName() throws InterruptedException {
+        DawProject project = new DawProject("Song", AudioFormat.CD_QUALITY);
+        ProjectVM vm = constructOnFx(project);
+        try {
+            project.setName("Renamed");
+            flushFx();
+            assertThat(snapshotOf(vm).name())
+                    .as("the name property follows a core NAME change")
+                    .isEqualTo("Renamed");
+        } finally {
+            disposeOnFx(vm);
+        }
+    }
+
+    @Test
+    void dirtyFollowsMarkDirtyThenClean() throws InterruptedException {
+        DawProject project = new DawProject("Song", AudioFormat.CD_QUALITY);
+        ProjectVM vm = constructOnFx(project);
+        try {
+            project.markDirty();
+            flushFx();
+            assertThat(snapshotOf(vm).dirty())
+                    .as("the dirty bit follows markDirty()").isTrue();
+
+            project.markClean();
+            flushFx();
+            assertThat(snapshotOf(vm).dirty())
+                    .as("the dirty bit follows markClean()").isFalse();
+        } finally {
+            disposeOnFx(vm);
+        }
+    }
+
+    @Test
+    void tracksFollowAddThenRemove() throws InterruptedException {
+        DawProject project = new DawProject("Song", AudioFormat.CD_QUALITY);
+        ProjectVM vm = constructOnFx(project);
+        try {
+            Track drums = project.createAudioTrack("Drums");
+            flushFx();
+            List<Track> afterAdd = snapshotOf(vm).tracks();
+            assertThat(afterAdd)
+                    .as("the track list follows a core TRACKS add")
+                    .containsExactly(drums);
+
+            project.removeTrack(drums);
+            flushFx();
+            assertThat(snapshotOf(vm).tracks())
+                    .as("the track list follows a core TRACKS remove")
+                    .isEmpty();
+        } finally {
+            disposeOnFx(vm);
+        }
+    }
+
+    @Test
+    void tracksListIsUnmodifiable() throws InterruptedException {
+        DawProject project = new DawProject("Song", AudioFormat.CD_QUALITY);
+        ProjectVM vm = constructOnFx(project);
+        try {
+            assertThatThrownBy(() -> vm.getTracks().add(null))
+                    .as("the exposed track list is an unmodifiable view")
+                    .isInstanceOf(UnsupportedOperationException.class);
+        } finally {
+            disposeOnFx(vm);
+        }
+    }
+
+    @Test
+    void disposeStopsUpdates() throws InterruptedException {
+        DawProject project = new DawProject("Song", AudioFormat.CD_QUALITY);
+        ProjectVM vm = constructOnFx(project);
+        boolean disposed = false;
+        try {
+            disposeOnFx(vm);
+            disposed = true;
+
+            project.setName("X");
+            flushFx();
+            assertThat(snapshotOf(vm).name())
+                    .as("after dispose() the VM ignores further core signals")
+                    .isEqualTo("Song");
+        } finally {
+            if (!disposed) {
+                disposeOnFx(vm);
+            }
+        }
+    }
+
+    @Test
+    void namePropertyIsReadOnly() throws InterruptedException {
+        DawProject project = new DawProject("Song", AudioFormat.CD_QUALITY);
+        ProjectVM vm = constructOnFx(project);
+        try {
+            assertThat(vm.nameProperty()).isInstanceOf(ReadOnlyStringProperty.class);
+        } finally {
+            disposeOnFx(vm);
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    /** Construct on FX: the constructor seeds the backing {@code ObservableList}. */
+    private static ProjectVM constructOnFx(DawProject project) throws InterruptedException {
+        return callOnFx(() -> new ProjectVM(project, new FxDispatcher()));
+    }
+
+    private static void disposeOnFx(ProjectVM vm) throws InterruptedException {
+        callOnFx(() -> {
+            vm.dispose();
+            return null;
+        });
+    }
+
+    /** Reads name / dirty / a defensive copy of the tracks off the FX thread. */
+    private static ProjectSnapshot snapshotOf(ProjectVM vm) throws InterruptedException {
+        return callOnFx(() -> new ProjectSnapshot(
+                vm.getName(), vm.isDirty(), List.copyOf(vm.getTracks())));
+    }
+
+    private record ProjectSnapshot(String name, boolean dirty, List<Track> tracks) {
+    }
+
+    // ── FX-thread helpers ──────────────────────────────────────────────────────
+
+    private static void flushFx() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(latch::countDown);
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("FX queue must flush within %ds", TIMEOUT_SECONDS).isTrue();
+    }
+
+    private static <T> T callOnFx(FxCallable<T> work) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<T> result = new AtomicReference<>();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Platform.runLater(() -> {
+            try {
+                result.set(work.call());
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+        Throwable t = thrown.get();
+        if (t instanceof RuntimeException re) {
+            throw re;
+        }
+        if (t instanceof Error e) {
+            throw e;
+        }
+        if (t != null) {
+            throw new AssertionError("FX work threw a checked exception", t);
+        }
+        return result.get();
+    }
+
+    @FunctionalInterface
+    private interface FxCallable<T> {
+        T call();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/SelectionVMTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/SelectionVMTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * (Control Synchronization Design Book §3.3, §5.5, §5.7). Unlike the model-derived
  * VMs it carries no {@link FxDispatcher} — its writer methods set the read-only
  * property wrappers synchronously on the calling FX thread — so every interaction
- * here runs inside {@link #runOnFx(Runnable)} and reads back through a thread-safe
+ * here runs inside {@link #callOnFx(FxCallable)} and reads back through a thread-safe
  * holder, never asserting on the FX thread itself.
  *
  * <p>{@link #clampTo(ProjectVM)} is the cascade's step-5 restore-and-clamp: a

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/SelectionVMTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/SelectionVMTest.java
@@ -1,0 +1,230 @@
+package com.benesquivelmusic.daw.app.ui.vm;
+
+import com.benesquivelmusic.daw.app.ui.EditTool;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.project.DawProject;
+import com.benesquivelmusic.daw.core.track.Track;
+
+import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyObjectProperty;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 292 — verifies {@link SelectionVM}: the UI-authoritative selection model
+ * (Control Synchronization Design Book §3.3, §5.5, §5.7). Unlike the model-derived
+ * VMs it carries no {@link FxDispatcher} — its writer methods set the read-only
+ * property wrappers synchronously on the calling FX thread — so every interaction
+ * here runs inside {@link #runOnFx(Runnable)} and reads back through a thread-safe
+ * holder, never asserting on the FX thread itself.
+ *
+ * <p>{@link #clampTo(ProjectVM)} is the cascade's step-5 restore-and-clamp: a
+ * selected track absent from the newly-loaded project is cleared so no surface
+ * binds a stale target.</p>
+ */
+class SelectionVMTest {
+
+    private static final long TIMEOUT_SECONDS = 5;
+
+    @BeforeAll
+    static void initToolkit() throws InterruptedException {
+        FxTestSupport.startToolkit();
+    }
+
+    @Test
+    void selectTrackUpdatesSelectedTrackProperty() throws InterruptedException {
+        SelectionVM vm = new SelectionVM();
+        try {
+            DawProject project = new DawProject("P", AudioFormat.CD_QUALITY);
+            Track trackA = project.createAudioTrack("A");
+
+            Track observed = callOnFx(() -> {
+                vm.selectTrack(trackA);
+                return vm.getSelectedTrack();
+            });
+
+            assertThat(observed)
+                    .as("selectTrack sets the exact track instance")
+                    .isSameAs(trackA);
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void defaultToolIsPointer() throws InterruptedException {
+        SelectionVM vm = new SelectionVM();
+        try {
+            EditTool tool = callOnFx(vm::getTool);
+            assertThat(tool).isEqualTo(EditTool.POINTER);
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void setToolUpdatesTool() throws InterruptedException {
+        SelectionVM vm = new SelectionVM();
+        try {
+            EditTool tool = callOnFx(() -> {
+                vm.setTool(EditTool.PENCIL);
+                return vm.getTool();
+            });
+            assertThat(tool).isEqualTo(EditTool.PENCIL);
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void clearResetsSelectionButKeepsTool() throws InterruptedException {
+        SelectionVM vm = new SelectionVM();
+        try {
+            DawProject project = new DawProject("P", AudioFormat.CD_QUALITY);
+            Track trackA = project.createAudioTrack("A");
+
+            SelectionSnapshot snapshot = callOnFx(() -> {
+                vm.selectTrack(trackA);
+                vm.selectClip(new Object());
+                vm.setTool(EditTool.PENCIL);
+                vm.clear();
+                return new SelectionSnapshot(
+                        vm.getSelectedTrack(), vm.getSelectedClip(), vm.getTool());
+            });
+
+            assertThat(snapshot.track()).as("clear() nulls the selected track").isNull();
+            assertThat(snapshot.clip()).as("clear() nulls the selected clip").isNull();
+            assertThat(snapshot.tool())
+                    .as("clear() leaves the edit tool untouched")
+                    .isEqualTo(EditTool.PENCIL);
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void selectedTrackPropertyIsReadOnly() {
+        SelectionVM vm = new SelectionVM();
+        try {
+            assertThat(vm.selectedTrackProperty()).isInstanceOf(ReadOnlyObjectProperty.class);
+        } finally {
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void clampToClearsSelectedTrackAbsentFromProject() throws InterruptedException {
+        SelectionVM vm = new SelectionVM();
+        ProjectVM projectVm2 = null;
+        try {
+            // trackA belongs to p1; p2 never contains it.
+            DawProject p1 = new DawProject("P1", AudioFormat.CD_QUALITY);
+            Track trackA = p1.createAudioTrack("A");
+            DawProject p2 = new DawProject("P2", AudioFormat.CD_QUALITY);
+
+            projectVm2 = constructProjectVmOnFx(p2);
+            ProjectVM clampTarget = projectVm2;
+
+            Track observed = callOnFx(() -> {
+                vm.selectTrack(trackA);
+                vm.clampTo(clampTarget);
+                return vm.getSelectedTrack();
+            });
+
+            assertThat(observed)
+                    .as("a selected track absent from the loaded project is cleared")
+                    .isNull();
+        } finally {
+            if (projectVm2 != null) {
+                projectVm2.dispose();
+            }
+            vm.dispose();
+        }
+    }
+
+    @Test
+    void clampToKeepsSelectedTrackPresentInProject() throws InterruptedException {
+        SelectionVM vm = new SelectionVM();
+        ProjectVM projectVm = null;
+        try {
+            // trackA belongs to the same project the ProjectVM mirrors.
+            DawProject project = new DawProject("P", AudioFormat.CD_QUALITY);
+            Track trackA = project.createAudioTrack("A");
+
+            projectVm = constructProjectVmOnFx(project);
+            ProjectVM clampTarget = projectVm;
+
+            Track observed = callOnFx(() -> {
+                vm.selectTrack(trackA);
+                vm.clampTo(clampTarget);
+                return vm.getSelectedTrack();
+            });
+
+            assertThat(observed)
+                    .as("a selected track still present in the project survives the clamp")
+                    .isSameAs(trackA);
+        } finally {
+            if (projectVm != null) {
+                projectVm.dispose();
+            }
+            vm.dispose();
+        }
+    }
+
+    // ── FX-thread helpers (capture results into holders, assert on the caller) ──
+
+    /** ProjectVM touches FX collections in its constructor, so build it on the FX thread. */
+    private static ProjectVM constructProjectVmOnFx(DawProject project) throws InterruptedException {
+        return callOnFx(() -> new ProjectVM(project, new FxDispatcher()));
+    }
+
+    private record SelectionSnapshot(Track track, Object clip, EditTool tool) {
+    }
+
+    /**
+     * Runs {@code work} on the FX thread, returning its result to the calling
+     * thread (so the assertion happens off the FX thread and is never swallowed).
+     */
+    private static <T> T callOnFx(FxCallable<T> work) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<T> result = new AtomicReference<>();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Platform.runLater(() -> {
+            try {
+                result.set(work.call());
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+        rethrow(thrown.get());
+        return result.get();
+    }
+
+    private static void rethrow(Throwable thrown) {
+        if (thrown instanceof RuntimeException re) {
+            throw re;
+        }
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown != null) {
+            throw new AssertionError("FX work threw a checked exception", thrown);
+        }
+    }
+
+    @FunctionalInterface
+    private interface FxCallable<T> {
+        T call();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectionUndoEventTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/vm/command/SelectionUndoEventTest.java
@@ -1,0 +1,304 @@
+package com.benesquivelmusic.daw.app.ui.vm.command;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.vm.HistoryControlBinder;
+import com.benesquivelmusic.daw.app.ui.vm.HistoryVM;
+import com.benesquivelmusic.daw.app.ui.vm.SelectionVM;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.event.DefaultEventBus;
+import com.benesquivelmusic.daw.core.event.EventBusPublisher;
+import com.benesquivelmusic.daw.core.project.DawProject;
+import com.benesquivelmusic.daw.core.track.Track;
+import com.benesquivelmusic.daw.core.undo.UndoManager;
+import com.benesquivelmusic.daw.core.undo.UndoableAction;
+import com.benesquivelmusic.daw.sdk.event.DispatchMode;
+import com.benesquivelmusic.daw.sdk.event.EventBus;
+import com.benesquivelmusic.daw.sdk.event.UiEvent;
+
+import javafx.application.Platform;
+import javafx.scene.control.Button;
+import javafx.scene.control.MenuItem;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 292 — verifies the command&rarr;handler&rarr;event path for the selection
+ * and history surfaces: a {@link SelectTrackCommand} run through
+ * {@link CoreSelectionIntentHandler} announces {@link UiEvent.SelectionChanged};
+ * an {@link UndoCommand} run through {@link CoreHistoryIntentHandler} announces
+ * {@link UiEvent.UndoStateChanged} <em>and</em> actually undoes (Control
+ * Synchronization Design Book §5.1, §5.5, §5.6, §6.9). Events are asserted via
+ * their bus payload — never {@code Event.getSource()} identity, never rendered
+ * output — mirroring {@code ChannelCommandEventTest}.
+ *
+ * <p>The handler's VALIDATE gate is proven discriminating: a re-issued identical
+ * selection announces nothing, and the undo/redo controls bound through
+ * {@link HistoryControlBinder} track {@link HistoryVM} after a flush.</p>
+ */
+class SelectionUndoEventTest {
+
+    private static final long TIMEOUT_SECONDS = 5;
+
+    private DefaultEventBus bus;
+
+    @BeforeAll
+    static void initToolkit() throws InterruptedException {
+        startToolkit();
+    }
+
+    @BeforeEach
+    void installBus() {
+        bus = new DefaultEventBus();
+        EventBusPublisher.setDefault(bus);
+    }
+
+    @AfterEach
+    void clearBus() {
+        EventBusPublisher.setDefault(null);
+        bus.close();
+    }
+
+    @Test
+    void selectTrackCommandAnnouncesSelectionChanged() throws InterruptedException {
+        DawProject project = new DawProject("Test", AudioFormat.CD_QUALITY);
+        Track trackA = project.createAudioTrack("A");
+        SelectionVM selection = new SelectionVM();
+        CoreSelectionIntentHandler handler = new CoreSelectionIntentHandler(selection);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<UiEvent.SelectionChanged> ref = new AtomicReference<>();
+        try (EventBus.Subscription s = bus.on(UiEvent.SelectionChanged.class,
+                DispatchMode.ON_CALLER_THREAD, e -> { ref.set(e); latch.countDown(); })) {
+
+            runOnFx(() -> new SelectTrackCommand(trackA).execute(handler));
+
+            assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    .as("selecting a track announces SelectionChanged").isTrue();
+            assertThat(ref.get())
+                    .as("the announced event is a SelectionChanged payload")
+                    .isInstanceOf(UiEvent.SelectionChanged.class);
+            assertThat(ref.get().timestamp())
+                    .as("SelectionChanged carries a wall-clock instant").isNotNull();
+        } finally {
+            selection.dispose();
+        }
+    }
+
+    @Test
+    void undoCommandAnnouncesUndoStateChangedAndUndoes() throws InterruptedException {
+        UndoManager manager = new UndoManager();
+        manager.execute(new FakeAction("Add Track")); // make an undo available
+        CoreHistoryIntentHandler handler = new CoreHistoryIntentHandler(manager);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<UiEvent.UndoStateChanged> ref = new AtomicReference<>();
+        try (EventBus.Subscription s = bus.on(UiEvent.UndoStateChanged.class,
+                DispatchMode.ON_CALLER_THREAD, e -> { ref.set(e); latch.countDown(); })) {
+
+            runOnFx(() -> new UndoCommand().execute(handler));
+
+            assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    .as("an undo announces UndoStateChanged").isTrue();
+            assertThat(ref.get()).isInstanceOf(UiEvent.UndoStateChanged.class);
+            assertThat(manager.canUndo())
+                    .as("the undo actually ran — nothing left to undo")
+                    .isFalse();
+        }
+    }
+
+    @Test
+    void idempotentSelectTrackDoesNotReAnnounce() throws InterruptedException {
+        DawProject project = new DawProject("Test", AudioFormat.CD_QUALITY);
+        Track trackA = project.createAudioTrack("A");
+        SelectionVM selection = new SelectionVM();
+        CoreSelectionIntentHandler handler = new CoreSelectionIntentHandler(selection);
+
+        AtomicInteger count = new AtomicInteger();
+        CountDownLatch firstAnnounce = new CountDownLatch(1);
+        try (EventBus.Subscription s = bus.on(UiEvent.SelectionChanged.class,
+                DispatchMode.ON_CALLER_THREAD, e -> { count.incrementAndGet(); firstAnnounce.countDown(); })) {
+
+            // Two identical selections: the second is gated out by VALIDATE.
+            runOnFx(() -> {
+                new SelectTrackCommand(trackA).execute(handler);
+                new SelectTrackCommand(trackA).execute(handler);
+            });
+
+            assertThat(firstAnnounce.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    .as("the first selection announces").isTrue();
+            // Give any erroneous second announce a chance to arrive before counting.
+            flushFx();
+            assertThat(count.get())
+                    .as("the idempotent re-selection announces no second SelectionChanged")
+                    .isEqualTo(1);
+        } finally {
+            selection.dispose();
+        }
+    }
+
+    @Test
+    void undoRedoControlsFollowHistoryVM() throws InterruptedException {
+        FxDispatcher dispatcher = new FxDispatcher();
+        UndoManager manager = new UndoManager(); // empty
+        HistoryVM vm = new HistoryVM(manager, dispatcher);
+        CoreHistoryIntentHandler handler = new CoreHistoryIntentHandler(manager);
+        HistoryControlBinder binder = new HistoryControlBinder(vm, cmd -> cmd.execute(handler));
+
+        AtomicReference<Button> undoBtnRef = new AtomicReference<>();
+        AtomicReference<Button> redoBtnRef = new AtomicReference<>();
+        AtomicReference<MenuItem> undoItemRef = new AtomicReference<>();
+        try {
+            // Build + bind the controls on FX; capture the empty-manager state.
+            ControlSnapshot initial = callOnFx(() -> {
+                Button undoBtn = new Button();
+                Button redoBtn = new Button();
+                MenuItem undoItem = new MenuItem();
+                undoBtnRef.set(undoBtn);
+                redoBtnRef.set(redoBtn);
+                undoItemRef.set(undoItem);
+
+                binder.bindUndoButton(undoBtn);
+                binder.bindRedoButton(redoBtn);
+                binder.bindUndoMenuItem(undoItem);
+                return snapshot(undoBtn, redoBtn, undoItem);
+            });
+            assertThat(initial.undoDisabled())
+                    .as("an empty manager disables the undo button").isTrue();
+
+            // Execute an action; HistoryVM republishes via dispatcher.onFx, so flush.
+            runOnFx(() -> manager.execute(new FakeAction("Add Track")));
+            flushFx();
+
+            ControlSnapshot afterExecute =
+                    callOnFx(() -> snapshot(undoBtnRef.get(), redoBtnRef.get(), undoItemRef.get()));
+            assertThat(afterExecute.undoDisabled())
+                    .as("an available undo enables the undo button").isFalse();
+            assertThat(afterExecute.undoItemText())
+                    .as("the undo menu item text follows the next-undo label")
+                    .isEqualTo("Undo Add Track");
+            assertThat(afterExecute.redoDisabled())
+                    .as("with nothing undone yet, redo stays disabled").isTrue();
+        } finally {
+            callOnFx(() -> {
+                binder.dispose();
+                return null;
+            });
+            vm.dispose();
+        }
+    }
+
+    private static ControlSnapshot snapshot(Button undo, Button redo, MenuItem undoItem) {
+        return new ControlSnapshot(
+                undo.isDisable(), redo.isDisable(), undoItem.getText());
+    }
+
+    private record ControlSnapshot(boolean undoDisabled, boolean redoDisabled, String undoItemText) {
+    }
+
+    /** A minimal undoable action whose {@link #description()} drives the control labels. */
+    private static final class FakeAction implements UndoableAction {
+        private final String description;
+
+        FakeAction(String description) {
+            this.description = description;
+        }
+
+        @Override
+        public String description() {
+            return description;
+        }
+
+        @Override
+        public void execute() {
+            // no model mutation needed
+        }
+
+        @Override
+        public void undo() {
+            // no model mutation needed
+        }
+    }
+
+    // ── toolkit + FX-thread helpers (this package is opened only to itself under
+    //    surefire, so a same-package static starter is used rather than a
+    //    cross-package @ExtendWith — see ChannelCommandEventTest) ───────────────
+
+    private static final AtomicBoolean STARTED = new AtomicBoolean(false);
+
+    private static void startToolkit() throws InterruptedException {
+        if (!STARTED.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            CountDownLatch startup = new CountDownLatch(1);
+            Platform.startup(startup::countDown);
+            if (!startup.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("JavaFX toolkit startup timed out");
+            }
+            Platform.setImplicitExit(false);
+        } catch (IllegalStateException e) {
+            String message = e.getMessage();
+            if (message == null || !message.contains("Toolkit already initialized")) {
+                throw e;
+            }
+        }
+    }
+
+    /** Posts a barrier onto the FX thread and blocks until it (and every earlier {@code onFx}) has run. */
+    private static void flushFx() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(latch::countDown);
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("FX queue must flush within %ds", TIMEOUT_SECONDS).isTrue();
+    }
+
+    private static void runOnFx(Runnable work) throws InterruptedException {
+        callOnFx(() -> {
+            work.run();
+            return null;
+        });
+    }
+
+    private static <T> T callOnFx(FxCallable<T> work) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<T> result = new AtomicReference<>();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Platform.runLater(() -> {
+            try {
+                result.set(work.call());
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+        Throwable t = thrown.get();
+        if (t instanceof RuntimeException re) {
+            throw re;
+        }
+        if (t instanceof Error e) {
+            throw e;
+        }
+        if (t != null) {
+            throw new AssertionError("FX work threw a checked exception", t);
+        }
+        return result.get();
+    }
+
+    @FunctionalInterface
+    private interface FxCallable<T> {
+        T call();
+    }
+}

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/concurrent/ChangeNotifier.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/concurrent/ChangeNotifier.java
@@ -1,0 +1,111 @@
+package com.benesquivelmusic.daw.core.concurrent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A small, allocation-free-on-notify observer list for the toolkit-neutral
+ * {@code Consumer<ChangeKind>} change signal that the engine models expose
+ * ({@code Track} / {@code MixerChannel} / {@code Transport} / {@code DawProject},
+ * Control Synchronization Design Book §3.2, §3.4). It is the single home for the
+ * register / unregister / notify mechanism each of those models used to copy
+ * verbatim.
+ *
+ * <h2>Why a fresh-snapshot array</h2>
+ *
+ * <p>Registration mutates a canonical {@link #listeners} list under
+ * {@link #lock}; each mutation rebuilds an immutable {@link #snapshot} array and
+ * publishes it through a {@code volatile} field. {@link #fire(Object)} reads that
+ * reference <em>once</em> into a local and iterates the array with a
+ * for-each — so the hot notify path takes no lock, allocates nothing (an array
+ * for-each compiles to an indexed loop, with no {@code Iterator}), and is immune
+ * to a listener being added or removed mid-notification (reentrantly, or from
+ * another thread): the captured array reference stays stable while an add/remove
+ * swaps in a fresh array. This makes {@code fire} safe to call from a
+ * {@code @RealTimeSafe} notify path (it is intentionally <em>not</em> annotated
+ * {@code @RealTimeSafe} itself, matching the un-annotated model
+ * {@code notifyChange} methods that delegate to it).</p>
+ *
+ * <p>{@code fire} invokes each listener on the calling thread; a listener must do
+ * only lock-free, non-blocking work (the sanctioned sink is the view-model's
+ * lock-free single-reader buffer, §4.1, §4.6). Exceptions from a listener
+ * propagate to the caller — listeners are trusted, in-process UI adapters.</p>
+ *
+ * @param <K> the change-tag type (each model's {@code ChangeKind} enum)
+ */
+public final class ChangeNotifier<K> {
+
+    /** Guards mutations to {@link #listeners}; never held on the {@link #fire} path. */
+    private final Object lock = new Object();
+
+    /**
+     * The canonical observer list, mutated only under {@link #lock}.
+     * {@link #snapshot} is rebuilt from it on each add/remove so the hot notify
+     * path never touches this list.
+     */
+    private final List<Consumer<K>> listeners = new ArrayList<>();
+
+    /**
+     * An immutable snapshot of {@link #listeners}, replaced wholesale (never
+     * mutated in place) on each add/remove and published through this
+     * {@code volatile} reference so {@link #fire} can read it lock-free.
+     */
+    @SuppressWarnings("unchecked")
+    private volatile Consumer<K>[] snapshot = (Consumer<K>[]) new Consumer<?>[0];
+
+    /**
+     * Registers a listener notified by every later {@link #fire(Object)}.
+     *
+     * @param listener the listener to add; must not be {@code null}
+     * @return a removal token; running it (equivalently, calling
+     *         {@link #remove(Consumer)}) unregisters the listener
+     * @throws NullPointerException if {@code listener} is {@code null}
+     */
+    public Runnable add(Consumer<K> listener) {
+        Objects.requireNonNull(listener, "listener must not be null");
+        synchronized (lock) {
+            listeners.add(listener);
+            snapshot = snapshotOf(listeners);
+        }
+        return () -> remove(listener);
+    }
+
+    /**
+     * Unregisters a previously {@linkplain #add(Consumer) added} listener. A
+     * listener that was never added (or was already removed) is silently ignored.
+     *
+     * @param listener the listener to remove; must not be {@code null}
+     * @throws NullPointerException if {@code listener} is {@code null}
+     */
+    public void remove(Consumer<K> listener) {
+        Objects.requireNonNull(listener, "listener must not be null");
+        synchronized (lock) {
+            if (listeners.remove(listener)) {
+                snapshot = snapshotOf(listeners);
+            }
+        }
+    }
+
+    /**
+     * Notifies every registered listener of {@code change}. Reads the
+     * {@code volatile} snapshot once into a stable local and iterates it, so the
+     * call takes no lock, allocates nothing, and tolerates a concurrent/reentrant
+     * add or remove.
+     *
+     * @param change the change tag to deliver
+     */
+    public void fire(K change) {
+        Consumer<K>[] current = snapshot; // read volatile once → stable local
+        for (Consumer<K> listener : current) { // array for-each allocates no iterator
+            listener.accept(change);
+        }
+    }
+
+    /** Builds a fresh immutable snapshot array from the canonical listener list. */
+    @SuppressWarnings("unchecked")
+    private static <K> Consumer<K>[] snapshotOf(List<Consumer<K>> listeners) {
+        return listeners.toArray((Consumer<K>[]) new Consumer<?>[listeners.size()]);
+    }
+}

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/event/DefaultEventBus.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/event/DefaultEventBus.java
@@ -1,6 +1,6 @@
 package com.benesquivelmusic.daw.core.event;
 
-import com.benesquivelmusic.daw.sdk.event.DawEvent;
+import com.benesquivelmusic.daw.sdk.event.BusEvent;
 import com.benesquivelmusic.daw.sdk.event.DispatchMode;
 import com.benesquivelmusic.daw.sdk.event.EventBus;
 import com.benesquivelmusic.daw.sdk.event.EventBusMetrics;
@@ -61,7 +61,7 @@ public final class DefaultEventBus implements EventBus {
 
     private final int bufferCapacity;
     private final Executor uiExecutor;
-    private final Map<Class<? extends DawEvent>, OverflowStrategy> strategyByType;
+    private final Map<Class<? extends BusEvent>, OverflowStrategy> strategyByType;
     private final OverflowStrategy defaultStrategy;
     private final ExecutorService dispatcher;
     private final List<Sub<?>> subs = new CopyOnWriteArrayList<>();
@@ -73,7 +73,7 @@ public final class DefaultEventBus implements EventBus {
         private int bufferCapacity = DEFAULT_BUFFER_CAPACITY;
         private Executor uiExecutor;
         private OverflowStrategy defaultStrategy = OverflowStrategy.DROP_OLDEST;
-        private final Map<Class<? extends DawEvent>, OverflowStrategy> strategies = new HashMap<>();
+        private final Map<Class<? extends BusEvent>, OverflowStrategy> strategies = new HashMap<>();
 
         /** Sets the per-subscription bounded-buffer capacity (default {@value #DEFAULT_BUFFER_CAPACITY}). */
         public Builder bufferCapacity(int capacity) {
@@ -100,7 +100,7 @@ public final class DefaultEventBus implements EventBus {
         }
 
         /** Registers a per-event-type overflow strategy override. */
-        public Builder overflowStrategy(Class<? extends DawEvent> type, OverflowStrategy strategy) {
+        public Builder overflowStrategy(Class<? extends BusEvent> type, OverflowStrategy strategy) {
             Objects.requireNonNull(type, "type");
             Objects.requireNonNull(strategy, "strategy");
             strategies.put(type, strategy);
@@ -135,7 +135,7 @@ public final class DefaultEventBus implements EventBus {
     }
 
     @Override
-    public void publish(DawEvent event) {
+    public void publish(BusEvent event) {
         Objects.requireNonNull(event, "event");
         if (closed.get()) {
             return;
@@ -166,7 +166,7 @@ public final class DefaultEventBus implements EventBus {
     }
 
     @Override
-    public <E extends DawEvent> Flow.Publisher<E> subscribe(Class<E> type) {
+    public <E extends BusEvent> Flow.Publisher<E> subscribe(Class<E> type) {
         Objects.requireNonNull(type, "type");
         if (closed.get()) {
             throw new IllegalStateException("EventBus is closed");
@@ -174,7 +174,7 @@ public final class DefaultEventBus implements EventBus {
         return downstream -> attachFlowSubscriber(type, downstream);
     }
 
-    private <E extends DawEvent> void attachFlowSubscriber(Class<E> type,
+    private <E extends BusEvent> void attachFlowSubscriber(Class<E> type,
                                                            Flow.Subscriber<? super E> downstream) {
         Objects.requireNonNull(downstream, "subscriber");
         if (closed.get()) {
@@ -206,7 +206,7 @@ public final class DefaultEventBus implements EventBus {
     }
 
     @Override
-    public <E extends DawEvent> Subscription on(Class<E> type,
+    public <E extends BusEvent> Subscription on(Class<E> type,
                                                 DispatchMode mode,
                                                 Consumer<? super E> handler) {
         Objects.requireNonNull(type, "type");
@@ -253,7 +253,7 @@ public final class DefaultEventBus implements EventBus {
     // Per-subscription worker
     // -----------------------------------------------------------------
 
-    private static final class Sub<E extends DawEvent> {
+    private static final class Sub<E extends BusEvent> {
         private final Class<E> type;
         private final int capacity;
         private final DispatchMode mode;
@@ -262,7 +262,7 @@ public final class DefaultEventBus implements EventBus {
         private final Metrics metrics;
         @SuppressWarnings("rawtypes")
         private final Consumer handler;
-        private final Deque<DawEvent> buffer = new ArrayDeque<>();
+        private final Deque<BusEvent> buffer = new ArrayDeque<>();
         private final ReentrantLock lock = new ReentrantLock();
         private final java.util.concurrent.locks.Condition notFull = lock.newCondition();
         private final java.util.concurrent.locks.Condition notEmpty = lock.newCondition();
@@ -302,7 +302,7 @@ public final class DefaultEventBus implements EventBus {
             metrics.unregisterSubscription(id);
         }
 
-        void tryEnqueue(DawEvent event, OverflowStrategy strategy) {
+        void tryEnqueue(BusEvent event, OverflowStrategy strategy) {
             if (cancelled.get() || !type.isInstance(event)) {
                 return;
             }
@@ -310,7 +310,7 @@ public final class DefaultEventBus implements EventBus {
             try {
                 if (buffer.size() >= capacity) {
                     if (strategy == OverflowStrategy.DROP_OLDEST) {
-                        DawEvent dropped = buffer.pollFirst();
+                        BusEvent dropped = buffer.pollFirst();
                         if (dropped != null) {
                             metrics.recordDropped(dropped.getClass());
                         }
@@ -332,7 +332,7 @@ public final class DefaultEventBus implements EventBus {
         @SuppressWarnings("unchecked")
         private void runLoop() {
             while (!cancelled.get()) {
-                DawEvent next;
+                BusEvent next;
                 lock.lock();
                 try {
                     while (buffer.isEmpty() && !cancelled.get()) {

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/event/EventBusPublisher.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/event/EventBusPublisher.java
@@ -1,15 +1,21 @@
 package com.benesquivelmusic.daw.core.event;
 
+import com.benesquivelmusic.daw.sdk.event.BusEvent;
 import com.benesquivelmusic.daw.sdk.event.DawEvent;
 import com.benesquivelmusic.daw.sdk.event.EventBus;
+import com.benesquivelmusic.daw.sdk.event.UiEvent;
 
 import java.util.Objects;
 
 /**
  * Story 283 — process-wide publisher seam for the typed
  * {@link EventBus} so that {@code UndoableAction} classes (and any
- * other model-mutating callers) can publish {@link DawEvent}s without
- * each one taking a constructor dependency on the bus.
+ * other model-mutating callers) can publish {@link BusEvent}s without
+ * each one taking a constructor dependency on the bus. The bus carries
+ * both families under {@link BusEvent}: {@link DawEvent} domain facts
+ * (the original story-283 producers) and, since story 292, {@link UiEvent}
+ * UI-only facts published by the {@code SelectionVM}/{@code HistoryVM}
+ * command handlers.
  *
  * <p>The application wires a single {@link EventBus} instance at
  * startup via {@link #setDefault(EventBus)}; tests that don't care
@@ -21,8 +27,8 @@ import java.util.Objects;
  * java.util.function.Consumer)} call is the consumer's choice.</p>
  *
  * <p>This class is the <em>only</em> publisher facade in the engine —
- * action classes call {@link #publish} directly, not a typed wrapper
- * per event family. The bus reference is read once at publish time
+ * action classes (and the UI command handlers) call {@link #publish}
+ * directly, not a typed wrapper per event family. The bus reference is read once at publish time
  * (volatile) so a hot-swap via {@link #setDefault(EventBus)} from a
  * test never tears.</p>
  */
@@ -72,7 +78,7 @@ public final class EventBusPublisher {
      * @param event the event to publish; must not be {@code null}
      * @throws NullPointerException if {@code event} is {@code null}
      */
-    public static void publish(DawEvent event) {
+    public static void publish(BusEvent event) {
         Objects.requireNonNull(event, "event must not be null");
         EventBus current = bus;
         if (current != null) {

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/event/EventBusPublisher.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/event/EventBusPublisher.java
@@ -21,7 +21,7 @@ import java.util.Objects;
  * startup via {@link #setDefault(EventBus)}; tests that don't care
  * about events simply leave the bus unset and every {@link #publish}
  * call becomes a no-op. Producers always call
- * {@link #publish(DawEvent)} — they never thread-marshal; the
+ * {@link #publish(BusEvent)} — they never thread-marshal; the
  * per-subscription {@code DispatchMode} on each
  * {@link EventBus#on(Class, com.benesquivelmusic.daw.sdk.event.DispatchMode,
  * java.util.function.Consumer)} call is the consumer's choice.</p>

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/mixer/MixerChannel.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/mixer/MixerChannel.java
@@ -1,6 +1,7 @@
 package com.benesquivelmusic.daw.core.mixer;
 
 import com.benesquivelmusic.daw.core.audio.EffectsChain;
+import com.benesquivelmusic.daw.core.concurrent.ChangeNotifier;
 import com.benesquivelmusic.daw.core.plugin.PluginInvocationSupervisor;
 import com.benesquivelmusic.daw.core.track.TrackColor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
@@ -69,29 +70,11 @@ public final class MixerChannel {
     }
 
     /**
-     * Mutex guarding mutations to {@link #registeredListeners}. Held only while a
-     * listener is added or removed — never on the {@link #notifyChange} path.
+     * Backs the toolkit-neutral {@code Consumer<ChangeKind>} change signal — the
+     * register / unregister / lock-free notify mechanism lives in the shared
+     * {@link ChangeNotifier}.
      */
-    private final Object listenerLock = new Object();
-
-    /**
-     * The canonical observer list, mutated only under {@link #listenerLock}.
-     * {@link #listenerSnapshot} is rebuilt from it on each add/remove so the hot
-     * notify path never touches this list.
-     */
-    private final List<Consumer<ChangeKind>> registeredListeners = new ArrayList<>();
-
-    /**
-     * An immutable snapshot of {@link #registeredListeners}, replaced wholesale
-     * (never mutated in place) on each add/remove. {@link #notifyChange(ChangeKind)}
-     * reads this {@code volatile} reference once into a local and iterates the array
-     * by index, so the notify path takes no lock and allocates nothing — and is
-     * immune to a listener being added or removed mid-notify (reentrantly or from
-     * another thread), because the captured array reference stays stable while a
-     * mutation swaps in a fresh array.
-     */
-    @SuppressWarnings("unchecked")
-    private volatile Consumer<ChangeKind>[] listenerSnapshot = (Consumer<ChangeKind>[]) new Consumer<?>[0];
+    private final ChangeNotifier<ChangeKind> changes = new ChangeNotifier<>();
 
     private final UUID id;
     private final String name;
@@ -629,12 +612,7 @@ public final class MixerChannel {
      * @throws NullPointerException if {@code listener} is {@code null}
      */
     public Runnable addChangeListener(Consumer<ChangeKind> listener) {
-        Objects.requireNonNull(listener, "listener must not be null");
-        synchronized (listenerLock) {
-            registeredListeners.add(listener);
-            listenerSnapshot = snapshotOf(registeredListeners);
-        }
-        return () -> removeChangeListener(listener);
+        return changes.add(listener);
     }
 
     /**
@@ -647,31 +625,11 @@ public final class MixerChannel {
      * @throws NullPointerException if {@code listener} is {@code null}
      */
     public void removeChangeListener(Consumer<ChangeKind> listener) {
-        Objects.requireNonNull(listener, "listener must not be null");
-        synchronized (listenerLock) {
-            if (registeredListeners.remove(listener)) {
-                listenerSnapshot = snapshotOf(registeredListeners);
-            }
-        }
+        changes.remove(listener);
     }
 
-    /**
-     * Notifies every registered observer of a change. Reads the
-     * {@link #listenerSnapshot} reference once into a local and iterates that array
-     * by index, so no lock is taken, no iterator is allocated, and a concurrent or
-     * reentrant {@code add}/{@code remove} (which swaps in a fresh array) cannot
-     * shrink the array being iterated.
-     */
+    /** Notifies registered observers of a change — delegates to {@link ChangeNotifier#fire}. */
     private void notifyChange(ChangeKind kind) {
-        Consumer<ChangeKind>[] snapshot = listenerSnapshot; // read volatile once → stable local
-        for (Consumer<ChangeKind> listener : snapshot) {    // array for-each allocates no iterator
-            listener.accept(kind);
-        }
-    }
-
-    /** Builds a fresh immutable snapshot array from the canonical observer list. */
-    @SuppressWarnings("unchecked")
-    private static Consumer<ChangeKind>[] snapshotOf(List<Consumer<ChangeKind>> listeners) {
-        return listeners.toArray((Consumer<ChangeKind>[]) new Consumer<?>[listeners.size()]);
+        changes.fire(kind);
     }
 }

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/project/DawProject.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/project/DawProject.java
@@ -1,6 +1,7 @@
 package com.benesquivelmusic.daw.core.project;
 
 import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.concurrent.ChangeNotifier;
 import com.benesquivelmusic.daw.core.marker.MarkerManager;
 import com.benesquivelmusic.daw.core.mixer.ChannelLinkManager;
 import com.benesquivelmusic.daw.core.mixer.CueBusManager;
@@ -24,6 +25,7 @@ import com.benesquivelmusic.daw.sdk.edit.RippleMode;
 import com.benesquivelmusic.daw.sdk.visualization.LoudnessTarget;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * Represents an entire DAW project/session.
@@ -49,7 +51,7 @@ public final class DawProject {
     private final BedBusManager bedBusManager = new BedBusManager();
     private RoomConfiguration roomConfiguration;
     private ProjectMetadata metadata;
-    private boolean dirty;
+    private volatile boolean dirty;
 
     /**
      * Tracks the mixer channel associated with each track, keyed by track ID.
@@ -74,6 +76,45 @@ public final class DawProject {
      * "no saved layouts; fall back to the Default built-in".
      */
     private String layoutJson;
+
+    // ── Toolkit-neutral change-notification seam (story 292) ─────────────────
+
+    /**
+     * The kinds of {@link DawProject} change a
+     * {@link #addChangeListener(Consumer) listener} is notified of. A neutral
+     * {@code Consumer<ChangeKind>} signal — never a {@code javafx.beans.Property}
+     * — mirroring the seam on {@code Track} / {@code Transport} /
+     * {@code MixerChannel} (stories 290/291), so {@code daw-core} stays
+     * JavaFX-free while {@code daw-app}'s {@code ProjectVM} can observe
+     * project-level facts (Control Synchronization Design Book §2.5, §3.2, §9).
+     */
+    public enum ChangeKind {
+        /** The {@linkplain #getName() project name} changed. */
+        NAME,
+        /** The {@linkplain #isDirty() unsaved-changes (dirty) flag} changed. */
+        DIRTY,
+        /**
+         * The {@linkplain #getTracks() track list} changed — a track was added,
+         * removed, moved, or duplicated.
+         */
+        TRACKS
+    }
+
+    /**
+     * Backs the toolkit-neutral {@code Consumer<ChangeKind>} change signal — the
+     * register / unregister / lock-free notify mechanism lives in the shared
+     * {@link ChangeNotifier}.
+     */
+    private final ChangeNotifier<ChangeKind> changes = new ChangeNotifier<>();
+
+    /**
+     * Guards the {@link #dirty}-flag transition so a concurrent
+     * {@link #markDirty()} / {@link #markClean()} cannot interleave and lose a state
+     * change (and its {@link ChangeKind#DIRTY} signal). The {@code dirty} field is
+     * {@code volatile} so {@link #isDirty()} reads the latest value without taking
+     * this lock; the listener notification fires outside the lock.
+     */
+    private final Object dirtyLock = new Object();
 
     /**
      * Creates a new DAW project.
@@ -101,6 +142,7 @@ public final class DawProject {
     public void setName(String name) {
         this.name = Objects.requireNonNull(name, "name must not be null");
         this.metadata = metadata.withName(name);
+        notifyChange(ChangeKind.NAME);
     }
 
     /** Returns the audio format. */
@@ -138,6 +180,7 @@ public final class DawProject {
         if (!mixer.getChannels().contains(channel)) {
             mixer.addChannel(channel);
         }
+        notifyChange(ChangeKind.TRACKS);
     }
 
     private static UUID parseUuidOrRandom(String s) {
@@ -190,6 +233,7 @@ public final class DawProject {
             if (channel != null) {
                 mixer.removeChannel(channel);
             }
+            notifyChange(ChangeKind.TRACKS);
         }
         return removed;
     }
@@ -215,6 +259,7 @@ public final class DawProject {
         Track track = tracks.remove(fromIndex);
         tracks.add(toIndex, track);
         mixer.moveChannel(fromIndex, toIndex);
+        notifyChange(ChangeKind.TRACKS);
     }
 
     /**
@@ -261,6 +306,7 @@ public final class DawProject {
         channel.setColor(copy.getColor());
         trackChannelMap.put(copy.getId(), channel);
         mixer.addChannel(channel);
+        notifyChange(ChangeKind.TRACKS);
         return copy;
     }
 
@@ -423,17 +469,72 @@ public final class DawProject {
     }
 
     /**
-     * Marks the project as having unsaved changes.
+     * Marks the project as having unsaved changes. Fires {@link ChangeKind#DIRTY}
+     * exactly once on the clean&rarr;dirty transition (idempotent while already
+     * dirty). The check-and-set runs under {@link #dirtyLock} so a concurrent
+     * {@link #markClean()} cannot interleave and drop the transition; the signal is
+     * fired outside the lock (a listener callback is never run while holding it).
      */
     public void markDirty() {
-        this.dirty = true;
+        synchronized (dirtyLock) {
+            if (dirty) {
+                return;
+            }
+            dirty = true;
+        }
+        notifyChange(ChangeKind.DIRTY);
     }
 
     /**
-     * Marks the project as clean (all changes saved).
+     * Marks the project as clean (all changes saved). Fires {@link ChangeKind#DIRTY}
+     * exactly once on the dirty&rarr;clean transition (idempotent while already
+     * clean), under the same {@link #dirtyLock} guard as {@link #markDirty()}.
      */
     public void markClean() {
-        this.dirty = false;
+        synchronized (dirtyLock) {
+            if (!dirty) {
+                return;
+            }
+            dirty = false;
+        }
+        notifyChange(ChangeKind.DIRTY);
+    }
+
+    // ── Change-listener registration (story 292) ─────────────────────────────
+
+    /**
+     * Registers a toolkit-neutral change listener notified after every
+     * {@link ChangeKind name / dirty / tracks} change. The listener may be
+     * invoked on whichever thread performed the mutation; a UI listener must
+     * marshal onto the FX thread itself (the {@code ProjectVM} does so through
+     * the story-289 {@code FxDispatcher}). Mirrors the seam on {@code Track} /
+     * {@code Transport} / {@code MixerChannel}.
+     *
+     * @param listener the listener to add; must not be {@code null}
+     * @return a {@link Runnable} removal token — running it (equivalently,
+     *         calling {@link #removeChangeListener(Consumer)}) unregisters the
+     *         listener
+     * @throws NullPointerException if {@code listener} is {@code null}
+     */
+    public Runnable addChangeListener(Consumer<ChangeKind> listener) {
+        return changes.add(listener);
+    }
+
+    /**
+     * Unregisters a previously {@linkplain #addChangeListener(Consumer) added}
+     * listener. A listener that was never added (or was already removed) is
+     * silently ignored.
+     *
+     * @param listener the listener to remove; must not be {@code null}
+     * @throws NullPointerException if {@code listener} is {@code null}
+     */
+    public void removeChangeListener(Consumer<ChangeKind> listener) {
+        changes.remove(listener);
+    }
+
+    /** Notifies registered listeners of a change — delegates to {@link ChangeNotifier#fire}. */
+    private void notifyChange(ChangeKind kind) {
+        changes.fire(kind);
     }
 
     // ── Folder track support ────────────────────────────────────────────────

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/track/Track.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/track/Track.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.audio.AudioClip;
 import com.benesquivelmusic.daw.core.audio.InputRouting;
 import com.benesquivelmusic.daw.core.automation.AutomationData;
 import com.benesquivelmusic.daw.core.comping.TakeComping;
+import com.benesquivelmusic.daw.core.concurrent.ChangeNotifier;
 import com.benesquivelmusic.daw.core.midi.MidiClip;
 import com.benesquivelmusic.daw.core.midi.SoundFontAssignment;
 import com.benesquivelmusic.daw.core.recording.InputMonitoringMode;
@@ -65,29 +66,11 @@ public final class Track {
     }
 
     /**
-     * Mutex guarding mutations to {@link #registeredListeners}. Held only while a
-     * listener is added or removed — never on the {@link #notifyChange} path.
+     * Backs the toolkit-neutral {@code Consumer<ChangeKind>} change signal — the
+     * register / unregister / lock-free notify mechanism lives in the shared
+     * {@link ChangeNotifier}.
      */
-    private final Object listenerLock = new Object();
-
-    /**
-     * The canonical observer list, mutated only under {@link #listenerLock}.
-     * {@link #listenerSnapshot} is rebuilt from it on each add/remove so the hot
-     * notify path never touches this list.
-     */
-    private final List<Consumer<ChangeKind>> registeredListeners = new ArrayList<>();
-
-    /**
-     * An immutable snapshot of {@link #registeredListeners}, replaced wholesale
-     * (never mutated in place) on each add/remove. {@link #notifyChange(ChangeKind)}
-     * reads this {@code volatile} reference once into a local and iterates the array
-     * by index, so the notify path takes no lock and allocates nothing — and is
-     * immune to a listener being added or removed mid-notify (reentrantly or from
-     * another thread), because the captured array reference stays stable while a
-     * mutation swaps in a fresh array.
-     */
-    @SuppressWarnings("unchecked")
-    private volatile Consumer<ChangeKind>[] listenerSnapshot = (Consumer<ChangeKind>[]) new Consumer<?>[0];
+    private final ChangeNotifier<ChangeKind> changes = new ChangeNotifier<>();
 
     private final String id;
     private final TrackType type;
@@ -828,12 +811,7 @@ public final class Track {
      * @throws NullPointerException if {@code listener} is {@code null}
      */
     public Runnable addChangeListener(Consumer<ChangeKind> listener) {
-        Objects.requireNonNull(listener, "listener must not be null");
-        synchronized (listenerLock) {
-            registeredListeners.add(listener);
-            listenerSnapshot = snapshotOf(registeredListeners);
-        }
-        return () -> removeChangeListener(listener);
+        return changes.add(listener);
     }
 
     /**
@@ -846,31 +824,11 @@ public final class Track {
      * @throws NullPointerException if {@code listener} is {@code null}
      */
     public void removeChangeListener(Consumer<ChangeKind> listener) {
-        Objects.requireNonNull(listener, "listener must not be null");
-        synchronized (listenerLock) {
-            if (registeredListeners.remove(listener)) {
-                listenerSnapshot = snapshotOf(registeredListeners);
-            }
-        }
+        changes.remove(listener);
     }
 
-    /**
-     * Notifies every registered observer of a change. Reads the
-     * {@link #listenerSnapshot} reference once into a local and iterates that array
-     * by index, so no lock is taken, no iterator is allocated, and a concurrent or
-     * reentrant {@code add}/{@code remove} (which swaps in a fresh array) cannot
-     * shrink the array being iterated.
-     */
+    /** Notifies registered observers of a change — delegates to {@link ChangeNotifier#fire}. */
     private void notifyChange(ChangeKind kind) {
-        Consumer<ChangeKind>[] snapshot = listenerSnapshot; // read volatile once → stable local
-        for (Consumer<ChangeKind> listener : snapshot) {    // array for-each allocates no iterator
-            listener.accept(kind);
-        }
-    }
-
-    /** Builds a fresh immutable snapshot array from the canonical observer list. */
-    @SuppressWarnings("unchecked")
-    private static Consumer<ChangeKind>[] snapshotOf(List<Consumer<ChangeKind>> listeners) {
-        return listeners.toArray((Consumer<ChangeKind>[]) new Consumer<?>[listeners.size()]);
+        changes.fire(kind);
     }
 }

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/transport/Transport.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/transport/Transport.java
@@ -1,10 +1,9 @@
 package com.benesquivelmusic.daw.core.transport;
 
+import com.benesquivelmusic.daw.core.concurrent.ChangeNotifier;
 import com.benesquivelmusic.daw.sdk.transport.PreRollPostRoll;
 import com.benesquivelmusic.daw.sdk.transport.PunchRegion;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -62,30 +61,13 @@ public final class Transport {
     }
 
     /**
-     * Mutex guarding mutations to {@link #registeredListeners}. Held only while a
-     * listener is added or removed — never on the {@link #notifyChange} path.
+     * Backs the toolkit-neutral {@code Consumer<ChangeKind>} change signal — the
+     * register / unregister / lock-free notify mechanism lives in the shared
+     * {@link ChangeNotifier}. {@link ChangeNotifier#fire} allocates nothing, so it
+     * is safe to invoke from the {@code @RealTimeSafe} render path via
+     * {@link #advancePosition(double)}.
      */
-    private final Object listenerLock = new Object();
-
-    /**
-     * The canonical observer list, mutated only under {@link #listenerLock}.
-     * {@link #listenerSnapshot} is rebuilt from it on each add/remove so the hot
-     * notify path never touches this list.
-     */
-    private final List<Consumer<ChangeKind>> registeredListeners = new ArrayList<>();
-
-    /**
-     * An immutable snapshot of {@link #registeredListeners}, replaced wholesale
-     * (never mutated in place) on each add/remove. {@link #notifyChange(ChangeKind)}
-     * reads this {@code volatile} reference once into a local and iterates the array
-     * by index, so the notify path takes no lock and allocates nothing — and is
-     * immune to a listener being added or removed mid-notify (reentrantly or from
-     * another thread), because the captured array reference stays stable while a
-     * mutation swaps in a fresh array. Safe to invoke from the {@code @RealTimeSafe}
-     * render path via {@link #advancePosition(double)}.
-     */
-    @SuppressWarnings("unchecked")
-    private volatile Consumer<ChangeKind>[] listenerSnapshot = (Consumer<ChangeKind>[]) new Consumer<?>[0];
+    private final ChangeNotifier<ChangeKind> changes = new ChangeNotifier<>();
 
     private TransportState state = TransportState.STOPPED;
     private double positionInBeats = 0.0;
@@ -499,12 +481,7 @@ public final class Transport {
      * @throws NullPointerException if {@code listener} is {@code null}
      */
     public Runnable addChangeListener(Consumer<ChangeKind> listener) {
-        Objects.requireNonNull(listener, "listener must not be null");
-        synchronized (listenerLock) {
-            registeredListeners.add(listener);
-            listenerSnapshot = snapshotOf(registeredListeners);
-        }
-        return () -> removeChangeListener(listener);
+        return changes.add(listener);
     }
 
     /**
@@ -517,32 +494,15 @@ public final class Transport {
      * @throws NullPointerException if {@code listener} is {@code null}
      */
     public void removeChangeListener(Consumer<ChangeKind> listener) {
-        Objects.requireNonNull(listener, "listener must not be null");
-        synchronized (listenerLock) {
-            if (registeredListeners.remove(listener)) {
-                listenerSnapshot = snapshotOf(registeredListeners);
-            }
-        }
+        changes.remove(listener);
     }
 
     /**
-     * Notifies every registered observer of a change. Reads the
-     * {@link #listenerSnapshot} reference once into a local and iterates that array
-     * by index, so no lock is taken, no iterator is allocated, and a concurrent or
-     * reentrant {@code add}/{@code remove} (which swaps in a fresh array) cannot
-     * shrink the array being iterated — safe to call from the {@code @RealTimeSafe}
+     * Notifies registered observers of a change — delegates to the allocation-free
+     * {@link ChangeNotifier#fire}, so it stays safe on the {@code @RealTimeSafe}
      * render path.
      */
     private void notifyChange(ChangeKind kind) {
-        Consumer<ChangeKind>[] snapshot = listenerSnapshot; // read volatile once → stable local
-        for (Consumer<ChangeKind> listener : snapshot) {    // array for-each allocates no iterator
-            listener.accept(kind);
-        }
-    }
-
-    /** Builds a fresh immutable snapshot array from the canonical observer list. */
-    @SuppressWarnings("unchecked")
-    private static Consumer<ChangeKind>[] snapshotOf(List<Consumer<ChangeKind>> listeners) {
-        return listeners.toArray((Consumer<ChangeKind>[]) new Consumer<?>[listeners.size()]);
+        changes.fire(kind);
     }
 }

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/concurrent/ChangeNotifierTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/concurrent/ChangeNotifierTest.java
@@ -1,0 +1,113 @@
+package com.benesquivelmusic.daw.core.concurrent;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+/**
+ * Unit tests for {@link ChangeNotifier} — the shared register / unregister /
+ * allocation-free notify mechanism extracted from {@code Track} /
+ * {@code MixerChannel} / {@code Transport} / {@code DawProject} (story 292 code
+ * review). Pins the contract those models delegate to: who is notified, that
+ * removal tokens work, and — the discriminating case — that a listener removed
+ * mid-notification cannot corrupt the iteration (the fresh-snapshot semantics).
+ */
+class ChangeNotifierTest {
+
+    @Test
+    void firesToEveryRegisteredListener() {
+        ChangeNotifier<String> notifier = new ChangeNotifier<>();
+        List<String> a = new ArrayList<>();
+        List<String> b = new ArrayList<>();
+        notifier.add(a::add);
+        notifier.add(b::add);
+
+        notifier.fire("X");
+
+        assertThat(a).containsExactly("X");
+        assertThat(b).containsExactly("X");
+    }
+
+    @Test
+    void fireWithNoListenersIsANoOp() {
+        ChangeNotifier<String> notifier = new ChangeNotifier<>();
+        // No throw, nothing to observe.
+        notifier.fire("X");
+    }
+
+    @Test
+    void removalTokenUnregistersTheListener() {
+        ChangeNotifier<String> notifier = new ChangeNotifier<>();
+        List<String> received = new ArrayList<>();
+        Runnable token = notifier.add(received::add);
+
+        notifier.fire("one");
+        token.run();
+        notifier.fire("two"); // after unregister — not recorded
+
+        assertThat(received).containsExactly("one");
+    }
+
+    @Test
+    void removeUnregistersTheListener() {
+        ChangeNotifier<String> notifier = new ChangeNotifier<>();
+        List<String> received = new ArrayList<>();
+        Consumer<String> listener = received::add;
+        notifier.add(listener);
+
+        notifier.fire("one");
+        notifier.remove(listener);
+        notifier.fire("two"); // after unregister — not recorded
+
+        assertThat(received).containsExactly("one");
+    }
+
+    @Test
+    void removingANeverAddedListenerIsSilent() {
+        ChangeNotifier<String> notifier = new ChangeNotifier<>();
+        // Must not throw.
+        notifier.remove(s -> { });
+    }
+
+    @Test
+    void rejectsNullListeners() {
+        ChangeNotifier<String> notifier = new ChangeNotifier<>();
+        assertThatNullPointerException()
+                .isThrownBy(() -> notifier.add(null))
+                .withMessage("listener must not be null");
+        assertThatNullPointerException()
+                .isThrownBy(() -> notifier.remove(null))
+                .withMessage("listener must not be null");
+    }
+
+    @Test
+    void aListenerRemovingAnotherDuringFireKeepsSnapshotSemantics() {
+        ChangeNotifier<String> notifier = new ChangeNotifier<>();
+        List<String> received = new ArrayList<>();
+
+        AtomicReference<Consumer<String>> bRef = new AtomicReference<>();
+        // Listener A, during its own notification, unregisters listener B.
+        Consumer<String> listenerA = s -> notifier.remove(bRef.get());
+        Consumer<String> listenerB = received::add;
+        bRef.set(listenerB);
+        notifier.add(listenerA);
+        notifier.add(listenerB);
+
+        // The snapshot is read once into a stable local before iterating, so B
+        // still receives THIS notification even though A removed it mid-loop —
+        // and the iteration does not throw.
+        notifier.fire("X");
+        assertThat(received).containsExactly("X");
+
+        // B was removed for good; the NEXT notification skips it.
+        received.clear();
+        notifier.fire("Y");
+        assertThat(received).isEmpty();
+    }
+}

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/project/CoreDawProjectSignalTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/project/CoreDawProjectSignalTest.java
@@ -1,0 +1,176 @@
+package com.benesquivelmusic.daw.core.project;
+
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.project.DawProject.ChangeKind;
+import com.benesquivelmusic.daw.core.track.Track;
+import com.benesquivelmusic.daw.core.track.TrackType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 292 — verifies the toolkit-neutral change-notification seam added to
+ * {@link DawProject} (mirrors {@code CoreTrackSignalTest} for {@code Track}).
+ * The seam is what {@code daw-app}'s {@code ProjectVM} subscribes to; these
+ * tests pin its contract: which mutation fires which {@link ChangeKind}, that
+ * the dirty flag is fire-on-change (an idempotent {@code markDirty} announces
+ * nothing), that removal tokens work, and — the discriminating case — that a
+ * listener removed mid-notification cannot corrupt the iteration.
+ */
+class CoreDawProjectSignalTest {
+
+    private static DawProject newProject() {
+        return new DawProject("Test", AudioFormat.CD_QUALITY);
+    }
+
+    @Test
+    void setNameFiresNameSignal() {
+        DawProject project = newProject();
+        List<ChangeKind> kinds = new ArrayList<>();
+        project.addChangeListener(kinds::add);
+
+        project.setName("Renamed");
+
+        assertThat(kinds).containsExactly(ChangeKind.NAME);
+        assertThat(project.getName()).isEqualTo("Renamed");
+    }
+
+    @Test
+    void markDirtyFiresDirtyOnceOnTransitionThenIsIdempotent() {
+        DawProject project = newProject(); // a new project starts clean
+        List<ChangeKind> kinds = new ArrayList<>();
+        project.addChangeListener(kinds::add);
+
+        project.markDirty();
+        project.markDirty(); // already dirty — must NOT re-announce
+
+        assertThat(kinds).containsExactly(ChangeKind.DIRTY);
+        assertThat(project.isDirty()).isTrue();
+    }
+
+    @Test
+    void markCleanFiresDirtyOnlyOnTransition() {
+        DawProject project = newProject();
+        project.markDirty(); // before the listener — not recorded
+        List<ChangeKind> kinds = new ArrayList<>();
+        project.addChangeListener(kinds::add);
+
+        project.markClean();
+        project.markClean(); // already clean — must NOT re-announce
+
+        assertThat(kinds).containsExactly(ChangeKind.DIRTY);
+        assertThat(project.isDirty()).isFalse();
+    }
+
+    @Test
+    void addTrackFiresTracksSignal() {
+        DawProject project = newProject();
+        List<ChangeKind> kinds = new ArrayList<>();
+        project.addChangeListener(kinds::add);
+
+        Track track = project.createAudioTrack("Drums");
+
+        assertThat(kinds).containsExactly(ChangeKind.TRACKS);
+        assertThat(project.getTracks()).containsExactly(track);
+    }
+
+    @Test
+    void removeTrackFiresTracksOnlyWhenItActuallyRemoves() {
+        DawProject project = newProject();
+        Track track = project.createAudioTrack("Drums"); // before the listener
+        List<ChangeKind> kinds = new ArrayList<>();
+        project.addChangeListener(kinds::add);
+
+        assertThat(project.removeTrack(track)).isTrue();
+        Track stranger = new Track("Stranger", TrackType.AUDIO);
+        assertThat(project.removeTrack(stranger)).isFalse(); // not in project — no signal
+
+        assertThat(kinds).containsExactly(ChangeKind.TRACKS);
+    }
+
+    @Test
+    void moveTrackFiresTracksButNotForANoOpMove() {
+        DawProject project = newProject();
+        Track a = project.createAudioTrack("A");
+        Track b = project.createAudioTrack("B");
+        List<ChangeKind> kinds = new ArrayList<>();
+        project.addChangeListener(kinds::add);
+
+        project.moveTrack(0, 1);
+        project.moveTrack(1, 1); // from == to — early return, fires nothing
+
+        assertThat(kinds).containsExactly(ChangeKind.TRACKS);
+        assertThat(project.getTracks()).containsExactly(b, a);
+    }
+
+    @Test
+    void duplicateTrackFiresTracksSignal() {
+        DawProject project = newProject();
+        Track a = project.createAudioTrack("A");
+        List<ChangeKind> kinds = new ArrayList<>();
+        project.addChangeListener(kinds::add);
+
+        Track copy = project.duplicateTrack(a);
+
+        assertThat(kinds).containsExactly(ChangeKind.TRACKS);
+        assertThat(project.getTracks()).containsExactly(a, copy);
+    }
+
+    @Test
+    void removalTokenUnregistersTheListener() {
+        DawProject project = newProject();
+        List<ChangeKind> kinds = new ArrayList<>();
+        Runnable token = project.addChangeListener(kinds::add);
+
+        project.setName("One");
+        token.run();
+        project.setName("Two"); // after unregister — not recorded
+
+        assertThat(kinds).containsExactly(ChangeKind.NAME);
+    }
+
+    @Test
+    void removeChangeListenerUnregistersTheListener() {
+        DawProject project = newProject();
+        List<ChangeKind> kinds = new ArrayList<>();
+        Consumer<ChangeKind> listener = kinds::add;
+        project.addChangeListener(listener);
+
+        project.markDirty();
+        project.removeChangeListener(listener);
+        project.markClean(); // after unregister — not recorded
+
+        assertThat(kinds).containsExactly(ChangeKind.DIRTY);
+    }
+
+    @Test
+    void aListenerRemovingAnotherDuringNotificationDoesNotThrowAndKeepsSnapshotSemantics() {
+        DawProject project = newProject();
+        List<ChangeKind> received = new ArrayList<>();
+
+        AtomicReference<Consumer<ChangeKind>> bRef = new AtomicReference<>();
+        // Listener A, during its own notification, unregisters listener B.
+        Consumer<ChangeKind> listenerA = kind -> project.removeChangeListener(bRef.get());
+        Consumer<ChangeKind> listenerB = received::add;
+        bRef.set(listenerB);
+        project.addChangeListener(listenerA);
+        project.addChangeListener(listenerB);
+
+        // The snapshot is read once into a stable local before iterating, so B
+        // still receives THIS notification even though A removed it mid-loop —
+        // and the iteration does not throw (a naive size()+get(i) loop would).
+        project.setName("X");
+        assertThat(received).containsExactly(ChangeKind.NAME);
+
+        // B was removed for good; the NEXT notification skips it.
+        received.clear();
+        project.setName("Y");
+        assertThat(received).isEmpty();
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/BusEvent.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/BusEvent.java
@@ -1,0 +1,38 @@
+package com.benesquivelmusic.daw.sdk.event;
+
+/**
+ * Sealed root of every event that may travel the typed {@link EventBus}.
+ *
+ * <p>The bus carries two sibling families:</p>
+ * <ul>
+ *   <li>{@link DawEvent} — domain facts the engine produces (transport, mixer,
+ *       track, clip, project, automation, plugin, x-run). These cross the
+ *       core↔UI boundary and are consumed by both engine-side and UI-side
+ *       subscribers.</li>
+ *   <li>{@link UiEvent} — UI-only discrete facts (selection changed, undo-state
+ *       changed) that <em>never</em> need to reach the core (Control
+ *       Synchronization Design Book §4.2, §7, Appendix A; story 292).</li>
+ * </ul>
+ *
+ * <p>{@code BusEvent} exists so a single {@link EventBus} can carry both families
+ * without {@link UiEvent} having to be a {@link DawEvent} — the design book
+ * keeps the {@code DawEvent} {@code permits} clause closed to the engine domain
+ * (story 292 Non-Goal: "Do not add the new UI events to {@code DawEvent}'s
+ * {@code permits}"), and the bus binds to this shared super-type instead of to
+ * {@code DawEvent}, so one bus carries UI facts too rather than spinning up a
+ * second bus (story 292: "Prefer reusing the existing bus infrastructure over a
+ * third bus").</p>
+ *
+ * <p>The hierarchy is sealed: the two permitted families are the only things a
+ * bus can carry, so a third family cannot be introduced without an explicit
+ * edit here. There is intentionally no exhaustive {@code switch} over
+ * {@code BusEvent} anywhere — consumers always subscribe to a concrete
+ * {@code DawEvent}/{@code UiEvent} sub-type; this type is purely the bus's
+ * type bound.</p>
+ *
+ * @see DawEvent
+ * @see UiEvent
+ * @see EventBus
+ */
+public sealed interface BusEvent permits DawEvent, UiEvent {
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/DawEvent.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/DawEvent.java
@@ -55,6 +55,14 @@ import java.time.Instant;
  * new event stream to the old listener callbacks until every call site
  * has migrated.</p>
  *
+ * <p>{@code DawEvent} is one of the two families carried by the typed
+ * {@link EventBus}; it shares the {@link BusEvent} super-type with the UI-only
+ * {@link UiEvent} family so a single bus can carry both (story 292). This
+ * {@code permits} clause is the engine domain and stays closed to it — UI-only
+ * facts go to {@link UiEvent}, never here.</p>
+ *
+ * @see BusEvent
+ * @see UiEvent
  * @see TransportEvent
  * @see MixerEvent
  * @see TrackEvent
@@ -64,7 +72,7 @@ import java.time.Instant;
  * @see PluginEvent
  * @see com.benesquivelmusic.daw.sdk.audio.XrunEvent
  */
-public sealed interface DawEvent
+public sealed interface DawEvent extends BusEvent
         permits TransportEvent,
                 MixerEvent,
                 TrackEvent,

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/EventBus.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/EventBus.java
@@ -4,7 +4,9 @@ import java.util.concurrent.Flow;
 import java.util.function.Consumer;
 
 /**
- * Central, typed publish/subscribe channel for {@link DawEvent}s.
+ * Central, typed publish/subscribe channel for {@link BusEvent}s — both the
+ * engine-domain {@link DawEvent} family and the UI-only {@link UiEvent} family
+ * ride the one bus (story 292).
  *
  * <p>The bus replaces the per-emitter ad-hoc listener lists used in
  * earlier iterations of the engine. Emitters call {@link #publish}
@@ -52,7 +54,7 @@ public interface EventBus {
      *
      * @param event the event to publish; must not be {@code null}
      */
-    void publish(DawEvent event);
+    void publish(BusEvent event);
 
     /**
      * Returns a {@link Flow.Publisher} that emits every event whose
@@ -77,7 +79,7 @@ public interface EventBus {
      * @param <E>  the event type
      * @return a per-call publisher emitting events of the requested type
      */
-    <E extends DawEvent> Flow.Publisher<E> subscribe(Class<E> type);
+    <E extends BusEvent> Flow.Publisher<E> subscribe(Class<E> type);
 
     /**
      * Convenience subscription that invokes {@code handler} on every
@@ -88,7 +90,7 @@ public interface EventBus {
      * @param <E>     the event type
      * @return a handle that, when closed, cancels the subscription
      */
-    default <E extends DawEvent> Subscription on(Class<E> type, Consumer<? super E> handler) {
+    default <E extends BusEvent> Subscription on(Class<E> type, Consumer<? super E> handler) {
         return on(type, DispatchMode.ON_CALLER_THREAD, handler);
     }
 
@@ -102,7 +104,7 @@ public interface EventBus {
      * @param <E>     the event type
      * @return a handle that, when closed, cancels the subscription
      */
-    <E extends DawEvent> Subscription on(Class<E> type,
+    <E extends BusEvent> Subscription on(Class<E> type,
                                          DispatchMode mode,
                                          Consumer<? super E> handler);
 

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/UiEvent.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/UiEvent.java
@@ -46,8 +46,10 @@ public sealed interface UiEvent extends BusEvent
 
     /**
      * Emitted when the UI selection changes — a different track, clip, or device
-     * becomes selected, the selection is cleared, or the edit tool changes
-     * (Control Synchronization Design Book §5.5). Subscribers (the inspector,
+     * becomes selected or the selection is cleared (Control Synchronization
+     * Design Book §5.5). Edit-tool changes do <em>not</em> raise this event: the
+     * tool is bound directly (§2.7, {@code SelectionVM#setTool}), so it never
+     * reaches {@code CoreSelectionIntentHandler}'s announce step. Subscribers (the inspector,
      * the menu-enablement policy, the canvas highlight, the mixer focus) re-read
      * the current selection from {@code SelectionVM}; the event itself is a bare
      * notification.

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/UiEvent.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/event/UiEvent.java
@@ -1,0 +1,77 @@
+package com.benesquivelmusic.daw.sdk.event;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Sealed family of <strong>UI-only discrete facts</strong> — the sibling of
+ * {@link DawEvent} for changes that several unrelated <em>surfaces</em> care
+ * about but that never need to reach the engine (Control Synchronization Design
+ * Book §4.2, §7, Appendix A; story 292).
+ *
+ * <p>Selection and undo-state are owned by the UI (the {@code SelectionVM} and
+ * {@code HistoryVM} view-models in {@code daw-app}), not by {@code daw-core}, so
+ * modelling them as {@code DawEvent}s would wrongly couple the engine domain to
+ * a UI concern. Instead they ride the <em>same</em> typed {@link EventBus} as a
+ * separate sealed family under the shared {@link BusEvent} super-type — reusing
+ * the bus, its per-subscription {@link DispatchMode} marshalling, and the
+ * {@code EventBusPublisher} seam rather than a second bus (story 292).</p>
+ *
+ * <h2>Notification, not a state-bearing delta</h2>
+ *
+ * <p>Like {@link DawEvent}, a {@code UiEvent} carries only the minimal fact that
+ * <em>something</em> changed plus a wall-clock {@link #timestamp()}; subscribers
+ * re-read the post-change state from the relevant view-model (the menu bar
+ * recomputes enablement from {@code SelectionVM}/{@code HistoryVM} via
+ * {@code MenuEnablementPolicy}; the toolbar re-reads {@code HistoryVM}). This is
+ * why a bare {@code SelectionChanged} (with no "what is now selected" payload) is
+ * sufficient — the canonical state lives in the VM, not in the event.</p>
+ *
+ * <h2>Exhaustiveness</h2>
+ *
+ * <p>The {@code permits} clause is explicit and exhaustive, so an exhaustive
+ * {@code switch} over {@code UiEvent} compiles without a {@code default} and
+ * adding a variant forces every consumer to be updated at compile time
+ * (story 202's sealing guarantee, mirrored here).</p>
+ *
+ * @see DawEvent
+ * @see BusEvent
+ */
+public sealed interface UiEvent extends BusEvent
+        permits UiEvent.SelectionChanged,
+                UiEvent.UndoStateChanged {
+
+    /** Returns the wall-clock instant at which this event was produced. */
+    Instant timestamp();
+
+    /**
+     * Emitted when the UI selection changes — a different track, clip, or device
+     * becomes selected, the selection is cleared, or the edit tool changes
+     * (Control Synchronization Design Book §5.5). Subscribers (the inspector,
+     * the menu-enablement policy, the canvas highlight, the mixer focus) re-read
+     * the current selection from {@code SelectionVM}; the event itself is a bare
+     * notification.
+     *
+     * @param timestamp wall-clock instant of the event
+     */
+    record SelectionChanged(Instant timestamp) implements UiEvent {
+        public SelectionChanged {
+            Objects.requireNonNull(timestamp, "timestamp must not be null");
+        }
+    }
+
+    /**
+     * Emitted when the command-history (undo/redo) state changes — an action was
+     * executed, undone, or redone (Control Synchronization Design Book §5.6,
+     * §6.9). Subscribers (the Edit menu, the undo/redo toolbar buttons, the
+     * history panel) re-read {@code HistoryVM}'s {@code canUndo}/{@code canRedo}
+     * and the next undo/redo labels.
+     *
+     * @param timestamp wall-clock instant of the event
+     */
+    record UndoStateChanged(Instant timestamp) implements UiEvent {
+        public UndoStateChanged {
+            Objects.requireNonNull(timestamp, "timestamp must not be null");
+        }
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/event/UiEventSealingTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/event/UiEventSealingTest.java
@@ -1,0 +1,103 @@
+package com.benesquivelmusic.daw.sdk.event;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 292 — verifies the closed shape of the new UI-only {@link UiEvent}
+ * sealed family and proves, the same way {@link DawEventExhaustiveSwitchTest}
+ * does for the engine domain, that:
+ *
+ * <ul>
+ *   <li>an exhaustive {@code switch} over {@link UiEvent} compiles with no
+ *       {@code default} branch (adding a permitted variant breaks compilation —
+ *       story 202's sealing guarantee, mirrored here);</li>
+ *   <li>{@link DawEvent}'s {@code permits} clause is <strong>unchanged</strong>
+ *       by this story — the UI events are a <em>sibling</em> family under the
+ *       shared {@link BusEvent} super-type, never added to {@code DawEvent}
+ *       (story 292 Non-Goal: "Do not add the new UI events to {@code DawEvent}'s
+ *       {@code permits}").</li>
+ * </ul>
+ */
+class UiEventSealingTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    /**
+     * Returns a short textual classification of the UI event.
+     *
+     * <p>This switch has <strong>no {@code default} branch</strong> and covers
+     * every permitted sub-type of {@link UiEvent}. If a new permitted sub-type is
+     * added to {@link UiEvent} without updating this method, compilation fails
+     * with "the switch expression does not cover all possible input values" — the
+     * compile-time exhaustiveness guarantee this story preserves for the UI
+     * family.</p>
+     */
+    private static String classify(UiEvent event) {
+        return switch (event) {
+            case UiEvent.SelectionChanged ignored -> "selection";
+            case UiEvent.UndoStateChanged ignored -> "undoState";
+        };
+    }
+
+    @Test
+    void exhaustiveSwitchCoversUiEvents() {
+        assertThat(classify(new UiEvent.SelectionChanged(T0))).isEqualTo("selection");
+        assertThat(classify(new UiEvent.UndoStateChanged(T0))).isEqualTo("undoState");
+    }
+
+    @Test
+    void uiEventPermitsExactlySelectionChangedAndUndoStateChanged() {
+        List<String> permitted = Arrays.stream(UiEvent.class.getPermittedSubclasses())
+                .map(Class::getSimpleName)
+                .toList();
+        assertThat(permitted).containsExactlyInAnyOrder("SelectionChanged", "UndoStateChanged");
+    }
+
+    @Test
+    void dawEventPermitsClauseIsUnchangedByThisStory() {
+        // The eight engine-domain families and nothing else — story 292 must NOT
+        // add SelectionChanged/UndoStateChanged here.
+        List<String> permitted = Arrays.stream(DawEvent.class.getPermittedSubclasses())
+                .map(Class::getSimpleName)
+                .toList();
+        assertThat(permitted).containsExactlyInAnyOrder(
+                "TransportEvent",
+                "MixerEvent",
+                "TrackEvent",
+                "ClipEvent",
+                "ProjectEvent",
+                "AutomationEvent",
+                "PluginEvent",
+                "XrunEvent");
+        assertThat(permitted).doesNotContain("UiEvent", "SelectionChanged", "UndoStateChanged");
+    }
+
+    @Test
+    void busEventPermitsExactlyDawEventAndUiEvent() {
+        List<String> permitted = Arrays.stream(BusEvent.class.getPermittedSubclasses())
+                .map(Class::getSimpleName)
+                .toList();
+        assertThat(permitted).containsExactlyInAnyOrder("DawEvent", "UiEvent");
+    }
+
+    @Test
+    void uiEventIsABusEventButNotADawEvent() {
+        UiEvent selection = new UiEvent.SelectionChanged(T0);
+        assertThat(selection).isInstanceOf(BusEvent.class);
+        // The whole point of the BusEvent split: a UiEvent rides the bus without
+        // being a DawEvent, so the engine domain stays closed (story 292).
+        assertThat(selection).isNotInstanceOf(DawEvent.class);
+    }
+
+    @Test
+    void uiEventsExposeTheirTimestamp() {
+        assertThat(new UiEvent.SelectionChanged(T0).timestamp()).isEqualTo(T0);
+        assertThat(new UiEvent.UndoStateChanged(T0).timestamp()).isEqualTo(T0);
+    }
+}

--- a/docs/user-stories/292-selectionvm-historyvm-projectvm-and-the-ordered-full-load-cascade.md
+++ b/docs/user-stories/292-selectionvm-historyvm-projectvm-and-the-ordered-full-load-cascade.md
@@ -129,7 +129,7 @@ Tests (assert on properties / declared order / bus events — never on rasterisa
 
 ## Implementation Note (2026-06-13)
 
-Implemented + independently verified, **uncommitted**. The 4th companion-design-book story (after
+Implemented + independently verified. The 4th companion-design-book story (after
 289/290/291) to gain production code. Built as a **test-proven seam, NOT live-wired** — mirroring
 290/291: `MainController` / `ProjectLifecycleController` / `DawMenuBarController` are **untouched**, and
 their refresh methods (`updateProjectInfo` / `updateUndoRedoState` / `syncSelectionToCanvas`, …) stay

--- a/docs/user-stories/292-selectionvm-historyvm-projectvm-and-the-ordered-full-load-cascade.md
+++ b/docs/user-stories/292-selectionvm-historyvm-projectvm-and-the-ordered-full-load-cascade.md
@@ -126,3 +126,80 @@ Tests (assert on properties / declared order / bus events — never on rasterisa
   `research-daw` (§1 modular, §3 real-time / lock-free), `dawg-annotations-reflection` (`@RealTimeSafe`).
 - Build/verify: `mvn -pl daw-sdk -am test -Dtest=UiEventSealing* -Dsurefire.failIfNoSpecifiedTests=false`
   then `mvn -pl daw-app -am test -Dtest=SelectionVM*,HistoryVM*,ProjectVM*,ProjectLoadCascadeOrder*,SelectionUndoEvent* -Dsurefire.failIfNoSpecifiedTests=false`.
+
+## Implementation Note (2026-06-13)
+
+Implemented + independently verified, **uncommitted**. The 4th companion-design-book story (after
+289/290/291) to gain production code. Built as a **test-proven seam, NOT live-wired** — mirroring
+290/291: `MainController` / `ProjectLifecycleController` / `DawMenuBarController` are **untouched**, and
+their refresh methods (`updateProjectInfo` / `updateUndoRedoState` / `syncSelectionToCanvas`, …) stay
+live. Retiring the god controller and wiring the cascade/binders/VMs into the live project-open path is
+**story 293** (the explicit Non-Goals here).
+
+### daw-sdk — the `UiEvent` family + the bus widening (the load-bearing decision)
+
+The story's "sibling `UiEvent` family" + "do **not** touch `DawEvent`'s `permits`" + "prefer reusing the
+existing bus over a third bus" + "a small generic widening" resolved to a new sealed **`BusEvent`**
+super-type (`permits DawEvent, UiEvent`) that both families extend, with the
+`EventBus` / `DefaultEventBus` / `EventBusPublisher` type bound **widened from `DawEvent` to `BusEvent`**.
+The one existing bus now carries `UiEvent` too, without `UiEvent` being a `DawEvent` (the Non-Goal).
+`DawEvent`'s `permits` is byte-for-byte unchanged (pinned by `UiEventSealingTest` via
+`getPermittedSubclasses()`). **Flagged for pre-commit review — this is the only change that modifies
+shared bus infrastructure** (4 `EventBus` signatures + `DefaultEventBus` generics + `EventBusPublisher
+.publish`); every existing publisher/subscriber compiles unchanged (a `DawEvent` *is-a* `BusEvent`), and
+the full daw-sdk (1037) + daw-core (6040) suites pass with zero regressions. New: `BusEvent`, `UiEvent`
+(`SelectionChanged`, `UndoStateChanged` records), `UiEventSealingTest` (6).
+
+### daw-core — the `DawProject` change seam
+
+Mirrors the `Track` / `Transport` / `MixerChannel` seam exactly (`volatile Consumer<ChangeKind>[]`
+snapshot, lock-free + allocation-free notify, no `javafx`, no `@RealTimeSafe`): `enum ChangeKind {NAME,
+DIRTY, TRACKS}` + `addChangeListener` / `removeChangeListener`, firing **after** `setName` (NAME),
+`markDirty` / `markClean` (DIRTY — **fire-on-change**, so an idempotent `markDirty` announces nothing),
+and `addTrack` / `removeTrack` / `moveTrack` / `duplicateTrack` (TRACKS). `CoreDawProjectSignalTest` (10,
+incl. the discriminating remove-a-listener-mid-notify case). No project UUID / checkpoint added —
+`DawProject` owns neither.
+
+### daw-app — the VM / command / cascade / binder layer (`ui/vm/` + `ui/vm/command/`)
+
+- **`ProjectVM`** (model-derived, mirrors `TrackVM`): `name` / `dirty` / `tracks` (unmodifiable
+  `ObservableList<Track>`) from the `DawProject` signal via `FxDispatcher`; `checkpoint`
+  **forward-declared** (seeded `""`, no producer yet — the session-status strip is 295-299, mirroring
+  story 291's `ChannelVM.meterLevel`).
+- **`HistoryVM`** (projection of `UndoManager` through its older `UndoHistoryListener`):
+  `canUndo` / `canRedo` / `undoLabel` / `redoLabel`, marshalled via `FxDispatcher`. Per-load lifetime (a
+  fresh `UndoManager` is installed per load → dispose + rebuild). Does **not** publish — the handler
+  announces (mirrors 290/291).
+- **`SelectionVM`** (UI-authoritative — **no core model, no dispatcher**): `selectedTrack` /
+  `selectedClip` / `selectedDevice` / `tool` read-only props; writer methods set synchronously on the FX
+  thread (selection only ever originates there). `clampTo(ProjectVM)` is the §5.7 step-5 clamp (clears a
+  selected track absent from the loaded project). `clip` / `device` are `Object` (no shared supertype;
+  their clamp + surfaces are story 294).
+- **`ProjectLoadCascade`**: an `enum Phase {TEAR_DOWN, BUILD_VMS, REBUILD_VIEWS, BIND_CONTINUOUS,
+  RESTORE_SELECTION, ANNOUNCE}` sequencer — `run()` executes injected per-phase `Runnable`s strictly in
+  enum order and records `executedPhases()`. The §1.6 fix: the **order is the contract** (293 supplies
+  the real per-phase steps — VM rebuild, view rebuild, selection clamp, announce).
+- **Commands** (separate-file records, mirroring 290/291): sealed `SelectionCommand` (SelectTrack /
+  SelectClip / SelectDevice / SetTool / ClearSelection) + `SelectionIntentHandler` +
+  `CoreSelectionIntentHandler` (VALIDATE idempotent → MUTATE the VM → ANNOUNCE `SelectionChanged`; a
+  **tool change is bound directly per §2.7 and announces nothing**); sealed `HistoryCommand` (Undo /
+  Redo) + `HistoryIntentHandler` + `CoreHistoryIntentHandler` (VALIDATE `canUndo`/`canRedo` → undo/redo
+  → ANNOUNCE `UndoStateChanged`).
+- **`HistoryControlBinder`**: binds undo/redo buttons' `disable` + tooltip and Edit-menu items'
+  `disable` + text to `HistoryVM`; clicks raise commands (mirrors `TransportControlBinder`).
+
+### Tests + verification
+
+`SelectionVMTest` (7) / `HistoryVMTest` (5) / `ProjectVMTest` (7) / `ProjectLoadCascadeOrderTest` (4) /
+`SelectionUndoEventTest` (4) — all **discriminating** and FX-thread-safe (results captured into holders
+and asserted off the FX thread, never inside a `runLater`). **43 new tests green** (sdk 6 + core 10 +
+app 27), verified on disk and re-run independently; full daw-sdk **1037**, daw-core **6040**, and the
+daw-app reactor are green. No `module-info` change (same-package test access, as 290/291 established). No
+new bus event types beyond `UiEvent`.
+
+### Deferred (NOT gaps — later-story scope)
+
+God-controller retirement + live wiring of the cascade / binders / VMs into `MainController` /
+`ProjectLifecycleController` / `DawMenuBarController` = **293**; inspector / clip-editor / plugin-chain
+selection-surface binding + clip/device clamp = **294**; the `checkpoint` / session-status producer =
+**295-299**. A distinct `ToolChanged` event and `ThemeChanged` are deferred (§5.5, §7).

--- a/docs/user-stories/292-selectionvm-historyvm-projectvm-and-the-ordered-full-load-cascade.md
+++ b/docs/user-stories/292-selectionvm-historyvm-projectvm-and-the-ordered-full-load-cascade.md
@@ -145,8 +145,7 @@ super-type (`permits DawEvent, UiEvent`) that both families extend, with the
 The one existing bus now carries `UiEvent` too, without `UiEvent` being a `DawEvent` (the Non-Goal).
 `DawEvent`'s `permits` is byte-for-byte unchanged (pinned by `UiEventSealingTest` via
 `getPermittedSubclasses()`). **Flagged for pre-commit review — this is the only change that modifies
-shared bus infrastructure** (4 `EventBus` signatures + `DefaultEventBus` generics + `EventBusPublisher
-.publish`); every existing publisher/subscriber compiles unchanged (a `DawEvent` *is-a* `BusEvent`), and
+shared bus infrastructure** (4 `EventBus` signatures + `DefaultEventBus` generics + `EventBusPublisher.publish`); every existing publisher/subscriber compiles unchanged (a `DawEvent` *is-a* `BusEvent`), and
 the full daw-sdk (1037) + daw-core (6040) suites pass with zero regressions. New: `BusEvent`, `UiEvent`
 (`SelectionChanged`, `UndoStateChanged` records), `UiEventSealingTest` (6).
 


### PR DESCRIPTION
# SelectionVM, HistoryVM, ProjectVM and the Ordered Full-Load Cascade

## Motivation

Stories 290 and 291 introduced `TransportVM`, `TrackVM`, and `ChannelVM` and proved the cascade contract
on mute/solo. This story takes Stage 4 of the §8 migration path: "`SelectionVM` drives inspector + menu
enablement; `HistoryVM` drives undo/redo UI; `ProjectVM` owns the single dirty bit and the full-load
cascade (§5.7)" (`docs/design/CONTROL_SYNCHRONIZATION_DESIGN_BOOK.md` §8 Stage 4).

The §1 problem-inventory items it resolves:

- **§1.6 no defined cascade order** — "When a project is loaded, many things must update … Today the
  order is whatever sequence of refresh calls the load handler happens to make. If the mixer rebuilds
  before the track list is repopulated, it briefly renders zero channels; if the playhead updates before
  the canvas knows the new length, it clamps to the wrong position." The project-open path today fires
  the imperative refreshers directly — exactly the ad-hoc sequence §5.7 replaces with a fixed phase
  order.
- **§1.2 every action hand-rolls its own cascade** — the recurring trailing pair is
  `host.updateUndoRedoState(); host.markProjectDirty();`. `ProjectVM.dirty` becomes "the one dirty bit
  (fixes §1.2's missed `markProjectDirty`)" (§7) and `HistoryVM` replaces the hand-pushed
  `MainController.updateUndoRedoState()` (`MainController.java:3688`).
- **§1.1 the god controller** — `updateProjectInfo()` (`MainController.java:3588`) and the selection
  refresher `syncSelectionToCanvas()` (`:3729`) are hand-pushed methods that should instead be **bound**
  to `ProjectVM`/`SelectionVM` properties (per §4.3's mapping table).

Per §4.2 and §7/Appendix A, some facts the UI needs "are UI-only and need a new sealed family or a small
UI-event addition" — specifically `SelectionChanged`, `UndoStateChanged`, and `ThemeChanged`. Selection
and undo-state never need to reach the core, so this story introduces a separate sealed `UiEvent` family
rather than adding them to `DawEvent` (whose `permits` clause — confirmed
`TransportEvent, MixerEvent, TrackEvent, ClipEvent, ProjectEvent, AutomationEvent, PluginEvent,
XrunEvent` — stays unchanged).

## Goals

- Introduce a new sealed `UiEvent` family in `daw-sdk/.../event/` (sibling to `DawEvent`) for UI-only
  discrete facts, initially `permits SelectionChanged, UndoStateChanged`. Because it is sealed, the
  `permits` clause is explicit and exhaustive (§7, story 202). `ThemeChanged` is **not** added here — it
  is deferred to the surface migration (story 294) and added only if a surface must react in code (most
  theming stays in CSS, §7). The `DawEvent` `permits` list is **not** touched.
- Add `SelectionVM`, `HistoryVM`, and `ProjectVM` in `daw-app/.../ui/vm/` (§3.3):
  - `SelectionVM` → `selectedTrack`, `selectedClip`, `selectedDevice`, `tool` (read-only
    `ObjectProperty`s; no `EnumProperty<T>`). Emits `SelectTrackCommand` etc.; publishes
    `SelectionChanged` on ANNOUNCE.
  - `HistoryVM` → `canUndo`, `canRedo`, `undoLabel`, `redoLabel`. Bound by the undo/redo buttons and
    menu items; the command-history mutation publishes `UndoStateChanged`.
  - `ProjectVM` → `name`, `dirty`, `checkpoint`, plus the observable `tracks` list (§3.3, §5.7).
- Each VM is the **single writer** of its properties and updates them via the story-289 `FxDispatcher`
  on a core signal / bus event (§2.4, §4.3). Selection itself is UI-authoritative state owned by
  `SelectionVM` (§3.3); project name/dirty/tracks derive from the core via the toolkit-neutral signal
  (story 290 pattern) plus the existing `TrackEvent`/`ProjectEvent` facts on the bus.
- Implement the **ordered full-load cascade** as a single declared sequence (§5.7), replacing the
  ad-hoc project-open refresh sequence (the chain of `updateProjectInfo()` / `refreshArrangementCanvas()`
  / `updateUndoRedoState()` / `syncSelectionToCanvas()` calls fired on open):
  1. Tear down: dispose old VMs + view subscriptions (remove listeners).
  2. Build model-derived VMs in order: `ProjectVM → TrackVMs → ChannelVMs → TransportVM → HistoryVM`.
  3. Rebuild structural views in order: track lanes → mixer strips → inserts/racks.
  4. Bind continuous views: playhead, meters, time/tempo display.
  5. Restore selection + viewport, **clamped** to the new project's bounds.
  6. Announce `ProjectLoaded` last → status bar, lock indicator, checkpoint, window title.
  The order is a named constant/enum so it can be asserted (§1.6). "Building VMs before views (step 2
  before 3) guarantees the mixer never renders zero channels and the playhead never clamps against an
  unknown length."
- Wire the selection-aware surfaces (inspector, mixer highlight, clip-editor target, plugin-chain view)
  and the undo/redo buttons + menu items to **bind** to `SelectionVM`/`HistoryVM` rather than being
  pushed by a controller; controls emit the selection/history commands. Menu enablement computes from VM
  state on `SelectionChanged`/`UndoStateChanged` (§6.9, `MenuEnablementPolicy`).

Tests (assert on properties / declared order / bus events — never on rasterisation):
- `UiEventSealingTest` (in `daw-sdk`) — asserts the `UiEvent` `permits` clause is exhaustive over the
  UI-only events and that an exhaustive `switch` compiles (mirrors story 202's sealing guarantee);
  asserts `DawEvent`'s `permits` is unchanged.
- `SelectionVMTest` / `HistoryVMTest` / `ProjectVMTest` — assert each VM is the single writer and its
  properties follow a selection change / history change / project mutation; drive the `FxDispatcher`
  drain manually for determinism.
- `ProjectLoadCascadeOrderTest` — asserts the full-load cascade runs the steps in the declared fixed
  order and clamps selection in step 5; assert the order via the named sequence and resulting property
  state, never via render timing (§1.6, headless pitfall).
- `SelectionUndoEventTest` — asserts `SelectionChanged` and `UndoStateChanged` reach subscribers via a
  parent `addEventFilter` on the payload, never `Event.getSource()` identity (bubbling-event pitfall);
  asserts undo/redo buttons' `disable` state and menu-item labels follow `HistoryVM`.

## Non-Goals

- **No god-controller deletion.** `updateProjectInfo()` (`:3588`), `updateUndoRedoState()` (`:3688`),
  and `syncSelectionToCanvas()` (`:3729`) may be left delegating to the VMs/cascade here; their removal
  and the remaining `update*/refresh*/sync*` deletions are story 293.
- **No re-entrancy-guard deletion** — story 293.
- **No plugin/settings/project-manager surface migration** — those keep their `Host` callbacks until
  story 294.
- **No `javafx.beans` in `daw-core`** — project facts cross via the toolkit-neutral signal + existing
  bus events.
- **No `ThemeChanged` event** here — deferred to story 294, added only if reaction-in-code is needed.
- **Do not add the new UI events to `DawEvent`'s `permits`** — use the separate `UiEvent` family.

## Technical Notes

- New: `daw-sdk/.../event/UiEvent.java` (sealed; `permits SelectionChanged, UndoStateChanged`), and
  `daw-app/.../ui/vm/SelectionVM.java`, `HistoryVM.java`, `ProjectVM.java` plus the selection/history
  commands. The story-289 `FxDispatcher` already supplies the bus's `ON_UI_THREAD` marshaller; the
  `UiEvent` family should ride the same dispatch discipline — confirm whether the existing `EventBus`
  carries `UiEvent` too or whether a small generic widening is cleaner. **Prefer reusing the existing
  bus infrastructure** over a third bus.
- The project-load cascade order is a named constant/enum in `daw-app` so the order is testable (§1.6);
  it composes the VM rebuilds and the selection clamp, then announces. It replaces the ad-hoc
  project-open refresh chain in `MainController` (`updateProjectInfo`/`refreshArrangementCanvas`/
  `updateUndoRedoState`/`syncSelectionToCanvas`).
- Build on stories 289 (dispatcher), 290 (core signal + `TransportVM`), 291 (`TrackVM`/`ChannelVM` +
  cascade), 283 (publishers), 202/203 (sealed events / typed bus). Reuse existing `TrackEvent`/
  `ProjectEvent` facts for the track list and dirty/load state.
- `@RealTimeSafe`: project load is a non-real-time path; the audio thread takes no UI dependency (§4.1).
- Register signals/subscriptions in VM constructors; `dispose()` unregisters and closes `Subscription`s
  (no leaks — `javafx-application-design` §11). No `EnumProperty<T>`; use `ObjectProperty<E>`.
- Verified facts: the book's refresh-method names are accurate — `updateProjectInfo()` (`:3588`),
  `refreshArrangementCanvas()` (`:3681`), `updateUndoRedoState()` (`:3688`), `updatePlayheadFromTransport()`
  (`:3708`), `syncLoopRegionToCanvas()` (`:3715`), and `syncSelectionToCanvas()` (`:3729`) all exist in
  `MainController` today (cluster `:3582-3735`).
- See `docs/design/CONTROL_SYNCHRONIZATION_DESIGN_BOOK.md` §1.1, §1.2, §1.6, §3.3, §4.2, §4.3, §5.1,
  §5.7, §6.9, §7, §8 Stage 4, Appendix A; and the companion design books in `docs/design/`
  (Project Manager, Plugin View, Settings View) for the surfaces story 294 will migrate.
- SKILL: `javafx-application-design` (§4 Properties, §11 threading, §12 typed events, §15 anti-patterns),
  `research-daw` (§1 modular, §3 real-time / lock-free), `dawg-annotations-reflection` (`@RealTimeSafe`).
- Build/verify: `mvn -pl daw-sdk -am test -Dtest=UiEventSealing* -Dsurefire.failIfNoSpecifiedTests=false`
  then `mvn -pl daw-app -am test -Dtest=SelectionVM*,HistoryVM*,ProjectVM*,ProjectLoadCascadeOrder*,SelectionUndoEvent* -Dsurefire.failIfNoSpecifiedTests=false`.

## Implementation Note (2026-06-13)

Implemented + independently verified, **uncommitted**. The 4th companion-design-book story (after
289/290/291) to gain production code. Built as a **test-proven seam, NOT live-wired** — mirroring
290/291: `MainController` / `ProjectLifecycleController` / `DawMenuBarController` are **untouched**, and
their refresh methods (`updateProjectInfo` / `updateUndoRedoState` / `syncSelectionToCanvas`, …) stay
live. Retiring the god controller and wiring the cascade/binders/VMs into the live project-open path is
**story 293** (the explicit Non-Goals here).

### daw-sdk — the `UiEvent` family + the bus widening (the load-bearing decision)

The story's "sibling `UiEvent` family" + "do **not** touch `DawEvent`'s `permits`" + "prefer reusing the
existing bus over a third bus" + "a small generic widening" resolved to a new sealed **`BusEvent`**
super-type (`permits DawEvent, UiEvent`) that both families extend, with the
`EventBus` / `DefaultEventBus` / `EventBusPublisher` type bound **widened from `DawEvent` to `BusEvent`**.
The one existing bus now carries `UiEvent` too, without `UiEvent` being a `DawEvent` (the Non-Goal).
`DawEvent`'s `permits` is byte-for-byte unchanged (pinned by `UiEventSealingTest` via
`getPermittedSubclasses()`). **Flagged for pre-commit review — this is the only change that modifies
shared bus infrastructure** (4 `EventBus` signatures + `DefaultEventBus` generics + `EventBusPublisher
.publish`); every existing publisher/subscriber compiles unchanged (a `DawEvent` *is-a* `BusEvent`), and
the full daw-sdk (1037) + daw-core (6040) suites pass with zero regressions. New: `BusEvent`, `UiEvent`
(`SelectionChanged`, `UndoStateChanged` records), `UiEventSealingTest` (6).

### daw-core — the `DawProject` change seam

Mirrors the `Track` / `Transport` / `MixerChannel` seam exactly (`volatile Consumer<ChangeKind>[]`
snapshot, lock-free + allocation-free notify, no `javafx`, no `@RealTimeSafe`): `enum ChangeKind {NAME,
DIRTY, TRACKS}` + `addChangeListener` / `removeChangeListener`, firing **after** `setName` (NAME),
`markDirty` / `markClean` (DIRTY — **fire-on-change**, so an idempotent `markDirty` announces nothing),
and `addTrack` / `removeTrack` / `moveTrack` / `duplicateTrack` (TRACKS). `CoreDawProjectSignalTest` (10,
incl. the discriminating remove-a-listener-mid-notify case). No project UUID / checkpoint added —
`DawProject` owns neither.

### daw-app — the VM / command / cascade / binder layer (`ui/vm/` + `ui/vm/command/`)

- **`ProjectVM`** (model-derived, mirrors `TrackVM`): `name` / `dirty` / `tracks` (unmodifiable
  `ObservableList<Track>`) from the `DawProject` signal via `FxDispatcher`; `checkpoint`
  **forward-declared** (seeded `""`, no producer yet — the session-status strip is 295-299, mirroring
  story 291's `ChannelVM.meterLevel`).
- **`HistoryVM`** (projection of `UndoManager` through its older `UndoHistoryListener`):
  `canUndo` / `canRedo` / `undoLabel` / `redoLabel`, marshalled via `FxDispatcher`. Per-load lifetime (a
  fresh `UndoManager` is installed per load → dispose + rebuild). Does **not** publish — the handler
  announces (mirrors 290/291).
- **`SelectionVM`** (UI-authoritative — **no core model, no dispatcher**): `selectedTrack` /
  `selectedClip` / `selectedDevice` / `tool` read-only props; writer methods set synchronously on the FX
  thread (selection only ever originates there). `clampTo(ProjectVM)` is the §5.7 step-5 clamp (clears a
  selected track absent from the loaded project). `clip` / `device` are `Object` (no shared supertype;
  their clamp + surfaces are story 294).
- **`ProjectLoadCascade`**: an `enum Phase {TEAR_DOWN, BUILD_VMS, REBUILD_VIEWS, BIND_CONTINUOUS,
  RESTORE_SELECTION, ANNOUNCE}` sequencer — `run()` executes injected per-phase `Runnable`s strictly in
  enum order and records `executedPhases()`. The §1.6 fix: the **order is the contract** (293 supplies
  the real per-phase steps — VM rebuild, view rebuild, selection clamp, announce).
- **Commands** (separate-file records, mirroring 290/291): sealed `SelectionCommand` (SelectTrack /
  SelectClip / SelectDevice / SetTool / ClearSelection) + `SelectionIntentHandler` +
  `CoreSelectionIntentHandler` (VALIDATE idempotent → MUTATE the VM → ANNOUNCE `SelectionChanged`; a
  **tool change is bound directly per §2.7 and announces nothing**); sealed `HistoryCommand` (Undo /
  Redo) + `HistoryIntentHandler` + `CoreHistoryIntentHandler` (VALIDATE `canUndo`/`canRedo` → undo/redo
  → ANNOUNCE `UndoStateChanged`).
- **`HistoryControlBinder`**: binds undo/redo buttons' `disable` + tooltip and Edit-menu items'
  `disable` + text to `HistoryVM`; clicks raise commands (mirrors `TransportControlBinder`).

### Tests + verification

`SelectionVMTest` (7) / `HistoryVMTest` (5) / `ProjectVMTest` (7) / `ProjectLoadCascadeOrderTest` (4) /
`SelectionUndoEventTest` (4) — all **discriminating** and FX-thread-safe (results captured into holders
and asserted off the FX thread, never inside a `runLater`). **43 new tests green** (sdk 6 + core 10 +
app 27), verified on disk and re-run independently; full daw-sdk **1037**, daw-core **6040**, and the
daw-app reactor are green. No `module-info` change (same-package test access, as 290/291 established). No
new bus event types beyond `UiEvent`.

### Deferred (NOT gaps — later-story scope)

God-controller retirement + live wiring of the cascade / binders / VMs into `MainController` /
`ProjectLifecycleController` / `DawMenuBarController` = **293**; inspector / clip-editor / plugin-chain
selection-surface binding + clip/device clamp = **294**; the `checkpoint` / session-status producer =
**295-299**. A distinct `ToolChanged` event and `ThemeChanged` are deferred (§5.5, §7).
