### PR TITLE
295-session-status-strip-and-project-operation-progress-model.md implementation

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -116,7 +116,6 @@ public final class MainController {
     @FXML private Label timeDisplay;
     @FXML private Label projectInfoLabel;
     @FXML private Label monitoringLabel;
-    @FXML private Label checkpointLabel;
     @FXML private Label statusBarLabel;
     @FXML private Label arrangementPlaceholder;
     @FXML private Label arrangementPanelHeader;
@@ -137,6 +136,10 @@ public final class MainController {
     @FXML private Label dskLabel;
     @FXML private Label recIndicator;
     @FXML private HBox notificationBarContainer;
+    /** Story 295 — bottom container that hosts the notification bar, the legacy
+     *  status bar, and (mounted by {@link #createSessionStatusStrip()}) the
+     *  Session Status Strip. */
+    @FXML private VBox bottomBar;
     @FXML private HBox transportGroup;
     @FXML private HBox trackGroup;
     @FXML private HBox undoRedoGroup;
@@ -148,7 +151,14 @@ public final class MainController {
     private final Button browserButton = new Button("Library");
     private final Button historyButton = new Button("History");
 
-    private DawProject project;
+    /**
+     * The in-memory project. {@code volatile} because it is reassigned on the FX
+     * thread (init / open / restore) yet read off the FX thread by the §1.8
+     * disk-scan {@code audioFormat} supplier on the scan virtual thread (story
+     * 295); the {@code volatile} gives that background read a happens-before view
+     * of each reassignment so a project switch is reflected on the next scan.
+     */
+    private volatile DawProject project;
     private PluginRegistry pluginRegistry;
     private ProjectManager projectManager;
     private UndoManager undoManager;
@@ -217,6 +227,16 @@ public final class MainController {
     private HistoryControlBinder historyBinder;
     private TransportVM transportVM;
     private ProjectVM projectVM;
+
+    // ── Story 295: Session Status Strip + the ProjectOperationProgress model ──
+    /** The single §5.5 source of project-status truth the strip binds to. */
+    private com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress projectOperationProgress;
+    /** The §4.4 status strip, mounted into {@link #bottomBar}. */
+    private com.benesquivelmusic.daw.app.ui.status.SessionStatusStrip sessionStatusStrip;
+    /** The §1.8 disk-space scan (30 s, virtual thread) feeding the model. */
+    private com.benesquivelmusic.daw.app.ui.status.SessionStatusDiskScanner diskScanner;
+    /** Start of the current working session (since project open/new); §3.3, drives the Session cell elapsed. */
+    private java.time.Instant sessionStartInstant;
     /** Disposers for the current VM generation (binders + VM unregistration); run on rebuild + hide. */
     private final java.util.List<Runnable> vmDisposers = new java.util.ArrayList<>();
     private ToolbarStateStore toolbarStateStore;
@@ -501,6 +521,14 @@ public final class MainController {
         // rebuild — against the stale outgoing VM — which left Save enablement one
         // project-load behind after Open / New / snapshot-restore.
         syncMenuStateIfPresent();
+
+        // Story 295 — (re)publish the facts the Session Status Strip binds to for
+        // this VM generation: bind the model's dirty bit to the FRESH ProjectVM,
+        // start a new working session, and seed schema / lock / session /
+        // next-checkpoint. Done AFTER the VMs are rebuilt so the dirty bind
+        // targets the live ProjectVM (mirrors syncMenuStateIfPresent above).
+        sessionStartInstant = java.time.Instant.now();
+        publishProjectStatusToModel();
     }
 
     /** Routes an undo/redo intent (button, menu, or shortcut) to the existing handlers (§2.8). */
@@ -520,6 +548,157 @@ public final class MainController {
     private void syncMenuStateIfPresent() {
         if (menuBarController != null) {
             menuBarController.syncMenuState();
+        }
+    }
+
+    // ── Story 295: Session Status Strip wiring ───────────────────────────────
+
+    /**
+     * Builds the {@link com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress}
+     * model, the {@link com.benesquivelmusic.daw.app.ui.status.SessionStatusStrip}
+     * (mounted into {@link #bottomBar}), the §1.8 disk scan, and the checkpoint
+     * listener that surfaces every autosave on the model. Called once in
+     * {@link #initialize()} after the {@link ProjectManager} exists and before
+     * the lifecycle controller (which now reports save status through the model).
+     */
+    private void createSessionStatusStrip() {
+        projectOperationProgress =
+                new com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress(dispatcher());
+        // §3.1 default workspace name; the switchable Project Hub is story 296.
+        projectOperationProgress.setWorkspaceName("Personal");
+        sessionStatusStrip = new com.benesquivelmusic.daw.app.ui.status.SessionStatusStrip(
+                projectOperationProgress, MotionManager.getDefault());
+        if (bottomBar != null) {
+            bottomBar.getChildren().add(sessionStatusStrip);
+        }
+
+        // §1.8 disk-space contract — scan every 30 s on a virtual thread; the FX
+        // thread never touches FileStore. The project dir / format are read live
+        // so a project open / close is reflected on the next scan.
+        diskScanner = new com.benesquivelmusic.daw.app.ui.status.SessionStatusDiskScanner(
+                projectOperationProgress,
+                () -> {
+                    // Read the current project ONCE: this supplier runs on the
+                    // scan virtual thread, and a concurrent FX-thread
+                    // close/abandon could otherwise null currentProject between a
+                    // two-call check and dereference (TOCTOU NPE).
+                    if (projectManager == null) {
+                        return null;
+                    }
+                    var meta = projectManager.getCurrentProject();
+                    return meta != null ? meta.projectPath() : null;
+                },
+                () -> {
+                    // Read the volatile project reference ONCE on the scan
+                    // virtual thread: a concurrent FX-thread open/new/restore
+                    // could otherwise reassign (or, defensively, null) it
+                    // between the check and the deref (the same TOCTOU the
+                    // projectPath supplier above guards against).
+                    var current = project;
+                    return current != null ? current.getFormat() : null;
+                });
+        diskScanner.start();
+
+        // §1.2 checkpoint visibility — every autosave updates the Saved cell and
+        // re-arms the countdown. The listener fires on the checkpoint virtual
+        // thread; the model marshals each write onto the FX thread (story 289).
+        projectManager.getCheckpointManager().addListener(
+                new com.benesquivelmusic.daw.sdk.event.AutoSaveListener() {
+                    @Override public void onBeforeCheckpoint(String checkpointId) {
+                        // no-op: a fast checkpoint shows only the Saved-cell flash
+                    }
+
+                    @Override public void onAfterCheckpoint(String checkpointId) {
+                        java.time.Duration interval = projectManager.getCheckpointManager()
+                                .getConfig().autoSaveInterval();
+                        projectOperationProgress.recordSaveSucceeded(java.time.Instant.now(),
+                                com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress
+                                        .SaveScope.FULL);
+                        projectOperationProgress.setNextCheckpoint(
+                                java.time.Instant.now().plus(interval), interval);
+                    }
+
+                    @Override public void onCheckpointFailed(String checkpointId, Throwable cause) {
+                        projectOperationProgress.recordSaveFailed();
+                    }
+                });
+    }
+
+    /**
+     * Publishes the project-status facts the strip binds to after a project
+     * load / new (called from {@link #rebuildViewModels()}): binds the model's
+     * dirty bit to the live {@link ProjectVM}, seeds the schema versions from the
+     * last migration report, arms the next-checkpoint countdown, and refreshes
+     * the session / lock facts.
+     */
+    private void publishProjectStatusToModel() {
+        if (projectOperationProgress == null) {
+            return;
+        }
+        if (projectVM != null) {
+            projectOperationProgress.bindDirtyTo(projectVM.dirtyProperty());
+        }
+        // Schema (§1.6): current registry version + the pre-migration backup
+        // version when the just-loaded project was migrated.
+        int current = com.benesquivelmusic.daw.core.persistence.migration.MigrationRegistry.CURRENT_VERSION;
+        int backup = com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress.UNKNOWN_VERSION;
+        if (projectManager != null) {
+            var report = projectManager.getLastMigrationReport();
+            if (report != null && report.wasMigrated()) {
+                backup = report.fromVersion();
+            }
+        }
+        projectOperationProgress.setSchema(current, backup);
+        // Next checkpoint (§6): arm the countdown when autosave is running.
+        if (projectManager != null) {
+            java.time.Duration interval = projectManager.getCheckpointManager()
+                    .getConfig().autoSaveInterval();
+            projectOperationProgress.setNextCheckpoint(
+                    projectManager.getCheckpointManager().isRunning()
+                            ? java.time.Instant.now().plus(interval) : null,
+                    interval);
+        }
+        refreshStripDynamicState();
+    }
+
+    /**
+     * Refreshes the time-varying strip facts (session elapsed, lock freshness)
+     * that have no push source. Called from {@link #publishProjectStatusToModel()}
+     * and the 5 s lock timeline.
+     */
+    private void refreshStripDynamicState() {
+        if (projectOperationProgress == null) {
+            return;
+        }
+        String name = project != null ? project.getName() : "";
+        java.time.Duration elapsed = sessionStartInstant != null
+                ? java.time.Duration.between(sessionStartInstant, java.time.Instant.now())
+                : java.time.Duration.ZERO;
+        projectOperationProgress.setSession(name, elapsed);
+        publishLockToModel();
+    }
+
+    /** Publishes the §1.3 lock holder + freshness onto the model. */
+    private void publishLockToModel() {
+        if (projectOperationProgress == null || projectManager == null) {
+            return;
+        }
+        com.benesquivelmusic.daw.core.persistence.LockStatus status =
+                projectManager.getLockManager().status();
+        if (status == com.benesquivelmusic.daw.core.persistence.LockStatus.HELD) {
+            var lock = projectManager.getLockManager().currentLock();
+            String holder = lock.map(l -> "you @ " + l.hostname()).orElse("you");
+            boolean fresh = lock
+                    .map(l -> !com.benesquivelmusic.daw.core.persistence.ProjectLockManager
+                            .isStale(l, java.time.Instant.now()))
+                    .orElse(true);
+            projectOperationProgress.setLock(holder, fresh);
+        } else if (status == com.benesquivelmusic.daw.core.persistence.LockStatus.READ_ONLY) {
+            projectOperationProgress.setLock("read-only", true);
+        } else if (status == com.benesquivelmusic.daw.core.persistence.LockStatus.STOLEN) {
+            projectOperationProgress.setLock("taken over", false);
+        } else {
+            projectOperationProgress.setLock("", true);
         }
     }
 
@@ -635,6 +814,10 @@ public final class MainController {
         createTransportController();
         mountPreRollPostRollControls();
         createMetronomeController(prefs);
+        // Story 295 — build the ProjectOperationProgress model + Session Status
+        // Strip + disk scan + checkpoint listener BEFORE the lifecycle
+        // controller, which now reports save status through the model.
+        createSessionStatusStrip();
         createProjectLifecycleController();
         createAnimationController();
         createViewNavigationController();
@@ -655,10 +838,9 @@ public final class MainController {
         transportController.syncLoopButtonState();
         applyProjectInfoLabels();
         mountLockStatusIndicator();
-        // Story 293 — static autosave/IO chrome, inlined from the deleted
-        // updateCheckpointStatus() (§274). ProjectVM.checkpoint has no producer until
-        // stories 295-299, so binding it would blank the cell — keep the static text.
-        checkpointLabel.setText(MESSAGES.getString("statusbar.autosave.on"));
+        // Story 295 — the old static "Auto-save: ON" checkpointLabel was retired;
+        // autosave / last-save / next-checkpoint are now live cells of the
+        // Session Status Strip (bound to ProjectOperationProgress).
         ioRoutingLabel.setText(MESSAGES.getString("statusbar.io.initializing"));
         initializeStatusBarPlaceholders();
         rebuildViewModels();
@@ -775,6 +957,10 @@ public final class MainController {
                             lockIndicatorTimeline.stop();
                             lockIndicatorTimeline = null;
                         }
+                        // Story 295 — release the disk-scan scheduler thread.
+                        if (diskScanner != null) {
+                            diskScanner.stop();
+                        }
                         if (dockManifestModel != null) {
                             dockManifestModel.dispose();
                         }
@@ -821,7 +1007,7 @@ public final class MainController {
                 new ToolbarAppearanceController.AppearanceLabels(
                         statusLabel, timeDisplay, tracksPanelHeader,
                         arrangementPanelHeader, arrangementPlaceholder,
-                        monitoringLabel, checkpointLabel, statusBarLabel,
+                        monitoringLabel, statusBarLabel,
                         ioRoutingLabel, recIndicator),
                 new ToolbarAppearanceController.OverflowGroups(
                         utilityGroup, undoRedoGroup),
@@ -957,7 +1143,7 @@ public final class MainController {
     private void createProjectLifecycleController() {
         projectLifecycleController = new ProjectLifecycleController(
                 projectManager, sessionInterchangeController, notificationBar,
-                statusBarLabel, checkpointLabel, rootPane, trackListPanel,
+                projectOperationProgress, rootPane, trackListPanel,
                 // Story 294 — direct functional deps replace the callback-up
                 // ProjectLifecycleController.Host (§4.2/§9). The swappable
                 // project / undo manager are live Suppliers (a load is reflected
@@ -3856,7 +4042,12 @@ public final class MainController {
         // so a low-frequency 5 s poll is the cheapest way to surface a
         // stolen lock or a take-over without changing the core API.
         lockIndicatorTimeline = new Timeline(
-                new KeyFrame(Duration.seconds(5), _ -> repaintLockIndicator()));
+                new KeyFrame(Duration.seconds(5), _ -> {
+                    repaintLockIndicator();
+                    // Story 295 — piggyback the strip's time-varying facts
+                    // (session elapsed, lock freshness) on the same 5 s poll.
+                    refreshStripDynamicState();
+                }));
         lockIndicatorTimeline.setCycleCount(Timeline.INDEFINITE);
         lockIndicatorTimeline.play();
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
@@ -1,8 +1,7 @@
 package com.benesquivelmusic.daw.app.ui;
 
-import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
-import com.benesquivelmusic.daw.app.ui.icons.IconNode;
 import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.audio.AudioClip;
 import com.benesquivelmusic.daw.core.audio.AudioFormat;
@@ -34,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -102,8 +102,16 @@ final class ProjectLifecycleController {
     private final ProjectManager projectManager;
     private final SessionInterchangeController sessionInterchangeController;
     private final NotificationBar notificationBar;
-    private final Label statusBarLabel;
-    private final Label checkpointLabel;
+    /**
+     * Story 295 — the single §5.5 project-status model. Save / autosave /
+     * archive paths report through this; the {@code statusBarLabel} and
+     * {@code checkpointLabel} this controller used to poke are gone (the §8
+     * rejection of "status text in {@code Label.setText}"). The Session Status
+     * Strip binds to this model. Transient action confirmations and errors
+     * still go through {@link #notificationBar} (§8: the notification bar is
+     * for things the user must see — errors, takeovers, migrations).
+     */
+    private final ProjectOperationProgress progress;
     private final BorderPane rootPane;
     private final VBox trackListPanel;
     private final Deps deps;
@@ -121,22 +129,20 @@ final class ProjectLifecycleController {
     ProjectLifecycleController(ProjectManager projectManager,
                                SessionInterchangeController sessionInterchangeController,
                                NotificationBar notificationBar,
-                               Label statusBarLabel,
-                               Label checkpointLabel,
+                               ProjectOperationProgress progress,
                                BorderPane rootPane,
                                VBox trackListPanel,
                                Deps deps,
                                ProjectArchiver projectArchiver) {
         this(projectManager, sessionInterchangeController, notificationBar,
-                statusBarLabel, checkpointLabel, rootPane, trackListPanel, deps,
+                progress, rootPane, trackListPanel, deps,
                 projectArchiver, FxDispatcher.getDefault());
     }
 
     ProjectLifecycleController(ProjectManager projectManager,
                                SessionInterchangeController sessionInterchangeController,
                                NotificationBar notificationBar,
-                               Label statusBarLabel,
-                               Label checkpointLabel,
+                               ProjectOperationProgress progress,
                                BorderPane rootPane,
                                VBox trackListPanel,
                                Deps deps,
@@ -146,8 +152,7 @@ final class ProjectLifecycleController {
         this.sessionInterchangeController = Objects.requireNonNull(sessionInterchangeController,
                 "sessionInterchangeController must not be null");
         this.notificationBar = Objects.requireNonNull(notificationBar, "notificationBar must not be null");
-        this.statusBarLabel = Objects.requireNonNull(statusBarLabel, "statusBarLabel must not be null");
-        this.checkpointLabel = Objects.requireNonNull(checkpointLabel, "checkpointLabel must not be null");
+        this.progress = Objects.requireNonNull(progress, "progress must not be null");
         this.rootPane = Objects.requireNonNull(rootPane, "rootPane must not be null");
         this.trackListPanel = Objects.requireNonNull(trackListPanel, "trackListPanel must not be null");
         this.deps = Objects.requireNonNull(deps, "deps must not be null");
@@ -191,17 +196,20 @@ final class ProjectLifecycleController {
             projectManager.saveDawProject(deps.project().get());
             projectManager.saveProject();
             deps.project().get().markClean();
-            int count = projectManager.getCheckpointManager().getCheckpointCount();
-            checkpointLabel.setText("Saved (checkpoint #" + count + ")");
-            checkpointLabel.setGraphic(IconNode.of(DawIcon.SUCCESS, 12));
-            statusBarLabel.setText("Project saved");
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.UPLOAD, 12));
-            notificationBar.show(NotificationLevel.SUCCESS, "Project saved");
+            // Story 295 — the Saved cell flashing for ~600 ms is the success
+            // signal for a fast save (§4.5). The old "Project saved" notification
+            // and the statusBarLabel / checkpointLabel "Saved (checkpoint #N)"
+            // pokes are retired (Appendix A). The autosave checkpoint listener
+            // also re-arms the countdown; this explicit record keeps the
+            // manual-save outcome exact even if no checkpoint fired.
+            progress.recordSaveSucceeded(Instant.now(), ProjectOperationProgress.SaveScope.FULL);
             LOG.info("Project saved successfully");
             return true;
         } catch (IOException e) {
-            statusBarLabel.setText("Save failed: " + e.getMessage());
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
+            // §4.5 — a save failure persists in the Saved cell (it does not
+            // auto-dismiss) and is also surfaced as an error notification the
+            // user must act on.
+            progress.recordSaveFailed();
             notificationBar.show(NotificationLevel.ERROR, "Save failed: " + e.getMessage());
             LOG.log(Level.WARNING, "Failed to save project", e);
             return false;
@@ -223,8 +231,6 @@ final class ProjectLifecycleController {
         // previously opened project's saved layouts don't leak into the
         // new project.
         deps.applyLayoutJson().accept(null);
-        statusBarLabel.setText("New project created");
-        statusBarLabel.setGraphic(IconNode.of(DawIcon.FOLDER, 12));
         notificationBar.show(NotificationLevel.SUCCESS, "New project created");
         LOG.info("Created new project");
     }
@@ -267,8 +273,7 @@ final class ProjectLifecycleController {
                 if (store != null) {
                     store.clear();
                 }
-                statusBarLabel.setText("Recent projects cleared");
-                statusBarLabel.setGraphic(IconNode.of(DawIcon.DELETE, 12));
+                notificationBar.show(NotificationLevel.SUCCESS, "Recent projects cleared");
             });
             menu.getItems().add(clearItem);
         }
@@ -309,14 +314,10 @@ final class ProjectLifecycleController {
             ThemeManager.getDefault().applyTo(summaryDialog.getDialogPane());
             summaryDialog.showAndWait();
 
-            statusBarLabel.setText("Imported session: " + result.sessionData().projectName());
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.DOWNLOAD, 12));
             notificationBar.show(NotificationLevel.SUCCESS,
                     "Imported session: " + result.sessionData().projectName());
             LOG.info("Imported DAWproject session from " + selected.toPath());
         } catch (IOException e) {
-            statusBarLabel.setText("Import failed: " + e.getMessage());
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
             notificationBar.show(NotificationLevel.ERROR,
                     "Import failed: " + e.getMessage());
             LOG.log(Level.WARNING, "Failed to import session", e);
@@ -339,8 +340,6 @@ final class ProjectLifecycleController {
             if (!result.warnings().isEmpty()) {
                 message += " (" + result.warnings().size() + " warnings)";
             }
-            statusBarLabel.setText(message);
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.UPLOAD, 12));
             notificationBar.show(NotificationLevel.SUCCESS, message);
 
             if (!result.warnings().isEmpty()) {
@@ -358,8 +357,6 @@ final class ProjectLifecycleController {
 
             LOG.info("Exported DAWproject session to " + result.outputPath());
         } catch (IOException e) {
-            statusBarLabel.setText("Export failed: " + e.getMessage());
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
             notificationBar.show(NotificationLevel.ERROR,
                     "Export failed: " + e.getMessage());
             LOG.log(Level.WARNING, "Failed to export session", e);
@@ -412,20 +409,24 @@ final class ProjectLifecycleController {
         // ProjectArchiver, so this dialog is purely informational.
         List<String> missing = collectMissingAssetPaths(current);
         if (!missing.isEmpty() && !ArchiveSummaryDialog.confirmMissingAssets(missing)) {
-            statusBarLabel.setText("Archive cancelled");
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
             return;
         }
 
         // Run the potentially expensive ZIP I/O on a background virtual
         // thread so the JavaFX application thread stays responsive.
-        // Progress is surfaced through a modeless TaskProgressIndicator
-        // following the same pattern used by TrackFreezeController.
+        // Progress is surfaced through a modeless TaskProgressIndicator and,
+        // per story 295, registered as a named operation on the
+        // ProjectOperationProgress model (\u00a75.5) so the strip's saving state
+        // reflects the in-flight archive.
         Window owner = rootPane.getScene().getWindow();
-        TaskProgressIndicator progress = new TaskProgressIndicator(owner, "Archiving project\u2026", fxDispatcher);
-        progress.hideCancelButton();
-        progress.show();
-        progress.update(-1.0, "Writing archive\u2026");
+        TaskProgressIndicator archiveProgress =
+                new TaskProgressIndicator(owner, "Archiving project\u2026", fxDispatcher);
+        archiveProgress.hideCancelButton();
+        archiveProgress.show();
+        archiveProgress.update(-1.0, "Writing archive\u2026");
+        ProjectOperationProgress.NamedOperation archiveOp =
+                new ProjectOperationProgress.NamedOperation("Archiving project\u2026");
+        progress.addOperation(archiveOp);
 
         Path finalArchivePath = archivePath;
         Thread.ofVirtual()
@@ -436,9 +437,8 @@ final class ProjectLifecycleController {
                                 current, finalArchivePath);
                         String headline = ArchiveSummaryDialog.formatHeadline(summary);
                         postFx(() -> {
-                            progress.close();
-                            statusBarLabel.setText(headline);
-                            statusBarLabel.setGraphic(IconNode.of(DawIcon.UPLOAD, 12));
+                            progress.removeOperation(archiveOp);
+                            archiveProgress.close();
                             notificationBar.show(NotificationLevel.SUCCESS,
                                     headline + " \u2014 "
                                             + ArchiveSummaryDialog.archivePathDisplay(finalArchivePath));
@@ -449,9 +449,8 @@ final class ProjectLifecycleController {
                                 + summary.totalAssetBytes() + " bytes)");
                     } catch (IOException | IllegalArgumentException e) {
                         postFx(() -> {
-                            progress.close();
-                            statusBarLabel.setText("Archive failed: " + e.getMessage());
-                            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
+                            progress.removeOperation(archiveOp);
+                            archiveProgress.close();
                             notificationBar.show(NotificationLevel.ERROR,
                                     "Archive failed: " + e.getMessage());
                         });
@@ -511,10 +510,14 @@ final class ProjectLifecycleController {
         // onto the FX thread via the FxDispatcher seam (story 289) once
         // extraction is complete.
         Window owner = rootPane.getScene().getWindow();
-        TaskProgressIndicator progress = new TaskProgressIndicator(owner, "Restoring archive\u2026", fxDispatcher);
-        progress.hideCancelButton();
-        progress.show();
-        progress.update(-1.0, "Extracting archive\u2026");
+        TaskProgressIndicator restoreProgress =
+                new TaskProgressIndicator(owner, "Restoring archive\u2026", fxDispatcher);
+        restoreProgress.hideCancelButton();
+        restoreProgress.show();
+        restoreProgress.update(-1.0, "Extracting archive\u2026");
+        ProjectOperationProgress.NamedOperation restoreOp =
+                new ProjectOperationProgress.NamedOperation("Restoring archive\u2026");
+        progress.addOperation(restoreOp);
 
         Thread.ofVirtual()
                 .name("daw-restore-worker")
@@ -539,7 +542,8 @@ final class ProjectLifecycleController {
                         // Load the restored project on the FX thread; only
                         // show the success notification if loading succeeded.
                         postFx(() -> {
-                            progress.close();
+                            progress.removeOperation(restoreOp);
+                            restoreProgress.close();
                             boolean loaded = loadProjectFromPath(destination);
                             if (loaded) {
                                 String message = "Restored archive: " + projectName
@@ -555,9 +559,8 @@ final class ProjectLifecycleController {
                                 + " into " + destination);
                     } catch (IOException e) {
                         postFx(() -> {
-                            progress.close();
-                            statusBarLabel.setText("Restore failed: " + e.getMessage());
-                            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
+                            progress.removeOperation(restoreOp);
+                            restoreProgress.close();
                             notificationBar.show(NotificationLevel.ERROR,
                                     "Restore failed: " + e.getMessage());
                         });
@@ -678,8 +681,6 @@ final class ProjectLifecycleController {
             // legacy projects, in which case the layout manager falls
             // back to the Default built-in).
             deps.applyLayoutJson().accept(dawProject.getLayoutJson());
-            statusBarLabel.setText("Opened: " + projectDir.getFileName());
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.FOLDER, 12));
             notificationBar.show(NotificationLevel.SUCCESS,
                     "Opened project: " + projectDir.getFileName());
             LOG.info("Opened project from " + projectDir);
@@ -693,15 +694,11 @@ final class ProjectLifecycleController {
             // Unmapped or broken migration chain — surface as an error
             // notification rather than letting the runtime exception
             // bubble out of the menu/action handler.
-            statusBarLabel.setText("Migration failed: " + e.getMessage());
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
             notificationBar.show(NotificationLevel.ERROR,
                     "Migration failed: " + e.getMessage());
             LOG.log(Level.WARNING, "Failed to migrate project on open", e);
             return false;
         } catch (IOException e) {
-            statusBarLabel.setText("Open failed: " + e.getMessage());
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
             notificationBar.show(NotificationLevel.ERROR,
                     "Open failed: " + e.getMessage());
             LOG.log(Level.WARNING, "Failed to open project", e);
@@ -766,16 +763,12 @@ final class ProjectLifecycleController {
                 deps.resetTrackCounters().run();
                 deps.project().get().markClean();
                 rebuildUI();
-                statusBarLabel.setText("Rolled back: discarded migrated project");
-                statusBarLabel.setGraphic(IconNode.of(DawIcon.INFO, 12));
                 notificationBar.show(NotificationLevel.SUCCESS,
                         "Discarded in-memory migration; the on-disk file is "
                                 + "still the original (v" + report.fromVersion() + ")");
                 LOG.info("Rolled back migration by abandoning in-memory project (no .bak yet)");
             }
         } catch (IOException e) {
-            statusBarLabel.setText("Roll back failed: " + e.getMessage());
-            statusBarLabel.setGraphic(IconNode.of(DawIcon.WARNING, 12));
             notificationBar.show(NotificationLevel.ERROR,
                     "Roll back failed: " + e.getMessage());
             LOG.log(Level.WARNING, "Failed to roll back migration", e);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ToolbarAppearanceController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ToolbarAppearanceController.java
@@ -49,7 +49,7 @@ final class ToolbarAppearanceController {
     record AppearanceLabels(Label status, Label timeDisplay,
                             Label tracksPanelHeader, Label arrangementPanelHeader,
                             Label arrangementPlaceholder,
-                            Label monitoringLabel, Label checkpointLabel,
+                            Label monitoringLabel,
                             Label statusBarLabel, Label ioRoutingLabel,
                             Label recIndicator) {}
 
@@ -137,7 +137,6 @@ final class ToolbarAppearanceController {
         clearGraphic(labels.tracksPanelHeader);
         clearGraphic(labels.arrangementPanelHeader);
         clearGraphic(labels.monitoringLabel);
-        clearGraphic(labels.checkpointLabel);
         clearGraphic(labels.statusBarLabel);
         clearGraphic(labels.ioRoutingLabel);
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/CheckpointCountdownCanvas.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/CheckpointCountdownCanvas.java
@@ -1,0 +1,580 @@
+package com.benesquivelmusic.daw.app.ui.status;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
+import com.benesquivelmusic.daw.app.ui.theme.HardcodedColorAllowed;
+
+import javafx.animation.AnimationTimer;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.css.CssMetaData;
+import javafx.css.StyleConverter;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
+import javafx.scene.Scene;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+import javafx.geometry.VPos;
+import javafx.scene.text.Font;
+import javafx.scene.text.TextAlignment;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * The "next checkpoint" countdown cell of the Session Status Strip — a
+ * plain {@link Canvas} that draws "Next checkpoint in M:SS" plus a
+ * horizontal progress bar showing the fraction of the autosave interval
+ * still remaining (Project Manager Design Book §4.4 / §6, story 295).
+ *
+ * <p>The draw routine is pure: given the same target instant, interval and
+ * geometry it produces the same pixels, so resize / theme / value changes
+ * are trivial full redraws ({@link GraphicsContext#clearRect} + re-issue
+ * draws — never a new Canvas/Image per frame). No glow, no shadow, no
+ * {@link javafx.scene.effect.Effect}.
+ *
+ * <h2>Lifecycle &amp; Reduce Motion (story 279)</h2>
+ *
+ * <p>When Reduce Motion is <strong>off</strong>, a 1&nbsp;Hz
+ * {@link AnimationTimer} owned by this view drives the countdown so the
+ * remaining time ticks down once per second
+ * ({@code javafx-application-design} §6: a control owns its own timer; §11:
+ * all draws happen on the FX thread). The timer runs <em>iff</em> the view
+ * is attached to a {@link Scene} <em>and</em> Reduce Motion is off; on
+ * scene-detach or when Reduce Motion is switched on, the timer is stopped
+ * so a hidden / reduce-motion cell never spins a frame loop.
+ *
+ * <p>When Reduce Motion is <strong>on</strong>, <em>no</em>
+ * {@link AnimationTimer} runs at all: the cell renders the remaining time
+ * as static text that is repainted only when the target instant, interval
+ * or a colour token actually changes — there is no per-frame animation.
+ *
+ * <h2>Tokenized colours</h2>
+ *
+ * <p>The three paints are forwarded {@code -ccd-*} CSS tokens with
+ * Palette-A hex fallbacks, mirroring {@code MixerChannelStrip}: styles.css
+ * declares e.g. {@code .checkpoint-countdown { -ccd-text: -text; }} so the
+ * role tokens forward without a circular looked-up-colour drop. The Java
+ * draw code reads the resolved {@link StyleableObjectProperty} values, never
+ * a hex mirror.
+ *
+ * @see FxAnimationTimerAllowed
+ * @see HardcodedColorAllowed
+ */
+@FxAnimationTimerAllowed(
+    "1 Hz checkpoint-countdown redraw owned by this view; gated on scene "
+    + "attachment and Reduce Motion (story 279); not a cross-thread marshalling "
+    + "seam — story 289 sentinel.")
+@HardcodedColorAllowed(
+    "story 277 follow-up: Canvas paints use forwarded -ccd-* tokens with hex "
+    + "Palette-A fallbacks, mirroring MixerChannelStrip.")
+public final class CheckpointCountdownCanvas extends Region {
+
+    /** Stable style class — selectable as {@code .checkpoint-countdown}. */
+    public static final String DEFAULT_STYLE_CLASS = "checkpoint-countdown";
+
+    /** Default autosave interval (denominator for the bar fraction). */
+    private static final Duration DEFAULT_INTERVAL = Duration.ofMinutes(5);
+
+    /** Throttle the {@link AnimationTimer} to exactly 1 Hz. */
+    private static final long ONE_SECOND_NANOS = 1_000_000_000L;
+
+    /** One hour in seconds — the switch point to the {@code H:MM:SS} format. */
+    private static final long SECONDS_PER_HOUR = 3600L;
+    private static final long SECONDS_PER_MINUTE = 60L;
+
+    // ── Preferred / min sizing (px), respecting insets. ───────────────────
+    private static final double PREF_WIDTH = 180.0;
+    private static final double PREF_HEIGHT = 28.0;
+    private static final double MIN_WIDTH = 120.0;
+
+    // ── Drawing constants (pure geometry, no effects). ────────────────────
+    private static final double FONT_PX = 11.0;
+    private static final double BAR_HEIGHT = 4.0;
+    private static final double BAR_GAP = 4.0;
+
+    // ── Palette A fallback colours (Project Manager Design Book §4.4). ─────
+    private static final Color FALLBACK_TEXT = Color.web("#B7BCC7");
+    private static final Color FALLBACK_TRACK = Color.web("#272A33");
+    private static final Color FALLBACK_FILL = Color.web("#7C8CFF");
+
+    private final Canvas canvas = new Canvas();
+
+    private long lastTickNanos = Long.MIN_VALUE;
+    private boolean running;
+    private int timerStartCount;
+
+    /**
+     * The 1&nbsp;Hz redraw loop. A private named inner class (mirroring
+     * {@code LevelMeterSkin}) so the class-level
+     * {@link FxAnimationTimerAllowed} sentinel covers it. {@code handle()}
+     * runs on the FX thread and only redraws — it is never a cross-thread
+     * hop.
+     */
+    private final class CountdownTimer extends AnimationTimer {
+        @Override
+        public void handle(long now) {
+            if (shouldRedraw(lastTickNanos, now)) {
+                lastTickNanos = now;
+                draw();
+            }
+        }
+    }
+
+    private CountdownTimer timer;
+
+    // ── Observable model properties ───────────────────────────────────────
+
+    /** The moment the next checkpoint fires; {@code null} = none scheduled. */
+    private final ObjectProperty<Instant> nextCheckpointInstant =
+            new SimpleObjectProperty<>(this, "nextCheckpointInstant", null) {
+                @Override
+                protected void invalidated() {
+                    requestRedraw();
+                }
+            };
+
+    /** The autosave interval (denominator for the bar fraction). */
+    private final ObjectProperty<Duration> interval =
+            new SimpleObjectProperty<>(this, "interval", DEFAULT_INTERVAL) {
+                @Override
+                protected void invalidated() {
+                    requestRedraw();
+                }
+            };
+
+    /** When {@code true}: no {@link AnimationTimer}, static text only (story 279). */
+    private final BooleanProperty reduceMotion =
+            new SimpleBooleanProperty(this, "reduceMotion", false) {
+                @Override
+                protected void invalidated() {
+                    updateTimerState();
+                    requestRedraw();
+                }
+            };
+
+    /**
+     * Creates an empty countdown cell: no checkpoint scheduled, a default
+     * {@code 5 min} autosave interval, Reduce Motion off.
+     */
+    public CheckpointCountdownCanvas() {
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        getChildren().add(canvas);
+        // Recompute the timer lifecycle whenever the scene attachment
+        // changes — the timer must run only while attached and not in
+        // Reduce Motion (mirrors LevelMeterSkin's scene-gating).
+        javafx.beans.value.ChangeListener<Scene> sceneListener =
+                (obs, oldScene, newScene) -> updateTimerState();
+        sceneProperty().addListener(sceneListener);
+        // Handle the case where the view is already attached at construction.
+        updateTimerState();
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(
+                CheckpointCountdownCanvas.class.getResource("checkpoint-countdown.css"),
+                "checkpoint-countdown.css not on classpath").toExternalForm();
+    }
+
+    // ── nextCheckpointInstant ─────────────────────────────────────────────
+
+    /** @return the next-checkpoint-instant property ({@code null} = none scheduled). */
+    public final ObjectProperty<Instant> nextCheckpointInstantProperty() {
+        return nextCheckpointInstant;
+    }
+
+    /** @return the instant the next checkpoint fires, or {@code null}. */
+    public final Instant getNextCheckpointInstant() {
+        return nextCheckpointInstant.get();
+    }
+
+    /** @param instant the next-checkpoint instant; {@code null} = none scheduled. */
+    public final void setNextCheckpointInstant(Instant instant) {
+        nextCheckpointInstant.set(instant);
+    }
+
+    // ── interval ──────────────────────────────────────────────────────────
+
+    /** @return the autosave-interval property (bar-fraction denominator). */
+    public final ObjectProperty<Duration> intervalProperty() {
+        return interval;
+    }
+
+    /** @return the autosave interval. */
+    public final Duration getInterval() {
+        return interval.get();
+    }
+
+    /** @param interval the autosave interval (bar-fraction denominator). */
+    public final void setInterval(Duration interval) {
+        this.interval.set(interval);
+    }
+
+    // ── reduceMotion ──────────────────────────────────────────────────────
+
+    /** @return the Reduce Motion property; when {@code true} the timer never runs. */
+    public final BooleanProperty reduceMotionProperty() {
+        return reduceMotion;
+    }
+
+    /** @return whether Reduce Motion is on (story 279). */
+    public final boolean isReduceMotion() {
+        return reduceMotion.get();
+    }
+
+    /** @param reduce whether Reduce Motion is on (story 279). */
+    public final void setReduceMotion(boolean reduce) {
+        reduceMotion.set(reduce);
+    }
+
+    // ── Diagnostics (test seams) ──────────────────────────────────────────
+
+    /** @return {@code true} iff the {@link AnimationTimer} is currently started. */
+    public boolean isCountdownTimerRunning() {
+        return running && timer != null;
+    }
+
+    /** @return how many times the timer has been (re)started (test seam). */
+    public int timerStartCount() {
+        return timerStartCount;
+    }
+
+    // ── Timer lifecycle (scene-gated, mirrors LevelMeterSkin) ─────────────
+
+    private void updateTimerState() {
+        // The timer runs only while attached to a scene AND not in Reduce
+        // Motion. In Reduce Motion the cell is static text repainted on
+        // change, so no frame loop is started (story 279).
+        boolean shouldRun = getScene() != null && !isReduceMotion();
+        if (shouldRun && !running) {
+            if (timer == null) {
+                timer = new CountdownTimer();
+            }
+            lastTickNanos = Long.MIN_VALUE;
+            timer.start();
+            running = true;
+            timerStartCount++;
+        } else if (!shouldRun && running) {
+            if (timer != null) {
+                timer.stop();
+            }
+            timer = null;
+            running = false;
+        }
+    }
+
+    /**
+     * Repaints immediately. In Reduce Motion this is the only repaint path
+     * (no timer); otherwise the timer covers per-second redraws but a model
+     * / colour change still repaints at once so the change is visible
+     * without waiting up to a second for the next tick.
+     */
+    private void requestRedraw() {
+        draw();
+    }
+
+    // ── Layout / sizing ───────────────────────────────────────────────────
+
+    @Override
+    protected void layoutChildren() {
+        // Size and position the canvas within the content area so CSS
+        // padding/insets are respected and content never overpaints them
+        // (mirrors how LevelMeterSkin sizes its canvas to the content box).
+        double x = snappedLeftInset();
+        double y = snappedTopInset();
+        double w = Math.max(0, getWidth() - x - snappedRightInset());
+        double h = Math.max(0, getHeight() - y - snappedBottomInset());
+        canvas.relocate(x, y);
+        canvas.setWidth(w);
+        canvas.setHeight(h);
+        draw();
+    }
+
+    @Override
+    protected double computePrefWidth(double height) {
+        return PREF_WIDTH + snappedLeftInset() + snappedRightInset();
+    }
+
+    @Override
+    protected double computePrefHeight(double width) {
+        return PREF_HEIGHT + snappedTopInset() + snappedBottomInset();
+    }
+
+    @Override
+    protected double computeMinWidth(double height) {
+        return MIN_WIDTH + snappedLeftInset() + snappedRightInset();
+    }
+
+    @Override
+    protected double computeMinHeight(double width) {
+        return PREF_HEIGHT + snappedTopInset() + snappedBottomInset();
+    }
+
+    @Override
+    protected double computeMaxWidth(double height) {
+        return Double.MAX_VALUE;
+    }
+
+    @Override
+    protected double computeMaxHeight(double width) {
+        return Double.MAX_VALUE;
+    }
+
+    // ── Painting (pure: same inputs → same pixels, no effects) ────────────
+
+    private void draw() {
+        double w = canvas.getWidth();
+        double h = canvas.getHeight();
+        if (w <= 0 || h <= 0) {
+            return;
+        }
+        GraphicsContext gc = canvas.getGraphicsContext2D();
+        gc.clearRect(0, 0, w, h);
+
+        Instant next = getNextCheckpointInstant();
+        Instant now = Instant.now();
+        Duration remaining = (next == null) ? null : Duration.between(now, next);
+
+        // Text row: left-aligned, vertically centred above the bar.
+        double barReserve = (remaining != null) ? (BAR_HEIGHT + BAR_GAP) : 0.0;
+        double textHeight = Math.max(0, h - barReserve);
+        gc.setFont(Font.font(FONT_PX));
+        gc.setTextAlign(TextAlignment.LEFT);
+        gc.setTextBaseline(VPos.CENTER);
+        gc.setFill(getTextColor());
+        gc.fillText(countdownText(remaining), 0, textHeight / 2.0);
+
+        if (remaining == null) {
+            return;
+        }
+
+        // Progress track + remaining-fraction fill, beneath the text. In
+        // Reduce Motion the bar is still drawn (statically): it only
+        // repaints on model/colour change, never per frame.
+        double barY = Math.max(0, h - BAR_HEIGHT);
+        gc.setFill(getTrackColor());
+        gc.fillRect(0, barY, w, BAR_HEIGHT);
+
+        double fraction = barFraction(now, next, getInterval());
+        double fillWidth = fraction * w;
+        if (fillWidth > 0) {
+            gc.setFill(getFillColor());
+            gc.fillRect(0, barY, fillWidth, BAR_HEIGHT);
+        }
+    }
+
+    // ── Pure static transforms (toolkit-free, unit-testable) ──────────────
+
+    /**
+     * Whether the 1&nbsp;Hz redraw loop should repaint at frame timestamp
+     * {@code now} given the timestamp of the last redraw, {@code lastTickNanos}
+     * ({@link Long#MIN_VALUE} = "no redraw since the last (re)start", so the
+     * first tick must always repaint). Pure and toolkit-free so the throttle —
+     * and specifically the first-tick sentinel — is unit-testable without the
+     * FX thread.
+     *
+     * <p>The first-tick case is an explicit {@code == Long.MIN_VALUE} test,
+     * <strong>not</strong> {@code now - lastTickNanos >= ONE_SECOND_NANOS}: the
+     * latter overflows when {@code lastTickNanos == Long.MIN_VALUE} and
+     * {@code now} is positive (as {@code AnimationTimer}'s
+     * {@code System.nanoTime()}-based timestamp is on Windows) — the subtraction
+     * wraps to a negative delta, so the first (and therefore every subsequent)
+     * tick failed the gate and the countdown never advanced.</p>
+     *
+     * @param lastTickNanos timestamp of the last redraw, or {@link Long#MIN_VALUE}
+     *                      if none since the last (re)start
+     * @param now           the current frame timestamp in nanoseconds
+     * @return {@code true} if a redraw should fire at {@code now}
+     */
+    public static boolean shouldRedraw(long lastTickNanos, long now) {
+        return lastTickNanos == Long.MIN_VALUE
+                || now - lastTickNanos >= ONE_SECOND_NANOS;
+    }
+
+    /**
+     * Formats a remaining duration as {@code "M:SS"} (or {@code "H:MM:SS"}
+     * when at least one hour). Negative, zero or {@code null} durations
+     * clamp to {@code "0:00"}.
+     *
+     * @param remaining the remaining duration (may be {@code null})
+     * @return the formatted countdown, never {@code null}
+     */
+    public static String formatRemaining(Duration remaining) {
+        if (remaining == null || remaining.isZero() || remaining.isNegative()) {
+            return "0:00";
+        }
+        long totalSeconds = remaining.getSeconds();
+        if (totalSeconds <= 0) {
+            return "0:00";
+        }
+        long hours = totalSeconds / SECONDS_PER_HOUR;
+        long minutes = (totalSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE;
+        long seconds = totalSeconds % SECONDS_PER_MINUTE;
+        if (hours >= 1) {
+            return String.format(Locale.ROOT, "%d:%02d:%02d", hours, minutes, seconds);
+        }
+        return String.format(Locale.ROOT, "%d:%02d", minutes, seconds);
+    }
+
+    /**
+     * Builds the cell's caption.
+     *
+     * @param remaining the remaining duration, or {@code null} if no
+     *                  checkpoint is scheduled
+     * @return {@code "Next checkpoint in M:SS"}, or
+     *         {@code "No checkpoint scheduled"} when {@code remaining} is
+     *         {@code null}
+     */
+    public static String countdownText(Duration remaining) {
+        if (remaining == null) {
+            return "No checkpoint scheduled";
+        }
+        return "Next checkpoint in " + formatRemaining(remaining);
+    }
+
+    /**
+     * Computes the fraction of the autosave interval still remaining,
+     * clamped to {@code [0, 1]}. Pure with respect to its arguments.
+     *
+     * @param now      the reference instant
+     * @param next     the instant the next checkpoint fires
+     * @param interval the autosave interval (the denominator)
+     * @return the remaining fraction in {@code [0, 1]}; {@code 0.0} when
+     *         {@code next} or {@code interval} is {@code null}, or the
+     *         interval is zero / negative
+     */
+    public static double barFraction(Instant now, Instant next, Duration interval) {
+        if (next == null || interval == null
+                || interval.isZero() || interval.isNegative()) {
+            return 0.0;
+        }
+        long intervalMillis = interval.toMillis();
+        if (intervalMillis <= 0) {
+            return 0.0;
+        }
+        long remainingMillis = Duration.between(now, next).toMillis();
+        double fraction = (double) remainingMillis / (double) intervalMillis;
+        if (fraction <= 0.0) {
+            return 0.0;
+        }
+        if (fraction >= 1.0) {
+            return 1.0;
+        }
+        return fraction;
+    }
+
+    // ── Styleable colour properties (consume forwarded -ccd-* tokens) ─────
+    //
+    // Internal -ccd-* names so styles.css can forward role tokens without a
+    // circular looked-up-colour drop, mirroring MixerChannelStrip's -mcs-*.
+
+    private final StyleableObjectProperty<Color> textColor =
+            new StyleableObjectProperty<>(FALLBACK_TEXT) {
+                @Override public Object getBean() { return CheckpointCountdownCanvas.this; }
+                @Override public String getName() { return "textColor"; }
+                @Override public CssMetaData<CheckpointCountdownCanvas, Color> getCssMetaData() {
+                    return StyleableProperties.TEXT;
+                }
+                @Override protected void invalidated() { requestRedraw(); }
+            };
+    private final StyleableObjectProperty<Color> trackColor =
+            new StyleableObjectProperty<>(FALLBACK_TRACK) {
+                @Override public Object getBean() { return CheckpointCountdownCanvas.this; }
+                @Override public String getName() { return "trackColor"; }
+                @Override public CssMetaData<CheckpointCountdownCanvas, Color> getCssMetaData() {
+                    return StyleableProperties.TRACK;
+                }
+                @Override protected void invalidated() { requestRedraw(); }
+            };
+    private final StyleableObjectProperty<Color> fillColor =
+            new StyleableObjectProperty<>(FALLBACK_FILL) {
+                @Override public Object getBean() { return CheckpointCountdownCanvas.this; }
+                @Override public String getName() { return "fillColor"; }
+                @Override public CssMetaData<CheckpointCountdownCanvas, Color> getCssMetaData() {
+                    return StyleableProperties.FILL;
+                }
+                @Override protected void invalidated() { requestRedraw(); }
+            };
+
+    /** @return the text styleable colour ({@code -ccd-text}, the countdown caption). */
+    public final StyleableObjectProperty<Color> textColorProperty() { return textColor; }
+    /** @return the resolved text colour. */
+    public final Color getTextColor() { return textColor.get(); }
+    /** @param c the text colour. */
+    public final void setTextColor(Color c) { textColor.set(c); }
+
+    /** @return the track styleable colour ({@code -ccd-track}, the bar background). */
+    public final StyleableObjectProperty<Color> trackColorProperty() { return trackColor; }
+    /** @return the resolved track colour. */
+    public final Color getTrackColor() { return trackColor.get(); }
+    /** @param c the track colour. */
+    public final void setTrackColor(Color c) { trackColor.set(c); }
+
+    /** @return the fill styleable colour ({@code -ccd-fill}, the remaining-fraction bar). */
+    public final StyleableObjectProperty<Color> fillColorProperty() { return fillColor; }
+    /** @return the resolved fill colour. */
+    public final Color getFillColor() { return fillColor.get(); }
+    /** @param c the fill colour. */
+    public final void setFillColor(Color c) { fillColor.set(c); }
+
+    // ── CssMetaData ───────────────────────────────────────────────────────
+
+    private static final class StyleableProperties {
+
+        private static CssMetaData<CheckpointCountdownCanvas, Color> color(
+                String name, Color fallback,
+                java.util.function.Function<CheckpointCountdownCanvas,
+                        StyleableObjectProperty<Color>> accessor) {
+            return new CssMetaData<>(name,
+                    StyleConverter.getColorConverter(), fallback) {
+                @Override
+                public boolean isSettable(CheckpointCountdownCanvas s) {
+                    return !accessor.apply(s).isBound();
+                }
+                @Override
+                public StyleableProperty<Color> getStyleableProperty(CheckpointCountdownCanvas s) {
+                    return accessor.apply(s);
+                }
+            };
+        }
+
+        static final CssMetaData<CheckpointCountdownCanvas, Color> TEXT =
+                color("-ccd-text", FALLBACK_TEXT, s -> s.textColor);
+        static final CssMetaData<CheckpointCountdownCanvas, Color> TRACK =
+                color("-ccd-track", FALLBACK_TRACK, s -> s.trackColor);
+        static final CssMetaData<CheckpointCountdownCanvas, Color> FILL =
+                color("-ccd-fill", FALLBACK_FILL, s -> s.fillColor);
+
+        static final List<CssMetaData<? extends Styleable, ?>> CSS_META_DATA;
+
+        static {
+            List<CssMetaData<? extends Styleable, ?>> list =
+                    new ArrayList<>(Region.getClassCssMetaData());
+            Collections.addAll(list, TEXT, TRACK, FILL);
+            CSS_META_DATA = Collections.unmodifiableList(list);
+        }
+
+        private StyleableProperties() {
+        }
+    }
+
+    /** @return the {@link CssMetaData} for this type, combined with {@link Region}'s. */
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return StyleableProperties.CSS_META_DATA;
+    }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        return getClassCssMetaData();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/ProjectOperationProgress.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/ProjectOperationProgress.java
@@ -1,0 +1,509 @@
+package com.benesquivelmusic.daw.app.ui.status;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
+import javafx.beans.property.ReadOnlyDoubleProperty;
+import javafx.beans.property.ReadOnlyDoubleWrapper;
+import javafx.beans.property.ReadOnlyIntegerProperty;
+import javafx.beans.property.ReadOnlyIntegerWrapper;
+import javafx.beans.property.ReadOnlyLongProperty;
+import javafx.beans.property.ReadOnlyLongWrapper;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * The single, named source of project-status truth for the Session Status
+ * Strip (Project Manager Design Book §5.5, story 295 — Stage 1 of the §7
+ * migration path). A JavaFX {@code Property}-heavy model
+ * ({@code javafx-application-design} §4): every visible status the strip
+ * renders is one observable property here, and the strip's cells
+ * {@code bind(...)} to them. No controller writes status text anywhere else
+ * — this model is the §8 rejection of "status text in {@code Label.setText}".
+ *
+ * <h2>The seven invisible signals, promoted to chrome (§2.2)</h2>
+ *
+ * <p>The properties cover the §2.2 facts the user previously could not see:
+ * the {@link #lastSaveTimeProperty() last save} (time + {@link SaveScope
+ * scope} + {@link #lastSaveSucceededProperty() outcome}), the
+ * {@link #nextCheckpointInstantProperty() next checkpoint}, the
+ * {@link #journalEventsQueuedProperty() journal queue}, the
+ * {@link #lockHolderLabelProperty() lock holder} + {@link #lockFreshProperty()
+ * freshness}, {@link #freeDiskBytesProperty() free disk} +
+ * {@link #estimatedRecordMinutesProperty() capture estimate}, the
+ * {@link #sessionNameProperty() session name} + {@link #sessionElapsedProperty()
+ * age}, and the {@link #currentSchemaVersionProperty() schema} +
+ * {@link #backupSchemaVersionProperty() backup schema}. In-flight long
+ * operations register on the {@link #getOperations() operations list} (§5.5);
+ * {@link #savingProperty() saving} is simply that list being non-empty.</p>
+ *
+ * <h2>Single writer; read-only views (§2.4)</h2>
+ *
+ * <p>Every property is a private {@code ReadOnly*Wrapper}; only the read-only
+ * view is handed to controls, so a bound cell can never write back. The model
+ * is the sole writer, through the keyed mutators below. {@link #dirtyProperty()
+ * dirty} is the one exception: it is <em>bound</em> to story 292's
+ * {@code ProjectVM.dirtyProperty()} via {@link #bindDirtyTo(ObservableValue)}
+ * rather than re-derived (the §295 goal "bind {@code dirty} to it"). ProjectVM
+ * exposes neither a last-save time nor a saving flag, so {@code lastSaveTime}
+ * is written by the save path and {@code saving} is derived from the
+ * operations list.</p>
+ *
+ * <h2>Threading — the FX-confinement seam (§2.1, story 289)</h2>
+ *
+ * <p>Status is produced off the FX thread (the 30&nbsp;s disk scan on a virtual
+ * thread, checkpoint callbacks on the checkpoint scheduler, save on the FX
+ * thread). Every mutator routes its write through the story-289
+ * {@link FxDispatcher#onFx(Object, Runnable) keyed} dispatcher, so the property
+ * is only ever set on the FX thread and N rapid mutations under the same key
+ * within one frame coalesce to a single strip repaint
+ * ({@code javafx-application-design} §6 "coalesce per frame", §11 "the FX thread
+ * is sacred"). Discrete operation register/unregister uses the un-keyed
+ * {@link FxDispatcher#onFx(Runnable)} so every add/remove survives (never
+ * coalesced away).</p>
+ */
+public final class ProjectOperationProgress {
+
+    /**
+     * Scope of a save: a full re-serialisation ({@link #FULL}) or a journal
+     * delta ({@link #DELTA}). Stage 1 only ever produces {@link #FULL} (the
+     * journal is story 298); the enum exists now so the Saved cell never needs
+     * an API break when delta saves land.
+     */
+    public enum SaveScope {
+        /** A complete re-serialisation of {@code project.daw}. */
+        FULL,
+        /** An incremental journal delta (story 298 — not produced in Stage 1). */
+        DELTA
+    }
+
+    /**
+     * Coalescing keys — one per logical fact group. N rapid mutations under one
+     * key within a single {@link FxDispatcher#pulse() frame} collapse to the
+     * latest (story 295 binding-test contract). Distinct facts use distinct keys
+     * so they never overwrite each other.
+     */
+    private enum Key { SAVE, CHECKPOINT, JOURNAL, LOCK, DISK, SESSION, SCHEMA, WORKSPACE }
+
+    /** Sentinel for an unknown numeric value (no project open / scan not yet run). */
+    public static final long UNKNOWN_BYTES = -1L;
+    /** Sentinel for an unknown record-minutes estimate. */
+    public static final double UNKNOWN_MINUTES = -1.0;
+    /** Sentinel for an unknown / inapplicable schema version (no project, or no backup). */
+    public static final int UNKNOWN_VERSION = -1;
+
+    private final FxDispatcher dispatcher;
+
+    private final ReadOnlyObjectWrapper<Instant> lastSaveTime =
+            new ReadOnlyObjectWrapper<>(this, "lastSaveTime", null);
+    private final ReadOnlyObjectWrapper<SaveScope> lastSaveScope =
+            new ReadOnlyObjectWrapper<>(this, "lastSaveScope", SaveScope.FULL);
+    private final ReadOnlyBooleanWrapper lastSaveSucceeded =
+            new ReadOnlyBooleanWrapper(this, "lastSaveSucceeded", true);
+
+    private final ReadOnlyObjectWrapper<Instant> nextCheckpointInstant =
+            new ReadOnlyObjectWrapper<>(this, "nextCheckpointInstant", null);
+    private final ReadOnlyObjectWrapper<Duration> checkpointInterval =
+            new ReadOnlyObjectWrapper<>(this, "checkpointInterval", Duration.ofMinutes(5));
+    private final ReadOnlyIntegerWrapper journalEventsQueued =
+            new ReadOnlyIntegerWrapper(this, "journalEventsQueued", 0);
+
+    private final ReadOnlyStringWrapper lockHolderLabel =
+            new ReadOnlyStringWrapper(this, "lockHolderLabel", "");
+    private final ReadOnlyBooleanWrapper lockFresh =
+            new ReadOnlyBooleanWrapper(this, "lockFresh", true);
+
+    private final ReadOnlyLongWrapper freeDiskBytes =
+            new ReadOnlyLongWrapper(this, "freeDiskBytes", UNKNOWN_BYTES);
+    private final ReadOnlyDoubleWrapper estimatedRecordMinutes =
+            new ReadOnlyDoubleWrapper(this, "estimatedRecordMinutes", UNKNOWN_MINUTES);
+
+    private final ReadOnlyStringWrapper sessionName =
+            new ReadOnlyStringWrapper(this, "sessionName", "");
+    private final ReadOnlyObjectWrapper<Duration> sessionElapsed =
+            new ReadOnlyObjectWrapper<>(this, "sessionElapsed", Duration.ZERO);
+
+    private final ReadOnlyIntegerWrapper currentSchemaVersion =
+            new ReadOnlyIntegerWrapper(this, "currentSchemaVersion", UNKNOWN_VERSION);
+    private final ReadOnlyIntegerWrapper backupSchemaVersion =
+            new ReadOnlyIntegerWrapper(this, "backupSchemaVersion", UNKNOWN_VERSION);
+
+    private final ReadOnlyStringWrapper workspaceName =
+            new ReadOnlyStringWrapper(this, "workspaceName", "");
+
+    /**
+     * The single dirty bit (§1.2), bound to {@code ProjectVM.dirty} (§295 goal
+     * "bind {@code dirty} to it"). <strong>Forward-declared</strong>: its visible
+     * form is the §8 Journal cell ("events queued since last checkpoint" — the
+     * dirty-dot replacement), whose producer is the write-ahead journal of story
+     * 298. Until then this bound bit has no rendered cell; it is exposed now so a
+     * later stage (or an external consumer) can read the one dirty source without
+     * an API break, mirroring the forward-declared {@code ProjectVM.checkpoint}.
+     */
+    private final ReadOnlyBooleanWrapper dirty =
+            new ReadOnlyBooleanWrapper(this, "dirty", false);
+
+    /** In-flight named operations (§5.5). Mutated only on the FX thread. */
+    private final ObservableList<NamedOperation> operationsBacking =
+            FXCollections.observableArrayList();
+    private final ObservableList<NamedOperation> operations =
+            FXCollections.unmodifiableObservableList(operationsBacking);
+
+    /** {@code true} while any operation is in flight (§4.5 slow-save HUD). */
+    private final ReadOnlyBooleanWrapper saving =
+            new ReadOnlyBooleanWrapper(this, "saving");
+
+    /**
+     * Creates a model whose every mutation is marshalled onto the FX thread
+     * through {@code dispatcher} (story 289).
+     *
+     * @param dispatcher the FX-confinement seam; must not be {@code null}
+     * @throws NullPointerException if {@code dispatcher} is {@code null}
+     */
+    public ProjectOperationProgress(FxDispatcher dispatcher) {
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
+        // saving := operations non-empty — the §4.5 "an operation is running"
+        // signal, derived rather than poked so it can never drift from the list.
+        saving.bind(Bindings.isNotEmpty(operationsBacking));
+    }
+
+    // ── Mutators (callable from any thread; keyed-coalesced onto the FX thread) ──
+
+    /**
+     * Records a successful save: stamps {@link #lastSaveTimeProperty() time},
+     * {@link #lastSaveScopeProperty() scope}, and flips
+     * {@link #lastSaveSucceededProperty()} to {@code true}. The strip's Saved
+     * cell flashes — that flash <em>is</em> the success signal (§4.5), replacing
+     * the retired "Project saved" notification.
+     *
+     * @param time  the moment the save completed; must not be {@code null}
+     * @param scope full vs. delta; must not be {@code null}
+     */
+    public void recordSaveSucceeded(Instant time, SaveScope scope) {
+        Objects.requireNonNull(time, "time must not be null");
+        Objects.requireNonNull(scope, "scope must not be null");
+        publish(Key.SAVE, () -> {
+            lastSaveTime.set(time);
+            lastSaveScope.set(scope);
+            lastSaveSucceeded.set(true);
+        });
+    }
+
+    /**
+     * Records a failed save: flips {@link #lastSaveSucceededProperty()} to
+     * {@code false} so the Saved cell turns to its error state (§4.5 — the cell
+     * persists the failure; it does not auto-dismiss). The last successful
+     * {@code lastSaveTime} is left untouched.
+     */
+    public void recordSaveFailed() {
+        publish(Key.SAVE, () -> lastSaveSucceeded.set(false));
+    }
+
+    /**
+     * Publishes the instant the next checkpoint will fire (or {@code null} when
+     * no project is open / autosave is off) <em>and</em> the autosave interval
+     * that is the §6 countdown bar's denominator. Both travel under one
+     * coalescing key and are set together so the strip's countdown is exact for
+     * both {@code AutoSaveConfig.DEFAULT} (5&nbsp;min) and {@code LONG_SESSION}
+     * (30&nbsp;s) (story 295 Technical Notes).
+     *
+     * @param instant  the next-fire instant, or {@code null} for "none scheduled"
+     * @param interval the autosave interval; must not be {@code null}
+     */
+    public void setNextCheckpoint(Instant instant, Duration interval) {
+        Objects.requireNonNull(interval, "interval must not be null");
+        publish(Key.CHECKPOINT, () -> {
+            nextCheckpointInstant.set(instant);
+            checkpointInterval.set(interval);
+        });
+    }
+
+    /**
+     * Publishes the number of journal events queued since the last checkpoint
+     * (the §8 replacement for the single dirty dot). Stage 1 has no journal
+     * (story 298), so production leaves this at {@code 0}; the cell exists now.
+     *
+     * @param count the queued-event count
+     */
+    public void setJournalEventsQueued(int count) {
+        publish(Key.JOURNAL, () -> journalEventsQueued.set(count));
+    }
+
+    /**
+     * Publishes the lock-holder label (e.g. {@code "you @ Studio-PC"}) and
+     * whether the heartbeat is fresh (§1.3).
+     *
+     * @param holderLabel the human-readable holder; must not be {@code null}
+     * @param fresh       whether the heartbeat is live (not stale)
+     */
+    public void setLock(String holderLabel, boolean fresh) {
+        Objects.requireNonNull(holderLabel, "holderLabel must not be null");
+        publish(Key.LOCK, () -> {
+            lockHolderLabel.set(holderLabel);
+            lockFresh.set(fresh);
+        });
+    }
+
+    /**
+     * Publishes the §1.8 disk-space contract: free bytes and the derived
+     * capture-minutes estimate. Sourced off the FX thread by the 30&nbsp;s disk
+     * scan; the disk cell goes amber under 30 record-minutes and red under 5
+     * (§6.2).
+     *
+     * @param freeBytes      usable bytes on the project's file store, or
+     *                       {@link #UNKNOWN_BYTES}
+     * @param recordMinutes  estimated minutes of capture room, or
+     *                       {@link #UNKNOWN_MINUTES}
+     */
+    public void setDisk(long freeBytes, double recordMinutes) {
+        publish(Key.DISK, () -> {
+            freeDiskBytes.set(freeBytes);
+            estimatedRecordMinutes.set(recordMinutes);
+        });
+    }
+
+    /**
+     * Publishes the §3.3 working-session name and elapsed time.
+     *
+     * @param name    the session name; must not be {@code null}
+     * @param elapsed the elapsed session time; must not be {@code null}
+     */
+    public void setSession(String name, Duration elapsed) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(elapsed, "elapsed must not be null");
+        publish(Key.SESSION, () -> {
+            sessionName.set(name);
+            sessionElapsed.set(elapsed);
+        });
+    }
+
+    /**
+     * Publishes the schema versions (§1.6): the current on-disk schema and the
+     * pre-migration backup schema, or {@link #UNKNOWN_VERSION} for "no backup".
+     *
+     * @param current the current schema version
+     * @param backup  the backup's schema version, or {@link #UNKNOWN_VERSION}
+     */
+    public void setSchema(int current, int backup) {
+        publish(Key.SCHEMA, () -> {
+            currentSchemaVersion.set(current);
+            backupSchemaVersion.set(backup);
+        });
+    }
+
+    /**
+     * Publishes the §3.1 workspace name shown in the Workspace cell.
+     *
+     * @param name the workspace name; must not be {@code null}
+     */
+    public void setWorkspaceName(String name) {
+        Objects.requireNonNull(name, "name must not be null");
+        publish(Key.WORKSPACE, () -> workspaceName.set(name));
+    }
+
+    /**
+     * Registers an in-flight operation (§5.5). Any operation running &gt;500&nbsp;ms
+     * shows progress in the strip (§8 "no background work without progress").
+     * Discrete — routed un-keyed so it is never coalesced away.
+     *
+     * @param operation the operation to add; must not be {@code null}
+     */
+    public void addOperation(NamedOperation operation) {
+        Objects.requireNonNull(operation, "operation must not be null");
+        dispatcher.onFx(() -> {
+            if (!operationsBacking.contains(operation)) {
+                operationsBacking.add(operation);
+            }
+        });
+    }
+
+    /**
+     * Unregisters a finished operation (§5.5). Discrete — routed un-keyed so it
+     * is never coalesced away.
+     *
+     * @param operation the operation to remove; must not be {@code null}
+     */
+    public void removeOperation(NamedOperation operation) {
+        Objects.requireNonNull(operation, "operation must not be null");
+        dispatcher.onFx(() -> operationsBacking.remove(operation));
+    }
+
+    /**
+     * Binds {@link #dirtyProperty()} to story 292's {@code ProjectVM.dirty}
+     * (the §1.2 "one dirty bit"), so the model mirrors the live core dirty bit
+     * rather than re-deriving it (§295 goal). Idempotent re-binding is the
+     * caller's responsibility; the composition root calls this once per
+     * {@code ProjectVM} generation.
+     *
+     * @param source the observable dirty bit to mirror; must not be {@code null}
+     */
+    public void bindDirtyTo(ObservableValue<? extends Boolean> source) {
+        Objects.requireNonNull(source, "source must not be null");
+        dirty.bind(source);
+    }
+
+    /**
+     * Routes a property write onto the FX thread with per-key coalescing
+     * (story 289). The write runs on the next {@link FxDispatcher#pulse()},
+     * and only the latest write per key in that frame survives.
+     */
+    private void publish(Key key, Runnable write) {
+        dispatcher.onFx(key, write);
+    }
+
+    // ── Read-only property views (the model is the sole writer, §2.4) ─────────
+
+    /** @return the last successful save time, or {@code null} if never saved. */
+    public ReadOnlyObjectProperty<Instant> lastSaveTimeProperty() { return lastSaveTime.getReadOnlyProperty(); }
+    /** @return the last save time, or {@code null}. */
+    public Instant getLastSaveTime() { return lastSaveTime.get(); }
+
+    /** @return the last save's {@link SaveScope} (full vs. delta). */
+    public ReadOnlyObjectProperty<SaveScope> lastSaveScopeProperty() { return lastSaveScope.getReadOnlyProperty(); }
+    /** @return the last save scope. */
+    public SaveScope getLastSaveScope() { return lastSaveScope.get(); }
+
+    /** @return whether the last save succeeded ({@code false} → Saved cell error state). */
+    public ReadOnlyBooleanProperty lastSaveSucceededProperty() { return lastSaveSucceeded.getReadOnlyProperty(); }
+    /** @return whether the last save succeeded. */
+    public boolean isLastSaveSucceeded() { return lastSaveSucceeded.get(); }
+
+    /** @return the instant the next checkpoint fires, or {@code null}. */
+    public ReadOnlyObjectProperty<Instant> nextCheckpointInstantProperty() { return nextCheckpointInstant.getReadOnlyProperty(); }
+    /** @return the next checkpoint instant, or {@code null}. */
+    public Instant getNextCheckpointInstant() { return nextCheckpointInstant.get(); }
+
+    /** @return the autosave interval (the §6 countdown bar's denominator). */
+    public ReadOnlyObjectProperty<Duration> checkpointIntervalProperty() { return checkpointInterval.getReadOnlyProperty(); }
+    /** @return the autosave interval. */
+    public Duration getCheckpointInterval() { return checkpointInterval.get(); }
+
+    /** @return the journal-events-queued count (the §8 dirty-dot replacement). */
+    public ReadOnlyIntegerProperty journalEventsQueuedProperty() { return journalEventsQueued.getReadOnlyProperty(); }
+    /** @return the queued journal-event count. */
+    public int getJournalEventsQueued() { return journalEventsQueued.get(); }
+
+    /** @return the lock-holder label (§1.3). */
+    public ReadOnlyStringProperty lockHolderLabelProperty() { return lockHolderLabel.getReadOnlyProperty(); }
+    /** @return the lock-holder label. */
+    public String getLockHolderLabel() { return lockHolderLabel.get(); }
+
+    /** @return whether the lock heartbeat is fresh (not stale). */
+    public ReadOnlyBooleanProperty lockFreshProperty() { return lockFresh.getReadOnlyProperty(); }
+    /** @return whether the lock is fresh. */
+    public boolean isLockFresh() { return lockFresh.get(); }
+
+    /** @return the free disk bytes, or {@link #UNKNOWN_BYTES} (§1.8). */
+    public ReadOnlyLongProperty freeDiskBytesProperty() { return freeDiskBytes.getReadOnlyProperty(); }
+    /** @return the free disk bytes, or {@link #UNKNOWN_BYTES}. */
+    public long getFreeDiskBytes() { return freeDiskBytes.get(); }
+
+    /** @return the estimated record-minutes, or {@link #UNKNOWN_MINUTES} (§6.2 amber/red). */
+    public ReadOnlyDoubleProperty estimatedRecordMinutesProperty() { return estimatedRecordMinutes.getReadOnlyProperty(); }
+    /** @return the estimated record-minutes, or {@link #UNKNOWN_MINUTES}. */
+    public double getEstimatedRecordMinutes() { return estimatedRecordMinutes.get(); }
+
+    /** @return the §3.3 session name. */
+    public ReadOnlyStringProperty sessionNameProperty() { return sessionName.getReadOnlyProperty(); }
+    /** @return the session name. */
+    public String getSessionName() { return sessionName.get(); }
+
+    /** @return the elapsed session time. */
+    public ReadOnlyObjectProperty<Duration> sessionElapsedProperty() { return sessionElapsed.getReadOnlyProperty(); }
+    /** @return the elapsed session time. */
+    public Duration getSessionElapsed() { return sessionElapsed.get(); }
+
+    /** @return the current on-disk schema version, or {@link #UNKNOWN_VERSION}. */
+    public ReadOnlyIntegerProperty currentSchemaVersionProperty() { return currentSchemaVersion.getReadOnlyProperty(); }
+    /** @return the current schema version. */
+    public int getCurrentSchemaVersion() { return currentSchemaVersion.get(); }
+
+    /** @return the pre-migration backup schema version, or {@link #UNKNOWN_VERSION} (no backup). */
+    public ReadOnlyIntegerProperty backupSchemaVersionProperty() { return backupSchemaVersion.getReadOnlyProperty(); }
+    /** @return the backup schema version, or {@link #UNKNOWN_VERSION}. */
+    public int getBackupSchemaVersion() { return backupSchemaVersion.get(); }
+
+    /** @return the §3.1 workspace name. */
+    public ReadOnlyStringProperty workspaceNameProperty() { return workspaceName.getReadOnlyProperty(); }
+    /** @return the workspace name. */
+    public String getWorkspaceName() { return workspaceName.get(); }
+
+    /** @return the single dirty bit (§1.2), bound to {@code ProjectVM.dirty}. */
+    public ReadOnlyBooleanProperty dirtyProperty() { return dirty.getReadOnlyProperty(); }
+    /** @return whether the project has unsaved changes. */
+    public boolean isDirty() { return dirty.get(); }
+
+    /** @return {@code true} while any operation is in flight (§4.5). */
+    public ReadOnlyBooleanProperty savingProperty() { return saving.getReadOnlyProperty(); }
+    /** @return whether an operation is in flight. */
+    public boolean isSaving() { return saving.get(); }
+
+    /**
+     * The in-flight named operations (§5.5). Unmodifiable observable view —
+     * mutate only through {@link #addOperation(NamedOperation)} /
+     * {@link #removeOperation(NamedOperation)}.
+     *
+     * @return the live, read-only operations list
+     */
+    public ObservableList<NamedOperation> getOperations() {
+        return operations;
+    }
+
+    /**
+     * A named, in-flight project operation (save, autosave, archive, …) with an
+     * observable progress in {@code [0,1]} or {@code -1} for indeterminate
+     * (§4.5 — a slow save overlays a progress bar on the Saved cell). The slow
+     * worker updates {@link #progressProperty()} as it runs.
+     */
+    public static final class NamedOperation {
+
+        /** Indeterminate-progress sentinel (an indeterminate progress bar). */
+        public static final double INDETERMINATE = -1.0;
+
+        private final String name;
+        private final javafx.beans.property.DoubleProperty progress;
+
+        /**
+         * Creates an indeterminate operation.
+         *
+         * @param name the human-readable operation name; must not be {@code null}
+         */
+        public NamedOperation(String name) {
+            this(name, INDETERMINATE);
+        }
+
+        /**
+         * Creates an operation with an initial progress.
+         *
+         * @param name     the human-readable operation name; must not be {@code null}
+         * @param progress {@code [0,1]} or {@link #INDETERMINATE}
+         */
+        public NamedOperation(String name, double progress) {
+            this.name = Objects.requireNonNull(name, "name must not be null");
+            this.progress = new javafx.beans.property.SimpleDoubleProperty(this, "progress", progress);
+        }
+
+        /** @return the operation name. */
+        public String name() { return name; }
+
+        /** @return the observable progress property ({@code [0,1]} or {@link #INDETERMINATE}). */
+        public javafx.beans.property.DoubleProperty progressProperty() { return progress; }
+
+        /** @return the current progress. */
+        public double getProgress() { return progress.get(); }
+
+        /** @param value the new progress ({@code [0,1]} or {@link #INDETERMINATE}). */
+        public void setProgress(double value) { progress.set(value); }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/SessionStatusDiskScanner.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/SessionStatusDiskScanner.java
@@ -1,0 +1,146 @@
+package com.benesquivelmusic.daw.app.ui.status;
+
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * The §1.8 disk-space contract source for the Session Status Strip (story 295).
+ * Every 30&nbsp;s it scans the current project's file store for free space and
+ * an estimated capture-minutes figure, then publishes both into
+ * {@link ProjectOperationProgress#setDisk(long, double)}.
+ *
+ * <h2>Off the FX thread (§2.1, {@code javafx-application-design} §11)</h2>
+ *
+ * <p>The scan runs on a <strong>background virtual thread</strong>
+ * ({@code Thread.ofVirtual()}, story 205) — the FX thread never calls
+ * {@link java.nio.file.FileStore#getUsableSpace()}. The result crosses to the
+ * FX thread only through the model's keyed {@link ProjectOperationProgress}
+ * mutator, which marshals via the story-289 {@code FxDispatcher}; many scans
+ * within one frame therefore coalesce to a single strip repaint. This is a
+ * single background task, not a structured-concurrency fan-out (a Non-Goal).</p>
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <p>{@link #start()} schedules the periodic scan (firing immediately, then
+ * every {@value #SCAN_INTERVAL_SECONDS}&nbsp;s) on a daemon scheduler;
+ * {@link #stop()} shuts it down. The project directory and audio format are
+ * read live through {@link Supplier}s, so a project open/close is reflected on
+ * the next scan with no re-wiring.</p>
+ */
+public final class SessionStatusDiskScanner {
+
+    /** Scan cadence in seconds (§4.4 / §6.2: refresh every 30 s). */
+    public static final long SCAN_INTERVAL_SECONDS = 30L;
+
+    private final ProjectOperationProgress progress;
+    private final Supplier<Path> projectDirectory;
+    private final Supplier<AudioFormat> audioFormat;
+    private final ScheduledExecutorService scheduler;
+
+    private boolean started;
+
+    /**
+     * Creates a scanner publishing into {@code progress}.
+     *
+     * @param progress         the status model to publish disk facts into; must not be {@code null}
+     * @param projectDirectory supplies the current project directory, or {@code null} when none is open; must not be {@code null}
+     * @param audioFormat      supplies the current project's audio format (for the capture estimate), or {@code null}; must not be {@code null}
+     */
+    public SessionStatusDiskScanner(ProjectOperationProgress progress,
+                                    Supplier<Path> projectDirectory,
+                                    Supplier<AudioFormat> audioFormat) {
+        this.progress = Objects.requireNonNull(progress, "progress must not be null");
+        this.projectDirectory = Objects.requireNonNull(projectDirectory, "projectDirectory must not be null");
+        this.audioFormat = Objects.requireNonNull(audioFormat, "audioFormat must not be null");
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "daw-disk-scan-scheduler");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    /**
+     * Starts the periodic disk scan — fires immediately, then every
+     * {@value #SCAN_INTERVAL_SECONDS}&nbsp;s. Idempotent.
+     */
+    public synchronized void start() {
+        if (started) {
+            return;
+        }
+        started = true;
+        scheduler.scheduleAtFixedRate(
+                this::scanNow, 0L, SCAN_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /** Stops the periodic scan and releases the scheduler thread. Idempotent. */
+    public synchronized void stop() {
+        started = false;
+        scheduler.shutdownNow();
+    }
+
+    /**
+     * Spawns one disk scan on a fresh background <strong>virtual</strong> thread
+     * and returns it (so callers — and tests — can join on completion). The
+     * scan reads the file store off the FX thread and publishes the result via
+     * the model's dispatcher-marshalled mutator.
+     *
+     * @return the started virtual scan thread
+     */
+    public Thread scanNow() {
+        Thread t = Thread.ofVirtual().name("daw-disk-scan").unstarted(this::scanOnce);
+        t.start();
+        return t;
+    }
+
+    /**
+     * Performs one scan on the calling (virtual) thread: reads the usable bytes
+     * of the current project's file store and the capture-minutes estimate, and
+     * publishes both into the model. When no project is open the disk facts are
+     * cleared to "unknown".
+     */
+    private void scanOnce() {
+        Path dir = projectDirectory.get();
+        if (dir == null) {
+            progress.setDisk(ProjectOperationProgress.UNKNOWN_BYTES,
+                    ProjectOperationProgress.UNKNOWN_MINUTES);
+            return;
+        }
+        long free = ProjectDiskUsage.usableSpaceBytes(dir);
+        AudioFormat format = audioFormat.get();
+        double minutes = (free < 0 || format == null)
+                ? ProjectOperationProgress.UNKNOWN_MINUTES
+                : estimatedRecordMinutes(free, format);
+        progress.setDisk(free, minutes);
+    }
+
+    /**
+     * Estimates the minutes of uncompressed multitrack capture that
+     * {@code freeBytes} affords at {@code format}. Pure and toolkit-free.
+     *
+     * @param freeBytes usable bytes on the file store ({@code < 0} → unknown)
+     * @param format    the capture audio format; must not be {@code null}
+     * @return the estimated minutes, or {@link ProjectOperationProgress#UNKNOWN_MINUTES}
+     *         when {@code freeBytes < 0} or the format yields a non-positive byte rate
+     */
+    public static double estimatedRecordMinutes(long freeBytes, AudioFormat format) {
+        Objects.requireNonNull(format, "format must not be null");
+        if (freeBytes < 0) {
+            return ProjectOperationProgress.UNKNOWN_MINUTES;
+        }
+        double bytesPerSecond =
+                format.sampleRate() * format.channels() * (format.bitDepth() / 8.0);
+        if (bytesPerSecond <= 0) {
+            return ProjectOperationProgress.UNKNOWN_MINUTES;
+        }
+        double bytesPerMinute = bytesPerSecond * 60.0;
+        return freeBytes / bytesPerMinute;
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/SessionStatusStrip.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/SessionStatusStrip.java
@@ -1,0 +1,155 @@
+package com.benesquivelmusic.daw.app.ui.status;
+
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+
+import javafx.scene.AccessibleRole;
+import javafx.scene.control.Button;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The Session Status Strip {@link Control} — a persistent two-row strip across
+ * the bottom of the window that promotes the §2.2 invisible signals (save,
+ * checkpoint, journal, lock, disk, session, schema, workspace) to first-class
+ * chrome (Project Manager Design Book §4.4, story 295 — Stage 1 of the §7
+ * migration path). This single strip <em>is</em> the §2.2 "state is always
+ * visible" principle.
+ *
+ * <h2>Binds only to {@link ProjectOperationProgress}</h2>
+ *
+ * <p>The strip's cells {@code bind(...)} to the single §5.5
+ * {@link ProjectOperationProgress} model and nothing else — no controller
+ * pokes {@code Label.setText} (the §8 rejection of "status text in
+ * {@code Label.setText}"). Each fact is its own small {@link StatusStripCell}
+ * (so a theme can restyle a cell without touching the strip), except the
+ * checkpoint countdown, which is a {@link CheckpointCountdownCanvas}
+ * ({@code Canvas} + 1&nbsp;Hz {@code AnimationTimer}, §6).</p>
+ *
+ * <h2>Eight cells, two rows, priority overflow (§4.4)</h2>
+ *
+ * <p>Row 1: Session · Saved · Checkpoint · Journal. Row 2: Disk · Lock ·
+ * Schema · Workspace. Below 1200&nbsp;px the strip collapses to a single row,
+ * hiding collapsible cells in the fixed priority order Workspace → Schema →
+ * Lock → Disk → Journal; the Session, Saved and Checkpoint cells never
+ * collapse. A trailing {@code ⋯} overflow button reveals the hidden cells in a
+ * popover ({@code javafx-application-design} §10). All layout/overflow logic
+ * lives in {@link SessionStatusStripSkin}; this control only holds the model,
+ * the {@link MotionManager} (for the §279 reduce-motion countdown gate), and
+ * the public API.</p>
+ *
+ * <p>Control/Skin split per {@code javafx-application-design} §3: the skin
+ * builds and binds the cells. The cell accessors below delegate to the
+ * realized skin — a test must attach the strip to a {@code Scene} and call
+ * {@code applyCss()} before reading them (the {@code javafx-application-design}
+ * §3 / headless-skin discipline).</p>
+ */
+public final class SessionStatusStrip extends Control {
+
+    /** Stable style class — selectable as {@code .session-status-strip}. */
+    public static final String DEFAULT_STYLE_CLASS = "session-status-strip";
+
+    /**
+     * Width (px) below which the strip collapses from two rows to a single row
+     * and begins hiding collapsible cells in priority order (§4.4).
+     */
+    public static final double TWO_ROW_MIN_WIDTH = 1200.0;
+
+    /**
+     * Width (px) below which the trailing {@code ⋯} overflow popover is the
+     * documented access point for every hidden cell (§4.4). The overflow
+     * button is shown whenever <em>any</em> cell is hidden (which first occurs
+     * just under {@link #TWO_ROW_MIN_WIDTH}); by 900&nbsp;px the popover is the
+     * sole way to reach the collapsed cells, as the spec requires.
+     */
+    public static final double SINGLE_ROW_OVERFLOW_WIDTH = 900.0;
+
+    private final ProjectOperationProgress progress;
+    private final MotionManager motionManager;
+
+    /**
+     * Creates a strip bound to {@code progress}, using the app-wide
+     * {@link MotionManager#getDefault()} to gate the countdown animation.
+     *
+     * @param progress the single status model; must not be {@code null}
+     */
+    public SessionStatusStrip(ProjectOperationProgress progress) {
+        this(progress, MotionManager.getDefault());
+    }
+
+    /**
+     * Creates a strip bound to {@code progress}, gating the countdown
+     * animation on {@code motionManager} (story 279).
+     *
+     * @param progress      the single status model; must not be {@code null}
+     * @param motionManager the reduce-motion source; must not be {@code null}
+     */
+    public SessionStatusStrip(ProjectOperationProgress progress, MotionManager motionManager) {
+        this.progress = Objects.requireNonNull(progress, "progress must not be null");
+        this.motionManager = Objects.requireNonNull(motionManager, "motionManager must not be null");
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        setAccessibleRole(AccessibleRole.PARENT);
+        setAccessibleRoleDescription("Session status strip");
+        setFocusTraversable(false);
+    }
+
+    /** @return the bound status model (read by the skin). */
+    public ProjectOperationProgress progress() {
+        return progress;
+    }
+
+    /** @return the reduce-motion source (read by the skin to gate the countdown). */
+    public MotionManager motionManager() {
+        return motionManager;
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new SessionStatusStripSkin(this);
+    }
+
+    private SessionStatusStripSkin skin() {
+        Skin<?> skin = getSkin();
+        if (!(skin instanceof SessionStatusStripSkin sss)) {
+            throw new IllegalStateException(
+                    "SessionStatusStrip skin is not realized yet — attach the strip "
+                            + "to a Scene and call applyCss() before reading its cells.");
+        }
+        return sss;
+    }
+
+    // ── Cell accessors (delegate to the realized skin) ────────────────────────
+
+    /** @return the Session cell (name + elapsed). */
+    public StatusStripCell sessionCell() { return skin().sessionCell(); }
+    /** @return the Saved cell (last-save time / scope / error). */
+    public StatusStripCell savedCell() { return skin().savedCell(); }
+    /** @return the live checkpoint-countdown cell. */
+    public CheckpointCountdownCanvas checkpointCountdown() { return skin().checkpointCountdown(); }
+    /** @return the Journal cell (events queued). */
+    public StatusStripCell journalCell() { return skin().journalCell(); }
+    /** @return the Disk cell (free space / capture estimate, §6.2 amber/red). */
+    public StatusStripCell diskCell() { return skin().diskCell(); }
+    /** @return the Lock cell (holder + freshness). */
+    public StatusStripCell lockCell() { return skin().lockCell(); }
+    /** @return the Schema cell (current + backup version). */
+    public StatusStripCell schemaCell() { return skin().schemaCell(); }
+    /** @return the Workspace cell. */
+    public StatusStripCell workspaceCell() { return skin().workspaceCell(); }
+
+    // ── Overflow diagnostics (for the §4.4 overflow tests) ────────────────────
+
+    /** @return the trailing {@code ⋯} overflow button. */
+    public Button overflowButton() { return skin().overflowButton(); }
+
+    /** @return whether the overflow button is currently shown (a cell is hidden). */
+    public boolean isOverflowButtonVisible() { return skin().overflowButton().isVisible(); }
+
+    /**
+     * @return the cells currently collapsed into the overflow popover, in the
+     *         §4.4 collapse order (Workspace, Schema, Lock, Disk, Journal)
+     */
+    public List<StatusStripCell> overflowCells() { return skin().overflowCells(); }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/SessionStatusStripSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/SessionStatusStripSkin.java
@@ -1,0 +1,449 @@
+package com.benesquivelmusic.daw.app.ui.status;
+
+import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress.SaveScope;
+import com.benesquivelmusic.daw.app.ui.status.StatusStripCell.Severity;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.value.ChangeListener;
+import javafx.geometry.Bounds;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.stage.Popup;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Skin for {@link SessionStatusStrip} (Project Manager Design Book §4.4, story
+ * 295). Builds the eight cells, binds each to the single
+ * {@link ProjectOperationProgress} model, and performs the §4.4 responsive
+ * layout: two rows when wide, collapsing to a single row with a priority
+ * overflow popover when narrow.
+ *
+ * <h2>Binding-only (§8)</h2>
+ *
+ * <p>Every cell's text is a {@code bind(...)} to a {@code StringBinding} over
+ * the model — there is no {@code Label.setText} anywhere in this file. The
+ * Disk cell's {@link Severity} (the §6.2 amber/red threshold) and the Saved
+ * cell's error severity are {@code bind(...)} to the model too. The checkpoint
+ * countdown's {@code nextCheckpointInstant} / {@code interval} are bound to the
+ * model and its {@code reduceMotion} to the {@code MotionManager} (story 279).</p>
+ *
+ * <h2>Priority overflow (§4.4, {@code javafx-application-design} §10)</h2>
+ *
+ * <p>At {@value SessionStatusStrip#TWO_ROW_MIN_WIDTH}&nbsp;px and wider the
+ * strip shows two full rows. Below that it collapses to a single row, hiding
+ * collapsible cells in the fixed priority order Workspace → Schema → Lock →
+ * Disk → Journal; the Session, Saved and Checkpoint cells never collapse. The
+ * hidden cells move into the trailing {@code ⋯} overflow popover. (Stage 1
+ * simplification: a collapsed cell is moved whole into the popover rather than
+ * rendered icon-only inline as §4.4's mockup ultimately envisions.)</p>
+ */
+public final class SessionStatusStripSkin extends SkinBase<SessionStatusStrip> {
+
+    // ── Collapse thresholds (px), in priority order. A collapsible cell is
+    //    hidden when the strip is narrower than its threshold. ───────────────
+    private static final double T_WORKSPACE = SessionStatusStrip.TWO_ROW_MIN_WIDTH; // 1200
+    private static final double T_SCHEMA = 1140.0;
+    private static final double T_LOCK = 1080.0;
+    private static final double T_DISK = 1020.0;
+    private static final double T_JOURNAL = 960.0;
+
+    /** Hover-popover show delay (§4.4 / §10). */
+    private static final javafx.util.Duration TOOLTIP_DELAY = javafx.util.Duration.millis(350);
+
+    private static final DateTimeFormatter CLOCK =
+            DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault());
+
+    private final ProjectOperationProgress model;
+
+    // ── Cells ─────────────────────────────────────────────────────────────
+    private final StatusStripCell sessionCell = new StatusStripCell();
+    private final StatusStripCell savedCell = new StatusStripCell();
+    private final CheckpointCountdownCanvas checkpointCountdown = new CheckpointCountdownCanvas();
+    private final StatusStripCell journalCell = new StatusStripCell();
+    private final StatusStripCell diskCell = new StatusStripCell();
+    private final StatusStripCell lockCell = new StatusStripCell();
+    private final StatusStripCell schemaCell = new StatusStripCell();
+    private final StatusStripCell workspaceCell = new StatusStripCell();
+
+    // ── Layout containers ───────────────────────────────────────────────────
+    private final HBox rowTop = new HBox();
+    private final HBox rowBottom = new HBox();
+    private final VBox rows = new VBox();
+
+    // ── Overflow ──────────────────────────────────────────────────────────
+    private final Button overflowButton = new Button("⋯"); // ⋯
+    private final VBox overflowContent = new VBox();
+    private final Popup overflowPopup = new Popup();
+
+    private final ChangeListener<Number> widthListener;
+
+    /**
+     * Builds the cells, binds them to the model, and installs the responsive
+     * layout listener.
+     *
+     * @param strip the owning {@link SessionStatusStrip}
+     */
+    public SessionStatusStripSkin(SessionStatusStrip strip) {
+        super(strip);
+        this.model = strip.progress();
+
+        rowTop.getStyleClass().add("status-strip-row");
+        rowBottom.getStyleClass().add("status-strip-row");
+        rows.getStyleClass().add("status-strip-rows");
+        overflowButton.getStyleClass().add("status-strip-overflow");
+        overflowButton.setFocusTraversable(false);
+        overflowContent.getStyleClass().add("status-strip-overflow-popover");
+        overflowPopup.getContent().add(overflowContent);
+        overflowPopup.setAutoHide(true);
+        overflowButton.setOnAction(_ -> toggleOverflowPopup());
+
+        bindCells();
+        installTooltips();
+
+        rows.getChildren().setAll(rowTop, rowBottom);
+        getChildren().add(rows);
+
+        widthListener = (_, _, w) -> reconcile(w.doubleValue());
+        strip.widthProperty().addListener(widthListener);
+        reconcile(strip.getWidth());
+    }
+
+    // ── Model → cell bindings (binding-only; no Label.setText) ───────────────
+
+    private void bindCells() {
+        sessionCell.textProperty().bind(Bindings.createStringBinding(
+                () -> {
+                    String name = model.getSessionName();
+                    if (name == null || name.isBlank()) {
+                        return "No session";
+                    }
+                    return "● " + name + " · " + formatElapsed(model.getSessionElapsed());
+                },
+                model.sessionNameProperty(), model.sessionElapsedProperty()));
+
+        savedCell.textProperty().bind(Bindings.createStringBinding(
+                () -> {
+                    // §4.5 — while a long operation runs (archive / restore /
+                    // slow save registered on the model's operations list), the
+                    // Saved cell shows its progress; on failure it shows the
+                    // persistent error; otherwise the last-save time + scope (the
+                    // flash for a fast save is itself the success signal).
+                    if (model.isSaving()) {
+                        var ops = model.getOperations();
+                        return "◐ " + (ops.isEmpty() ? "Working…" : ops.get(0).name());
+                    }
+                    if (!model.isLastSaveSucceeded()) {
+                        return "⚠ Save failed";
+                    }
+                    Instant t = model.getLastSaveTime();
+                    if (t == null) {
+                        return "Not saved yet";
+                    }
+                    String scope = model.getLastSaveScope() == SaveScope.DELTA ? "delta" : "full";
+                    return "✓ Saved " + CLOCK.format(t) + " (" + scope + ")";
+                },
+                model.savingProperty(), model.getOperations(),
+                model.lastSaveSucceededProperty(), model.lastSaveTimeProperty(),
+                model.lastSaveScopeProperty()));
+        savedCell.severityProperty().bind(Bindings.createObjectBinding(
+                () -> model.isLastSaveSucceeded() ? Severity.NORMAL : Severity.CRITICAL,
+                model.lastSaveSucceededProperty()));
+
+        journalCell.textProperty().bind(Bindings.createStringBinding(
+                () -> {
+                    int n = model.getJournalEventsQueued();
+                    return "Journal: " + n + (n == 1 ? " event queued" : " events queued");
+                },
+                model.journalEventsQueuedProperty()));
+
+        diskCell.textProperty().bind(Bindings.createStringBinding(
+                () -> {
+                    long bytes = model.getFreeDiskBytes();
+                    if (bytes < 0) {
+                        return "Disk: —";
+                    }
+                    double mins = model.getEstimatedRecordMinutes();
+                    if (mins < 0) {
+                        return "Disk: " + formatBytes(bytes);
+                    }
+                    return "Disk: " + formatBytes(bytes) + " · " + formatCaptureLeft(mins);
+                },
+                model.freeDiskBytesProperty(), model.estimatedRecordMinutesProperty()));
+        diskCell.severityProperty().bind(Bindings.createObjectBinding(
+                () -> severityForRecordMinutes(model.getEstimatedRecordMinutes()),
+                model.estimatedRecordMinutesProperty()));
+
+        lockCell.textProperty().bind(Bindings.createStringBinding(
+                () -> {
+                    String holder = model.getLockHolderLabel();
+                    if (holder == null || holder.isBlank()) {
+                        return "Lock: —";
+                    }
+                    return "Lock: " + holder + " · " + (model.isLockFresh() ? "live" : "stale");
+                },
+                model.lockHolderLabelProperty(), model.lockFreshProperty()));
+
+        schemaCell.textProperty().bind(Bindings.createStringBinding(
+                () -> {
+                    int cur = model.getCurrentSchemaVersion();
+                    if (cur < 0) {
+                        return "Schema: —";
+                    }
+                    int backup = model.getBackupSchemaVersion();
+                    String s = "Schema: v" + cur;
+                    if (backup >= 0) {
+                        s += " · backup v" + backup + " available";
+                    }
+                    return s;
+                },
+                model.currentSchemaVersionProperty(), model.backupSchemaVersionProperty()));
+
+        workspaceCell.textProperty().bind(Bindings.createStringBinding(
+                () -> {
+                    String ws = model.getWorkspaceName();
+                    if (ws == null || ws.isBlank()) {
+                        return "Workspace: —";
+                    }
+                    return "Workspace: " + ws;
+                },
+                model.workspaceNameProperty()));
+
+        // Checkpoint countdown — the model feeds both the next-fire instant and
+        // the interval (the bar denominator); MotionManager gates the animation
+        // (story 279).
+        checkpointCountdown.nextCheckpointInstantProperty().bind(model.nextCheckpointInstantProperty());
+        checkpointCountdown.intervalProperty().bind(model.checkpointIntervalProperty());
+        checkpointCountdown.reduceMotionProperty().bind(
+                getSkinnable().motionManager().reduceMotionProperty());
+    }
+
+    private void installTooltips() {
+        installTooltip(sessionCell);
+        installTooltip(savedCell);
+        installTooltip(journalCell);
+        installTooltip(diskCell);
+        installTooltip(lockCell);
+        installTooltip(schemaCell);
+        installTooltip(workspaceCell);
+    }
+
+    private static void installTooltip(StatusStripCell cell) {
+        Tooltip tip = new Tooltip();
+        tip.setShowDelay(TOOLTIP_DELAY);
+        tip.textProperty().bind(cell.textProperty());
+        Tooltip.install(cell, tip);
+    }
+
+    // ── Responsive layout / overflow (§4.4) ──────────────────────────────────
+
+    private void reconcile(double width) {
+        List<StatusStripCell> hidden = new ArrayList<>();
+        // Collapse order: Workspace first, Journal last (§4.4).
+        if (width < T_WORKSPACE) {
+            hidden.add(workspaceCell);
+        }
+        if (width < T_SCHEMA) {
+            hidden.add(schemaCell);
+        }
+        if (width < T_LOCK) {
+            hidden.add(lockCell);
+        }
+        if (width < T_DISK) {
+            hidden.add(diskCell);
+        }
+        if (width < T_JOURNAL) {
+            hidden.add(journalCell);
+        }
+
+        boolean twoRows = width >= SessionStatusStrip.TWO_ROW_MIN_WIDTH;
+        if (twoRows) {
+            // Wide: two full rows, every fact inline, no overflow.
+            rowTop.getChildren().setAll(sessionCell, savedCell, checkpointCountdown, journalCell);
+            rowBottom.getChildren().setAll(diskCell, lockCell, schemaCell, workspaceCell);
+            setRowBottomShown(true);
+            overflowContent.getChildren().clear();
+            setOverflowButtonShown(false);
+            if (overflowPopup.isShowing()) {
+                overflowPopup.hide();
+            }
+            return;
+        }
+
+        // Narrow: a single row of the never-collapse cells plus the still-visible
+        // collapsible cells in inline order, then the overflow button.
+        List<Node> single = new ArrayList<>();
+        single.add(sessionCell);
+        single.add(savedCell);
+        single.add(checkpointCountdown);
+        if (!hidden.contains(journalCell)) {
+            single.add(journalCell);
+        }
+        if (!hidden.contains(diskCell)) {
+            single.add(diskCell);
+        }
+        if (!hidden.contains(lockCell)) {
+            single.add(lockCell);
+        }
+        if (!hidden.contains(schemaCell)) {
+            single.add(schemaCell);
+        }
+        if (!hidden.contains(workspaceCell)) {
+            single.add(workspaceCell);
+        }
+        single.add(overflowButton);
+        rowTop.getChildren().setAll(single);
+        rowBottom.getChildren().clear();
+        setRowBottomShown(false);
+
+        // The popover holds exactly the hidden cells, in collapse order.
+        overflowContent.getChildren().setAll(hidden);
+        boolean any = !hidden.isEmpty();
+        setOverflowButtonShown(any);
+        if (!any && overflowPopup.isShowing()) {
+            overflowPopup.hide();
+        }
+    }
+
+    private void setRowBottomShown(boolean shown) {
+        rowBottom.setVisible(shown);
+        rowBottom.setManaged(shown);
+    }
+
+    private void setOverflowButtonShown(boolean shown) {
+        overflowButton.setVisible(shown);
+        overflowButton.setManaged(shown);
+    }
+
+    private void toggleOverflowPopup() {
+        if (overflowPopup.isShowing()) {
+            overflowPopup.hide();
+            return;
+        }
+        Bounds b = overflowButton.localToScreen(overflowButton.getBoundsInLocal());
+        if (b != null) {
+            overflowPopup.show(overflowButton, b.getMinX(), b.getMinY() - overflowContent.prefHeight(-1));
+        }
+    }
+
+    // ── Accessors for the control (delegated to from SessionStatusStrip) ─────
+
+    StatusStripCell sessionCell() { return sessionCell; }
+    StatusStripCell savedCell() { return savedCell; }
+    CheckpointCountdownCanvas checkpointCountdown() { return checkpointCountdown; }
+    StatusStripCell journalCell() { return journalCell; }
+    StatusStripCell diskCell() { return diskCell; }
+    StatusStripCell lockCell() { return lockCell; }
+    StatusStripCell schemaCell() { return schemaCell; }
+    StatusStripCell workspaceCell() { return workspaceCell; }
+    Button overflowButton() { return overflowButton; }
+
+    List<StatusStripCell> overflowCells() {
+        List<StatusStripCell> cells = new ArrayList<>();
+        for (Node n : overflowContent.getChildren()) {
+            if (n instanceof StatusStripCell cell) {
+                cells.add(cell);
+            }
+        }
+        return cells;
+    }
+
+    // ── Formatting helpers (pure, package-private) ───────────────────────────
+
+    /** Maps estimated record-minutes to a cell severity (§6.2: <30 amber, <5 red). */
+    static Severity severityForRecordMinutes(double minutes) {
+        if (minutes < 0) {
+            return Severity.NORMAL; // unknown
+        }
+        if (minutes < 5) {
+            return Severity.CRITICAL;
+        }
+        if (minutes < 30) {
+            return Severity.WARN;
+        }
+        return Severity.NORMAL;
+    }
+
+    /** Formats an elapsed session duration as {@code "Hh Mm"} / {@code "Mm"}. */
+    static String formatElapsed(java.time.Duration elapsed) {
+        if (elapsed == null || elapsed.isNegative()) {
+            return "0m";
+        }
+        long totalMinutes = elapsed.toMinutes();
+        long hours = totalMinutes / 60;
+        long minutes = totalMinutes % 60;
+        if (hours > 0) {
+            return hours + "h " + minutes + "m";
+        }
+        return minutes + "m";
+    }
+
+    /**
+     * Humanises a byte count: one decimal at terabyte scale ({@code "X.X TB"}),
+     * whole units below it ({@code "X GB"} / {@code "X MB"} / {@code "X KB"},
+     * matching the §4.4 mockup's "412 GB"). Returns {@code "—"} for a negative
+     * (unknown) count.
+     */
+    static String formatBytes(long bytes) {
+        if (bytes < 0) {
+            return "—";
+        }
+        double kb = bytes / 1024.0;
+        double mb = kb / 1024.0;
+        double gb = mb / 1024.0;
+        double tb = gb / 1024.0;
+        if (tb >= 1.0) {
+            return String.format(Locale.ROOT, "%.1f TB", tb);
+        }
+        if (gb >= 1.0) {
+            return String.format(Locale.ROOT, "%.0f GB", gb);
+        }
+        if (mb >= 1.0) {
+            return String.format(Locale.ROOT, "%.0f MB", mb);
+        }
+        return String.format(Locale.ROOT, "%.0f KB", kb);
+    }
+
+    /** Formats capture room as {@code "X h capture left"} / {@code "X min capture left"}. */
+    static String formatCaptureLeft(double minutes) {
+        if (minutes < 0) {
+            return "—";
+        }
+        if (minutes >= 60) {
+            return String.format(Locale.ROOT, "%.0f h capture left", minutes / 60.0);
+        }
+        return String.format(Locale.ROOT, "%.0f min capture left", minutes);
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────
+
+    @Override
+    public void dispose() {
+        getSkinnable().widthProperty().removeListener(widthListener);
+        if (overflowPopup.isShowing()) {
+            overflowPopup.hide();
+        }
+        sessionCell.textProperty().unbind();
+        savedCell.textProperty().unbind();
+        savedCell.severityProperty().unbind();
+        journalCell.textProperty().unbind();
+        diskCell.textProperty().unbind();
+        diskCell.severityProperty().unbind();
+        lockCell.textProperty().unbind();
+        schemaCell.textProperty().unbind();
+        workspaceCell.textProperty().unbind();
+        checkpointCountdown.nextCheckpointInstantProperty().unbind();
+        checkpointCountdown.intervalProperty().unbind();
+        checkpointCountdown.reduceMotionProperty().unbind();
+        super.dispose();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/StatusStripCell.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/StatusStripCell.java
@@ -1,0 +1,190 @@
+package com.benesquivelmusic.daw.app.ui.status;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.AccessibleRole;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+
+import java.util.Objects;
+
+/**
+ * Session Status Strip cell {@link Control} — one text fact in the §4.4
+ * status strip (e.g. {@code SR 48k}, {@code BUF 256}, {@code DISK OK}).
+ *
+ * <p>Story 295. Project Manager Design Book §4.4: the strip is a row of
+ * discrete facts and "each cell is itself a small {@code Control}
+ * ({@code StatusStripCell}) so themes can restyle it without touching the
+ * strip." Following the same {@code Control + SkinBase + package-resource
+ * user-agent stylesheet} convention as the Phase 2 controls
+ * ({@code MixerChannelStrip}, {@code Knob}, {@code Fader}, …) and the
+ * {@code javafx-application-design} skill §3 (Control/Skin split) and §8
+ * (themeable via a user-agent stylesheet plus stable style classes).
+ *
+ * <h2>Binding-only contract</h2>
+ *
+ * <p>The cell is a <strong>binding-only</strong> surface. The strip binds
+ * {@link #textProperty()} to its model and nothing ever calls
+ * {@code Label.setText} — the skin ({@link StatusStripCellSkin}) binds the
+ * inner label's text via {@code bind(...)}. The {@link #setText(String)}
+ * declaration below mutates the cell's own {@link StringProperty} (so the
+ * convenience constructor and direct callers still work) and is <em>not</em>
+ * a label mutation. This keeps the source free of any {@code Label.setText}
+ * call, which the story's conformance test source-scans for.
+ *
+ * <h2>Severity</h2>
+ *
+ * <p>{@link #severityProperty()} drives the §6.2 disk amber/red treatment by
+ * flipping <em>style classes on the control itself</em> (not pseudo-classes,
+ * and not via the skin) so the visual state is correct even in a headless,
+ * unrealized-skin test. {@link Severity#NORMAL} carries no extra class;
+ * {@link Severity#WARN} adds {@link #SEVERITY_WARN_CLASS}; and
+ * {@link Severity#CRITICAL} adds {@link #SEVERITY_CRITICAL_CLASS}. The
+ * matching {@code -fx-text-fill} rules live in {@code status-strip-cell.css}.
+ *
+ * @see StatusStripCellSkin
+ */
+public final class StatusStripCell extends Control {
+
+    /** Stable style class — selectable as {@code .status-strip-cell} in CSS. */
+    public static final String DEFAULT_STYLE_CLASS = "status-strip-cell";
+
+    /**
+     * Style class added when {@link #severityProperty()} is
+     * {@link Severity#WARN} (the §6.2 disk amber treatment). Public so the
+     * strip and the conformance tests can reference the exact name.
+     */
+    public static final String SEVERITY_WARN_CLASS = "status-cell-warn";
+
+    /**
+     * Style class added when {@link #severityProperty()} is
+     * {@link Severity#CRITICAL} (the §6.2 disk red treatment). Public so the
+     * strip and the conformance tests can reference the exact name.
+     */
+    public static final String SEVERITY_CRITICAL_CLASS = "status-cell-critical";
+
+    /**
+     * Cell severity. {@link #NORMAL} adds no extra class; {@link #WARN} adds
+     * {@link #SEVERITY_WARN_CLASS}; {@link #CRITICAL} adds
+     * {@link #SEVERITY_CRITICAL_CLASS}.
+     */
+    public enum Severity {
+        /** Default — no extra style class, text fill is {@code -ssc-text}. */
+        NORMAL,
+        /** Warning — adds {@link #SEVERITY_WARN_CLASS} ({@code -ssc-warn}). */
+        WARN,
+        /** Critical — adds {@link #SEVERITY_CRITICAL_CLASS} ({@code -ssc-critical}). */
+        CRITICAL
+    }
+
+    private final StringProperty text =
+            new SimpleStringProperty(this, "text", "");
+
+    /**
+     * Severity property whose {@code invalidated()} reconciles the
+     * severity style classes directly on this control (headless-safe — it
+     * does not rely on the skin) and whose {@code set(...)} coerces a
+     * {@code null} to {@link Severity#NORMAL}.
+     */
+    private final ObjectProperty<Severity> severity =
+            new SimpleObjectProperty<>(this, "severity", Severity.NORMAL) {
+                @Override
+                public void set(Severity newValue) {
+                    super.set(newValue == null ? Severity.NORMAL : newValue);
+                }
+
+                @Override
+                protected void invalidated() {
+                    // Remove both first (guards against duplicate adds), then
+                    // add at most one — mirrors MixerChannelStrip's invalidated()
+                    // pseudo-class flip, but with getStyleClass() add/remove so
+                    // the state is correct without a realized skin.
+                    getStyleClass().removeAll(SEVERITY_WARN_CLASS, SEVERITY_CRITICAL_CLASS);
+                    Severity s = get();
+                    if (s == Severity.WARN) {
+                        getStyleClass().add(SEVERITY_WARN_CLASS);
+                    } else if (s == Severity.CRITICAL) {
+                        getStyleClass().add(SEVERITY_CRITICAL_CLASS);
+                    }
+                }
+            };
+
+    /** Creates an empty cell ({@link Severity#NORMAL}, blank text). */
+    public StatusStripCell() {
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        setAccessibleRole(AccessibleRole.TEXT);
+        setFocusTraversable(false);
+    }
+
+    /**
+     * Creates a cell with initial text ({@link Severity#NORMAL}).
+     *
+     * @param text the initial fact text (a {@code null} becomes {@code ""}
+     *             via the underlying property's behaviour)
+     */
+    public StatusStripCell(String text) {
+        this();
+        this.text.set(text);
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new StatusStripCellSkin(this);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(
+                StatusStripCell.class.getResource("status-strip-cell.css"),
+                "status-strip-cell.css not on classpath").toExternalForm();
+    }
+
+    // ── text ──────────────────────────────────────────────────────────────
+
+    /** @return the fact-text property; bound by the skin's label via {@code bind(...)}. */
+    public final StringProperty textProperty() {
+        return text;
+    }
+
+    /** @return the fact text. */
+    public final String getText() {
+        return text.get();
+    }
+
+    /**
+     * Sets the cell's fact text. Mutates this control's own
+     * {@link StringProperty} (not a {@code Label}); the skin's label observes
+     * it via a one-way bind, so the binding-only contract holds.
+     *
+     * @param text the fact text
+     */
+    public final void setText(String text) {
+        this.text.set(text);
+    }
+
+    // ── severity ──────────────────────────────────────────────────────────
+
+    /**
+     * @return the severity property. Setting it (or invalidating it)
+     *         reconciles the {@link #SEVERITY_WARN_CLASS} /
+     *         {@link #SEVERITY_CRITICAL_CLASS} style classes on this control.
+     */
+    public final ObjectProperty<Severity> severityProperty() {
+        return severity;
+    }
+
+    /** @return the current severity (never {@code null}). */
+    public final Severity getSeverity() {
+        return severity.get();
+    }
+
+    /**
+     * @param severity the severity; a {@code null} is coerced to
+     *                 {@link Severity#NORMAL}
+     */
+    public final void setSeverity(Severity severity) {
+        this.severity.set(severity);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/StatusStripCellSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/status/StatusStripCellSkin.java
@@ -1,0 +1,48 @@
+package com.benesquivelmusic.daw.app.ui.status;
+
+import javafx.scene.control.Label;
+import javafx.scene.control.SkinBase;
+
+/**
+ * Skin for {@link StatusStripCell} — the visual half of the §4.4 status-cell
+ * Control/Skin split ({@code javafx-application-design} skill §3). Renders a
+ * single {@link Label} carrying the {@code .status-strip-cell-text} style
+ * class, laid out to fill by {@link SkinBase}'s default
+ * {@code layoutChildren} (no override needed for one child).
+ *
+ * <h2>Binding-only contract</h2>
+ *
+ * <p>The label's text is wired to the control via a one-way
+ * {@code bind(...)} — this skin <strong>never</strong> calls
+ * {@code Label.setText}. Story 295 forbids any {@code Label} text mutation in
+ * the cell sources so a theme or the strip can only ever drive the text
+ * through {@link StatusStripCell#textProperty()}. {@link #dispose()} unbinds
+ * the label before delegating to the superclass so the skin can be swapped
+ * (e.g. on a theme change) without leaking the binding.
+ */
+public final class StatusStripCellSkin extends SkinBase<StatusStripCell> {
+
+    private final Label label;
+
+    /**
+     * Builds the skin's single label child and binds its text to the
+     * control's text property.
+     *
+     * @param control the owning {@link StatusStripCell}
+     */
+    public StatusStripCellSkin(StatusStripCell control) {
+        super(control);
+        label = new Label();
+        label.getStyleClass().add("status-strip-cell-text");
+        // Binding-only: the label mirrors the control's text via bind(); no
+        // setText call appears in this file or in StatusStripCell.
+        label.textProperty().bind(getSkinnable().textProperty());
+        getChildren().add(label);
+    }
+
+    @Override
+    public void dispose() {
+        label.textProperty().unbind();
+        super.dispose();
+    }
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/main-view.fxml
@@ -167,7 +167,7 @@
 
     <!-- Bottom: Notification Bar + Status Bar -->
     <bottom>
-        <VBox>
+        <VBox fx:id="bottomBar">
             <Separator/>
             <HBox fx:id="notificationBarContainer"/>
             <!-- Story 274 — Status bar: one row of dot-separated cells, ZERO
@@ -175,10 +175,12 @@
                  from the 16 px gap, not drawn lines. The "· " separator is
                  part of each non-first cell's text because JavaFX CSS has no
                  :first-child (Skill §15). projectInfoLabel is the first cell →
-                 no leading dot. checkpointLabel/statusBarLabel are written
-                 from ~30 dynamic sites (Transport/ProjectLifecycle), so they
-                 are StatusCellLabel — the single seam that guarantees their
-                 leading "· " for every writer (idempotent). Padding stays a
+                 no leading dot. statusBarLabel is written from many dynamic
+                 sites (Transport/Metronome/…), so it is a StatusCellLabel — the
+                 single seam that guarantees its leading "· " for every writer
+                 (idempotent). (Story 295 retired the sibling checkpointLabel:
+                 last-save / checkpoint are now SessionStatusStrip cells.)
+                 Padding stays a
                  numeric <Insets 4/16/4/16> (= -spacing-xs/-lg, §5.11's 24 px
                  height) because JavaFX CSS has no looked-up numeric values;
                  TokenValidationTest + MainViewFxmlSpacingTest guard it. The
@@ -202,8 +204,11 @@
                 <Label fx:id="dskLabel" text="· DSK --"
                        styleClass="body, numeric-value"/>
                 <Region HBox.hgrow="ALWAYS"/>
-                <StatusCellLabel fx:id="checkpointLabel" text="· Auto-save: ON"
-                       styleClass="body"/>
+                <!-- Story 295 — the old checkpointLabel ("Auto-save: ON" /
+                     "Saved (checkpoint #N)") was retired here: the last-save and
+                     next-checkpoint facts are now first-class cells of the
+                     SessionStatusStrip (mounted into this VBox by MainController),
+                     bound to ProjectOperationProgress. -->
                 <!-- Ripple-mode red banner (visible only when ripple is active) -->
                 <Label fx:id="rippleBannerLabel" text="" styleClass="ripple-banner"
                        visible="false" managed="false"/>

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/status/checkpoint-countdown.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/status/checkpoint-countdown.css
@@ -1,0 +1,5 @@
+/* Story 295 — checkpoint countdown cell. Colours are drawn in Java from the
+   -ccd-* StyleableObjectProperty tokens (forwarded by styles.css). */
+.checkpoint-countdown {
+    -fx-padding: 0;
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/status/status-strip-cell.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/status/status-strip-cell.css
@@ -1,0 +1,17 @@
+/* Story 295 — Session Status Strip cell. Consumes -ssc-* tokens forwarded by
+   styles.css (author origin); never references raw role tokens here
+   (feedback_control_css_role_token_forwarding). */
+.status-strip-cell {
+    -fx-padding: 0 0 0 0;
+}
+.status-strip-cell .status-strip-cell-text {
+    -fx-text-fill: -ssc-text;
+    -fx-font-size: 12px;
+    -fx-font-weight: 500;
+}
+.status-strip-cell.status-cell-warn .status-strip-cell-text {
+    -fx-text-fill: -ssc-warn;
+}
+.status-strip-cell.status-cell-critical .status-strip-cell-text {
+    -fx-text-fill: -ssc-critical;
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -1047,6 +1047,64 @@
     -fx-font-weight: 500;
 }
 
+/* ── Session Status Strip (story 295, Project Manager Design Book §4.4) ──
+ * A persistent two-row strip that surfaces the §2.2 invisible signals
+ * (save / checkpoint / journal / lock / disk / session / schema /
+ * workspace), bound to the single ProjectOperationProgress model. The strip
+ * itself is app chrome styled here (author origin), matching .status-bar
+ * above. The per-cell colour tokens are FORWARDED to the cells' user-agent
+ * stylesheets via local -ssc-* / -ccd-* names so those UA sheets never
+ * reference raw role tokens
+ * (feedback_control_css_role_token_forwarding). */
+.session-status-strip {
+    -fx-background-color: -surface-1;
+    -fx-border-color: -line-soft transparent transparent transparent;
+    -fx-border-width: 1 0 0 0;
+}
+.session-status-strip .status-strip-rows {
+    -fx-spacing: 2;
+    -fx-padding: 4 16 4 16;
+}
+.session-status-strip .status-strip-row {
+    -fx-spacing: 16;
+    -fx-alignment: CENTER_LEFT;
+}
+
+/* Forward role tokens onto the status-strip cells as local -ssc-* names so
+ * status-strip-cell.css (USER_AGENT origin) consumes them without a raw
+ * role-token reference or a circular looked-up-colour drop. */
+.status-strip-cell {
+    -ssc-text: -text;
+    -ssc-warn: -warn;
+    -ssc-critical: -danger;
+}
+
+/* Forward role tokens onto the checkpoint-countdown canvas; its Java draw
+ * code reads the resolved -ccd-* StyleableObjectProperty values. */
+.checkpoint-countdown {
+    -ccd-text: -text;
+    -ccd-track: -surface-3;
+    -ccd-fill: -accent;
+}
+
+/* Trailing "⋯" overflow button + its popover of collapsed cells (§4.4). */
+.session-status-strip .status-strip-overflow {
+    -fx-background-color: transparent;
+    -fx-text-fill: -text-mute;
+    -fx-padding: 0 4 0 4;
+}
+.session-status-strip .status-strip-overflow:hover {
+    -fx-text-fill: -text;
+}
+.status-strip-overflow-popover {
+    -fx-background-color: -surface-2;
+    -fx-border-color: -line-soft;
+    -fx-border-width: 1;
+    -fx-spacing: 4;
+    -fx-padding: 8;
+    -fx-effect: -elevation-2;
+}
+
 /* ── Separator ── */
 .separator > .line {
     -fx-border-color: -line-soft;

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/CheckpointCountdownReducedMotionTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/CheckpointCountdownReducedMotionTest.java
@@ -1,0 +1,176 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.status.CheckpointCountdownCanvas;
+
+import javafx.scene.Group;
+import javafx.scene.Scene;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Story 295 — the §6 checkpoint countdown cell ({@link CheckpointCountdownCanvas})
+ * under Reduce Motion (story 279) and its pure, toolkit-free text/geometry
+ * transforms.
+ *
+ * <p>The cell's caption and progress-bar fraction are computed by pure static
+ * methods that need no FX thread, so those are asserted directly. The
+ * {@code AnimationTimer} lifecycle is scene-gated: it runs <em>iff</em> the cell
+ * is attached to a {@link Scene} and Reduce Motion is off
+ * ({@code javafx-application-design} §6 "a control owns its own timer"; §11 "all
+ * draws on the FX thread"). Attaching the canvas to a {@code Scene} is what arms
+ * the timer; Reduce Motion gates it back off so a reduce-motion cell never spins
+ * a frame loop and instead repaints static text only on change.</p>
+ *
+ * <p>Assertions that run inside a {@code Platform.runLater} body are swallowed by
+ * JavaFX, so every FX-thread assertion goes through {@link #runOnFx(Runnable)},
+ * which captures and rethrows the failure on the test thread.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class CheckpointCountdownReducedMotionTest {
+
+    // ── (a) Pure transforms — no FX thread required ───────────────────────────
+
+    @Test
+    void formatRemainingProducesMinuteSecondAndHourForms() {
+        assertThat(CheckpointCountdownCanvas.formatRemaining(Duration.ofSeconds(37)))
+                .as("37s formats as M:SS")
+                .isEqualTo("0:37");
+        assertThat(CheckpointCountdownCanvas.formatRemaining(Duration.ofSeconds(125)))
+                .as("125s = 2m05s formats as M:SS")
+                .isEqualTo("2:05");
+        assertThat(CheckpointCountdownCanvas.formatRemaining(Duration.ZERO))
+                .as("zero clamps to 0:00")
+                .isEqualTo("0:00");
+        assertThat(CheckpointCountdownCanvas.formatRemaining(Duration.ofSeconds(-5)))
+                .as("a negative duration clamps to 0:00")
+                .isEqualTo("0:00");
+        assertThat(CheckpointCountdownCanvas.formatRemaining(Duration.ofSeconds(3725)))
+                .as("3725s = 1h02m05s switches to the H:MM:SS form")
+                .isEqualTo("1:02:05");
+    }
+
+    @Test
+    void countdownTextDescribesScheduledAndUnscheduledStates() {
+        assertThat(CheckpointCountdownCanvas.countdownText(null))
+                .as("a null remaining means no checkpoint is scheduled")
+                .isEqualTo("No checkpoint scheduled");
+        assertThat(CheckpointCountdownCanvas.countdownText(Duration.ofSeconds(37)))
+                .as("a scheduled checkpoint reads 'Next checkpoint in M:SS'")
+                .isEqualTo("Next checkpoint in 0:37");
+    }
+
+    @Test
+    void barFractionIsRemainingFractionClampedToUnitInterval() {
+        Instant now = Instant.now();
+        Instant next = now.plusSeconds(30);
+        assertThat(CheckpointCountdownCanvas.barFraction(now, next, Duration.ofSeconds(60)))
+                .as("30s remaining of a 60s interval is roughly half the bar")
+                .isCloseTo(0.5, within(0.05));
+        assertThat(CheckpointCountdownCanvas.barFraction(now, now, Duration.ofSeconds(60)))
+                .as("no time remaining means an empty bar")
+                .isCloseTo(0.0, within(0.05));
+    }
+
+    @Test
+    void shouldRedrawFiresOnFirstTickThenThrottlesToOneHzWithoutOverflow() {
+        // Positive frame timestamps, as AnimationTimer's System.nanoTime()-based
+        // `now` is on Windows. The first tick after a (re)start carries the
+        // Long.MIN_VALUE sentinel; it MUST redraw. A bare
+        // `now - Long.MIN_VALUE >= ONE_SECOND_NANOS` overflows to a negative
+        // delta here and would never fire — this is the regression guard.
+        long firstNow = 5_000_000_000L;
+        assertThat(CheckpointCountdownCanvas.shouldRedraw(Long.MIN_VALUE, firstNow))
+                .as("the first tick after a (re)start always redraws despite the "
+                        + "Long.MIN_VALUE sentinel (now - Long.MIN_VALUE overflow regression)")
+                .isTrue();
+
+        // Once a real timestamp is recorded, the loop throttles to 1 Hz.
+        assertThat(CheckpointCountdownCanvas.shouldRedraw(firstNow, firstNow + 500_000_000L))
+                .as("a sub-second tick (0.5 s after the last redraw) is throttled")
+                .isFalse();
+        assertThat(CheckpointCountdownCanvas.shouldRedraw(firstNow, firstNow + 1_000_000_000L))
+                .as("a tick exactly 1 s after the last redraw fires")
+                .isTrue();
+        assertThat(CheckpointCountdownCanvas.shouldRedraw(firstNow, firstNow + 2_500_000_000L))
+                .as("a tick well past 1 s fires")
+                .isTrue();
+    }
+
+    // ── (b) Reduce Motion ON → no timer (static text) ─────────────────────────
+
+    @Test
+    void reduceMotionOnLeavesTimerStoppedEvenWhenAttachedToScene() throws Exception {
+        boolean[] running = new boolean[1];
+        int[] starts = new int[1];
+        runOnFx(() -> {
+            CheckpointCountdownCanvas canvas = new CheckpointCountdownCanvas();
+            canvas.setReduceMotion(true);
+            // Attaching to a Scene normally arms the scene-gated timer; Reduce
+            // Motion must gate it back off.
+            new Scene(new Group(canvas));
+            running[0] = canvas.isCountdownTimerRunning();
+            starts[0] = canvas.timerStartCount();
+        });
+        assertThat(running[0])
+                .as("with Reduce Motion on, no AnimationTimer runs even when the "
+                        + "cell is attached to a Scene (story 279 — static text only)")
+                .isFalse();
+        assertThat(starts[0])
+                .as("the timer was never started under Reduce Motion")
+                .isZero();
+    }
+
+    // ── (c) Reduce Motion OFF → timer started exactly once ────────────────────
+
+    @Test
+    void reduceMotionOffStartsTheTimerOnceWhenAttachedToScene() throws Exception {
+        boolean[] running = new boolean[1];
+        int[] starts = new int[1];
+        runOnFx(() -> {
+            CheckpointCountdownCanvas canvas = new CheckpointCountdownCanvas();
+            canvas.setReduceMotion(false);
+            // Attaching to a Scene arms the scene-gated 1 Hz redraw timer.
+            new Scene(new Group(canvas));
+            running[0] = canvas.isCountdownTimerRunning();
+            starts[0] = canvas.timerStartCount();
+        });
+        assertThat(running[0])
+                .as("with Reduce Motion off and the cell attached to a Scene, the "
+                        + "1 Hz countdown timer runs")
+                .isTrue();
+        assertThat(starts[0])
+                .as("the scene-gated timer started exactly once")
+                .isEqualTo(1);
+    }
+
+    // ── FX-thread helper (captures + rethrows swallowed assertion failures) ────
+
+    private static void runOnFx(Runnable action) throws Exception {
+        java.util.concurrent.atomic.AtomicReference<Throwable> error =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.CountDownLatch latch =
+                new java.util.concurrent.CountDownLatch(1);
+        javafx.application.Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
+            throw new RuntimeException("FX action timed out");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DiskCellThresholdTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DiskCellThresholdTest.java
@@ -1,0 +1,109 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress;
+import com.benesquivelmusic.daw.app.ui.status.SessionStatusStrip;
+import com.benesquivelmusic.daw.app.ui.status.StatusStripCell;
+
+import javafx.scene.Group;
+import javafx.scene.Scene;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 295 — the Disk cell's §6.2 capture-room thresholds drive its severity
+ * style class: amber ({@link StatusStripCell#SEVERITY_WARN_CLASS}) under 30
+ * record-minutes, red ({@link StatusStripCell#SEVERITY_CRITICAL_CLASS}) under 5.
+ *
+ * <p>The cell flips those classes on its own {@code getStyleClass()} when its
+ * severity changes (headless-safe — independent of a realized skin), and the
+ * skin binds the disk cell's severity to {@code estimatedRecordMinutes}.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class DiskCellThresholdTest {
+
+    /**
+     * Feeds three capture-room estimates through the model and asserts the disk
+     * cell's severity style classes flip across the §6.2 amber/red thresholds.
+     */
+    @Test
+    void diskCellSeverityClassFlipsAcrossThresholds() throws Exception {
+        FxDispatcher dispatcher = new FxDispatcher();
+        ProjectOperationProgress progress = new ProjectOperationProgress(dispatcher);
+
+        AtomicReference<SessionStatusStrip> stripRef = new AtomicReference<>();
+        runOnFx(() -> stripRef.set(realizedStrip(progress)));
+        SessionStatusStrip strip = stripRef.get();
+
+        runOnFx(() -> {
+            // 29 record-minutes → amber (WARN), not red.
+            progress.setDisk(100L * 1024 * 1024 * 1024, 29.0);
+            dispatcher.pulse();
+            assertThat(strip.diskCell().getStyleClass())
+                    .as("29 record-minutes (< 30) flips the disk cell to the amber WARN class")
+                    .contains(StatusStripCell.SEVERITY_WARN_CLASS)
+                    .doesNotContain(StatusStripCell.SEVERITY_CRITICAL_CLASS);
+
+            // 4 record-minutes → red (CRITICAL), not amber.
+            progress.setDisk(5L * 1024 * 1024 * 1024, 4.0);
+            dispatcher.pulse();
+            assertThat(strip.diskCell().getStyleClass())
+                    .as("4 record-minutes (< 5) flips the disk cell to the red CRITICAL class")
+                    .contains(StatusStripCell.SEVERITY_CRITICAL_CLASS)
+                    .doesNotContain(StatusStripCell.SEVERITY_WARN_CLASS);
+
+            // 120 record-minutes → healthy (NORMAL): neither severity class present.
+            progress.setDisk(500L * 1024 * 1024 * 1024, 120.0);
+            dispatcher.pulse();
+            assertThat(strip.diskCell().getStyleClass())
+                    .as("120 record-minutes (>= 30) carries neither severity class")
+                    .doesNotContain(
+                            StatusStripCell.SEVERITY_WARN_CLASS,
+                            StatusStripCell.SEVERITY_CRITICAL_CLASS);
+        });
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link SessionStatusStrip} over {@code progress} and realizes its
+     * skin headlessly so the disk cell is created and its severity bound. Must
+     * run on the FX thread.
+     */
+    private static SessionStatusStrip realizedStrip(ProjectOperationProgress progress) {
+        SessionStatusStrip strip = new SessionStatusStrip(progress, MotionManager.getDefault());
+        Group root = new Group(strip);
+        new Scene(root, 1400, 80);
+        strip.applyCss();
+        strip.layout();
+        return strip;
+    }
+
+    private static void runOnFx(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        javafx.application.Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DiskScanOffFxThreadTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DiskScanOffFxThreadTest.java
@@ -1,0 +1,135 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress;
+import com.benesquivelmusic.daw.app.ui.status.SessionStatusDiskScanner;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Story 295 — the §1.8 disk-space scan ({@link SessionStatusDiskScanner}) reads
+ * the file store off the FX thread on a background <strong>virtual</strong> thread
+ * ({@code javafx-application-design} §11 "the FX thread is sacred — marshal
+ * deliberately"; story 205 virtual threads) and publishes its result back through
+ * the story-289 {@link FxDispatcher} keyed seam, never by writing the model
+ * property directly off-thread.
+ *
+ * <p>The scanner reads its {@code projectDirectory} and {@code audioFormat}
+ * suppliers <em>on the scan thread</em>, so the test captures {@code
+ * Thread.currentThread()} inside the directory supplier and asserts the captured
+ * thread is a virtual thread that is not the FX Application Thread. Per the
+ * project's headless-test discipline, FX-thread identity is asserted by comparing
+ * captured {@link Thread} objects on the test thread — never by calling
+ * {@code Platform.isFxApplicationThread()} from inside a background/swallowed
+ * runnable.</p>
+ *
+ * <p>The publish is then verified to have landed: the model's disk facts only
+ * become visible after a {@link FxDispatcher#pulse()} drains the keyed work on the
+ * FX thread (the scanner enqueues via {@code progress.setDisk(...)}, which routes
+ * through the dispatcher).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class DiskScanOffFxThreadTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void scanRunsOnAVirtualNonFxThreadAndPublishesThroughTheDispatcher() throws Exception {
+        FxDispatcher dispatcher = new FxDispatcher();
+        ProjectOperationProgress progress = new ProjectOperationProgress(dispatcher);
+
+        // Capture the FX Application Thread separately so we can prove the scan
+        // ran elsewhere (comparing Thread objects on the test thread, not asserting
+        // FX-thread identity from inside a swallowed runnable).
+        AtomicReference<Thread> fxThread = new AtomicReference<>();
+        runOnFx(() -> fxThread.set(Thread.currentThread()));
+        assertThat(fxThread.get())
+                .as("the FX Application Thread must have been captured")
+                .isNotNull();
+
+        // The scanner reads projectDirectory.get() ON the scan thread — capture it.
+        AtomicReference<Thread> scanThread = new AtomicReference<>();
+        SessionStatusDiskScanner scanner = new SessionStatusDiskScanner(
+                progress,
+                () -> {
+                    scanThread.set(Thread.currentThread());
+                    return tempDir;
+                },
+                () -> AudioFormat.CD_QUALITY);
+
+        Thread t = scanner.scanNow();
+        t.join(5000);
+
+        assertThat(scanThread.get())
+                .as("the scan must have run (the directory supplier was invoked)")
+                .isNotNull();
+        assertThat(scanThread.get().isVirtual())
+                .as("the disk scan runs on a background virtual thread (story 205)")
+                .isTrue();
+        assertThat(scanThread.get())
+                .as("the disk scan must NOT run on the FX Application Thread "
+                        + "(javafx-application-design §11)")
+                .isNotSameAs(fxThread.get());
+
+        // The publish routes through the dispatcher's keyed work, which only
+        // applies on a pulse() drained on the FX thread.
+        runOnFx(dispatcher::pulse);
+
+        assertThat(progress.getFreeDiskBytes())
+                .as("tempDir is on a real file store, so usable bytes are non-negative")
+                .isGreaterThanOrEqualTo(0L);
+        assertThat(progress.getEstimatedRecordMinutes())
+                .as("a non-negative free-space figure yields a positive capture estimate")
+                .isGreaterThan(0.0);
+    }
+
+    @Test
+    void estimatedRecordMinutesMatchesUncompressedByteRateAndHonoursUnknown() {
+        // CD quality: 44100 Hz * 2 channels * 2 bytes/sample (16-bit) per second.
+        long freeBytes = 10L * 1024 * 1024 * 1024; // 10 GiB
+        double expected = freeBytes / (44_100.0 * 2 * 2 * 60.0);
+        assertThat(SessionStatusDiskScanner.estimatedRecordMinutes(
+                        freeBytes, AudioFormat.CD_QUALITY))
+                .as("estimate = freeBytes / (sampleRate * channels * bytesPerSample * 60)")
+                .isCloseTo(expected, within(1e-6));
+
+        assertThat(SessionStatusDiskScanner.estimatedRecordMinutes(
+                        -1L, AudioFormat.CD_QUALITY))
+                .as("a negative (unknown) free-byte count yields UNKNOWN_MINUTES")
+                .isEqualTo(ProjectOperationProgress.UNKNOWN_MINUTES);
+    }
+
+    // ── FX-thread helper (captures + rethrows swallowed assertion failures) ────
+
+    private static void runOnFx(Runnable action) throws Exception {
+        java.util.concurrent.atomic.AtomicReference<Throwable> error =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.CountDownLatch latch =
+                new java.util.concurrent.CountDownLatch(1);
+        javafx.application.Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
+            throw new RuntimeException("FX action timed out");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleControllerTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleControllerTest.java
@@ -42,7 +42,7 @@ class ProjectLifecycleControllerTest {
             assertThatNullPointerException()
                 .isThrownBy(() -> new ProjectLifecycleController(
                         null, dummySessionInterchange(), dummyNotificationBar(),
-                        dummyLabel(), dummyLabel(), dummyBorderPane(),
+                        dummyProgress(),dummyBorderPane(),
                         dummyVBox(), dummyDeps(), dummyArchiver()))
                 .withMessageContaining("projectManager"));
     }
@@ -53,7 +53,7 @@ class ProjectLifecycleControllerTest {
             assertThatNullPointerException()
                 .isThrownBy(() -> new ProjectLifecycleController(
                         dummyProjectManager(), null, dummyNotificationBar(),
-                        dummyLabel(), dummyLabel(), dummyBorderPane(),
+                        dummyProgress(),dummyBorderPane(),
                         dummyVBox(), dummyDeps(), dummyArchiver()))
                 .withMessageContaining("sessionInterchangeController"));
     }
@@ -64,31 +64,20 @@ class ProjectLifecycleControllerTest {
             assertThatNullPointerException()
                 .isThrownBy(() -> new ProjectLifecycleController(
                         dummyProjectManager(), dummySessionInterchange(), null,
-                        dummyLabel(), dummyLabel(), dummyBorderPane(),
+                        dummyProgress(),dummyBorderPane(),
                         dummyVBox(), dummyDeps(), dummyArchiver()))
                 .withMessageContaining("notificationBar"));
     }
 
     @Test
-    void constructorRejectsNullStatusBarLabel() throws Exception {
+    void constructorRejectsNullProgress() throws Exception {
         runOnFxThread(() ->
             assertThatNullPointerException()
                 .isThrownBy(() -> new ProjectLifecycleController(
                         dummyProjectManager(), dummySessionInterchange(), dummyNotificationBar(),
-                        null, dummyLabel(), dummyBorderPane(),
+                        null, dummyBorderPane(),
                         dummyVBox(), dummyDeps(), dummyArchiver()))
-                .withMessageContaining("statusBarLabel"));
-    }
-
-    @Test
-    void constructorRejectsNullCheckpointLabel() throws Exception {
-        runOnFxThread(() ->
-            assertThatNullPointerException()
-                .isThrownBy(() -> new ProjectLifecycleController(
-                        dummyProjectManager(), dummySessionInterchange(), dummyNotificationBar(),
-                        dummyLabel(), null, dummyBorderPane(),
-                        dummyVBox(), dummyDeps(), dummyArchiver()))
-                .withMessageContaining("checkpointLabel"));
+                .withMessageContaining("progress"));
     }
 
     @Test
@@ -97,7 +86,7 @@ class ProjectLifecycleControllerTest {
             assertThatNullPointerException()
                 .isThrownBy(() -> new ProjectLifecycleController(
                         dummyProjectManager(), dummySessionInterchange(), dummyNotificationBar(),
-                        dummyLabel(), dummyLabel(), null,
+                        dummyProgress(),null,
                         dummyVBox(), dummyDeps(), dummyArchiver()))
                 .withMessageContaining("rootPane"));
     }
@@ -108,7 +97,7 @@ class ProjectLifecycleControllerTest {
             assertThatNullPointerException()
                 .isThrownBy(() -> new ProjectLifecycleController(
                         dummyProjectManager(), dummySessionInterchange(), dummyNotificationBar(),
-                        dummyLabel(), dummyLabel(), dummyBorderPane(),
+                        dummyProgress(),dummyBorderPane(),
                         null, dummyDeps(), dummyArchiver()))
                 .withMessageContaining("trackListPanel"));
     }
@@ -119,7 +108,7 @@ class ProjectLifecycleControllerTest {
             assertThatNullPointerException()
                 .isThrownBy(() -> new ProjectLifecycleController(
                         dummyProjectManager(), dummySessionInterchange(), dummyNotificationBar(),
-                        dummyLabel(), dummyLabel(), dummyBorderPane(),
+                        dummyProgress(),dummyBorderPane(),
                         dummyVBox(), null, dummyArchiver()))
                 .withMessageContaining("deps"));
     }
@@ -130,7 +119,7 @@ class ProjectLifecycleControllerTest {
             assertThatNullPointerException()
                 .isThrownBy(() -> new ProjectLifecycleController(
                         dummyProjectManager(), dummySessionInterchange(), dummyNotificationBar(),
-                        dummyLabel(), dummyLabel(), dummyBorderPane(),
+                        dummyProgress(),dummyBorderPane(),
                         dummyVBox(), dummyDeps(), null))
                 .withMessageContaining("projectArchiver"));
     }
@@ -147,7 +136,7 @@ class ProjectLifecycleControllerTest {
         AtomicReference<ProjectLifecycleController> ref = new AtomicReference<>();
         runOnFxThread(() -> ref.set(new ProjectLifecycleController(
                 pm, dummySessionInterchange(), dummyNotificationBar(),
-                dummyLabel(), dummyLabel(), dummyBorderPane(),
+                dummyProgress(),dummyBorderPane(),
                 dummyVBox(), dummyDeps(), dummyArchiver())));
 
         ref.get().resetProjectState();
@@ -162,7 +151,7 @@ class ProjectLifecycleControllerTest {
         AtomicReference<ProjectLifecycleController> ref = new AtomicReference<>();
         runOnFxThread(() -> ref.set(new ProjectLifecycleController(
                 pm, dummySessionInterchange(), dummyNotificationBar(),
-                dummyLabel(), dummyLabel(), dummyBorderPane(),
+                dummyProgress(),dummyBorderPane(),
                 dummyVBox(), dummyDeps(), dummyArchiver())));
 
         ref.get().resetProjectState();
@@ -204,7 +193,7 @@ class ProjectLifecycleControllerTest {
         runOnFxThread(() -> {
             ref.set(new ProjectLifecycleController(
                     pm, dummySessionInterchange(), dummyNotificationBar(),
-                    dummyLabel(), dummyLabel(), dummyBorderPane(),
+                    dummyProgress(),dummyBorderPane(),
                     dummyVBox(), dummyDeps(), dummyArchiver()));
             loaded.set(ref.get().loadProjectFromPath(metadata.projectPath()));
         });
@@ -245,7 +234,7 @@ class ProjectLifecycleControllerTest {
         AtomicReference<ProjectLifecycleController> ref = new AtomicReference<>();
         runOnFxThread(() -> ref.set(new ProjectLifecycleController(
                 pm, dummySessionInterchange(), dummyNotificationBar(),
-                dummyLabel(), dummyLabel(), dummyBorderPane(),
+                dummyProgress(),dummyBorderPane(),
                 dummyVBox(), dummyDeps(), dummyArchiver())));
 
         // Confirm a .bak exists pre-rollback.
@@ -285,7 +274,7 @@ class ProjectLifecycleControllerTest {
         AtomicReference<ProjectLifecycleController> ref = new AtomicReference<>();
         runOnFxThread(() -> ref.set(new ProjectLifecycleController(
                 pm, dummySessionInterchange(), dummyNotificationBar(),
-                dummyLabel(), dummyLabel(), dummyBorderPane(),
+                dummyProgress(),dummyBorderPane(),
                 dummyVBox(), dummyDeps(), dummyArchiver())));
 
         runOnFxThread(() -> ref.get().rollbackMigration(metadata.projectPath(), report));
@@ -355,8 +344,9 @@ class ProjectLifecycleControllerTest {
         return new NotificationBar();
     }
 
-    private static javafx.scene.control.Label dummyLabel() {
-        return new javafx.scene.control.Label();
+    private static com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress dummyProgress() {
+        return new com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress(
+                new com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher());
     }
 
     private static javafx.scene.layout.BorderPane dummyBorderPane() {

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectOperationProgressBindingTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectOperationProgressBindingTest.java
@@ -1,0 +1,139 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress;
+import com.benesquivelmusic.daw.app.ui.status.SessionStatusStrip;
+
+import javafx.scene.Group;
+import javafx.scene.Scene;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 295 — binding contract between {@link ProjectOperationProgress} (the
+ * single §5.5 status model) and the {@link SessionStatusStrip}'s bound cells,
+ * marshalled through the story-289 {@link FxDispatcher}.
+ *
+ * <p>Verifies the two §2.1 / §6 "coalesce per frame" guarantees the strip relies
+ * on: (a) an off-FX-thread mutation is reflected on the bound cell only after a
+ * {@link FxDispatcher#pulse() pulse}, and (b) N rapid same-key mutations within
+ * one frame collapse to a single observable update (latest-wins).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ProjectOperationProgressBindingTest {
+
+    /**
+     * A mutation published to the model off-pulse becomes visible on the bound
+     * cell text only after {@link FxDispatcher#pulse()} drains the keyed work.
+     */
+    @Test
+    void offThreadMutationReflectedOnBoundCellAfterPulse() throws Exception {
+        // The setters are thread-safe (FxDispatcher.onFx may be called from any
+        // thread), so publish from the test thread before hopping onto FX.
+        FxDispatcher dispatcher = new FxDispatcher();
+        ProjectOperationProgress progress = new ProjectOperationProgress(dispatcher);
+
+        AtomicReference<SessionStatusStrip> stripRef = new AtomicReference<>();
+        runOnFx(() -> stripRef.set(realizedStrip(progress)));
+        SessionStatusStrip strip = stripRef.get();
+
+        // Publish off the FX thread (the disk scan / save path's real situation).
+        progress.setJournalEventsQueued(4);
+        progress.setWorkspaceName("Studio");
+
+        runOnFx(() -> {
+            // Before the pulse the keyed work is still queued; draining it on the
+            // FX thread is what flips the bound properties (and hence the cells).
+            dispatcher.pulse();
+
+            assertThat(strip.journalCell().getText())
+                    .as("journal cell binds \"Journal: <n> events queued\" after pulse")
+                    .contains("4");
+            assertThat(strip.workspaceCell().getText())
+                    .as("workspace cell binds the workspace name after pulse")
+                    .contains("Studio");
+        });
+    }
+
+    /**
+     * Three rapid same-key mutations with no intervening pulse collapse to a
+     * single observable update on the next pulse, and the latest value wins.
+     */
+    @Test
+    void rapidSameKeyMutationsCoalesceToSingleUpdate() throws Exception {
+        FxDispatcher dispatcher = new FxDispatcher();
+        ProjectOperationProgress progress = new ProjectOperationProgress(dispatcher);
+
+        // Everything inside one FX block so ordering is deterministic:
+        // add listener -> 3 same-key sets (no pulse between) -> single pulse -> assert.
+        runOnFx(() -> {
+            AtomicInteger fireCount = new AtomicInteger(0);
+            progress.journalEventsQueuedProperty()
+                    .addListener(observable -> fireCount.incrementAndGet());
+
+            progress.setJournalEventsQueued(1);
+            progress.setJournalEventsQueued(2);
+            progress.setJournalEventsQueued(3);
+
+            // Not yet drained: the keyed work coalesces to the latest runnable, and
+            // the property has not changed, so the listener has not fired.
+            assertThat(fireCount.get())
+                    .as("no observable update before the pulse drains the keyed work")
+                    .isZero();
+
+            dispatcher.pulse();
+
+            assertThat(fireCount.get())
+                    .as("three rapid same-key mutations coalesce to exactly one update")
+                    .isEqualTo(1);
+            assertThat(progress.getJournalEventsQueued())
+                    .as("latest-wins coalescing keeps the last published value")
+                    .isEqualTo(3);
+        });
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link SessionStatusStrip} over {@code progress} and realizes its
+     * skin headlessly (Group + Scene + applyCss) so the cell accessors return
+     * live, bound cells. Must run on the FX thread.
+     */
+    private static SessionStatusStrip realizedStrip(ProjectOperationProgress progress) {
+        SessionStatusStrip strip = new SessionStatusStrip(progress, MotionManager.getDefault());
+        Group root = new Group(strip);
+        new Scene(root, 1400, 80);
+        strip.applyCss(); // realizes the skin (creates + binds the cells)
+        strip.layout();
+        return strip;
+    }
+
+    private static void runOnFx(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        javafx.application.Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectSurfaceWiringTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectSurfaceWiringTest.java
@@ -94,7 +94,8 @@ class ProjectSurfaceWiringTest {
             // Build the lifecycle surface wired to this project, then Save.
             ProjectLifecycleController controller = callOnFx(() -> new ProjectLifecycleController(
                     pm, new SessionInterchangeController(), new NotificationBar(),
-                    new Label(), new Label(), new BorderPane(), new VBox(),
+                    new com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress(new FxDispatcher()),
+                    new BorderPane(), new VBox(),
                     depsFor(project), new ProjectArchiver()));
             callOnFx(() -> {
                 controller.onSaveProject();

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarFxmlTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarFxmlTest.java
@@ -48,7 +48,7 @@ final class StatusBarFxmlTest {
      * {@link MainController#mountLockStatusIndicator()} (HBox index + 1
      * after {@code projectInfoLabel}), not declared in the FXML.
      *
-     * <p>9 cells + 1 spacer {@code <Region>} = 10 direct children:
+     * <p>8 cells + 1 spacer {@code <Region>} = 9 direct children:
      * <ol>
      *   <li>projectInfoLabel  (project name + format — first cell, no dot)
      *   <li>monitoringLabel   (mono/stereo/surround prose)
@@ -57,23 +57,24 @@ final class StatusBarFxmlTest {
      *   <li>memLabel          (static placeholder, numeric)
      *   <li>dskLabel          (static placeholder, numeric)
      *   <li><Region hgrow=ALWAYS>  (the single spacer)
-     *   <li>checkpointLabel   (live last-save / autosave cell —
-     *       {@code <StatusCellLabel>}: written from ~30 dynamic sites, so
-     *       the type is the seam that guarantees its leading "· ")
      *   <li>rippleBannerLabel (plain Label; visible/managed false — a
      *       special banner, NOT a dot cell)
-     *   <li>statusBarLabel    (transport status — {@code <StatusCellLabel>}
-     *       for the same reason as checkpointLabel)
+     *   <li>statusBarLabel    (transport/metronome status — {@code
+     *       <StatusCellLabel>}: written from many dynamic sites, so the type
+     *       is the seam that guarantees its leading "· ")
      * </ol>
      * A "cell" is any direct child that is not the {@code <Region>} spacer:
-     * {@code <Label>} or {@code <StatusCellLabel>}. Exactly two cells are
+     * {@code <Label>} or {@code <StatusCellLabel>}. Exactly one cell is a
      * {@code <StatusCellLabel>} — locking in the story-274 dot seam so a
      * regression back to plain {@code <Label>} (which would drop the
      * separator on the first runtime status update) fails this test.
+     * (Story 295 retired the sibling checkpointLabel: last-save / checkpoint
+     * are now cells of the SessionStatusStrip, mounted at runtime below the
+     * legacy status bar and not declared in this FXML.)
      */
-    private static final int EXPECTED_CELL_CHILDREN = 9;
+    private static final int EXPECTED_CELL_CHILDREN = 8;
     private static final int EXPECTED_SPACER_CHILDREN = 1;
-    private static final int EXPECTED_STATUS_CELL_LABELS = 2;
+    private static final int EXPECTED_STATUS_CELL_LABELS = 1;
     private static final int EXPECTED_TOTAL_CHILDREN =
             EXPECTED_CELL_CHILDREN + EXPECTED_SPACER_CHILDREN;
 
@@ -117,13 +118,14 @@ final class StatusBarFxmlTest {
                 .isEqualTo(EXPECTED_CELL_CHILDREN);
 
         assertThat(statusCellLabels)
-                .as("checkpointLabel and statusBarLabel must be "
-                        + "<StatusCellLabel> (not plain <Label>): they are "
-                        + "written from ~30 dynamic sites, so the type is the "
-                        + "single seam that keeps their leading \"· \" "
+                .as("statusBarLabel must be a "
+                        + "<StatusCellLabel> (not plain <Label>): it is "
+                        + "written from many dynamic sites, so the type is the "
+                        + "single seam that keeps its leading \"· \" "
                         + "separator (story 274 S1). A regression to <Label> "
                         + "would silently drop the dot on the first runtime "
-                        + "status update.")
+                        + "status update. (checkpointLabel was retired by "
+                        + "story 295.)")
                 .isEqualTo(EXPECTED_STATUS_CELL_LABELS);
 
         assertThat(directChildren.size())

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarMonoNumericsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusBarMonoNumericsTest.java
@@ -36,7 +36,7 @@ final class StatusBarMonoNumericsTest {
      * The status-bar cells whose displayed value is a number per §5.11
      * (sample-rate / bit-depth / channels live in projectInfoLabel; the
      * kHz I/O figure in ioRoutingLabel; the CPU/MEM/DSK placeholders).
-     * The prose cells — monitoringLabel, checkpointLabel, statusBarLabel,
+     * The prose cells — monitoringLabel, statusBarLabel,
      * rippleBannerLabel — are NOT numeric and carry {@code .body} only.
      */
     private static final List<String> NUMERIC_CELL_IDS = List.of(

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusStripNoLabelSetTextTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusStripNoLabelSetTextTest.java
@@ -1,0 +1,178 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 295 — guards the §8 "no status text in {@code Label.setText}" contract
+ * for the Session Status Strip (Project Manager Design Book §5.5;
+ * {@code javafx-application-design} §15 "a control is observable Properties, not
+ * imperative setters"). The strip and its cells are <em>binding-only</em>: every
+ * visible status the strip renders is one observable {@code Property} on
+ * {@link com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress}, and the
+ * cells drive their text exclusively via {@code textProperty().bind(...)} — never
+ * by poking a {@link javafx.scene.control.Label}/{@link
+ * javafx.scene.control.Labeled} with {@code setText(...)}.
+ *
+ * <p>This is the source-scan sibling of {@code RunLaterConsolidationTest}: a green
+ * gate that scans the strip's four source files and prevents drift — a future edit
+ * cannot reintroduce an imperative {@code Label.setText} that would let the strip's
+ * displayed text diverge from the model it is meant to mirror.</p>
+ *
+ * <h3>Scope &amp; preprocessing</h3>
+ *
+ * <p>The scan covers exactly the four strip source files under {@code
+ * …app.ui.status}: {@code SessionStatusStrip.java}, {@code
+ * SessionStatusStripSkin.java}, {@code StatusStripCell.java} and {@code
+ * StatusStripCellSkin.java}. Each is asserted to exist and to be scanned (a guard
+ * against a vacuously-empty scan from a broken path). To stay faithful to a
+ * SOURCE-level scan it strips {@code //} and {@code /* *\/} comments before
+ * matching — exactly as {@code RunLaterConsolidationTest} does — so a Javadoc
+ * {@code {@code Label.setText}} mention does not false-match. It then looks for a
+ * dotted {@code .setText(} invocation (a receiver-qualified text mutation); the
+ * dot requirement means a method <em>named</em> {@code setText} declared in the
+ * source (none of these files declares one) would not match on its own
+ * declaration line either.</p>
+ */
+final class StatusStripNoLabelSetTextTest {
+
+    /**
+     * A receiver-qualified {@code .setText(} call — the imperative
+     * {@link javafx.scene.control.Labeled#setText(String)} mutation this story
+     * rejects. The leading dot requires a receiver (e.g. {@code label.setText(}),
+     * so it matches a call expression rather than a method declaration.
+     */
+    private static final Pattern DOTTED_SET_TEXT =
+            Pattern.compile("\\.\\s*setText\\s*\\(");
+
+    /**
+     * One Java comment or one string / text-block literal. Alternation order
+     * matters: a literal is matched before {@code //} and {@code /*} so a
+     * delimiter inside a string is not mistaken for a comment, and a quote inside
+     * a comment is consumed as part of the comment. Mirrors
+     * {@code RunLaterConsolidationTest#COMMENT_OR_STRING}.
+     */
+    private static final Pattern COMMENT_OR_STRING = Pattern.compile(
+            "\"\"\"[\\s\\S]*?\"\"\""        // text block
+            + "|\"(?:\\\\.|[^\"\\\\])*\""   // string literal
+            + "|//[^\\n]*"                  // line comment
+            + "|/\\*[\\s\\S]*?\\*/");       // block comment
+
+    /** The four source files that make up the strip and its cell control. */
+    private static final List<String> STRIP_SOURCE_FILES = List.of(
+            "SessionStatusStrip.java",
+            "SessionStatusStripSkin.java",
+            "StatusStripCell.java",
+            "StatusStripCellSkin.java");
+
+    @Test
+    void stripSourcesDriveTextOnlyViaBindingNeverLabelSetText() throws IOException {
+        Path statusDir = locateDawAppModule()
+                .resolve("src/main/java/com/benesquivelmusic/daw/app/ui/status");
+        assertThat(Files.isDirectory(statusDir))
+                .as("the Session Status Strip sources must live under %s", statusDir)
+                .isTrue();
+
+        List<String> offenders = new ArrayList<>();
+        List<String> scanned = new ArrayList<>();
+
+        for (String fileName : STRIP_SOURCE_FILES) {
+            Path file = statusDir.resolve(fileName);
+            assertThat(Files.isRegularFile(file))
+                    .as("strip source file must exist: %s", file)
+                    .isTrue();
+            scanned.add(fileName);
+
+            // Strip comments (so a {@code Label.setText} mention in Javadoc does
+            // not false-match) but keep string literals — a setText written inside
+            // a string literal would still be code worth flagging, and none of
+            // these files legitimately contains the substring in a string.
+            String code = stripComments(Files.readString(file, StandardCharsets.UTF_8));
+            if (DOTTED_SET_TEXT.matcher(code).find()) {
+                offenders.add(fileName
+                        + "  — contains a dotted .setText(...) call; the strip must "
+                        + "drive text via textProperty().bind(...) only (story 295 §8)");
+            }
+        }
+
+        // Guard against a silently-empty scan — if the path resolved wrong and no
+        // file were read, the offenders list would be vacuously empty.
+        assertThat(scanned)
+                .as("all four strip source files must be scanned")
+                .containsExactlyInAnyOrderElementsOf(STRIP_SOURCE_FILES);
+
+        offenders.sort(String::compareTo);
+        assertThat(offenders)
+                .as("Story 295 — the Session Status Strip is binding-only "
+                        + "(javafx-application-design §15): its cells must bind "
+                        + "their text to ProjectOperationProgress properties and "
+                        + "never call Label/Labeled.setText(...). Offending files:%n  %s",
+                        String.join("\n  ", offenders))
+                .isEmpty();
+    }
+
+    /**
+     * Locate the {@code daw-app} module root. Surefire normally sets the working
+     * directory to the module itself; the fallbacks cover invocations from the
+     * repo root (e.g. {@code mvn -pl daw-app test}). Mirrors
+     * {@code RunLaterConsolidationTest#locateDawAppModule()}.
+     */
+    private static Path locateDawAppModule() {
+        Path cwd = Paths.get("").toAbsolutePath();
+        if (isDawAppModule(cwd)) {
+            return cwd;
+        }
+        Path child = cwd.resolve("daw-app");
+        if (isDawAppModule(child)) {
+            return child;
+        }
+        Path candidate = cwd.getParent();
+        for (int i = 0; i < 5 && candidate != null; i++) {
+            if (isDawAppModule(candidate)) {
+                return candidate;
+            }
+            Path nested = candidate.resolve("daw-app");
+            if (isDawAppModule(nested)) {
+                return nested;
+            }
+            candidate = candidate.getParent();
+        }
+        return cwd;
+    }
+
+    private static boolean isDawAppModule(Path dir) {
+        return Files.isRegularFile(dir.resolve("pom.xml"))
+                && Files.isDirectory(
+                        dir.resolve("src/main/java/com/benesquivelmusic/daw/app"));
+    }
+
+    /**
+     * Removes {@code //} and {@code /* *\/} comments while preserving string /
+     * text-block literals. Mirrors {@code RunLaterConsolidationTest#stripComments}.
+     */
+    private static String stripComments(String source) {
+        Matcher m = COMMENT_OR_STRING.matcher(source);
+        StringBuilder out = new StringBuilder(source.length());
+        while (m.find()) {
+            String token = m.group();
+            // A string / text block (starts with a quote) is code — keep it
+            // verbatim; anything else the alternation matched is a comment and is
+            // replaced with a single space.
+            m.appendReplacement(out, token.charAt(0) == '"'
+                    ? Matcher.quoteReplacement(token) : " ");
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusStripOverflowPriorityTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/StatusStripOverflowPriorityTest.java
@@ -1,0 +1,162 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress;
+import com.benesquivelmusic.daw.app.ui.status.SessionStatusStrip;
+
+import javafx.scene.Group;
+import javafx.scene.Scene;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 295 — the §4.4 priority-overflow contract of the
+ * {@link SessionStatusStrip} skin. As the strip narrows, collapsible cells are
+ * hidden into the {@code ⋯} overflow popover in the fixed order Workspace →
+ * Schema → Lock → Disk → Journal; Session, Saved and Checkpoint never collapse.
+ *
+ * <p>Thresholds (a collapsible cell is hidden when strip width &lt; threshold):
+ * Workspace &lt; 1200, Schema &lt; 1140, Lock &lt; 1080, Disk &lt; 1020,
+ * Journal &lt; 960. At &ge; 1200 all cells are visible across two rows and the
+ * overflow button is hidden.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class StatusStripOverflowPriorityTest {
+
+    /** At &ge; 1200 px every cell is inline (two rows) and nothing overflows. */
+    @Test
+    void atFullWidthNoCellOverflows() throws Exception {
+        runOnFx(() -> {
+            SessionStatusStrip strip = realizedStrip();
+            resizeTo(strip, 1300.0);
+
+            assertThat(strip.isOverflowButtonVisible())
+                    .as("overflow button is hidden when no cell is collapsed (width 1300 >= 1200)")
+                    .isFalse();
+            assertThat(strip.overflowCells())
+                    .as("no cell is collapsed at width 1300")
+                    .isEmpty();
+
+            // Every fact is present: never-collapse cells and all collapsibles.
+            assertThat(strip.sessionCell().isManaged()).as("session cell present").isTrue();
+            assertThat(strip.savedCell().isManaged()).as("saved cell present").isTrue();
+            assertThat(strip.checkpointCountdown().isManaged()).as("checkpoint present").isTrue();
+            assertThat(strip.journalCell().isManaged()).as("journal cell present").isTrue();
+            assertThat(strip.diskCell().isManaged()).as("disk cell present").isTrue();
+            assertThat(strip.lockCell().isManaged()).as("lock cell present").isTrue();
+            assertThat(strip.schemaCell().isManaged()).as("schema cell present").isTrue();
+            assertThat(strip.workspaceCell().isManaged()).as("workspace cell present").isTrue();
+        });
+    }
+
+    /**
+     * Between 1140 and 1200 only the lowest-priority cell (Workspace) collapses;
+     * the overflow button appears and the never-collapse cells stay inline.
+     */
+    @Test
+    void betweenSchemaAndWorkspaceOnlyWorkspaceCollapses() throws Exception {
+        runOnFx(() -> {
+            SessionStatusStrip strip = realizedStrip();
+            resizeTo(strip, 1160.0);
+
+            assertThat(strip.overflowCells())
+                    .as("at width 1160 only Workspace is collapsed (first in the priority order)")
+                    .containsExactly(strip.workspaceCell());
+            assertThat(strip.isOverflowButtonVisible())
+                    .as("overflow button is shown once any cell is collapsed")
+                    .isTrue();
+
+            // The never-collapse cells remain managed/inline.
+            assertThat(strip.sessionCell().isManaged()).as("session never collapses").isTrue();
+            assertThat(strip.savedCell().isManaged()).as("saved never collapses").isTrue();
+            assertThat(strip.checkpointCountdown().isManaged()).as("checkpoint never collapses").isTrue();
+        });
+    }
+
+    /**
+     * Below every threshold (and below the 900 px single-row mark) all five
+     * collapsible cells are hidden, in collapse order; the never-collapse cells
+     * stay inline.
+     */
+    @Test
+    void belowAllThresholdsEveryCollapsibleCellOverflowsInOrder() throws Exception {
+        runOnFx(() -> {
+            SessionStatusStrip strip = realizedStrip();
+            resizeTo(strip, 850.0);
+
+            assertThat(strip.overflowCells())
+                    .as("at width 850 all five collapsibles overflow in collapse order")
+                    .containsExactly(
+                            strip.workspaceCell(),
+                            strip.schemaCell(),
+                            strip.lockCell(),
+                            strip.diskCell(),
+                            strip.journalCell());
+            assertThat(strip.isOverflowButtonVisible())
+                    .as("overflow button is shown when cells are collapsed")
+                    .isTrue();
+
+            // Session, Saved and Checkpoint still inline.
+            assertThat(strip.sessionCell().isManaged()).as("session never collapses").isTrue();
+            assertThat(strip.savedCell().isManaged()).as("saved never collapses").isTrue();
+            assertThat(strip.checkpointCountdown().isManaged()).as("checkpoint never collapses").isTrue();
+        });
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link SessionStatusStrip} (over a fresh, unstarted dispatcher's
+     * model) and realizes its skin headlessly. The strip is wrapped in a
+     * {@link Group} so it does not get resized by a parent layout pass — the
+     * test drives width explicitly via {@link #resizeTo}. Must run on the FX
+     * thread.
+     */
+    private static SessionStatusStrip realizedStrip() {
+        ProjectOperationProgress progress = new ProjectOperationProgress(new FxDispatcher());
+        SessionStatusStrip strip = new SessionStatusStrip(progress, MotionManager.getDefault());
+        Group root = new Group(strip); // Group does not resize its child, so resize(...) sticks
+        new Scene(root, 1400, 80);
+        strip.applyCss(); // realizes the skin (creates cells + width listener + initial reconcile)
+        strip.layout();
+        return strip;
+    }
+
+    /**
+     * Sets the strip width (which fires the skin's width listener and runs the
+     * reconcile) then re-applies CSS and lays out. The skin is already realized.
+     */
+    private static void resizeTo(SessionStatusStrip strip, double width) {
+        strip.resize(width, 60.0);
+        strip.applyCss();
+        strip.layout();
+    }
+
+    private static void runOnFx(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        javafx.application.Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/backup/ProjectDiskUsage.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/backup/ProjectDiskUsage.java
@@ -1,6 +1,7 @@
 package com.benesquivelmusic.daw.core.persistence.backup;
 
 import java.io.IOException;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -59,6 +60,38 @@ public record ProjectDiskUsage(long autosavesBytes, long archivesBytes, long ass
         long total = sizeOf(projectDirectory);
         long assets = Math.max(0L, total - autosaves - archives);
         return new ProjectDiskUsage(autosaves, archives, assets);
+    }
+
+    /**
+     * Returns the usable bytes on the file store backing {@code directory} —
+     * the §1.8 disk-space contract input for the Session Status Strip (story
+     * 295). A "plain value" the JavaFX-free core supplies; the UI's 30&nbsp;s
+     * background disk scan calls this off the FX thread (the FX thread must
+     * never call {@link FileStore#getUsableSpace()} —
+     * {@code javafx-application-design} §11).
+     *
+     * <p>When {@code directory} does not exist yet (e.g. a not-yet-saved
+     * project) the nearest existing ancestor's file store is measured, so a
+     * fresh project still reports a meaningful free-space figure. Returns
+     * {@code -1} when no ancestor exists or the store cannot be queried.</p>
+     *
+     * @param directory the directory whose file store to measure
+     * @return usable bytes on that file store, or {@code -1} if unknown
+     */
+    public static long usableSpaceBytes(Path directory) {
+        Objects.requireNonNull(directory, "directory must not be null");
+        Path probe = directory.toAbsolutePath();
+        while (probe != null && !Files.exists(probe)) {
+            probe = probe.getParent();
+        }
+        if (probe == null) {
+            return -1L;
+        }
+        try {
+            return Files.getFileStore(probe).getUsableSpace();
+        } catch (IOException e) {
+            return -1L;
+        }
     }
 
     private static long sizeOf(Path root) throws IOException {


### PR DESCRIPTION
# Session Status Strip and the ProjectOperationProgress Model

## Motivation

The Project Manager Design Book opens by naming the user's "extremely flaky" complaint and concludes that the flakiness is **"almost entirely at the UI seam, not in `daw-core`"** (§1.10). `daw-core` already protects long sessions; the user simply cannot *see* it working. This story is **Stage 1** of the §7 migration path — pure visibility, no data-format change — and it directly attacks four §1 problems:

- **§1.1 (the Save button is the only way to feel safe).** Today `ProjectLifecycleController` writes status through a `Label statusBarLabel` (`ProjectLifecycleController.java:100`) and `Label checkpointLabel` (`:101`), set with `setText(...)` at the save sites (`:155-159`). The "Saved (checkpoint #N)" text disappears the moment the user does anything else, so after three hours of recording there is no standing evidence the autosave system is alive.
- **§1.2 (checkpoints are invisible).** `CheckpointManager` fires every 5 minutes (`AutoSaveConfig.DEFAULT`) or every 30 s (`AutoSaveConfig.LONG_SESSION`), serialising on a virtual-thread `saveExecutor` (`CheckpointManager.java:98`) — but the user cannot see *when the next one fires*, *the last one's outcome*, or *that it is running at all*.
- **§1.3 (locks never explain themselves).** `ProjectLockManager` keeps a live heartbeat; the holder identity and freshness are never surfaced as standing chrome.
- **§1.8 (no disk-space contract).** A 12-hour multitrack session can produce tens of gigabytes; free space and estimated record-minutes appear nowhere.

The fix is the §4.4 **Session Status Strip**: a persistent two-row strip across the bottom of the window that promotes the seven §2.2 invisible signals to first-class chrome, backed by the single §5.5 `ProjectOperationProgress` model. This is the keystone of design principle §2.2 ("state is always visible").

## Goals

- **Add a `ProjectOperationProgress` model in `daw-app`** (per §5.5) — a JavaFX `Property`-heavy class (`javafx-application-design` §4) that is the *single* source of project-status truth: `lastSaveTime`, `lastSaveScope` (full vs. delta), `lastSaveSucceeded`, `nextCheckpointInstant`, `journalEventsQueued`, `lockHolderLabel`, `lockFresh`, `freeDiskBytes`, `estimatedRecordMinutes`, `sessionName`, `sessionElapsed`, `currentSchemaVersion`, `backupSchemaVersion`, and an observable list of in-flight named operations. Existing save / autosave / archive paths register and unregister operations on it; no controller writes status text anywhere else.
- **Build the `SessionStatusStrip` as a `Control` + `Skin`** (`javafx-application-design` §3) hosting twelve cells on two rows (§4.4 mockup). Each cell is itself a small `Control` (`StatusStripCell`) so themes can restyle it without touching the strip. The strip binds **only** to `ProjectOperationProgress` — no `Label.setText` (the §8 / §5.5 rejection of "status text in `Label.setText`").
- **Replace the legacy labels.** Remove `statusBarLabel` and `checkpointLabel` (`ProjectLifecycleController.java:100-101`) and the ad-hoc "Saved (checkpoint #N)" / `notificationBar.show(SUCCESS, "Project saved")` path (the `setText`/`notificationBar.show` block at `:155-159`; §4.5, Appendix A); the strip's Saved cell flashing for 600 ms *is* the success signal for fast saves.
- **Live checkpoint countdown** driven by a `Canvas` + `AnimationTimer` at **1 Hz** (`javafx-application-design` §6, §4.4) reading `nextCheckpointInstant`. Gated by `MotionManager` Reduce Motion (story 279): when reduced, render the remaining time as static text on each value change instead of an animating bar.
- **All status sourcing runs off the FX thread.** The disk-space scan refreshes every 30 s on a **background virtual thread** (`Thread.ofVirtual()`, story 205) and publishes into `ProjectOperationProgress`; the strip reads the property on the FX thread. The FX thread never calls `FileStore.getUsableSpace()` (`javafx-application-design` §11; book §2.1). Disk cell goes amber under 30 record-minutes and red under 5 (§6.2).
- **Route every status mutation through the FX-confinement seam.** Background producers publish via story 289's Control-Sync `FxDispatcher` so many updates within one frame coalesce to one strip repaint; where save / checkpoint already expose story 292's `ProjectVM`, bind `ProjectOperationProgress.lastSaveTime` / `dirty` / `saving` to it rather than re-deriving them.
- **Narrow-window overflow** per §4.4: below 1200 px collapse cells in the fixed priority order (Workspace → Schema → Lock → Disk → Journal); the Session, Saved, and Checkpoint-timer cells never collapse; below 900 px a trailing "⋯" overflow button opens a popover with the hidden cells (`javafx-application-design` §10 priority overflow). Hovering any cell opens its detail popover (350 ms delay, 80 ms fade — §10).
- Tests:
  - `ProjectOperationProgressBindingTest` (new): mutate each property off the FX thread through the `FxDispatcher`, assert the bound `SessionStatusStrip` cell reflects the value on the FX thread and that N rapid mutations to one key coalesce to a single observable strip update.
  - `StatusStripNoLabelSetTextTest` (new): source-scan `SessionStatusStrip` / `StatusStripCell` for `setText(` on a raw `Label` written from a controller; assert none — the strip is binding-only (mirrors the §8 rejection, `javafx-application-design` §15).
  - `CheckpointCountdownReducedMotionTest` (new): with `MotionManager` reduce-motion on, assert the countdown surface is static text (no running `AnimationTimer`); with it off, assert the timer is started once. Test pure transforms off-toolkit (`feedback_javafx_headless_test_pitfalls.md`).
  - `DiskCellThresholdTest` (new): feed `estimatedRecordMinutes` = 29 then 4, assert the disk cell's style class flips to the amber then red token (style-class assertion, headless-safe).
  - `StatusStripOverflowPriorityTest` (new): shrink the strip below 1200 px then 900 px, assert cells hide in the documented priority and that Session/Saved/Checkpoint never leave; assert the "⋯" popover contains exactly the hidden cells.
  - `DiskScanOffFxThreadTest` (new): assert the 30 s disk scan executes on a virtual (non-FX) thread and publishes via the dispatcher (capture the executing thread; do not assert FX-thread behaviour from inside a swallowed runnable — `feedback_javafx_headless_test_pitfalls.md`).

## Non-Goals

- **No new persistence behaviour.** Stage 1 is pure UI re-expression (§7 Stage 1: "Visibility, no model changes"). No journal (story 298), no `sessions/` manifests (story 297), no snapshots (story 299), no Project Hub (story 296). `CheckpointManager`, `ProjectLockManager`, and `AutoSaveConfig` are consumed unchanged.
- **No checkpoint *browsing* or *restore* from the strip.** The strip surfaces the *next* and *last* checkpoint; the navigable history is the Session Manager dock (story 297) and snapshots (story 299). The strip's Saved cell only flashes / shows progress / shows error.
- **No fix for the §1.1 `/tmp` first-save bug here.** Prompting for a real location on first save and abandoning `Files.createTempDirectory` is folded into the Welcome / Project Hub flow (story 296, §8 "silent first-save into /tmp"). Stage 1 only *shows* where the project lives.
- **No DAWproject-Exchange rename here.** Renaming the `SessionExportResult` / `SessionImportResult` menus to "DAWproject Exchange" (§3.3) lands with the surface that owns those menus; this story only fixes the meaning of the *Session* cell (the §3.3 working session) and must not reuse "Session" for import/export.
- **No structured-concurrency fan-out.** `DawScope.openShutdownOnFailure` is for archive / restore / recover (stories 298, 299); the disk scan and status publish are single background tasks.

## Technical Notes

- Files: new `daw-app/.../ui/status/ProjectOperationProgress.java` (the §5.5 model), `daw-app/.../ui/status/SessionStatusStrip.java` + `SessionStatusStripSkin.java`, `daw-app/.../ui/status/StatusStripCell.java` + skin, a `CheckpointCountdownCanvas` (`Canvas` + 1 Hz `AnimationTimer`); edits to `daw-app/.../ui/ProjectLifecycleController.java` (delete `statusBarLabel`/`checkpointLabel` at :100-101 and the "Project saved" `setText`/notification block at :155-159; register save/autosave operations on `ProjectOperationProgress` — note every `statusBarLabel.setText(...)` call site in this file, e.g. :155-165, :186-188, :272-280, :300-304, :321-323, :400-415, :518-520, :640-664, :728-738, must migrate to the model); `styles.css` (strip + cell tokens, amber/red disk tokens as derivatives of existing role tokens — tokens not hex, `feedback_ui_design_philosophy.md`).
- Bind, do not poll: the strip's cells are `bind(...)` to `ProjectOperationProgress` properties (`javafx-application-design` §4). Control UA stylesheets consume forwarded local tokens, never raw `-accent`/`-surface-1` (`feedback_control_css_role_token_forwarding.md`); the styles.css author copy overrides the component UA copy by origin (`feedback_css_author_overrides_useragent_duplication.md`).
- Threading: the disk scan and any size computation use `ProjectDiskUsage` (`daw-core/.../persistence/backup/ProjectDiskUsage.java`) on a virtual thread; results cross to the FX thread only through the `FxDispatcher`. Never block the FX thread on `FileStore`/`Files` calls (`javafx-application-design` §11; `java-26.agent.md` Project Loom — virtual threads for I/O).
- `nextCheckpointInstant` derivation: `CheckpointManager` runs on a fixed-rate `ScheduledExecutorService` at `config.autoSaveInterval()` (`CheckpointManager.java:99-104`); expose the next-fire instant (or compute it from the last fire + interval) and feed it to `ProjectOperationProgress` so the §6 countdown is exact for both `DEFAULT` (5 min) and `LONG_SESSION` (30 s).
- `daw-core` stays JavaFX-free: `ProjectOperationProgress` and the strip live in `daw-app`; `daw-core` only supplies plain values (disk usage, checkpoint instants, lock state) — consistent with the whole-reactor JPMS module boundaries (`project_daw_app_non_modular.md`).
- Reference: Project Manager Design Book §1.1-§1.3, §1.8, §2.1, §2.2, §4.4, §4.5, §5.5, §6.2, Appendix A (the `statusBarLabel`/`checkpointLabel` mapping) and Appendix B; Control Synchronization Design Book §2 (`FxDispatcher`) and §3 (`ProjectVM`); user story 289 (`FxDispatcher` — the FX-confinement seam), 292 (`ProjectVM` / full-load cascade — bind `dirty`/`saving`/`lastSaveTime`), 279 (Reduce Motion — gate the countdown animation), 205 (virtual threads for non-realtime work — the disk scan), 019 (project save/load/autosave — the operations being surfaced). SKILLs: `javafx-application-design` (§3 Control/Skin, §4 Properties, §6 Canvas+AnimationTimer, §10 overflow/tooltip, §11 threading, §15 anti-patterns), `java-26.agent.md` Project Loom (virtual threads, `ReentrantLock` not `synchronized` on virtual threads).
