### PR TITLE
296-project-hub-welcome-screen-with-project-card-control.md implementation

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/DawApplication.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/DawApplication.java
@@ -145,6 +145,13 @@ public final class DawApplication extends Application {
         primaryStage.setMinHeight(720);
         primaryStage.setMaximized(true);
         primaryStage.show();
+
+        // Story 296 — show the §4.1 Welcome screen on launch when no project is
+        // open on disk (a fresh start has only the in-memory Untitled project).
+        // Done after show() so it opens as an owned window over the main scene.
+        if (mainController != null) {
+            mainController.showWelcomeIfNoProjectOpen();
+        }
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1165,6 +1165,23 @@ public final class MainController {
     }
 
     /**
+     * Story 296 — shows the §4.1 Welcome screen on launch when no project is
+     * open on disk ({@code projectManager.getCurrentProject() == null}, which is
+     * true at a fresh start: the in-memory Untitled project is not yet an
+     * on-disk project). Called by {@code DawApplication} right after the primary
+     * stage is shown, so the Welcome opens as an owned window over the main
+     * scene. Recover lists projects whose lock shows an unclean exit; Continue
+     * lists recent projects; Start offers New / Open / Restore / Import.
+     */
+    public void showWelcomeIfNoProjectOpen() {
+        if (projectManager != null
+                && projectManager.getCurrentProject() == null
+                && projectLifecycleController != null) {
+            projectLifecycleController.showWelcome();
+        }
+    }
+
+    /**
      * Story 282 — captures the live Mission-Control layout JSON to embed in the
      * project file before save (the {@code ProjectLifecycleController.Deps}
      * {@code captureLayoutJson} supplier). Returns {@code null} when the layout

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
@@ -1062,7 +1062,13 @@ final class ProjectLifecycleController {
             try {
                 if (java.awt.Desktop.isDesktopSupported()
                         && java.awt.Desktop.getDesktop().isSupported(java.awt.Desktop.Action.OPEN)) {
-                    java.awt.Desktop.getDesktop().open(projectDir.toFile());
+                    Path toOpen = Files.isDirectory(projectDir) ? projectDir : projectDir.getParent();
+                    if (toOpen == null) {
+                        postFx(() -> notificationBar.show(NotificationLevel.ERROR,
+                                "Could not reveal project: no parent directory"));
+                        return;
+                    }
+                    java.awt.Desktop.getDesktop().open(toOpen.toFile());
                 } else {
                     postFx(() -> notificationBar.show(NotificationLevel.ERROR,
                             "Reveal is not supported on this platform"));

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
@@ -898,7 +898,6 @@ final class ProjectLifecycleController {
         ProjectHubView hub = new ProjectHubView(
                 projectManager.getRecentProjectPaths(),
                 new ProjectHealthScanner(d),
-                d,
                 projectDir -> {
                     if (projectDir != null && confirmDiscardUnsavedChanges()) {
                         dismiss(ref[0]);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
@@ -295,7 +295,7 @@ final class ProjectLifecycleController {
             // Persist the full initial state (createProject writes a metadata-only
             // file first); saveDawProject marks the project clean itself, then we
             // flash the Saved cell.
-            newProject.setLayoutJson(deps.captureLayoutJson().get());
+            newProject.setLayoutJson(null);
             projectManager.saveDawProject(newProject);
             progress.recordSaveSucceeded(Instant.now(), ProjectOperationProgress.SaveScope.FULL);
             createdOnDisk = true;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
@@ -1,5 +1,9 @@
 package com.benesquivelmusic.daw.app.ui;
 
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHealthScanner;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHubView;
+import com.benesquivelmusic.daw.app.ui.hub.WelcomeView;
+import com.benesquivelmusic.daw.app.ui.density.DensityManager;
 import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
@@ -20,6 +24,8 @@ import com.benesquivelmusic.daw.core.track.Track;
 import com.benesquivelmusic.daw.core.undo.UndoManager;
 import com.benesquivelmusic.daw.sdk.session.SessionExportResult;
 import com.benesquivelmusic.daw.sdk.session.SessionImportResult;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
@@ -126,6 +132,45 @@ final class ProjectLifecycleController {
      */
     private final FxDispatcher fxDispatcher;
 
+    /**
+     * Story 296 — supplies the destination <em>parent</em> directory for a
+     * brand-new project, replacing the §8/§1.1 silent
+     * {@code Files.createTempDirectory} first-save. The default
+     * ({@link #promptNewProjectLocation()}) prompts once via a
+     * {@link DirectoryChooser} rooted at the §3.1 workspace ({@code ~/DAW
+     * Projects}); a {@code null} return means the user cancelled, so no project
+     * is created on disk. Tests inject a stub via
+     * {@link #setNewProjectLocationPrompt(Supplier)}.
+     */
+    private Supplier<Path> newProjectLocationPrompt = this::promptNewProjectLocation;
+
+    /**
+     * Story 296 — presents the §4.2 Project Hub built by
+     * {@link #buildProjectHub()}. The default ({@link #presentProjectHub(ProjectHubView)})
+     * opens it in its own themed {@link Stage}; tests inject a capturing
+     * presenter via {@link #setProjectHubPresenter(Consumer)} so the headless
+     * {@code RecentMenuOpensHubTest} can assert the hub was opened (rather than a
+     * filename {@code ContextMenu} built).
+     */
+    private Consumer<ProjectHubView> projectHubPresenter = this::presentProjectHub;
+
+    /**
+     * Story 296 — presents the §4.1 Welcome screen built by
+     * {@link #buildWelcomeView()}. The default
+     * ({@link #presentWelcome(WelcomeView)}) opens it in its own themed
+     * {@link Stage}; tests inject a capturing presenter via
+     * {@link #setWelcomePresenter(Consumer)}.
+     */
+    private Consumer<WelcomeView> welcomePresenter = this::presentWelcome;
+
+    /**
+     * Story 296 — the single auxiliary window currently hosting a Hub / Welcome
+     * surface (opened by {@link #showInOwnedStage(String, Parent)}), or
+     * {@code null} when none is open. Tracked so a repeat "Project Hub…" closes
+     * the prior window instead of stacking a second orphan over it.
+     */
+    private Stage auxiliaryStage;
+
     ProjectLifecycleController(ProjectManager projectManager,
                                SessionInterchangeController sessionInterchangeController,
                                NotificationBar notificationBar,
@@ -185,8 +230,16 @@ final class ProjectLifecycleController {
     private boolean trySaveProject() {
         try {
             if (projectManager.getCurrentProject() == null) {
-                Path tempDir = Files.createTempDirectory("daw-project-");
-                projectManager.createProject(deps.project().get().getName(), tempDir);
+                // §8 / §1.1 — a brand-new project that has never been saved
+                // prompts for a real destination once instead of the silent
+                // Files.createTempDirectory into the system temp dir (which the
+                // next reboot can wipe). A null return means the user cancelled
+                // the location prompt, so nothing is saved — but no /tmp leak.
+                Path parentDirectory = newProjectLocationPrompt.get();
+                if (parentDirectory == null) {
+                    return false;
+                }
+                projectManager.createProject(deps.project().get().getName(), parentDirectory);
             }
             // Story 282 — capture the live layout state into the project
             // model before serialisation. {@code null} from the supplier
@@ -220,19 +273,51 @@ final class ProjectLifecycleController {
         if (!confirmDiscardUnsavedChanges()) {
             return;
         }
+        // §8 / §1.1 — prompt for a real destination once, then write the project
+        // there immediately. A null return means the user cancelled, so we do
+        // NOT silently create an Untitled project that would later first-save
+        // into the system temp directory (the §8 rejection of "silent first-save
+        // into /tmp"). createProject() writes project.daw, acquires the lock and
+        // starts the heartbeat/autosave on the chosen directory.
+        Path parentDirectory = newProjectLocationPrompt.get();
+        if (parentDirectory == null) {
+            return;
+        }
         resetProjectState();
-        deps.setProject().accept(new DawProject("Untitled Project", AudioFormat.STUDIO_QUALITY));
+        DawProject newProject = new DawProject("Untitled Project", AudioFormat.STUDIO_QUALITY);
+        deps.setProject().accept(newProject);
         deps.setUndoManager().accept(new UndoManager());
         deps.rebuildHistoryPanel().run();
         deps.resetTrackCounters().run();
-        deps.project().get().markClean();
+        boolean createdOnDisk = false;
+        try {
+            projectManager.createProject(newProject.getName(), parentDirectory);
+            // Persist the full initial state (createProject writes a metadata-only
+            // file first); saveDawProject marks the project clean itself, then we
+            // flash the Saved cell.
+            newProject.setLayoutJson(deps.captureLayoutJson().get());
+            projectManager.saveDawProject(newProject);
+            progress.recordSaveSucceeded(Instant.now(), ProjectOperationProgress.SaveScope.FULL);
+            createdOnDisk = true;
+        } catch (IOException e) {
+            // The on-disk create failed (e.g. permissions); keep the in-memory
+            // project so the UI is still usable and surface the error.
+            progress.recordSaveFailed();
+            notificationBar.show(NotificationLevel.ERROR,
+                    "Could not create project: " + e.getMessage());
+            LOG.log(Level.WARNING, "Failed to create new project on disk", e);
+        }
         rebuildUI();
         // Story 282 — Reset layouts to the built-in Default so that a
         // previously opened project's saved layouts don't leak into the
         // new project.
         deps.applyLayoutJson().accept(null);
-        notificationBar.show(NotificationLevel.SUCCESS, "New project created");
-        LOG.info("Created new project");
+        // Only confirm success when the project actually reached disk — the
+        // catch above already surfaced the failure, so don't contradict it.
+        if (createdOnDisk) {
+            notificationBar.show(NotificationLevel.SUCCESS, "New project created");
+            LOG.info("Created new project");
+        }
     }
 
     void onOpenProject() {
@@ -249,35 +334,16 @@ final class ProjectLifecycleController {
         loadProjectFromPath(selected.toPath());
     }
 
+    /**
+     * Opens the §4.2 Project Hub — the replacement for the old filename
+     * {@code ContextMenu} of recent projects (§1.4; §8 "a Recent Projects menu
+     * that is just filenames"). Appendix A: "menu retains a 'Project Hub…'
+     * item". The File-menu entry now opens this full-window browser, which
+     * surfaces last-opened, size-on-disk, a health badge, search, and a
+     * per-project detail strip instead of bare filenames.
+     */
     void onRecentProjects() {
-        List<Path> recentPaths = projectManager.getRecentProjectPaths();
-        ContextMenu menu = new ContextMenu();
-        if (recentPaths.isEmpty()) {
-            MenuItem emptyItem = new MenuItem("No recent projects");
-            emptyItem.setDisable(true);
-            menu.getItems().add(emptyItem);
-        } else {
-            for (Path path : recentPaths) {
-                MenuItem item = new MenuItem(path.getFileName().toString());
-                item.setOnAction(_ -> {
-                    if (confirmDiscardUnsavedChanges()) {
-                        loadProjectFromPath(path);
-                    }
-                });
-                menu.getItems().add(item);
-            }
-            menu.getItems().add(new SeparatorMenuItem());
-            MenuItem clearItem = new MenuItem("Clear Recent Projects");
-            clearItem.setOnAction(_ -> {
-                RecentProjectsStore store = projectManager.getRecentProjectsStore();
-                if (store != null) {
-                    store.clear();
-                }
-                notificationBar.show(NotificationLevel.SUCCESS, "Recent projects cleared");
-            });
-            menu.getItems().add(clearItem);
-        }
-        menu.show(rootPane.getScene().getWindow());
+        projectHubPresenter.accept(buildProjectHub());
     }
 
     // ── Session Import/Export ────────────────────────────────────────────────
@@ -811,5 +877,242 @@ final class ProjectLifecycleController {
         trackListPanel.getChildren().add(header);
         MixerView newMixerView = new MixerView(deps.project().get(), deps.undoManager().get(), fxDispatcher);
         deps.onProjectUIRebuild().accept(newMixerView);
+    }
+
+    // ── Project Hub / Welcome (story 296) ─────────────────────────────────────
+
+    /**
+     * Builds the §4.2 Project Hub bound to this manager's recent projects, a
+     * fresh {@link ProjectHealthScanner}, and the open / reveal actions. Each
+     * card's size + health is scanned on a background virtual thread and
+     * marshalled to the FX thread through the {@link FxDispatcher} (§2.1) — the
+     * FX thread never walks a project tree.
+     *
+     * @return a new Project Hub view
+     */
+    ProjectHubView buildProjectHub() {
+        FxDispatcher d = resolveDispatcher();
+        // Self-reference so "Open" can dismiss the Hub window before loading;
+        // "Reveal" is a side action and leaves the Hub open.
+        ProjectHubView[] ref = new ProjectHubView[1];
+        ProjectHubView hub = new ProjectHubView(
+                projectManager.getRecentProjectPaths(),
+                new ProjectHealthScanner(d),
+                d,
+                projectDir -> { dismiss(ref[0]); openProjectFromHub(projectDir); },
+                this::revealInFileBrowser,
+                this::clearRecentProjects);
+        ref[0] = hub;
+        return hub;
+    }
+
+    /**
+     * Clears the recent-projects list (the Hub's §1.4 "Clear Recent" action,
+     * carried over from the retired recent-projects {@code ContextMenu}).
+     */
+    private void clearRecentProjects() {
+        RecentProjectsStore store = projectManager.getRecentProjectsStore();
+        if (store != null) {
+            store.clear();
+        }
+        notificationBar.show(NotificationLevel.SUCCESS, "Recent projects cleared");
+    }
+
+    /**
+     * Builds the §4.1 Welcome screen (Recover → Continue → Start) bound to this
+     * manager's recent projects. The four Start tiles route to the existing
+     * lifecycle flows; "Recover" / a Continue card route through
+     * {@link #openProjectFromHub(Path)} (the Stage-2 surface only lists recover
+     * candidates and opens them — the journal-replay recovery dialog is story
+     * 298).
+     *
+     * @return a new Welcome view
+     */
+    WelcomeView buildWelcomeView() {
+        FxDispatcher d = resolveDispatcher();
+        // Self-reference so every Welcome action dismisses the launch window
+        // first, then runs the chosen flow over the main window.
+        WelcomeView[] ref = new WelcomeView[1];
+        WelcomeView view = new WelcomeView(
+                projectManager.getRecentProjectPaths(),
+                new ProjectHealthScanner(d),
+                d,
+                () -> { dismiss(ref[0]); onNewProject(); },
+                projectDir -> { dismiss(ref[0]); openProjectFromHub(projectDir); },
+                () -> { dismiss(ref[0]); onOpenProject(); },
+                () -> { dismiss(ref[0]); onRestoreFromArchive(); },
+                () -> { dismiss(ref[0]); onImportSession(); });
+        ref[0] = view;
+        return view;
+    }
+
+    /** Hides the window hosting {@code surface} (a Hub / Welcome launch surface), if shown. */
+    private static void dismiss(javafx.scene.Node surface) {
+        if (surface != null && surface.getScene() != null && surface.getScene().getWindow() != null) {
+            surface.getScene().getWindow().hide();
+        }
+    }
+
+    /**
+     * Presents the §4.1 Welcome screen (shown on launch when no project is
+     * open). Routed through the {@link #welcomePresenter} seam so a test can
+     * capture it without opening a window.
+     */
+    void showWelcome() {
+        welcomePresenter.accept(buildWelcomeView());
+    }
+
+    /** Confirms any unsaved changes, then opens {@code projectDir} (Hub / Welcome action). */
+    private void openProjectFromHub(Path projectDir) {
+        if (projectDir != null && confirmDiscardUnsavedChanges()) {
+            loadProjectFromPath(projectDir);
+        }
+    }
+
+    // ── Seam defaults (overridable for tests / custom wiring) ─────────────────
+
+    /**
+     * Default {@link #newProjectLocationPrompt}: a {@link DirectoryChooser}
+     * rooted at the §3.1 workspace ({@code ~/DAW Projects}). Returns the chosen
+     * parent directory, or {@code null} if the user cancelled.
+     */
+    private Path promptNewProjectLocation() {
+        DirectoryChooser chooser = new DirectoryChooser();
+        chooser.setTitle("Choose a location for the new project");
+        Path workspace = workspaceRoot();
+        if (workspace != null && Files.isDirectory(workspace)) {
+            chooser.setInitialDirectory(workspace.toFile());
+        }
+        Window owner = rootPane.getScene() != null ? rootPane.getScene().getWindow() : null;
+        java.io.File chosen = chooser.showDialog(owner);
+        return chosen == null ? null : chosen.toPath();
+    }
+
+    /** The §3.1 default workspace root ({@code ~/DAW Projects}); {@code null} if no home. */
+    private static Path workspaceRoot() {
+        String home = System.getProperty("user.home");
+        if (home == null || home.isBlank()) {
+            return null;
+        }
+        return Path.of(home, "DAW Projects");
+    }
+
+    /** Default {@link #projectHubPresenter}: open the Hub in its own themed Stage. */
+    private void presentProjectHub(ProjectHubView hub) {
+        showInOwnedStage("Project Hub", hub);
+    }
+
+    /** Default {@link #welcomePresenter}: open the Welcome screen in its own themed Stage. */
+    private void presentWelcome(WelcomeView welcome) {
+        showInOwnedStage("Welcome", welcome);
+    }
+
+    /**
+     * Shows {@code content} as the root of a new {@link Stage} owned by the main
+     * window, themed exactly like the primary scene (the ordered
+     * {@link ThemeManager} stylesheets + the {@link DensityManager} density
+     * class) so role tokens resolve and a theme/density switch reaches it.
+     */
+    private void showInOwnedStage(String title, Parent content) {
+        if (!content.getStyleClass().contains("root-pane")) {
+            content.getStyleClass().add("root-pane");
+        }
+        Scene scene = new Scene(content, 1100, 720);
+        ThemeManager.getDefault().applyTo(scene);
+        DensityManager.getDefault().applyTo(scene);
+        Stage stage = new Stage();
+        stage.setTitle(title);
+        Window owner = rootPane.getScene() != null ? rootPane.getScene().getWindow() : null;
+        if (owner != null) {
+            stage.initOwner(owner);
+        }
+        stage.setScene(scene);
+        // Only ever one auxiliary Hub/Welcome window at a time: close any prior one
+        // so a repeated "Project Hub…" replaces rather than stacks orphan windows
+        // (each running its own background scans). The hidden-handler clears the
+        // reference when the user closes the window themselves.
+        if (auxiliaryStage != null && auxiliaryStage.isShowing()) {
+            auxiliaryStage.close();
+        }
+        auxiliaryStage = stage;
+        stage.setOnHidden(_ -> {
+            if (auxiliaryStage == stage) {
+                auxiliaryStage = null;
+            }
+        });
+        stage.show();
+    }
+
+    /**
+     * Reveals {@code projectDir} in the OS file browser (the Hub's "Reveal"
+     * action). Runs the launch on a background virtual thread so a slow shell
+     * never stalls the FX thread; errors are marshalled back to the
+     * notification bar.
+     */
+    private void revealInFileBrowser(Path projectDir) {
+        if (projectDir == null) {
+            return;
+        }
+        Thread.ofVirtual().name("daw-reveal").start(() -> {
+            try {
+                if (java.awt.Desktop.isDesktopSupported()
+                        && java.awt.Desktop.getDesktop().isSupported(java.awt.Desktop.Action.OPEN)) {
+                    java.awt.Desktop.getDesktop().open(projectDir.toFile());
+                } else {
+                    postFx(() -> notificationBar.show(NotificationLevel.ERROR,
+                            "Reveal is not supported on this platform"));
+                }
+            } catch (IOException | RuntimeException e) {
+                postFx(() -> notificationBar.show(NotificationLevel.ERROR,
+                        "Could not reveal project: " + e.getMessage()));
+                LOG.log(Level.WARNING, "Failed to reveal project directory", e);
+            }
+        });
+    }
+
+    /**
+     * Resolves a non-{@code null} {@link FxDispatcher} for the scanner / views:
+     * the injected one, else the app-scoped default, else a fresh instance (the
+     * scanner only uses {@link FxDispatcher#onFx(Runnable)}, which works without
+     * {@code start()}).
+     */
+    private FxDispatcher resolveDispatcher() {
+        if (fxDispatcher != null) {
+            return fxDispatcher;
+        }
+        FxDispatcher def = FxDispatcher.getDefault();
+        return def != null ? def : new FxDispatcher();
+    }
+
+    // ── Seam overrides (story 296) ────────────────────────────────────────────
+
+    /**
+     * Overrides the new-project location prompt (the §8 "kill the /tmp
+     * first-save" seam). Tests inject a stub returning a fixed directory.
+     *
+     * @param prompt supplies the destination parent directory, or {@code null}
+     *               to cancel; must not be {@code null}
+     */
+    void setNewProjectLocationPrompt(Supplier<Path> prompt) {
+        this.newProjectLocationPrompt = Objects.requireNonNull(prompt, "prompt must not be null");
+    }
+
+    /**
+     * Overrides the Project Hub presenter. Tests inject a capturing consumer to
+     * assert the Hub was opened without showing a window.
+     *
+     * @param presenter the hub presenter; must not be {@code null}
+     */
+    void setProjectHubPresenter(Consumer<ProjectHubView> presenter) {
+        this.projectHubPresenter = Objects.requireNonNull(presenter, "presenter must not be null");
+    }
+
+    /**
+     * Overrides the Welcome-screen presenter. Tests inject a capturing consumer.
+     *
+     * @param presenter the welcome presenter; must not be {@code null}
+     */
+    void setWelcomePresenter(Consumer<WelcomeView> presenter) {
+        this.welcomePresenter = Objects.requireNonNull(presenter, "presenter must not be null");
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ProjectLifecycleController.java
@@ -899,7 +899,12 @@ final class ProjectLifecycleController {
                 projectManager.getRecentProjectPaths(),
                 new ProjectHealthScanner(d),
                 d,
-                projectDir -> { dismiss(ref[0]); openProjectFromHub(projectDir); },
+                projectDir -> {
+                    if (projectDir != null && confirmDiscardUnsavedChanges()) {
+                        dismiss(ref[0]);
+                        loadProjectFromPath(projectDir);
+                    }
+                },
                 this::revealInFileBrowser,
                 this::clearRecentProjects);
         ref[0] = hub;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/HealthBadge.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/HealthBadge.java
@@ -1,0 +1,56 @@
+package com.benesquivelmusic.daw.app.ui.hub;
+
+import java.util.List;
+
+/**
+ * The health classification shown on a {@link ProjectCard} in the story-296
+ * Project Hub / Welcome screen. Each badge carries the exact style class the
+ * card adds to itself (so the {@code .project-card.project-card-…} CSS targets
+ * its health label) and a default human label.
+ *
+ * <p>Standalone enum (not nested in {@link ProjectCard}) so the JavaFX-free
+ * {@link ProjectScanResult} record can carry a {@code HealthBadge} without
+ * depending on the JavaFX {@code Control}.</p>
+ */
+public enum HealthBadge {
+
+    /** Loads cleanly at the current schema, all assets present. */
+    HEALTHY("project-card-healthy", "✓ healthy"),
+    /** Was migrated from an older schema (a pre-migration backup exists). */
+    MIGRATED("project-card-migrated", "⚠ migrated"),
+    /** One or more referenced assets are missing on disk. */
+    MISSING_ASSETS("project-card-missing", "⚠ missing assets");
+
+    private final String styleClass;
+    private final String label;
+
+    HealthBadge(String styleClass, String label) {
+        this.styleClass = styleClass;
+        this.label = label;
+    }
+
+    /** @return the single style class the card adds to itself for this badge. */
+    public String styleClass() {
+        return styleClass;
+    }
+
+    /**
+     * @return the base label for this badge; callers may append a detail such
+     *         as {@code "vN→vM"} (migrated) or a count (missing assets)
+     */
+    public String defaultLabel() {
+        return label;
+    }
+
+    /**
+     * @return all three badge style classes, for the card's remove-then-add
+     *         style-class reconciliation (so flipping the badge never leaves a
+     *         stale class on the control)
+     */
+    public static List<String> allStyleClasses() {
+        return List.of(
+                HEALTHY.styleClass,
+                MIGRATED.styleClass,
+                MISSING_ASSETS.styleClass);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/HubFormat.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/HubFormat.java
@@ -1,0 +1,106 @@
+package com.benesquivelmusic.daw.app.ui.hub;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
+/**
+ * Pure, toolkit-free helpers for the story-296 Project Hub cards: a humanised
+ * byte count, a relative "last opened" label, and a path base-name. All methods
+ * are static and side-effect-free.
+ */
+public final class HubFormat {
+
+    private static final DateTimeFormatter CLOCK =
+            DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT);
+    private static final DateTimeFormatter SHORT_DATE =
+            DateTimeFormatter.ofPattern("dd MMM", Locale.ROOT);
+
+    private HubFormat() {
+        // Static utility — no instances.
+    }
+
+    /**
+     * The base (file) name of {@code path} — the single shared implementation
+     * for the hub's card-name seeding (previously copied, with a divergent
+     * fallback, across {@code ProjectHubView} and {@code ProjectHealthScanner}).
+     * Falls back to the full path string for a root path whose
+     * {@link Path#getFileName()} is {@code null}, so a card never seeds blank.
+     *
+     * @param path the path; must not be {@code null}
+     * @return the file name, or the full path string when there is no file name
+     */
+    public static String baseName(Path path) {
+        Path fileName = path.getFileName();
+        return fileName != null ? fileName.toString() : path.toString();
+    }
+
+    /**
+     * Humanises a byte count: one decimal at terabyte scale ({@code "X.X TB"}),
+     * whole units below it ({@code "X GB"} / {@code "X MB"} / {@code "X KB"}),
+     * and {@code "—"} for a negative (unknown) count.
+     *
+     * <p>Known intentional duplication of
+     * {@code SessionStatusStripSkin.formatBytes} — the hub keeps its own copy
+     * to avoid coupling the {@code hub} package to the {@code status} package.</p>
+     *
+     * @param bytes the byte count ({@code < 0} → unknown)
+     * @return the humanised string
+     */
+    public static String formatBytes(long bytes) {
+        if (bytes < 0) {
+            return "—";
+        }
+        double kb = bytes / 1024.0;
+        double mb = kb / 1024.0;
+        double gb = mb / 1024.0;
+        double tb = gb / 1024.0;
+        if (tb >= 1.0) {
+            return String.format(Locale.ROOT, "%.1f TB", tb);
+        }
+        if (gb >= 1.0) {
+            return String.format(Locale.ROOT, "%.0f GB", gb);
+        }
+        if (mb >= 1.0) {
+            return String.format(Locale.ROOT, "%.0f MB", mb);
+        }
+        return String.format(Locale.ROOT, "%.0f KB", kb);
+    }
+
+    /**
+     * Formats a "last opened" instant relative to {@code clock}: {@code "—"}
+     * when {@code null}; {@code "HH:mm today"} on the same calendar day;
+     * {@code "Yesterday"} for the previous day; {@code "N days ago"} when under
+     * a week; otherwise a short {@code "dd MMM"} date. {@link Locale#ROOT} and
+     * the system default zone.
+     *
+     * @param when  the instant, or {@code null} for unknown
+     * @param clock the clock supplying "now"; must not be {@code null}
+     * @return the relative label
+     */
+    public static String formatRelativeOpened(Instant when, InstantSource clock) {
+        if (when == null) {
+            return "—";
+        }
+        ZoneId zone = ZoneId.systemDefault();
+        LocalDate day = when.atZone(zone).toLocalDate();
+        LocalDate today = clock.instant().atZone(zone).toLocalDate();
+
+        if (day.equals(today)) {
+            return CLOCK.format(when.atZone(zone)) + " today";
+        }
+        if (day.equals(today.minusDays(1))) {
+            return "Yesterday";
+        }
+        long daysBetween = ChronoUnit.DAYS.between(day, today);
+        if (daysBetween > 0 && daysBetween < 7) {
+            return daysBetween + " days ago";
+        }
+        return SHORT_DATE.format(when.atZone(zone));
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectCard.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectCard.java
@@ -1,0 +1,322 @@
+package com.benesquivelmusic.daw.app.ui.hub;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.LongProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleLongProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.AccessibleRole;
+import javafx.scene.control.Control;
+import javafx.scene.control.Label;
+import javafx.scene.control.Skin;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * One project tile in the story-296 Project Hub / Welcome screen — a custom
+ * {@link Control} carrying a project's name, last-opened time, on-disk size,
+ * session count, schema / backup versions, lock holder and a {@link HealthBadge}.
+ *
+ * <p>Follows the {@code Control + SkinBase + package-resource user-agent
+ * stylesheet} convention of {@link com.benesquivelmusic.daw.app.ui.status.StatusStripCell}
+ * and {@link com.benesquivelmusic.daw.app.ui.status.SessionStatusStrip}
+ * ({@code javafx-application-design} skill §3 Control/Skin split, §8 themeable
+ * via a user-agent stylesheet plus stable style classes).</p>
+ *
+ * <h2>Headless-safe style-class reconciliation</h2>
+ *
+ * <p>The {@link #healthProperty() health}, {@link #selectedProperty() selected}
+ * and {@link #pinnedProperty() pinned} properties reconcile their style classes
+ * <em>on this control itself</em> from {@code invalidated()} (mirroring
+ * {@code StatusStripCell.severity}) so the visual state is correct even in a
+ * headless, unrealized-skin test. The matching {@code -fx-*} rules live in
+ * {@code project-card.css}.</p>
+ *
+ * <h2>Control/Skin split</h2>
+ *
+ * <p>{@link ProjectCardSkin} builds and binds the labels. The label accessors
+ * below delegate to the realized skin — a test must attach the card to a
+ * {@code Scene} and call {@code applyCss()} before reading them.</p>
+ *
+ * @see ProjectCardSkin
+ * @see ProjectScanResult
+ */
+public final class ProjectCard extends Control {
+
+    /** Stable style class — selectable as {@code .project-card}. */
+    public static final String DEFAULT_STYLE_CLASS = "project-card";
+
+    /** Style class added while {@link #selectedProperty()} is {@code true}. */
+    public static final String SELECTED_CLASS = "project-card-selected";
+
+    /** Style class added while {@link #pinnedProperty()} is {@code true}. */
+    public static final String PINNED_CLASS = "project-card-pinned";
+
+    private final StringProperty name =
+            new SimpleStringProperty(this, "name", "");
+    private final ObjectProperty<Instant> lastOpened =
+            new SimpleObjectProperty<>(this, "lastOpened", null);
+    private final LongProperty sizeOnDiskBytes =
+            new SimpleLongProperty(this, "sizeOnDiskBytes", -1L);
+    private final IntegerProperty sessionCount =
+            new SimpleIntegerProperty(this, "sessionCount", -1);
+    private final IntegerProperty missingAssetCount =
+            new SimpleIntegerProperty(this, "missingAssetCount", 0);
+    private final IntegerProperty schemaVersion =
+            new SimpleIntegerProperty(this, "schemaVersion", -1);
+    private final IntegerProperty backupSchemaVersion =
+            new SimpleIntegerProperty(this, "backupSchemaVersion", -1);
+    private final StringProperty lockHolderLabel =
+            new SimpleStringProperty(this, "lockHolderLabel", "");
+    private final BooleanProperty lockStale =
+            new SimpleBooleanProperty(this, "lockStale", false);
+
+    /**
+     * Pinned state. Its {@code invalidated()} reconciles the
+     * {@link #PINNED_CLASS} style class on this control (headless-safe).
+     */
+    private final BooleanProperty pinned =
+            new SimpleBooleanProperty(this, "pinned", false) {
+                @Override
+                protected void invalidated() {
+                    reconcileFlagClass(PINNED_CLASS, get());
+                }
+            };
+
+    /**
+     * Selected state. Its {@code invalidated()} reconciles the
+     * {@link #SELECTED_CLASS} style class on this control (headless-safe).
+     */
+    private final BooleanProperty selected =
+            new SimpleBooleanProperty(this, "selected", false) {
+                @Override
+                protected void invalidated() {
+                    reconcileFlagClass(SELECTED_CLASS, get());
+                }
+            };
+
+    /**
+     * Health badge. Its {@code set(...)} coerces {@code null} to
+     * {@link HealthBadge#HEALTHY}, and its {@code invalidated()} reconciles the
+     * three badge style classes directly on this control (headless-safe —
+     * copies {@code StatusStripCell.severity}): remove all three, add exactly
+     * the current badge's class.
+     */
+    private final ObjectProperty<HealthBadge> health =
+            new SimpleObjectProperty<>(this, "health", HealthBadge.HEALTHY) {
+                @Override
+                public void set(HealthBadge newValue) {
+                    super.set(newValue == null ? HealthBadge.HEALTHY : newValue);
+                }
+
+                @Override
+                protected void invalidated() {
+                    getStyleClass().removeAll(HealthBadge.allStyleClasses());
+                    getStyleClass().add(get().styleClass());
+                }
+            };
+
+    /** Creates a blank card ({@link HealthBadge#HEALTHY}, unknown facts). */
+    public ProjectCard() {
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        // Seed the health style class so a card constructed but never re-set
+        // still carries .project-card-healthy.
+        getStyleClass().add(HealthBadge.HEALTHY.styleClass());
+        setAccessibleRole(AccessibleRole.BUTTON);
+        setFocusTraversable(true);
+        // Keep the screen-reader text in step with the name (no bind on a
+        // read-only-style accessor — a listener + setter, like the design notes).
+        name.addListener((_, _, n) -> setAccessibleText(n == null ? "" : n));
+        setAccessibleText(name.get());
+    }
+
+    private void reconcileFlagClass(String styleClass, boolean on) {
+        // Remove first (guards against a duplicate add), then add when on —
+        // mirrors StatusStripCell.severity's add/remove so the state is correct
+        // without a realized skin.
+        getStyleClass().remove(styleClass);
+        if (on) {
+            getStyleClass().add(styleClass);
+        }
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new ProjectCardSkin(this);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(
+                ProjectCard.class.getResource("project-card.css"),
+                "project-card.css not on classpath").toExternalForm();
+    }
+
+    /**
+     * Applies a {@link ProjectScanResult} to this card's properties — the
+     * scan's name, last-opened, size, session count, missing-asset count,
+     * schema / backup versions, lock holder + staleness, and health. Leaves
+     * {@link #pinnedProperty() pinned} and {@link #selectedProperty() selected}
+     * untouched (those are view state, not scan output). Call on the FX thread.
+     *
+     * @param r the scan result; must not be {@code null}
+     */
+    public void applyScanResult(ProjectScanResult r) {
+        Objects.requireNonNull(r, "scan result must not be null");
+        setName(r.name());
+        setLastOpened(r.lastOpened());
+        setSizeOnDiskBytes(r.sizeOnDiskBytes());
+        setSessionCount(r.sessionCount());
+        setMissingAssetCount(r.missingAssetCount());
+        setSchemaVersion(r.schemaVersion());
+        setBackupSchemaVersion(r.backupSchemaVersion());
+        setLockHolderLabel(r.lockHolderLabel());
+        setLockStale(r.lockStale());
+        setHealth(r.health());
+    }
+
+    // ── name ─────────────────────────────────────────────────────────────────
+
+    /** @return the project-name property. */
+    public final StringProperty nameProperty() { return name; }
+    /** @return the project name. */
+    public final String getName() { return name.get(); }
+    /** @param name the project name. */
+    public final void setName(String name) { this.name.set(name); }
+
+    // ── lastOpened ─────────────────────────────────────────────────────────────
+
+    /** @return the last-opened property (value may be {@code null}). */
+    public final ObjectProperty<Instant> lastOpenedProperty() { return lastOpened; }
+    /** @return the last-opened instant, or {@code null}. */
+    public final Instant getLastOpened() { return lastOpened.get(); }
+    /** @param lastOpened the last-opened instant, or {@code null}. */
+    public final void setLastOpened(Instant lastOpened) { this.lastOpened.set(lastOpened); }
+
+    // ── sizeOnDiskBytes ────────────────────────────────────────────────────────
+
+    /** @return the on-disk-size property ({@code -1} = unknown). */
+    public final LongProperty sizeOnDiskBytesProperty() { return sizeOnDiskBytes; }
+    /** @return the on-disk size in bytes, or {@code -1} if unknown. */
+    public final long getSizeOnDiskBytes() { return sizeOnDiskBytes.get(); }
+    /** @param bytes the on-disk size in bytes ({@code -1} = unknown). */
+    public final void setSizeOnDiskBytes(long bytes) { this.sizeOnDiskBytes.set(bytes); }
+
+    // ── sessionCount ───────────────────────────────────────────────────────────
+
+    /** @return the session-count property ({@code -1} = unknown). */
+    public final IntegerProperty sessionCountProperty() { return sessionCount; }
+    /** @return the session count, or {@code -1} if unknown. */
+    public final int getSessionCount() { return sessionCount.get(); }
+    /** @param count the session count ({@code -1} = unknown). */
+    public final void setSessionCount(int count) { this.sessionCount.set(count); }
+
+    // ── missingAssetCount ──────────────────────────────────────────────────────
+
+    /** @return the missing-asset-count property. */
+    public final IntegerProperty missingAssetCountProperty() { return missingAssetCount; }
+    /** @return the missing-asset count. */
+    public final int getMissingAssetCount() { return missingAssetCount.get(); }
+    /** @param count the missing-asset count. */
+    public final void setMissingAssetCount(int count) { this.missingAssetCount.set(count); }
+
+    // ── schemaVersion ──────────────────────────────────────────────────────────
+
+    /** @return the schema-version property ({@code -1} = unknown). */
+    public final IntegerProperty schemaVersionProperty() { return schemaVersion; }
+    /** @return the schema version, or {@code -1} if unknown. */
+    public final int getSchemaVersion() { return schemaVersion.get(); }
+    /** @param version the schema version ({@code -1} = unknown). */
+    public final void setSchemaVersion(int version) { this.schemaVersion.set(version); }
+
+    // ── backupSchemaVersion ────────────────────────────────────────────────────
+
+    /** @return the backup-schema-version property ({@code -1} = none). */
+    public final IntegerProperty backupSchemaVersionProperty() { return backupSchemaVersion; }
+    /** @return the backup schema version, or {@code -1} if none. */
+    public final int getBackupSchemaVersion() { return backupSchemaVersion.get(); }
+    /** @param version the backup schema version ({@code -1} = none). */
+    public final void setBackupSchemaVersion(int version) { this.backupSchemaVersion.set(version); }
+
+    // ── lockHolderLabel ────────────────────────────────────────────────────────
+
+    /** @return the lock-holder-label property ({@code ""} = no lock). */
+    public final StringProperty lockHolderLabelProperty() { return lockHolderLabel; }
+    /** @return the lock-holder label, or {@code ""} if no lock. */
+    public final String getLockHolderLabel() { return lockHolderLabel.get(); }
+    /** @param label the lock-holder label ({@code ""} = no lock). */
+    public final void setLockHolderLabel(String label) { this.lockHolderLabel.set(label); }
+
+    // ── lockStale ──────────────────────────────────────────────────────────────
+
+    /** @return the lock-stale property. */
+    public final BooleanProperty lockStaleProperty() { return lockStale; }
+    /** @return whether the lock is stale. */
+    public final boolean isLockStale() { return lockStale.get(); }
+    /** @param stale whether the lock is stale. */
+    public final void setLockStale(boolean stale) { this.lockStale.set(stale); }
+
+    // ── pinned ─────────────────────────────────────────────────────────────────
+
+    /**
+     * @return the pinned property; setting it reconciles the
+     *         {@link #PINNED_CLASS} style class on this control
+     */
+    public final BooleanProperty pinnedProperty() { return pinned; }
+    /** @return whether this card is pinned. */
+    public final boolean isPinned() { return pinned.get(); }
+    /** @param pinned whether this card is pinned. */
+    public final void setPinned(boolean pinned) { this.pinned.set(pinned); }
+
+    // ── selected ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return the selected property; setting it reconciles the
+     *         {@link #SELECTED_CLASS} style class on this control
+     */
+    public final BooleanProperty selectedProperty() { return selected; }
+    /** @return whether this card is selected. */
+    public final boolean isSelected() { return selected.get(); }
+    /** @param selected whether this card is selected. */
+    public final void setSelected(boolean selected) { this.selected.set(selected); }
+
+    // ── health ─────────────────────────────────────────────────────────────────
+
+    /**
+     * @return the health property. Setting it (or invalidating it) reconciles
+     *         the {@link HealthBadge#allStyleClasses()} style classes on this
+     *         control, leaving exactly the current badge's class.
+     */
+    public final ObjectProperty<HealthBadge> healthProperty() { return health; }
+    /** @return the current health badge (never {@code null}). */
+    public final HealthBadge getHealth() { return health.get(); }
+    /** @param health the health badge; a {@code null} is coerced to {@link HealthBadge#HEALTHY}. */
+    public final void setHealth(HealthBadge health) { this.health.set(health); }
+
+    // ── Skin-delegated label accessors ───────────────────────────────────────────
+
+    private ProjectCardSkin skin() {
+        Skin<?> skin = getSkin();
+        if (!(skin instanceof ProjectCardSkin pcs)) {
+            throw new IllegalStateException(
+                    "ProjectCard skin is not realized yet — attach the card to a "
+                            + "Scene and call applyCss() before reading its labels.");
+        }
+        return pcs;
+    }
+
+    /** @return the name label (delegates to the realized skin). */
+    public Label nameLabel() { return skin().nameLabel(); }
+
+    /** @return the meta label (the "14:22 today · 1.8 GB · 12 sess." line). */
+    public Label metaLabel() { return skin().metaLabel(); }
+
+    /** @return the health label. */
+    public Label healthLabel() { return skin().healthLabel(); }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectCardSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectCardSkin.java
@@ -1,0 +1,122 @@
+package com.benesquivelmusic.daw.app.ui.hub;
+
+import javafx.beans.binding.Bindings;
+import javafx.scene.control.Label;
+import javafx.scene.control.SkinBase;
+import javafx.scene.layout.VBox;
+
+import java.time.InstantSource;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Skin for {@link ProjectCard} (story-296 Project Hub / Welcome screen,
+ * {@code javafx-application-design} skill §3). Builds a small card layout — a
+ * name, a one-line meta summary and a health line — and binds each label's
+ * text to a {@code StringBinding} over the card's properties.
+ *
+ * <h2>Binding-only</h2>
+ *
+ * <p>Every label's text is wired via {@code bind(...)}; this skin never calls
+ * {@code Label.setText} after construction. {@link #dispose()} unbinds all
+ * labels before delegating to the superclass so the skin can be swapped (e.g.
+ * on a theme change) without leaking the bindings ({@code javafx-application-design}
+ * §3/§4).</p>
+ */
+public final class ProjectCardSkin extends SkinBase<ProjectCard> {
+
+    private final Label nameLabel = new Label();
+    private final Label metaLabel = new Label();
+    private final Label healthLabel = new Label();
+    private final VBox content = new VBox();
+
+    /**
+     * Clock backing the relative "last opened" label — captured once rather than
+     * re-fetched on every binding recompute. (Stage 2 uses the system clock; a
+     * later stage can make this injectable for a deterministic relative label.)
+     */
+    private final InstantSource clock = InstantSource.system();
+
+    /**
+     * Builds the card's labels and binds them to the control's properties.
+     *
+     * @param card the owning {@link ProjectCard}
+     */
+    public ProjectCardSkin(ProjectCard card) {
+        super(card);
+
+        nameLabel.getStyleClass().add("project-card-name");
+        metaLabel.getStyleClass().add("project-card-meta");
+        healthLabel.getStyleClass().add("project-card-health");
+        content.getStyleClass().add("project-card-content");
+
+        // Name — straight mirror of the control's name property.
+        nameLabel.textProperty().bind(card.nameProperty());
+
+        // Meta — "<last opened> · <size> · N sess.", omitting the session
+        // fragment when the count is unknown (-1), joined by " · ".
+        metaLabel.textProperty().bind(Bindings.createStringBinding(
+                () -> {
+                    List<String> parts = new ArrayList<>(3);
+                    parts.add(HubFormat.formatRelativeOpened(
+                            card.getLastOpened(), clock));
+                    parts.add(HubFormat.formatBytes(card.getSizeOnDiskBytes()));
+                    int sessions = card.getSessionCount();
+                    if (sessions >= 0) {
+                        parts.add(sessions + " sess.");
+                    }
+                    return String.join(" · ", parts);
+                },
+                card.lastOpenedProperty(), card.sizeOnDiskBytesProperty(),
+                card.sessionCountProperty()));
+
+        // Health — badge label, with a migrated-version detail and a
+        // missing-assets count when those facts are known.
+        healthLabel.textProperty().bind(Bindings.createStringBinding(
+                () -> healthText(card),
+                card.healthProperty(), card.backupSchemaVersionProperty(),
+                card.schemaVersionProperty(), card.missingAssetCountProperty()));
+
+        content.getChildren().setAll(nameLabel, metaLabel, healthLabel);
+        getChildren().add(content);
+    }
+
+    /**
+     * The §health-line text for {@code card}: {@code "✓ healthy"} when healthy;
+     * {@code "⚠ migrated v{backup}→v{schema}"} when migrated (omitting the
+     * arrow detail if either version is unknown); {@code "⚠ {n} missing assets"}
+     * when assets are missing.
+     */
+    private static String healthText(ProjectCard card) {
+        HealthBadge badge = card.getHealth();
+        return switch (badge) {
+            case HEALTHY -> HealthBadge.HEALTHY.defaultLabel();
+            case MIGRATED -> {
+                int backup = card.getBackupSchemaVersion();
+                int schema = card.getSchemaVersion();
+                if (backup >= 0 && schema >= 0) {
+                    yield HealthBadge.MIGRATED.defaultLabel() + " v" + backup + "→v" + schema;
+                }
+                yield HealthBadge.MIGRATED.defaultLabel();
+            }
+            case MISSING_ASSETS -> {
+                int missing = card.getMissingAssetCount();
+                yield "⚠ " + missing + " missing assets";
+            }
+        };
+    }
+
+    // ── Accessors for the control (delegated to from ProjectCard) ───────────────
+
+    Label nameLabel() { return nameLabel; }
+    Label metaLabel() { return metaLabel; }
+    Label healthLabel() { return healthLabel; }
+
+    @Override
+    public void dispose() {
+        nameLabel.textProperty().unbind();
+        metaLabel.textProperty().unbind();
+        healthLabel.textProperty().unbind();
+        super.dispose();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectCardSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectCardSkin.java
@@ -101,7 +101,8 @@ public final class ProjectCardSkin extends SkinBase<ProjectCard> {
             }
             case MISSING_ASSETS -> {
                 int missing = card.getMissingAssetCount();
-                yield "⚠ " + missing + " missing assets";
+                String noun = missing == 1 ? "asset" : "assets";
+                yield "⚠ " + missing + " missing " + noun;
             }
         };
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHealthScanner.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHealthScanner.java
@@ -1,0 +1,237 @@
+package com.benesquivelmusic.daw.app.ui.hub;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.persistence.ProjectLock;
+import com.benesquivelmusic.daw.core.persistence.ProjectLockManager;
+import com.benesquivelmusic.daw.core.persistence.ProjectMetadata;
+import com.benesquivelmusic.daw.core.persistence.ProjectMetadataReader;
+import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
+import com.benesquivelmusic.daw.core.persistence.migration.MigrationRegistry;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Produces a {@link ProjectScanResult} for a project directory — the quick
+ * on-open scan that populates a {@link ProjectCard} in the story-296 Project
+ * Hub / Welcome screen.
+ *
+ * <h2>Off the FX thread ({@code javafx-application-design} §11)</h2>
+ *
+ * <p>{@link #scanBlocking(Path, InstantSource)} performs all the I/O on the
+ * calling thread and never touches JavaFX. {@link #scan(Path, Consumer)} spawns
+ * a background <strong>virtual thread</strong> ({@code Thread.ofVirtual()}),
+ * runs {@code scanBlocking} there, then marshals the result to the FX-thread
+ * consumer through the story-289 {@link FxDispatcher} — exactly the shape of
+ * {@code SessionStatusDiskScanner.scanNow()}. {@link #scanInto(Path, ProjectCard)}
+ * is the common case: scan, then apply onto a card on the FX thread.</p>
+ *
+ * <h2>Stage 2 scope</h2>
+ *
+ * <p>This stage scans name + last-opened (via {@link ProjectMetadataReader}),
+ * on-disk size (via {@link ProjectDiskUsage}), the advisory lock (via
+ * {@link ProjectLockManager#peekLock(Path)} — no side effect), and the newest
+ * pre-migration backup ({@code project.daw.v<n>.<stamp>.bak}). The session
+ * count is reported as unknown ({@code -1}) and the missing-asset count as
+ * {@code 0}; both are filled in by a later stage.</p>
+ */
+public final class ProjectHealthScanner {
+
+    private static final String PROJECT_FILE_NAME = "project.daw";
+
+    /**
+     * Matches a pre-migration backup sibling written by
+     * {@code ProjectManager.writeMigrationBackup}:
+     * {@code project.daw.v<digits>.<stamp>.bak} (optionally
+     * {@code …-<n>.bak} on a same-second collision). Group 1 is the version;
+     * group 2 is the {@code yyyyMMdd-HHmmss[-<n>]} stamp, which is
+     * lexicographically time-ordered.
+     */
+    private static final Pattern BACKUP_PATTERN =
+            Pattern.compile(Pattern.quote(PROJECT_FILE_NAME) + "\\.v(\\d+)\\.(.+)\\.bak");
+
+    private final FxDispatcher dispatcher;
+
+    /**
+     * Creates a scanner that marshals scan results through {@code dispatcher}.
+     *
+     * @param dispatcher the FX marshalling seam; must not be {@code null}
+     */
+    public ProjectHealthScanner(FxDispatcher dispatcher) {
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
+    }
+
+    /**
+     * Performs a full project scan on the <strong>calling</strong> thread (all
+     * I/O; never touches JavaFX). Robust: a failed disk-usage walk yields a
+     * {@code null} {@code diskUsage} rather than throwing.
+     *
+     * @param projectDir the project directory to scan; must not be {@code null}
+     * @param clock      the clock used for stale-lock classification; must not be {@code null}
+     * @return the scan result (never {@code null})
+     */
+    public static ProjectScanResult scanBlocking(Path projectDir, InstantSource clock) {
+        Objects.requireNonNull(projectDir, "projectDir must not be null");
+        Objects.requireNonNull(clock, "clock must not be null");
+
+        // ── name + lastOpened ──────────────────────────────────────────────
+        Optional<ProjectMetadata> metadata = ProjectMetadataReader.read(projectDir);
+        String name = metadata
+                .map(ProjectMetadata::name)
+                .filter(n -> !n.isBlank())
+                .orElseGet(() -> HubFormat.baseName(projectDir));
+        Instant lastOpened = metadata
+                .map(ProjectMetadata::lastModified)
+                .orElseGet(() -> lastModifiedInstant(projectDir.resolve(PROJECT_FILE_NAME)));
+
+        // ── disk usage ─────────────────────────────────────────────────────
+        ProjectDiskUsage diskUsage;
+        try {
+            diskUsage = ProjectDiskUsage.compute(projectDir);
+        } catch (IOException e) {
+            diskUsage = null; // best-effort — a card still renders
+        }
+
+        // ── lock (side-effect-free peek) ───────────────────────────────────
+        Optional<ProjectLock> lock = ProjectLockManager.peekLock(projectDir);
+        boolean lockPresent = lock.isPresent();
+        boolean lockStale = lock
+                .map(l -> ProjectLockManager.isStale(l, clock.instant()))
+                .orElse(false);
+        String lockHolderLabel = lock
+                .map(l -> l.user() + " @ " + l.hostname())
+                .orElse("");
+
+        // ── newest pre-migration backup ────────────────────────────────────
+        int backupSchemaVersion = newestBackupSchemaVersion(projectDir);
+
+        int schemaVersion = MigrationRegistry.CURRENT_VERSION;
+        HealthBadge health = (backupSchemaVersion >= 0) ? HealthBadge.MIGRATED : HealthBadge.HEALTHY;
+        int missingAssetCount = 0;          // Stage 2
+        int sessionCount = -1;              // Stage 2 — no sessions/ yet
+        boolean recoverable = lockPresent && lockStale;
+
+        return new ProjectScanResult(
+                projectDir, name, lastOpened, diskUsage, sessionCount, health,
+                missingAssetCount, schemaVersion, backupSchemaVersion,
+                lockHolderLabel, lockPresent, lockStale, recoverable);
+    }
+
+    /**
+     * Spawns one scan on a fresh background <strong>virtual</strong> thread and
+     * returns it (so callers — and tests — can join on completion). The scan
+     * runs {@link #scanBlocking(Path, InstantSource)} off the FX thread and
+     * marshals the result to {@code fxConsumer} via {@link FxDispatcher#onFx(Runnable)}.
+     *
+     * @param projectDir the project directory to scan; must not be {@code null}
+     * @param fxConsumer the FX-thread consumer of the result; must not be {@code null}
+     * @return the started virtual scan thread
+     */
+    public Thread scan(Path projectDir, Consumer<ProjectScanResult> fxConsumer) {
+        Objects.requireNonNull(projectDir, "projectDir must not be null");
+        Objects.requireNonNull(fxConsumer, "fxConsumer must not be null");
+        Thread t = Thread.ofVirtual().name("daw-project-health-scan").unstarted(() -> {
+            ProjectScanResult r = scanBlocking(projectDir, InstantSource.system());
+            dispatcher.onFx(() -> fxConsumer.accept(r));
+        });
+        t.start();
+        return t;
+    }
+
+    /**
+     * Scans {@code projectDir} on a background virtual thread and applies the
+     * result onto {@code card} on the FX thread.
+     *
+     * @param projectDir the project directory to scan; must not be {@code null}
+     * @param card       the card to populate; must not be {@code null}
+     * @return the started virtual scan thread
+     */
+    public Thread scanInto(Path projectDir, ProjectCard card) {
+        Objects.requireNonNull(card, "card must not be null");
+        return scan(projectDir, card::applyScanResult);
+    }
+
+    /**
+     * Cheap synchronous recover classification — a single small lock-file read
+     * (NOT a tree walk). Used by the Welcome view to place a card in the
+     * "Recover" group vs the "Continue" group deterministically.
+     *
+     * @param projectDir the project directory; must not be {@code null}
+     * @param clock      the clock for the stale comparison; must not be {@code null}
+     * @return {@code true} when a stale lock is present (did not exit cleanly)
+     */
+    public static boolean isRecoverable(Path projectDir, InstantSource clock) {
+        Objects.requireNonNull(projectDir, "projectDir must not be null");
+        Objects.requireNonNull(clock, "clock must not be null");
+        return ProjectLockManager.peekLock(projectDir)
+                .map(l -> ProjectLockManager.isStale(l, clock.instant()))
+                .orElse(false);
+    }
+
+    /**
+     * Scans {@code projectDir} for {@code project.daw.v<n>.<stamp>.bak} siblings,
+     * returning the version of the <em>newest</em> backup (the one the user most
+     * recently migrated from), or {@code -1} when none exist.
+     *
+     * <p>Newest is determined by the {@code yyyyMMdd-HHmmss[-<n>]} stamp (regex
+     * group 2), which is lexicographically time-ordered — <strong>not</strong>
+     * by the whole filename: the leading {@code vN} segment would sort
+     * {@code v10} before {@code v2} and so report the wrong version when a
+     * long-lived project carries backups from more than one schema version.</p>
+     */
+    private static int newestBackupSchemaVersion(Path projectDir) {
+        String newestStamp = null;
+        int versionOfNewest = -1;
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(projectDir)) {
+            for (Path entry : stream) {
+                Path fileName = entry.getFileName();
+                if (fileName == null) {
+                    continue;
+                }
+                Matcher matcher = BACKUP_PATTERN.matcher(fileName.toString());
+                if (!matcher.matches()) {
+                    continue;
+                }
+                String stamp = matcher.group(2);
+                if (newestStamp == null || stamp.compareTo(newestStamp) > 0) {
+                    newestStamp = stamp;
+                    versionOfNewest = parseVersion(matcher.group(1));
+                }
+            }
+        } catch (IOException | RuntimeException e) {
+            return -1; // unreadable directory — no backup info
+        }
+        return versionOfNewest;
+    }
+
+    /** Parses a backup's version digits, or {@code -1} for a pathologically long run. */
+    private static int parseVersion(String digits) {
+        try {
+            return Integer.parseInt(digits);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private static Instant lastModifiedInstant(Path file) {
+        try {
+            if (!Files.exists(file)) {
+                return null;
+            }
+            FileTime time = Files.getLastModifiedTime(file);
+            return time.toInstant();
+        } catch (IOException | RuntimeException e) {
+            return null;
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHealthScanner.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHealthScanner.java
@@ -218,7 +218,6 @@ public final class ProjectHealthScanner {
                     versionOfNewest = parseVersion(matcher.group(1));
                 }
             }
-        }
         } catch (IOException | RuntimeException e) {
             return -1; // unreadable directory — no backup info
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHealthScanner.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHealthScanner.java
@@ -190,7 +190,8 @@ public final class ProjectHealthScanner {
      * long-lived project carries backups from more than one schema version.</p>
      */
     private static int newestBackupSchemaVersion(Path projectDir) {
-        String newestStamp = null;
+        String newestTime = null;
+        int newestCollision = -1;
         int versionOfNewest = -1;
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(projectDir)) {
             for (Path entry : stream) {
@@ -203,11 +204,21 @@ public final class ProjectHealthScanner {
                     continue;
                 }
                 String stamp = matcher.group(2);
-                if (newestStamp == null || stamp.compareTo(newestStamp) > 0) {
-                    newestStamp = stamp;
+                String time = stamp;
+                int collision = 0;
+                int suffixIndex = stamp.indexOf('-', 15); // "yyyyMMdd-HHmmss" is 15 chars
+                if (suffixIndex > 0) {
+                    time = stamp.substring(0, suffixIndex);
+                    collision = parseVersion(stamp.substring(suffixIndex + 1));
+                }
+                if (newestTime == null || time.compareTo(newestTime) > 0
+                        || (time.equals(newestTime) && collision > newestCollision)) {
+                    newestTime = time;
+                    newestCollision = collision;
                     versionOfNewest = parseVersion(matcher.group(1));
                 }
             }
+        }
         } catch (IOException | RuntimeException e) {
             return -1; // unreadable directory — no backup info
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -330,6 +330,9 @@ public final class ProjectHubView extends BorderPane {
         // Scan on a virtual thread; retain the disk-usage breakdown for the
         // detail strip, apply onto the card, and refresh the strip if selected.
         Thread t = scanner.scan(dir, r -> {
+            if (!pathByCard.containsKey(card)) {
+                return;
+            }
             usageByCard.put(card, r.diskUsage());
             card.applyScanResult(r);
             // The scan replaced the seeded directory name with the metadata name,

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -260,7 +260,12 @@ public final class ProjectHubView extends BorderPane {
         // relayout the grids when the mode flips.
         viewGroup.selectedToggleProperty().addListener((_, old, now) -> {
             if (now == null) {
-                gridToggle.setSelected(old == gridToggle);
+                if (old != null) {
+                    old.setSelected(true);
+                } else {
+                    gridToggle.setSelected(true);
+                }
+                return;
             }
             applyViewMode();
         });

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -1,0 +1,769 @@
+package com.benesquivelmusic.daw.app.ui.hub;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
+
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * The story-296 §4.2 <strong>Project Hub</strong> — a full-window project
+ * browser that replaces the §1.4 "Recent Projects" filename context menu.
+ *
+ * <p>A one-off application layout, so it subclasses {@link BorderPane} directly
+ * rather than the {@code Control + Skin} pattern reserved for reusable widgets
+ * ({@code javafx-application-design} skill §3: "for one-off layouts inside an
+ * app, prefer a plain {@code Region}/{@code Pane} subclass"). The reusable tile
+ * it composes — {@link ProjectCard} — <em>is</em> a {@code Control + Skin}.</p>
+ *
+ * <h2>Layout (per the §4.2 mockup)</h2>
+ *
+ * <ul>
+ *   <li><b>Top</b> — a toolbar: a Workspace label, a {@link #searchField search}
+ *       field that live-filters cards by name, a Grid/List view toggle, and a
+ *       {@link #sortChoice sort} control (Recently opened / Name).</li>
+ *   <li><b>Center</b> — a {@link ScrollPane} of three sections in order
+ *       <b>Pinned</b>, <b>Recent</b>, <b>Archived (.dawz)</b>; each is a
+ *       {@code .panel-header} label over a {@code .project-hub-grid}
+ *       {@link FlowPane} of cards, and is hidden when it has no cards.</li>
+ *   <li><b>Bottom</b> — the §1.4 <b>detail strip</b>: every fact the model
+ *       carries about the selected card (path, schema, size-on-disk broken down,
+ *       sessions, sample rate, lock) plus {@code [Reveal]} and {@code [Open ▸]}
+ *       actions. A muted placeholder when nothing is selected.</li>
+ * </ul>
+ *
+ * <h2>Scanning &amp; threading ({@code javafx-application-design} §11)</h2>
+ *
+ * <p>Each project-directory card is populated by a background virtual-thread
+ * {@link ProjectHealthScanner#scan(Path, Consumer) scan} whose result is
+ * marshalled back to the FX thread through the story-289 {@link FxDispatcher};
+ * the FX thread never walks a project tree. The scan threads are collected into
+ * {@link #pendingScans()} so a test can join them. Archive {@code .dawz} entries
+ * are files (not directories): they are populated directly on the FX thread
+ * (name = file name, size = file length) without a directory scan.</p>
+ *
+ * <h2>Detail-strip facts</h2>
+ *
+ * <p>The strip reads the selected card's <em>current</em> property values
+ * (schema, lock, sessions, …) plus the {@link ProjectDiskUsage} breakdown
+ * retained per card in {@link #usageByCard} (captured in the scan consumer), so
+ * it can show "audio / checkpoints / archives" without re-walking the tree.</p>
+ *
+ * <h2>Styling</h2>
+ *
+ * <p>Loads its own {@code project-hub.css} via {@link #getStylesheets()}; it is
+ * a {@link Region}, not a {@code Control}, so it has no
+ * {@code getUserAgentStylesheet()}. That sheet consumes the role tokens
+ * ({@code -surface-1}, {@code -line-soft}, {@code -text}, {@code -text-hi},
+ * {@code -text-mute}, {@code -accent}) defined on the scene's {@code .root-pane}
+ * — they resolve by CSS inheritance because the Hub is shown in a scene that
+ * loads the app {@code styles.css}.</p>
+ *
+ * @see ProjectCard
+ * @see ProjectHealthScanner
+ */
+public final class ProjectHubView extends BorderPane {
+
+    /** Stable style class — selectable as {@code .project-hub}. */
+    public static final String DEFAULT_STYLE_CLASS = "project-hub";
+
+    private static final String SORT_RECENT = "Recently opened";
+    private static final String SORT_NAME = "Name";
+
+    private final ProjectHealthScanner scanner;
+    private final FxDispatcher dispatcher;
+    private final Consumer<Path> onOpen;
+    private final Consumer<Path> onReveal;
+    private final Consumer<Path> onRestoreArchive;
+    private final Runnable onClearRecent;
+
+    /** Display-order model lists (independent of the search filter). */
+    private final List<ProjectCard> pinned = new ArrayList<>();
+    private final List<ProjectCard> recent = new ArrayList<>();
+    private final List<ProjectCard> archived = new ArrayList<>();
+
+    /** Every card → its project (dir) or archive (.dawz) path. */
+    private final Map<ProjectCard, Path> pathByCard = new IdentityHashMap<>();
+    /** Card → its last scan's disk-usage breakdown (for the detail strip). */
+    private final Map<ProjectCard, ProjectDiskUsage> usageByCard = new IdentityHashMap<>();
+
+    /** Every scan thread started at construction, so a test can join them. */
+    private final List<Thread> pendingScans = new ArrayList<>();
+
+    // Toolbar controls.
+    private final TextField searchField = new TextField();
+    private final ToggleButton gridToggle = new ToggleButton("Grid");
+    private final ToggleButton listToggle = new ToggleButton("List");
+    private final ChoiceBox<String> sortChoice = new ChoiceBox<>();
+    private final Button clearRecentButton = new Button("Clear Recent");
+
+    // Section containers (header + grid each; whole VBox hidden when empty).
+    private final FlowPane pinnedGrid = newGrid();
+    private final FlowPane recentGrid = newGrid();
+    private final FlowPane archivedGrid = newGrid();
+    private final VBox pinnedSection = newSection("PINNED", pinnedGrid);
+    private final VBox recentSection = newSection("RECENT", recentGrid);
+    private final VBox archivedSection = newSection("ARCHIVED (.dawz)", archivedGrid);
+
+    // Detail strip.
+    private final ProjectDetailStrip detailStrip;
+
+    private ProjectCard selected;
+
+    /**
+     * Builds the full Project Hub.
+     *
+     * @param recentPaths      recent project directories, most-recent-first; {@code null} → empty
+     * @param pinnedPaths      pinned project directories; {@code null} → empty
+     * @param archivePaths     {@code .dawz} archive files; may be empty / {@code null}
+     * @param scanner          the virtual-thread health/size scanner; must not be {@code null}
+     * @param dispatcher       the FX marshalling seam; must not be {@code null}
+     * @param onOpen           opens a project directory; must not be {@code null}
+     * @param onReveal         reveals a directory in the OS file browser; must not be {@code null}
+     * @param onRestoreArchive restores a {@code .dawz} archive; must not be {@code null}
+     * @param onClearRecent    clears the recent-projects list (the §1.4 "Clear
+     *                         Recent" affordance carried over from the old menu);
+     *                         must not be {@code null} (use {@code () -> {}} for none)
+     */
+    public ProjectHubView(
+            List<Path> recentPaths,
+            List<Path> pinnedPaths,
+            List<Path> archivePaths,
+            ProjectHealthScanner scanner,
+            FxDispatcher dispatcher,
+            Consumer<Path> onOpen,
+            Consumer<Path> onReveal,
+            Consumer<Path> onRestoreArchive,
+            Runnable onClearRecent) {
+        this.scanner = Objects.requireNonNull(scanner, "scanner must not be null");
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
+        this.onOpen = Objects.requireNonNull(onOpen, "onOpen must not be null");
+        this.onReveal = Objects.requireNonNull(onReveal, "onReveal must not be null");
+        this.onRestoreArchive =
+                Objects.requireNonNull(onRestoreArchive, "onRestoreArchive must not be null");
+        this.onClearRecent = Objects.requireNonNull(onClearRecent, "onClearRecent must not be null");
+
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+
+        this.detailStrip = new ProjectDetailStrip();
+
+        setTop(buildToolbar());
+        setCenter(buildCenter());
+        setBottom(detailStrip);
+
+        // Build cards in the §4.2 order: pinned, then recent, then archives.
+        for (Path p : safe(pinnedPaths)) {
+            addDirectoryCard(p, pinnedGrid, pinned, true);
+        }
+        for (Path p : safe(recentPaths)) {
+            addDirectoryCard(p, recentGrid, recent, false);
+        }
+        for (Path p : safe(archivePaths)) {
+            addArchiveCard(p);
+        }
+
+        applySort();
+        reconcileSectionVisibility();
+        clearRecentButton.setDisable(recent.isEmpty());
+        detailStrip.showPlaceholder();
+
+        getStylesheets().add(Objects.requireNonNull(
+                ProjectHubView.class.getResource("project-hub.css"),
+                "project-hub.css not on classpath").toExternalForm());
+    }
+
+    /**
+     * Convenience constructor: no pinned or archived projects, and a no-op
+     * archive-restore. Used by the §4.2 "open the Hub" call site (which also
+     * wires Clear Recent) and tests.
+     *
+     * @param recentPaths recent project directories, most-recent-first; {@code null} → empty
+     * @param scanner     the scanner; must not be {@code null}
+     * @param dispatcher  the FX dispatcher; must not be {@code null}
+     * @param onOpen      opens a project directory; must not be {@code null}
+     * @param onReveal    reveals a directory in the OS file browser; must not be {@code null}
+     * @param onClearRecent clears the recent-projects list; must not be {@code null}
+     */
+    public ProjectHubView(
+            List<Path> recentPaths,
+            ProjectHealthScanner scanner,
+            FxDispatcher dispatcher,
+            Consumer<Path> onOpen,
+            Consumer<Path> onReveal,
+            Runnable onClearRecent) {
+        this(recentPaths, List.of(), List.of(), scanner, dispatcher,
+                onOpen, onReveal, p -> { }, onClearRecent);
+    }
+
+    /**
+     * Convenience constructor with no Clear-Recent action (a no-op). Used by the
+     * {@code RecentProjectsStoreFeedsHubTest} acceptance test.
+     *
+     * @param recentPaths recent project directories, most-recent-first; {@code null} → empty
+     * @param scanner     the scanner; must not be {@code null}
+     * @param dispatcher  the FX dispatcher; must not be {@code null}
+     * @param onOpen      opens a project directory; must not be {@code null}
+     * @param onReveal    reveals a directory in the OS file browser; must not be {@code null}
+     */
+    public ProjectHubView(
+            List<Path> recentPaths,
+            ProjectHealthScanner scanner,
+            FxDispatcher dispatcher,
+            Consumer<Path> onOpen,
+            Consumer<Path> onReveal) {
+        this(recentPaths, scanner, dispatcher, onOpen, onReveal, () -> { });
+    }
+
+    // ── toolbar ──────────────────────────────────────────────────────────────
+
+    private Node buildToolbar() {
+        Label workspace = new Label("Workspace: Personal");
+        workspace.getStyleClass().add("project-hub-workspace");
+
+        searchField.setPromptText("Search");
+        searchField.getStyleClass().add("project-hub-search");
+        HBox.setHgrow(searchField, Priority.ALWAYS);
+        searchField.textProperty().addListener((_, _, q) -> applySearch(q));
+
+        ToggleGroup viewGroup = new ToggleGroup();
+        gridToggle.setToggleGroup(viewGroup);
+        listToggle.setToggleGroup(viewGroup);
+        gridToggle.setSelected(true);
+        gridToggle.getStyleClass().add("project-hub-view-toggle");
+        listToggle.getStyleClass().add("project-hub-view-toggle");
+        // Keep one always selected (a ToggleGroup otherwise allows none), and
+        // relayout the grids when the mode flips.
+        viewGroup.selectedToggleProperty().addListener((_, old, now) -> {
+            if (now == null) {
+                gridToggle.setSelected(old == gridToggle);
+            }
+            applyViewMode();
+        });
+        HBox viewToggles = new HBox(gridToggle, listToggle);
+        viewToggles.getStyleClass().add("project-hub-view-toggles");
+
+        sortChoice.getItems().setAll(SORT_RECENT, SORT_NAME);
+        sortChoice.setValue(SORT_RECENT);
+        sortChoice.getStyleClass().add("project-hub-sort");
+        sortChoice.valueProperty().addListener((_, _, _) -> applySort());
+
+        // §1.4 — the "Clear Recent" affordance the old recent-projects menu had,
+        // carried onto the Hub toolbar. Disabled when there is nothing to clear.
+        clearRecentButton.getStyleClass().add("project-hub-clear-recent");
+        clearRecentButton.setOnAction(_ -> clearRecent());
+
+        HBox toolbar = new HBox(workspace, searchField,
+                new Label("View:"), viewToggles,
+                new Label("Sort:"), sortChoice,
+                clearRecentButton);
+        toolbar.getStyleClass().add("project-hub-toolbar");
+        toolbar.setAlignment(Pos.CENTER_LEFT);
+        return toolbar;
+    }
+
+    private Node buildCenter() {
+        VBox sections = new VBox(pinnedSection, recentSection, archivedSection);
+        sections.getStyleClass().add("project-hub-sections");
+
+        ScrollPane scroll = new ScrollPane(sections);
+        scroll.setFitToWidth(true);
+        scroll.getStyleClass().add("project-hub-scroll");
+        return scroll;
+    }
+
+    // ── card construction ──────────────────────────────────────────────────────
+
+    private void addDirectoryCard(Path dir, FlowPane grid, List<ProjectCard> model, boolean pin) {
+        ProjectCard card = new ProjectCard();
+        card.setPinned(pin);
+        // Seed a name immediately (the dir name) so the card reads sensibly
+        // before the async scan lands and so name-sort is deterministic at once.
+        card.setName(HubFormat.baseName(dir));
+        wireSelection(card);
+        card.setOnMouseClicked(e -> {
+            select(card);
+            if (e.getClickCount() >= 2) {
+                onOpen.accept(dir);
+            }
+        });
+
+        model.add(card);
+        grid.getChildren().add(card);
+        pathByCard.put(card, dir);
+
+        // Scan on a virtual thread; retain the disk-usage breakdown for the
+        // detail strip, apply onto the card, and refresh the strip if selected.
+        Thread t = scanner.scan(dir, r -> {
+            usageByCard.put(card, r.diskUsage());
+            card.applyScanResult(r);
+            // The scan replaced the seeded directory name with the metadata name,
+            // so re-evaluate this card against the live search query and re-order
+            // its section under a "Name" sort (otherwise the card would sit in the
+            // wrong alphabetical slot / be wrongly shown or hidden).
+            applySearchToCard(card);
+            sortGrid(model, grid, sortByName());
+            if (card.isSelected()) {
+                detailStrip.show(card);
+            }
+        });
+        pendingScans.add(t);
+    }
+
+    private void addArchiveCard(Path archive) {
+        ProjectCard card = new ProjectCard();
+        card.setName(HubFormat.baseName(archive));
+        // Archives are .dawz files, not directories — populate name + size
+        // directly on the FX thread; no tree scan, no health classification.
+        card.setSizeOnDiskBytes(fileSizeOf(archive));
+        wireSelection(card);
+        card.setOnMouseClicked(e -> {
+            select(card);
+            if (e.getClickCount() >= 2) {
+                onRestoreArchive.accept(archive);
+            }
+        });
+
+        archived.add(card);
+        archivedGrid.getChildren().add(card);
+        pathByCard.put(card, archive);
+    }
+
+    private void wireSelection(ProjectCard card) {
+        card.setFocusTraversable(true);
+    }
+
+    private void select(ProjectCard card) {
+        for (ProjectCard other : pathByCard.keySet()) {
+            if (other != card) {
+                other.setSelected(false);
+            }
+        }
+        card.setSelected(true);
+        selected = card;
+        detailStrip.show(card);
+    }
+
+    // ── search / sort / view-mode ──────────────────────────────────────────────
+
+    private void applySearch(String query) {
+        String needle = normalise(query);
+        for (ProjectCard card : pathByCard.keySet()) {
+            setCardVisible(card, nameMatches(card, needle));
+        }
+        dropSelectionIfHidden();
+    }
+
+    /**
+     * Re-evaluates a single card's visibility against the <em>live</em> search
+     * query — called after an async scan lands a card's real name (the bulk
+     * {@link #applySearch} ran earlier against the seeded directory name).
+     */
+    private void applySearchToCard(ProjectCard card) {
+        setCardVisible(card, nameMatches(card, currentNeedle()));
+        dropSelectionIfHidden();
+    }
+
+    /** The live, normalised search needle from the search field. */
+    private String currentNeedle() {
+        return normalise(searchField.getText());
+    }
+
+    private static String normalise(String query) {
+        return query == null ? "" : query.strip().toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean nameMatches(ProjectCard card, String needle) {
+        if (needle.isEmpty()) {
+            return true;
+        }
+        String name = card.getName();
+        return name != null && name.toLowerCase(Locale.ROOT).contains(needle);
+    }
+
+    private static void setCardVisible(ProjectCard card, boolean visible) {
+        card.setVisible(visible);
+        card.setManaged(visible);
+    }
+
+    /**
+     * Clears the selection (and the detail strip) when the selected card has been
+     * filtered out, so its Reveal / Open ▸ actions never act on a card the user
+     * can no longer see.
+     */
+    private void dropSelectionIfHidden() {
+        if (selected != null && !selected.isVisible()) {
+            selected.setSelected(false);
+            selected = null;
+            detailStrip.showPlaceholder();
+        }
+    }
+
+    private void applySort() {
+        boolean byName = sortByName();
+        sortGrid(recent, recentGrid, byName);
+        sortGrid(pinned, pinnedGrid, byName);
+        sortGrid(archived, archivedGrid, byName);
+    }
+
+    private boolean sortByName() {
+        return SORT_NAME.equals(sortChoice.getValue());
+    }
+
+    /**
+     * Clears the recent-projects list: runs the injected {@link #onClearRecent}
+     * (the store mutation), then empties the Recent section in place so the open
+     * Hub reflects the cleared list immediately.
+     */
+    private void clearRecent() {
+        onClearRecent.run();
+        if (selected != null && recent.contains(selected)) {
+            selected.setSelected(false);
+            selected = null;
+            detailStrip.showPlaceholder();
+        }
+        for (ProjectCard card : recent) {
+            pathByCard.remove(card);
+            usageByCard.remove(card);
+        }
+        recent.clear();
+        recentGrid.getChildren().clear();
+        reconcileSectionVisibility();
+        clearRecentButton.setDisable(true);
+    }
+
+    /**
+     * Reorders a grid's children. "Recently opened" keeps the model's insertion
+     * order (the given most-recent-first order); "Name" sorts by card name. The
+     * model list itself is left in its original order so {@link #recentCards()}
+     * and friends always report the canonical given order.
+     */
+    private void sortGrid(List<ProjectCard> model, FlowPane grid, boolean byName) {
+        List<ProjectCard> ordered = new ArrayList<>(model);
+        if (byName) {
+            ordered.sort(Comparator.comparing(
+                    c -> c.getName() == null ? "" : c.getName(),
+                    String.CASE_INSENSITIVE_ORDER));
+        }
+        grid.getChildren().setAll(ordered);
+    }
+
+    private void applyViewMode() {
+        boolean list = listToggle.isSelected();
+        // List view = one card per row; Grid view = the cards' natural tile width,
+        // wrapped across the viewport. The centre ScrollPane is fitToWidth, so the
+        // FlowPane is stretched to the viewport and wraps at that width regardless
+        // of prefWrapLength — a single column therefore can't be expressed through
+        // the wrap length. Instead the list column is forced by binding each card's
+        // preferred width to the grid width (one card fills a row, the next wraps),
+        // and released back to the computed tile width for the grid.
+        for (FlowPane grid : List.of(pinnedGrid, recentGrid, archivedGrid)) {
+            for (Node child : grid.getChildren()) {
+                if (child instanceof ProjectCard card) {
+                    card.prefWidthProperty().unbind();
+                    if (list) {
+                        card.prefWidthProperty().bind(grid.widthProperty());
+                    } else {
+                        card.setPrefWidth(Region.USE_COMPUTED_SIZE);
+                    }
+                }
+            }
+        }
+    }
+
+    private void reconcileSectionVisibility() {
+        setSectionVisible(pinnedSection, !pinned.isEmpty());
+        setSectionVisible(recentSection, !recent.isEmpty());
+        setSectionVisible(archivedSection, !archived.isEmpty());
+    }
+
+    private static void setSectionVisible(Node section, boolean on) {
+        section.setVisible(on);
+        section.setManaged(on);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static FlowPane newGrid() {
+        FlowPane grid = new FlowPane();
+        grid.getStyleClass().add("project-hub-grid");
+        return grid;
+    }
+
+    private static VBox newSection(String headerText, FlowPane grid) {
+        Label header = new Label(headerText);
+        header.getStyleClass().add("panel-header");
+        VBox section = new VBox(header, grid);
+        section.getStyleClass().add("project-hub-section");
+        return section;
+    }
+
+    private static List<Path> safe(List<Path> paths) {
+        return paths == null ? List.of() : paths;
+    }
+
+    private static long fileSizeOf(Path file) {
+        try {
+            return Files.isRegularFile(file) ? Files.size(file) : -1L;
+        } catch (IOException | RuntimeException e) {
+            return -1L;
+        }
+    }
+
+    // ── test / controller accessors ─────────────────────────────────────────────
+
+    /**
+     * @return the Recent cards in display order — the full model list,
+     *         independent of any active search filter
+     */
+    public List<ProjectCard> recentCards() {
+        return List.copyOf(recent);
+    }
+
+    /** @return the Pinned cards in display order (full model list). */
+    public List<ProjectCard> pinnedCards() {
+        return List.copyOf(pinned);
+    }
+
+    /** @return the Archived ({@code .dawz}) cards in display order (full model list). */
+    public List<ProjectCard> archivedCards() {
+        return List.copyOf(archived);
+    }
+
+    /**
+     * @return every scan thread started at construction (one per project-directory
+     *         card; archives are not scanned), so a test can join on completion
+     */
+    public List<Thread> pendingScans() {
+        return List.copyOf(pendingScans);
+    }
+
+    /** @return the currently selected card, or {@code null} when none is selected. */
+    public ProjectCard selectedCard() {
+        return selected;
+    }
+
+    /** @return the project (or archive) path backing {@code card}, or {@code null}. */
+    public Path pathFor(ProjectCard card) {
+        return pathByCard.get(card);
+    }
+
+    /** @return the bottom detail-strip node (the §1.4 fix surface). */
+    public Node detailStrip() {
+        return detailStrip;
+    }
+
+    /** @return the live search field (prompt "Search"); live-filters cards by name. */
+    public TextField searchField() {
+        return searchField;
+    }
+
+    /** @return the sort control ("Recently opened" / "Name"). */
+    public ChoiceBox<String> sortChoice() {
+        return sortChoice;
+    }
+
+    /** @return the Grid view toggle (selected by default; cards wrap across the viewport). */
+    public ToggleButton gridToggle() {
+        return gridToggle;
+    }
+
+    /** @return the List view toggle (selecting it lays the cards out one per row). */
+    public ToggleButton listToggle() {
+        return listToggle;
+    }
+
+    /** @return the toolbar "Clear Recent" button (disabled when nothing is recent). */
+    public Button clearRecentButton() {
+        return clearRecentButton;
+    }
+
+    /**
+     * The §1.4 detail strip: the selected project's facts plus Reveal / Open.
+     * A nested {@link Region} so the Hub can keep its label fields private while
+     * still exposing the strip node via {@link ProjectHubView#detailStrip()}.
+     */
+    private final class ProjectDetailStrip extends VBox {
+
+        private final Label heading = new Label();
+        private final Label pathValue = newValue();
+        private final Label schemaValue = newValue();
+        private final Label sizeValue = newValue();
+        private final Label sessionsValue = newValue();
+        private final Label sampleRateValue = newValue();
+        private final Label lockValue = newValue();
+        private final Button revealButton = new Button("Reveal");
+        private final Button openButton = new Button("Open ▸");
+        private final Label placeholder = new Label("Select a project");
+
+        ProjectDetailStrip() {
+            getStyleClass().add("project-hub-detail");
+
+            heading.getStyleClass().add("project-hub-detail-heading");
+            placeholder.getStyleClass().add("project-hub-detail-placeholder");
+
+            revealButton.getStyleClass().add("project-hub-detail-action");
+            openButton.getStyleClass().add("project-hub-detail-action");
+            revealButton.setOnAction(_ -> fireAction(onReveal));
+            openButton.setOnAction(_ -> fireAction(onOpen));
+
+            HBox actions = new HBox(revealButton, openButton);
+            actions.getStyleClass().add("project-hub-detail-actions");
+            actions.setAlignment(Pos.CENTER_LEFT);
+
+            HBox headerRow = new HBox(heading, spacer(), actions);
+            headerRow.getStyleClass().add("project-hub-detail-header");
+            headerRow.setAlignment(Pos.CENTER_LEFT);
+
+            getChildren().setAll(
+                    headerRow,
+                    row("Path:", pathValue),
+                    row("Schema:", schemaValue),
+                    row("Size on disk:", sizeValue),
+                    row("Sessions:", sessionsValue),
+                    row("Sample rate:", sampleRateValue),
+                    row("Lock:", lockValue),
+                    placeholder);
+        }
+
+        private void fireAction(Consumer<Path> action) {
+            if (selected == null) {
+                return;
+            }
+            Path path = pathByCard.get(selected);
+            if (path != null) {
+                action.accept(path);
+            }
+        }
+
+        void showPlaceholder() {
+            heading.setText("Selected: —");
+            setRowsVisible(false);
+            placeholder.setVisible(true);
+            placeholder.setManaged(true);
+            revealButton.setDisable(true);
+            openButton.setDisable(true);
+        }
+
+        void show(ProjectCard card) {
+            Path dir = pathByCard.get(card);
+            heading.setText("Selected: " + safeName(card));
+            pathValue.setText(dir == null ? "—" : dir.toString());
+            schemaValue.setText(formatSchema(card));
+            sizeValue.setText(formatSize(card));
+            sessionsValue.setText(formatSessions(card));
+            sampleRateValue.setText("—"); // Stage 2 — no sample-rate fact yet.
+            lockValue.setText(formatLock(card));
+
+            setRowsVisible(true);
+            placeholder.setVisible(false);
+            placeholder.setManaged(false);
+            revealButton.setDisable(false);
+            openButton.setDisable(false);
+        }
+
+        private void setRowsVisible(boolean on) {
+            for (Node child : getChildren()) {
+                if (child instanceof DetailRow) {
+                    child.setVisible(on);
+                    child.setManaged(on);
+                }
+            }
+        }
+
+        private String formatSchema(ProjectCard card) {
+            int schema = card.getSchemaVersion();
+            if (schema < 0) {
+                return "—";
+            }
+            String base = "v" + schema + " (current)";
+            int backup = card.getBackupSchemaVersion();
+            return backup >= 0 ? base + " · backup v" + backup + " available" : base;
+        }
+
+        private String formatSize(ProjectCard card) {
+            long total = card.getSizeOnDiskBytes();
+            String headline = HubFormat.formatBytes(total);
+            ProjectDiskUsage usage = usageByCard.get(card);
+            if (usage == null) {
+                return headline;
+            }
+            // Stage 2 has no journal / snapshots — show only the categories
+            // ProjectDiskUsage actually breaks out (audio / checkpoints / archives).
+            return headline
+                    + "   audio " + HubFormat.formatBytes(usage.assetsBytes())
+                    + " · checkpoints " + HubFormat.formatBytes(usage.autosavesBytes())
+                    + " · archives " + HubFormat.formatBytes(usage.archivesBytes());
+        }
+
+        private String formatSessions(ProjectCard card) {
+            int count = card.getSessionCount();
+            return count < 0 ? "—" : Integer.toString(count);
+        }
+
+        private String formatLock(ProjectCard card) {
+            String holder = card.getLockHolderLabel();
+            if (holder == null || holder.isBlank()) {
+                return "—";
+            }
+            return holder + " · " + (card.isLockStale() ? "stale" : "live");
+        }
+
+        private String safeName(ProjectCard card) {
+            String name = card.getName();
+            return name == null || name.isBlank() ? "—" : name;
+        }
+    }
+
+    private static Label newValue() {
+        Label label = new Label("—");
+        label.getStyleClass().add("project-hub-detail-value");
+        return label;
+    }
+
+    private static Region spacer() {
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        return spacer;
+    }
+
+    private static DetailRow row(String key, Label value) {
+        Label keyLabel = new Label(key);
+        keyLabel.getStyleClass().add("project-hub-detail-key");
+        return new DetailRow(keyLabel, value);
+    }
+
+    /** A {@code key: value} line in the detail strip — typed so the strip can
+     *  toggle every fact row's visibility without touching the header / actions. */
+    private static final class DetailRow extends HBox {
+        DetailRow(Label key, Label value) {
+            super(key, value);
+            getStyleClass().add("project-hub-detail-row");
+            setAlignment(Pos.CENTER_LEFT);
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -356,9 +356,20 @@ public final class ProjectHubView extends BorderPane {
         card.setSizeOnDiskBytes(fileSizeOf(archive));
         wireSelection(card);
         card.setOnMouseClicked(e -> {
+            if (e.getButton() != javafx.scene.input.MouseButton.PRIMARY) {
+                return;
+            }
             select(card);
             if (e.getClickCount() >= 2) {
                 onRestoreArchive.accept(archive);
+            }
+        });
+        card.setOnKeyPressed(e -> {
+            if (e.getCode() == javafx.scene.input.KeyCode.ENTER
+                    || e.getCode() == javafx.scene.input.KeyCode.SPACE) {
+                select(card);
+                onRestoreArchive.accept(archive);
+                e.consume();
             }
         });
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -60,9 +60,9 @@ import java.util.function.Consumer;
  *
  * <p>Each project-directory card is populated by a background virtual-thread
  * {@link ProjectHealthScanner#scan(Path, Consumer) scan} whose result is
- * marshalled back to the FX thread via {@code Platform.runLater};
+ * marshalled back to the FX thread via
+ * {@link com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher#onFx(Runnable)};
  * the FX thread never walks a project tree. The scan threads are collected into
- * {@link #pendingScans()} so a test can join them. Archive {@code .dawz} entries
  * are files (not directories): they are populated directly on the FX thread
  * (name = file name, size = file length) without a directory scan.</p>
  *

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -306,9 +306,20 @@ public final class ProjectHubView extends BorderPane {
         card.setName(HubFormat.baseName(dir));
         wireSelection(card);
         card.setOnMouseClicked(e -> {
+            if (e.getButton() != javafx.scene.input.MouseButton.PRIMARY) {
+                return;
+            }
             select(card);
             if (e.getClickCount() >= 2) {
                 onOpen.accept(dir);
+            }
+        });
+        card.setOnKeyPressed(e -> {
+            if (e.getCode() == javafx.scene.input.KeyCode.ENTER
+                    || e.getCode() == javafx.scene.input.KeyCode.SPACE) {
+                select(card);
+                onOpen.accept(dir);
+                e.consume();
             }
         });
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -1,6 +1,5 @@
 package com.benesquivelmusic.daw.app.ui.hub;
 
-import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
 
 import javafx.geometry.Pos;
@@ -61,7 +60,7 @@ import java.util.function.Consumer;
  *
  * <p>Each project-directory card is populated by a background virtual-thread
  * {@link ProjectHealthScanner#scan(Path, Consumer) scan} whose result is
- * marshalled back to the FX thread through the story-289 {@link FxDispatcher};
+ * marshalled back to the FX thread via {@code Platform.runLater};
  * the FX thread never walks a project tree. The scan threads are collected into
  * {@link #pendingScans()} so a test can join them. Archive {@code .dawz} entries
  * are files (not directories): they are populated directly on the FX thread
@@ -96,7 +95,6 @@ public final class ProjectHubView extends BorderPane {
     private static final String SORT_NAME = "Name";
 
     private final ProjectHealthScanner scanner;
-    private final FxDispatcher dispatcher;
     private final Consumer<Path> onOpen;
     private final Consumer<Path> onReveal;
     private final Consumer<Path> onRestoreArchive;
@@ -142,7 +140,6 @@ public final class ProjectHubView extends BorderPane {
      * @param pinnedPaths      pinned project directories; {@code null} → empty
      * @param archivePaths     {@code .dawz} archive files; may be empty / {@code null}
      * @param scanner          the virtual-thread health/size scanner; must not be {@code null}
-     * @param dispatcher       the FX marshalling seam; must not be {@code null}
      * @param onOpen           opens a project directory; must not be {@code null}
      * @param onReveal         reveals a directory in the OS file browser; must not be {@code null}
      * @param onRestoreArchive restores a {@code .dawz} archive; must not be {@code null}
@@ -155,13 +152,11 @@ public final class ProjectHubView extends BorderPane {
             List<Path> pinnedPaths,
             List<Path> archivePaths,
             ProjectHealthScanner scanner,
-            FxDispatcher dispatcher,
             Consumer<Path> onOpen,
             Consumer<Path> onReveal,
             Consumer<Path> onRestoreArchive,
             Runnable onClearRecent) {
         this.scanner = Objects.requireNonNull(scanner, "scanner must not be null");
-        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
         this.onOpen = Objects.requireNonNull(onOpen, "onOpen must not be null");
         this.onReveal = Objects.requireNonNull(onReveal, "onReveal must not be null");
         this.onRestoreArchive =
@@ -204,7 +199,6 @@ public final class ProjectHubView extends BorderPane {
      *
      * @param recentPaths recent project directories, most-recent-first; {@code null} → empty
      * @param scanner     the scanner; must not be {@code null}
-     * @param dispatcher  the FX dispatcher; must not be {@code null}
      * @param onOpen      opens a project directory; must not be {@code null}
      * @param onReveal    reveals a directory in the OS file browser; must not be {@code null}
      * @param onClearRecent clears the recent-projects list; must not be {@code null}
@@ -212,11 +206,10 @@ public final class ProjectHubView extends BorderPane {
     public ProjectHubView(
             List<Path> recentPaths,
             ProjectHealthScanner scanner,
-            FxDispatcher dispatcher,
             Consumer<Path> onOpen,
             Consumer<Path> onReveal,
             Runnable onClearRecent) {
-        this(recentPaths, List.of(), List.of(), scanner, dispatcher,
+        this(recentPaths, List.of(), List.of(), scanner,
                 onOpen, onReveal, p -> { }, onClearRecent);
     }
 
@@ -226,17 +219,15 @@ public final class ProjectHubView extends BorderPane {
      *
      * @param recentPaths recent project directories, most-recent-first; {@code null} → empty
      * @param scanner     the scanner; must not be {@code null}
-     * @param dispatcher  the FX dispatcher; must not be {@code null}
      * @param onOpen      opens a project directory; must not be {@code null}
      * @param onReveal    reveals a directory in the OS file browser; must not be {@code null}
      */
     public ProjectHubView(
             List<Path> recentPaths,
             ProjectHealthScanner scanner,
-            FxDispatcher dispatcher,
             Consumer<Path> onOpen,
             Consumer<Path> onReveal) {
-        this(recentPaths, scanner, dispatcher, onOpen, onReveal, () -> { });
+        this(recentPaths, scanner, onOpen, onReveal, () -> { });
     }
 
     // ── toolbar ──────────────────────────────────────────────────────────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -461,6 +461,8 @@ public final class ProjectHubView extends BorderPane {
             detailStrip.showPlaceholder();
         }
         for (ProjectCard card : recent) {
+            card.prefWidthProperty().unbind(); // in case List mode bound it to grid width
+            card.setPrefWidth(Region.USE_COMPUTED_SIZE);
             pathByCard.remove(card);
             usageByCard.remove(card);
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectHubView.java
@@ -693,8 +693,9 @@ public final class ProjectHubView extends BorderPane {
             setRowsVisible(true);
             placeholder.setVisible(false);
             placeholder.setManaged(false);
-            revealButton.setDisable(false);
-            openButton.setDisable(false);
+            boolean isArchive = dir != null && dir.toString().toLowerCase(Locale.ROOT).endsWith(".dawz");
+            revealButton.setDisable(dir == null);
+            openButton.setDisable(dir == null || isArchive);
         }
 
         private void setRowsVisible(boolean on) {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectScanResult.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectScanResult.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * @param sessionCount        number of sessions, or {@code -1} when unknown (Stage 2 has no sessions)
  * @param health              the health badge; coerced to {@link HealthBadge#HEALTHY} when {@code null}
  * @param missingAssetCount   number of missing referenced assets ({@code 0} in Stage 2)
- * @param schemaVersion       the current schema version, or {@code -1} when unknown
+ * @param schemaVersion       the schema version this build considers current (post-migration target), or {@code -1} when unknown
  * @param backupSchemaVersion the schema version of the newest pre-migration backup, or {@code -1} when none
  * @param lockHolderLabel     {@code "user @ host"} when a lock is present, else {@code ""} (coerced from {@code null})
  * @param lockPresent         whether a {@code .project.lock} sidecar exists

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectScanResult.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/ProjectScanResult.java
@@ -1,0 +1,71 @@
+package com.benesquivelmusic.daw.app.ui.hub;
+
+import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * The immutable output of one quick, on-open project scan for the story-296
+ * Project Hub / Welcome screen (see {@link ProjectHealthScanner}). JavaFX-free
+ * so the scan can be produced entirely off the FX thread on a background
+ * virtual thread, then applied to a {@link ProjectCard} on the FX thread via
+ * {@link ProjectCard#applyScanResult(ProjectScanResult)}.
+ *
+ * <p>Several fields use {@code -1} or {@code null} as an explicit "unknown"
+ * sentinel rather than throwing on a partial scan: a project whose disk-usage
+ * walk failed still produces a card (with {@code diskUsage == null}); a Stage-2
+ * project that has no {@code sessions/} directory yet reports
+ * {@code sessionCount == -1}.</p>
+ *
+ * @param projectDir          the scanned project directory; never {@code null}
+ * @param name                the project display name; coerced to {@code ""} when {@code null}
+ * @param lastOpened          when the project was last opened/modified, or {@code null} if unknown
+ * @param diskUsage           the on-disk size breakdown, or {@code null} when the scan failed
+ * @param sessionCount        number of sessions, or {@code -1} when unknown (Stage 2 has no sessions)
+ * @param health              the health badge; coerced to {@link HealthBadge#HEALTHY} when {@code null}
+ * @param missingAssetCount   number of missing referenced assets ({@code 0} in Stage 2)
+ * @param schemaVersion       the current schema version, or {@code -1} when unknown
+ * @param backupSchemaVersion the schema version of the newest pre-migration backup, or {@code -1} when none
+ * @param lockHolderLabel     {@code "user @ host"} when a lock is present, else {@code ""} (coerced from {@code null})
+ * @param lockPresent         whether a {@code .project.lock} sidecar exists
+ * @param lockStale           whether the present lock is stale (past the heartbeat threshold)
+ * @param recoverable         {@code lockPresent && lockStale} — the project did not exit cleanly
+ */
+public record ProjectScanResult(
+        Path projectDir,
+        String name,
+        Instant lastOpened,
+        ProjectDiskUsage diskUsage,
+        int sessionCount,
+        HealthBadge health,
+        int missingAssetCount,
+        int schemaVersion,
+        int backupSchemaVersion,
+        String lockHolderLabel,
+        boolean lockPresent,
+        boolean lockStale,
+        boolean recoverable
+) {
+    public ProjectScanResult {
+        Objects.requireNonNull(projectDir, "projectDir must not be null");
+        if (name == null) {
+            name = "";
+        }
+        if (health == null) {
+            health = HealthBadge.HEALTHY;
+        }
+        if (lockHolderLabel == null) {
+            lockHolderLabel = "";
+        }
+    }
+
+    /**
+     * @return the total on-disk size in bytes, or {@code -1} when the disk-usage
+     *         scan failed ({@code diskUsage == null})
+     */
+    public long sizeOnDiskBytes() {
+        return diskUsage == null ? -1L : diskUsage.totalBytes();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/WelcomeView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/WelcomeView.java
@@ -324,6 +324,7 @@ public final class WelcomeView extends BorderPane {
         Button button = new Button();
         button.getStyleClass().add("tile");
         button.setGraphic(content);
+        button.setAccessibleText(title + " — " + subtitle);
         button.setMaxWidth(Double.MAX_VALUE);
         button.setOnAction(_ -> action.run());
         return button;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/WelcomeView.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/hub/WelcomeView.java
@@ -1,0 +1,428 @@
+package com.benesquivelmusic.daw.app.ui.hub;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.status.SessionStatusDiskScanner;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
+
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+import java.nio.file.Path;
+import java.time.InstantSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * The story-296 §4.1 Welcome screen — shown on launch when no project is open.
+ *
+ * <p>A one-off application layout, so it subclasses {@link BorderPane} directly
+ * rather than the {@code Control + Skin} pattern ({@code javafx-application-design}
+ * §3 / §16: "one-off layout inside an app → subclass {@code Region}/{@code VBox}"
+ * — the reusable {@link ProjectCard} <em>is</em> a {@code Control}, the screen
+ * that arranges them is not).</p>
+ *
+ * <h2>Three regions, Recover first (§4.1)</h2>
+ *
+ * <p>The {@linkplain #sectionsBox() centre VBox} stacks, in order:</p>
+ * <ol>
+ *   <li><b>Recover</b> — projects whose {@code .project.lock} shows the prior
+ *       process did not exit cleanly. Each gets a row with a project card and
+ *       {@code [Discard recovery]} / {@code [Recover session ▸]} buttons. The
+ *       region is hidden and unmanaged when there is nothing to recover.</li>
+ *   <li><b>Continue</b> — the remaining recent projects as a grid of cards.</li>
+ *   <li><b>Start</b> — four large tiles: New, Open, Restore archive, Import.</li>
+ * </ol>
+ *
+ * <p>The "did not exit cleanly" split is computed <strong>synchronously</strong>
+ * at construction via {@link ProjectHealthScanner#isRecoverable(Path, InstantSource)}
+ * — a single cheap lock-file read per recent path, not a tree walk — so a card's
+ * Recover-vs-Continue placement is deterministic the instant the view is built
+ * (the {@code WelcomeRecoverBeforeRecentTest} asserts placement with no
+ * dispatcher pump). The Recover-scan reuses the existing {@code ProjectLockManager}
+ * staleness APIs and invents no new crash flag (§4.1 note; story goal
+ * "Recover-scan reuses existing lock APIs").</p>
+ *
+ * <h2>Size / health off the FX thread</h2>
+ *
+ * <p>Each rendered card's name/size/health badge is filled by a background
+ * virtual-thread scan kicked off through
+ * {@link ProjectHealthScanner#scanInto(Path, ProjectCard)}, whose result crosses
+ * to the FX thread only through the story-289 {@link FxDispatcher} — the FX
+ * thread never walks a project tree ({@code javafx-application-design} §11). The
+ * footer disk line is likewise filled off the FX thread (see
+ * {@link #startDiskScan()}).</p>
+ *
+ * <h2>Stage 2 routing</h2>
+ *
+ * <p>{@code [Recover session ▸]} routes to {@code onOpenProject}; Stage 2 only
+ * surfaces the recoverable candidates and hands them to the open flow. The real
+ * recovery dialog and journal replay are <strong>story 298</strong> — this view
+ * adds no files to the project directory.</p>
+ */
+public final class WelcomeView extends BorderPane {
+
+    /** Style class on the root — selectable as {@code .welcome-view}. */
+    public static final String ROOT_STYLE_CLASS = "welcome-view";
+
+    private final ProjectHealthScanner scanner;
+    private final FxDispatcher dispatcher;
+    private final InstantSource clock;
+
+    // ── classified inputs (computed once, synchronously, at construction) ──────
+    private final List<Path> recoverPaths = new ArrayList<>();
+    private final List<Path> continuePaths = new ArrayList<>();
+    private final List<ProjectCard> continueCards = new ArrayList<>();
+    private final List<Thread> pendingScans = new ArrayList<>();
+
+    // ── live nodes the tests reach for ─────────────────────────────────────────
+    private final VBox sectionsBox = new VBox();
+    private final VBox recoverSection = new VBox();
+    private final VBox continueSection = new VBox();
+    private final Label diskLine = new Label("Free disk: —");
+
+    /**
+     * Full constructor.
+     *
+     * @param recentPaths       the recent project directories, most-recent first;
+     *                          {@code null} is treated as empty
+     * @param scanner           the background health/size scanner; must not be {@code null}
+     * @param dispatcher        the FX marshalling seam; must not be {@code null}
+     * @param clock             the clock used to classify a lock as stale (tests
+     *                          inject a fixed clock); must not be {@code null}
+     * @param onNewProject      invoked by the Start "New project" tile; must not be {@code null}
+     * @param onOpenProject     invoked with a project directory to open a recent
+     *                          card or route a {@code [Recover session ▸]}; must not be {@code null}
+     * @param onOpenFromDisk    invoked by the Start "Open project…" tile; must not be {@code null}
+     * @param onRestoreArchive  invoked by the Start "Restore archive…" tile; must not be {@code null}
+     * @param onImportDawproject invoked by the Start "Import DAWproject" tile; must not be {@code null}
+     */
+    public WelcomeView(List<Path> recentPaths,
+                       ProjectHealthScanner scanner,
+                       FxDispatcher dispatcher,
+                       InstantSource clock,
+                       Runnable onNewProject,
+                       Consumer<Path> onOpenProject,
+                       Runnable onOpenFromDisk,
+                       Runnable onRestoreArchive,
+                       Runnable onImportDawproject) {
+        this.scanner = Objects.requireNonNull(scanner, "scanner must not be null");
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
+        Objects.requireNonNull(onNewProject, "onNewProject must not be null");
+        Objects.requireNonNull(onOpenProject, "onOpenProject must not be null");
+        Objects.requireNonNull(onOpenFromDisk, "onOpenFromDisk must not be null");
+        Objects.requireNonNull(onRestoreArchive, "onRestoreArchive must not be null");
+        Objects.requireNonNull(onImportDawproject, "onImportDawproject must not be null");
+
+        getStyleClass().add(ROOT_STYLE_CLASS);
+        getStylesheets().add(Objects.requireNonNull(
+                WelcomeView.class.getResource("welcome-view.css"),
+                "welcome-view.css not on classpath").toExternalForm());
+
+        classify(recentPaths == null ? List.of() : recentPaths);
+
+        buildRecoverSection(onOpenProject);
+        buildContinueSection(onOpenProject);
+        VBox startSection = buildStartSection(
+                onNewProject, onOpenFromDisk, onRestoreArchive, onImportDawproject);
+
+        sectionsBox.getStyleClass().add("welcome-sections");
+        // Order is the contract: Recover ▸ Continue ▸ Start (§4.1, "Recover ahead
+        // of recent — the user just lost work").
+        sectionsBox.getChildren().addAll(recoverSection, continueSection, startSection);
+        setCenter(sectionsBox);
+
+        setBottom(buildFooter());
+
+        startDiskScan();
+    }
+
+    /**
+     * Convenience constructor using the {@linkplain InstantSource#system() system
+     * clock} for the stale-lock classification.
+     */
+    public WelcomeView(List<Path> recentPaths,
+                       ProjectHealthScanner scanner,
+                       FxDispatcher dispatcher,
+                       Runnable onNewProject,
+                       Consumer<Path> onOpenProject,
+                       Runnable onOpenFromDisk,
+                       Runnable onRestoreArchive,
+                       Runnable onImportDawproject) {
+        this(recentPaths, scanner, dispatcher, InstantSource.system(),
+                onNewProject, onOpenProject, onOpenFromDisk, onRestoreArchive, onImportDawproject);
+    }
+
+    // ── classification ─────────────────────────────────────────────────────────
+
+    /**
+     * Splits the recent paths into Recover (stale-lock → did not exit cleanly)
+     * and Continue, synchronously and in order. A single cheap lock-file read per
+     * path keeps placement deterministic for the test.
+     */
+    private void classify(List<Path> recentPaths) {
+        for (Path path : recentPaths) {
+            if (path == null) {
+                continue;
+            }
+            if (ProjectHealthScanner.isRecoverable(path, clock)) {
+                recoverPaths.add(path);
+            } else {
+                continuePaths.add(path);
+            }
+        }
+    }
+
+    // ── Recover region ───────────────────────────────────────────────────────
+
+    private void buildRecoverSection(Consumer<Path> onOpenProject) {
+        recoverSection.getStyleClass().add("welcome-recover");
+        Label header = new Label("RECOVER");
+        header.getStyleClass().add("welcome-section-header");
+        recoverSection.getChildren().add(header);
+
+        // Only the first (top) recover row carries the default button: JavaFX
+        // activates a single default button on Enter, and more than one would both
+        // ambiguously style every row as primary and make Enter recover an
+        // arbitrary project rather than the top one.
+        boolean first = true;
+        for (Path path : recoverPaths) {
+            recoverSection.getChildren().add(buildRecoverRow(path, onOpenProject, first));
+            first = false;
+        }
+
+        // Nothing to recover → take the region out of the layout entirely so
+        // Continue sits at the top (§4.1: Recover only when there is work lost).
+        boolean hasRecoverable = !recoverPaths.isEmpty();
+        recoverSection.setVisible(hasRecoverable);
+        recoverSection.setManaged(hasRecoverable);
+    }
+
+    private HBox buildRecoverRow(Path path, Consumer<Path> onOpenProject, boolean makeDefault) {
+        HBox row = new HBox();
+        row.getStyleClass().add("welcome-recover-row");
+        row.setAlignment(Pos.CENTER_LEFT);
+
+        ProjectCard card = new ProjectCard();
+        pendingScans.add(scanner.scanInto(path, card)); // size/health off the FX thread
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        HBox actions = new HBox();
+        actions.getStyleClass().add("welcome-recover-actions");
+        actions.setAlignment(Pos.CENTER_RIGHT);
+
+        Button discard = new Button("Discard recovery");
+        discard.getStyleClass().add("welcome-recover-discard");
+        // Stage-2 stub: the destructive discard-recovery flow is owned by the
+        // story-298 recovery dialog; here it is inert so the row reads correctly.
+        discard.setDisable(true);
+
+        Button recover = new Button("Recover session ▸");
+        recover.getStyleClass().add("welcome-recover-action");
+        recover.setDefaultButton(makeDefault);
+        // Stage 2 only routes the candidate into the open flow; the real recovery
+        // dialog + journal replay is story 298.
+        recover.setOnAction(_ -> onOpenProject.accept(path));
+
+        actions.getChildren().addAll(discard, recover);
+        row.getChildren().addAll(card, spacer, actions);
+        return row;
+    }
+
+    // ── Continue region ──────────────────────────────────────────────────────
+
+    private void buildContinueSection(Consumer<Path> onOpenProject) {
+        continueSection.getStyleClass().add("welcome-continue");
+        Label header = new Label("CONTINUE");
+        header.getStyleClass().add("welcome-section-header");
+
+        FlowPane grid = new FlowPane();
+        grid.getStyleClass().add("welcome-grid");
+        for (Path path : continuePaths) {
+            ProjectCard card = new ProjectCard();
+            pendingScans.add(scanner.scanInto(path, card)); // size/health off the FX thread
+            wireOpen(card, path, onOpenProject); // double-click / Enter / Space reopens it
+            continueCards.add(card);
+            grid.getChildren().add(card);
+        }
+
+        continueSection.getChildren().addAll(header, grid);
+    }
+
+    /**
+     * Makes a Continue {@link ProjectCard} actually open its project — a primary
+     * double-click plus keyboard {@code Enter}/{@code Space} activation, matching
+     * the card's {@code AccessibleRole.BUTTON} ({@code javafx-application-design}
+     * §14) and the Project Hub's double-click-to-open. Without this the Continue
+     * cards render but do nothing, stranding the user on the launch screen instead
+     * of letting them return to recent work.
+     */
+    private static void wireOpen(ProjectCard card, Path path, Consumer<Path> onOpen) {
+        card.setOnMouseClicked(e -> {
+            if (e.getButton() == MouseButton.PRIMARY && e.getClickCount() >= 2) {
+                onOpen.accept(path);
+            }
+        });
+        card.setOnKeyPressed(e -> {
+            if (e.getCode() == KeyCode.ENTER || e.getCode() == KeyCode.SPACE) {
+                onOpen.accept(path);
+                e.consume();
+            }
+        });
+    }
+
+    // ── Start region ───────────────────────────────────────────────────────────
+
+    private VBox buildStartSection(Runnable onNewProject,
+                                   Runnable onOpenFromDisk,
+                                   Runnable onRestoreArchive,
+                                   Runnable onImportDawproject) {
+        VBox start = new VBox();
+        start.getStyleClass().add("welcome-start");
+        Label header = new Label("START");
+        header.getStyleClass().add("welcome-section-header");
+
+        FlowPane tiles = new FlowPane();
+        tiles.getStyleClass().add("welcome-tiles");
+        tiles.getChildren().addAll(
+                tile("New project", "Start fresh", onNewProject),
+                tile("Open project…", "From any directory", onOpenFromDisk),
+                tile("Restore archive…", ".dawz portable", onRestoreArchive),
+                tile("Import DAWproject", "Interchange", onImportDawproject));
+
+        start.getChildren().addAll(header, tiles);
+        return start;
+    }
+
+    private static Button tile(String title, String subtitle, Runnable action) {
+        // A two-line tile: bold title over a muted subtitle, stacked in the
+        // button's graphic so the whole tile is one focusable, themeable control.
+        Label titleLabel = new Label(title);
+        titleLabel.getStyleClass().add("welcome-tile-title");
+        Label subtitleLabel = new Label(subtitle);
+        subtitleLabel.getStyleClass().add("welcome-tile-subtitle");
+
+        VBox content = new VBox(titleLabel, subtitleLabel);
+        content.getStyleClass().add("welcome-tile-content");
+        content.setAlignment(Pos.CENTER_LEFT);
+
+        Button button = new Button();
+        button.getStyleClass().add("tile");
+        button.setGraphic(content);
+        button.setMaxWidth(Double.MAX_VALUE);
+        button.setOnAction(_ -> action.run());
+        return button;
+    }
+
+    // ── Footer ───────────────────────────────────────────────────────────────
+
+    private Region buildFooter() {
+        HBox footer = new HBox();
+        footer.getStyleClass().add("welcome-footer");
+        footer.setAlignment(Pos.CENTER_LEFT);
+
+        Label workspace = new Label("Workspace: Personal");
+        workspace.getStyleClass().add("welcome-workspace");
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        diskLine.getStyleClass().add("welcome-disk-line");
+
+        footer.getChildren().addAll(workspace, spacer, diskLine);
+        return footer;
+    }
+
+    /**
+     * Fills the footer disk line off the FX thread. {@code usableSpaceBytes} and
+     * the capture estimate are computed on a background virtual thread (story
+     * 205); the formatted text crosses back to the FX thread through the
+     * dispatcher ({@code javafx-application-design} §11 — the FX thread must
+     * never call {@link java.nio.file.FileStore#getUsableSpace()}).
+     */
+    private void startDiskScan() {
+        Path home = Path.of(System.getProperty("user.home", "."));
+        Thread t = Thread.ofVirtual().name("daw-welcome-disk-scan").unstarted(() -> {
+            long free = ProjectDiskUsage.usableSpaceBytes(home);
+            String text = diskLineText(free);
+            dispatcher.onFx(() -> diskLine.setText(text));
+        });
+        t.start();
+        pendingScans.add(t);
+    }
+
+    /**
+     * Builds the §1.8 disk line — {@code "Free disk: 412 GB"} plus, when both the
+     * free space and the capture estimate are known, {@code " ≈ N h record"} at
+     * {@link AudioFormat#STUDIO_QUALITY}. A negative (unknown) free count yields
+     * the bare {@code "Free disk: —"} seed text.
+     */
+    private static String diskLineText(long free) {
+        String base = "Free disk: " + HubFormat.formatBytes(free);
+        if (free < 0) {
+            return base;
+        }
+        double minutes = SessionStatusDiskScanner.estimatedRecordMinutes(
+                free, AudioFormat.STUDIO_QUALITY);
+        if (minutes <= 0) {
+            return base;
+        }
+        long hours = Math.round(minutes / 60.0);
+        return base + " ≈ " + hours + " h record";
+    }
+
+    // ── test accessors (public — the flat …app.ui test reads these) ────────────
+
+    /** @return the Recover region node (hidden + unmanaged when nothing to recover). */
+    public Region recoverSection() {
+        return recoverSection;
+    }
+
+    /** @return the Continue region node. */
+    public Region continueSection() {
+        return continueSection;
+    }
+
+    /** @return the common parent VBox of the regions (its child order is the §4.1 contract). */
+    public Pane sectionsBox() {
+        return sectionsBox;
+    }
+
+    /** @return the recent paths classified as recoverable (stale lock), in order. */
+    public List<Path> recoverPaths() {
+        return List.copyOf(recoverPaths);
+    }
+
+    /** @return the recent paths classified as Continue (not recoverable), in order. */
+    public List<Path> continuePaths() {
+        return List.copyOf(continuePaths);
+    }
+
+    /**
+     * @return the Continue cards in display order; each opens its project on a
+     *         primary double-click or keyboard {@code Enter}/{@code Space}
+     */
+    public List<ProjectCard> continueCards() {
+        return List.copyOf(continueCards);
+    }
+
+    /** @return the background scan threads started by this view (card scans + the disk scan). */
+    public List<Thread> pendingScans() {
+        return List.copyOf(pendingScans);
+    }
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/hub/project-card.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/hub/project-card.css
@@ -1,0 +1,78 @@
+/*
+ * Story 296 — ProjectCard user-agent stylesheet (Project Hub / Welcome screen).
+ *
+ * Returned by ProjectCard#getUserAgentStylesheet(). Self-contained (mirrors
+ * knob.css / fader.css, story 268): the local -pc-* tokens carry literal
+ * Palette-A defaults here so the card renders correctly with NO application
+ * stylesheet loaded (e.g. an isolated control test, or the Hub shown before the
+ * scene's styles.css resolves). The author-origin forward block in styles.css
+ * (`.project-card { -pc-surface: -surface-1; … }`) RE-declares the same tokens
+ * from role tokens and WINS by CSS origin (AUTHOR > USER_AGENT), so a theme
+ * overlay re-tints the cards for free (feedback_control_css_role_token_forwarding,
+ * feedback_css_author_overrides_useragent_duplication). The literal values below
+ * match Palette A in styles.css; TokenValidationTest scans only styles.css /
+ * theme overlays, not control UA sheets, so these literals are by design.
+ */
+.project-card {
+    -pc-surface:      #15161B;  /* -surface-1   */
+    -pc-line:         #22242C;  /* -line-soft   */
+    -pc-line-strong:  #2E323D;  /* -line-strong */
+    -pc-accent:       #7C8CFF;  /* -accent      */
+    -pc-accent-soft:  rgba(124, 140, 255, 0.14);  /* -accent-soft */
+    -pc-text-hi:      #ECEEF2;  /* -text-hi     */
+    -pc-text-mute:    #7A808C;  /* -text-mute   */
+    -pc-ok:           #5BD2A0;  /* -ok          */
+    -pc-warn:         #E6B450;  /* -warn        */
+    -pc-danger:       #E5484D;  /* -danger      */
+
+    -fx-background-color: -pc-surface;
+    -fx-background-radius: 8;
+    -fx-border-color: -pc-line;
+    -fx-border-width: 1;
+    -fx-border-radius: 8;
+    -fx-padding: 12 16 12 16;
+    -fx-min-width: 200;
+    -fx-pref-width: 240;
+    -fx-min-height: 84;
+}
+
+.project-card:hover {
+    -fx-border-color: -pc-line-strong;
+}
+
+.project-card.project-card-selected {
+    -fx-background-color: -pc-accent-soft;
+    -fx-border-color: -pc-accent;
+}
+
+.project-card .project-card-content {
+    -fx-spacing: 3;
+}
+
+.project-card-name {
+    -fx-text-fill: -pc-text-hi;
+    -fx-font-size: 14px;
+    -fx-font-weight: 600;
+}
+
+.project-card-meta {
+    -fx-text-fill: -pc-text-mute;
+    -fx-font-size: 12px;
+}
+
+.project-card-health {
+    -fx-text-fill: -pc-text-mute;
+    -fx-font-size: 12px;
+}
+
+/* Health-label fills per badge — the card adds exactly one of these classes
+   to itself (ProjectCard.healthProperty().invalidated()). */
+.project-card.project-card-healthy .project-card-health {
+    -fx-text-fill: -pc-ok;
+}
+.project-card.project-card-migrated .project-card-health {
+    -fx-text-fill: -pc-warn;
+}
+.project-card.project-card-missing .project-card-health {
+    -fx-text-fill: -pc-danger;
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/hub/project-hub.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/hub/project-hub.css
@@ -1,0 +1,106 @@
+/* Story 296 — ProjectHubView (the §4.2 full-window Project Hub).
+ *
+ * Unlike project-card.css (a Control USER_AGENT sheet that consumes only the
+ * forwarded local -pc-* tokens), this is an AUTHOR sheet loaded via
+ * getStylesheets() on a Region that lives inside the app scene. It therefore
+ * consumes the role tokens (-surface-1 / -line-soft / -text / -text-hi /
+ * -text-mute / -accent) directly: they resolve by CSS inheritance from the
+ * scene's .root-pane where styles.css defines them. No literal hex here. */
+
+.project-hub {
+    -fx-background-color: -surface-bg;
+}
+
+/* ── toolbar ─────────────────────────────────────────────────────────────── */
+
+.project-hub-toolbar {
+    -fx-background-color: -surface-1;
+    -fx-border-color: -line-soft;
+    -fx-border-width: 0 0 1 0;
+    -fx-padding: 8 12 8 12;
+    -fx-spacing: 12;
+}
+
+.project-hub-toolbar .label {
+    -fx-text-fill: -text-mute;
+}
+
+.project-hub-workspace {
+    -fx-text-fill: -text;
+}
+
+.project-hub-search {
+    -fx-min-width: 180;
+}
+
+.project-hub-view-toggles {
+    -fx-spacing: 0;
+}
+
+.project-hub-sort {
+    -fx-min-width: 150;
+}
+
+/* ── center sections ─────────────────────────────────────────────────────── */
+
+.project-hub-scroll {
+    -fx-background-color: transparent;
+    -fx-background: transparent;
+}
+
+.project-hub-sections {
+    -fx-padding: 16;
+    -fx-spacing: 20;
+}
+
+.project-hub-section {
+    -fx-spacing: 8;
+}
+
+.project-hub-grid {
+    -fx-hgap: 12;
+    -fx-vgap: 12;
+}
+
+/* ── detail strip (the §1.4 fix) ─────────────────────────────────────────── */
+
+.project-hub-detail {
+    -fx-background-color: -surface-1;
+    -fx-border-color: -line-soft;
+    -fx-border-width: 1 0 0 0;
+    -fx-padding: 12 16 12 16;
+    -fx-spacing: 4;
+}
+
+.project-hub-detail-header {
+    -fx-spacing: 12;
+    -fx-padding: 0 0 4 0;
+}
+
+.project-hub-detail-heading {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 14px;
+    -fx-font-weight: bold;
+}
+
+.project-hub-detail-actions {
+    -fx-spacing: 8;
+}
+
+.project-hub-detail-row {
+    -fx-spacing: 8;
+}
+
+.project-hub-detail-key {
+    -fx-text-fill: -text-mute;
+    -fx-min-width: 110;
+}
+
+.project-hub-detail-value {
+    -fx-text-fill: -text;
+}
+
+.project-hub-detail-placeholder {
+    -fx-text-fill: -text-mute;
+    -fx-font-style: italic;
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/hub/welcome-view.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/hub/welcome-view.css
@@ -1,0 +1,117 @@
+/* Story 296 — WelcomeView (§4.1 launch screen). A scene-loaded stylesheet, so
+   it consumes the app's role tokens (-surface-1, -line-soft, -text*, -accent,
+   -warn) directly — they are defined on .root in styles.css. No literal hex. */
+
+.welcome-view {
+    -fx-background-color: -surface-1;
+}
+
+.welcome-sections {
+    -fx-spacing: 24;
+    -fx-padding: 24 28 24 28;
+}
+
+/* Section headers: small, spaced, muted caps ("RECOVER" / "CONTINUE" / "START"). */
+.welcome-section-header {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+    -fx-font-weight: bold;
+    -fx-padding: 0 0 6 2;
+}
+
+/* ── Recover ───────────────────────────────────────────────────────────────── */
+
+.welcome-recover {
+    -fx-spacing: 8;
+}
+
+.welcome-recover-row {
+    -fx-background-color: -surface-1;
+    -fx-border-color: -warn;
+    -fx-border-width: 1;
+    -fx-border-radius: 8;
+    -fx-background-radius: 8;
+    -fx-padding: 10 12 10 12;
+    -fx-spacing: 12;
+}
+
+.welcome-recover-actions {
+    -fx-spacing: 8;
+}
+
+/* ── Continue ──────────────────────────────────────────────────────────────── */
+
+.welcome-continue {
+    -fx-spacing: 8;
+}
+
+.welcome-grid {
+    -fx-hgap: 12;
+    -fx-vgap: 12;
+}
+
+/* ── Start tiles ───────────────────────────────────────────────────────────── */
+
+.welcome-start {
+    -fx-spacing: 8;
+}
+
+.welcome-tiles {
+    -fx-hgap: 12;
+    -fx-vgap: 12;
+}
+
+.tile {
+    -fx-background-color: -surface-1;
+    -fx-border-color: -line-soft;
+    -fx-border-width: 1;
+    -fx-border-radius: 8;
+    -fx-background-radius: 8;
+    -fx-padding: 14 16 14 16;
+    -fx-min-width: 200;
+    -fx-pref-width: 240;
+    -fx-cursor: hand;
+}
+
+.tile:hover {
+    -fx-border-color: -accent;
+}
+
+.tile:focused {
+    -fx-border-color: -accent;
+}
+
+.welcome-tile-content {
+    -fx-spacing: 2;
+}
+
+.welcome-tile-title {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 14px;
+    -fx-font-weight: 600;
+}
+
+.welcome-tile-subtitle {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 12px;
+}
+
+/* ── Footer ────────────────────────────────────────────────────────────────── */
+
+.welcome-footer {
+    -fx-background-color: -surface-1;
+    -fx-border-color: -line-soft transparent transparent transparent;
+    -fx-border-width: 1 0 0 0;
+    -fx-padding: 8 28 8 28;
+    -fx-spacing: 16;
+}
+
+.welcome-workspace {
+    -fx-text-fill: -text;
+    -fx-font-size: 12px;
+}
+
+.welcome-disk-line {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 12px;
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/hub/welcome-view.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/hub/welcome-view.css
@@ -1,6 +1,6 @@
 /* Story 296 — WelcomeView (§4.1 launch screen). A scene-loaded stylesheet, so
    it consumes the app's role tokens (-surface-1, -line-soft, -text*, -accent,
-   -warn) directly — they are defined on .root in styles.css. No literal hex. */
+   -warn) directly — they are defined on .root-pane in styles.css. No literal hex. */
 
 .welcome-view {
     -fx-background-color: -surface-1;

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -1105,6 +1105,25 @@
     -fx-effect: -elevation-2;
 }
 
+/* ── Project Hub / Welcome screen — ProjectCard (story 296) ──
+ * Forward role tokens onto ProjectCard local -pc-* names so project-card.css
+ * (USER_AGENT origin) consumes them without a raw role token
+ * (feedback_control_css_role_token_forwarding). The forwards use distinct
+ * source/target names so they are NOT circular looked-up colours; a theme can
+ * re-tint the cards just by overriding the role tokens on .root-pane. */
+.project-card {
+    -pc-surface:      -surface-1;
+    -pc-line:         -line-soft;
+    -pc-line-strong:  -line-strong;
+    -pc-accent:       -accent;
+    -pc-accent-soft:  -accent-soft;
+    -pc-text-hi:      -text-hi;
+    -pc-text-mute:    -text-mute;
+    -pc-ok:           -ok;
+    -pc-warn:         -warn;
+    -pc-danger:       -danger;
+}
+
 /* ── Separator ── */
 .separator > .line {
     -fx-border-color: -line-soft;

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/HealthScanOffFxThreadTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/HealthScanOffFxThreadTest.java
@@ -1,0 +1,188 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.hub.HealthBadge;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHealthScanner;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectScanResult;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.persistence.ProjectLockManager;
+import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link ProjectHealthScanner#scan} runs OFF the FX thread on a
+ * virtual thread and marshals its result back through the {@link FxDispatcher},
+ * and that {@link ProjectHealthScanner#scanBlocking} classifies migrated /
+ * healthy projects and stale recoverable locks.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class HealthScanOffFxThreadTest {
+
+    @TempDir
+    Path projectDir;
+
+    private FxDispatcher dispatcher;
+
+    @BeforeEach
+    void installDispatcher() throws Exception {
+        dispatcher = new FxDispatcher();
+        FxDispatcher.installDefault(dispatcher);
+        runOnFxThread(dispatcher::start);
+    }
+
+    @AfterEach
+    void disposeDispatcher() throws Exception {
+        runOnFxThread(dispatcher::dispose);
+        FxDispatcher.installDefault(null);
+    }
+
+    @Test
+    void scanRunsOnVirtualThreadAndMarshalsResultToFx() throws Exception {
+        Instant modified = Instant.parse("2026-04-01T12:00:00Z");
+        writeXmlProject("Off-Thread Song", modified);
+        // Give the project some on-disk weight in checkpoints/ so the size is non-zero.
+        Path checkpoints = Files.createDirectories(projectDir.resolve(ProjectDiskUsage.AUTOSAVES_DIR));
+        Files.write(checkpoints.resolve("cp1.bin"), new byte[4096]);
+
+        long expectedBytes = ProjectDiskUsage.compute(projectDir).totalBytes();
+
+        AtomicReference<ProjectScanResult> captured = new AtomicReference<>();
+        Thread t = dispatcher == null ? null : new ProjectHealthScanner(dispatcher)
+                .scan(projectDir, captured::set);
+
+        assertThat(t).isNotNull();
+        assertThat(t.isVirtual()).isTrue(); // proves the scan ran OFF the FX thread
+        t.join(2_000);
+        assertThat(t.isAlive()).isFalse();
+
+        // scan() posts the consumer via dispatcher.onFx (runLater); flush it
+        // with an FX-thread barrier before reading the captured result.
+        runOnFxThread(() -> { /* barrier — lets the posted consumer run first */ });
+
+        ProjectScanResult result = captured.get();
+        assertThat(result).isNotNull();
+        assertThat(result.name()).isEqualTo("Off-Thread Song");
+        assertThat(result.sizeOnDiskBytes()).isEqualTo(expectedBytes);
+        assertThat(result.lastOpened()).isEqualTo(modified);
+    }
+
+    @Test
+    void scanBlockingReportsMigratedWhenBackupSiblingPresent() throws IOException {
+        writeXmlProject("Migrated Song", Instant.parse("2026-01-01T00:00:00Z"));
+        // A pre-migration backup sibling: project.daw.v7.<stamp>.bak
+        Files.writeString(projectDir.resolve("project.daw.v7.20260101-000000.bak"), "<old/>");
+
+        ProjectScanResult result =
+                ProjectHealthScanner.scanBlocking(projectDir, InstantSource.system());
+
+        assertThat(result.health()).isEqualTo(HealthBadge.MIGRATED);
+        assertThat(result.backupSchemaVersion()).isEqualTo(7);
+    }
+
+    @Test
+    void scanBlockingReportsNewestBackupByTimestampNotFilenameOrder() throws IOException {
+        writeXmlProject("Multi-Migration Song", Instant.parse("2026-06-01T00:00:00Z"));
+        // Two pre-migration backups: a v2 migration in January and a v10
+        // migration in June. The newest backup (by yyyyMMdd-HHmmss timestamp) is
+        // the v10 one — but the v2 *filename* sorts lexicographically GREATER
+        // ("…v2…" > "…v10…" because '2' > '1'), so a filename-order scan would
+        // wrongly report v2.
+        Files.writeString(projectDir.resolve("project.daw.v2.20260101-000000.bak"), "<old/>");
+        Files.writeString(projectDir.resolve("project.daw.v10.20260601-000000.bak"), "<old/>");
+
+        ProjectScanResult result =
+                ProjectHealthScanner.scanBlocking(projectDir, InstantSource.system());
+
+        assertThat(result.health()).isEqualTo(HealthBadge.MIGRATED);
+        assertThat(result.backupSchemaVersion())
+                .as("newest backup is chosen by timestamp, not filename order")
+                .isEqualTo(10);
+    }
+
+    @Test
+    void scanBlockingReportsHealthyWhenNoBackupSibling() throws IOException {
+        writeXmlProject("Clean Song", Instant.parse("2026-01-01T00:00:00Z"));
+
+        ProjectScanResult result =
+                ProjectHealthScanner.scanBlocking(projectDir, InstantSource.system());
+
+        assertThat(result.health()).isEqualTo(HealthBadge.HEALTHY);
+        assertThat(result.backupSchemaVersion()).isEqualTo(-1);
+        assertThat(result.sessionCount()).isEqualTo(-1); // Stage 2
+        assertThat(result.recoverable()).isFalse();
+    }
+
+    @Test
+    void scanBlockingReportsRecoverableForStaleLock() throws IOException {
+        writeXmlProject("Crashed Song", Instant.parse("2026-01-01T00:00:00Z"));
+
+        // Acquire a lock at t0, then evaluate the scan with a clock 11 minutes
+        // later — past the 10-minute stale threshold.
+        Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+        ProjectLockManager holder =
+                new ProjectLockManager(InstantSource.fixed(t0), "alice", "studio-mac", 1L);
+        holder.tryAcquire(projectDir);
+
+        InstantSource later = InstantSource.fixed(t0.plus(Duration.ofMinutes(11)));
+
+        ProjectScanResult result = ProjectHealthScanner.scanBlocking(projectDir, later);
+
+        assertThat(result.lockPresent()).isTrue();
+        assertThat(result.lockStale()).isTrue();
+        assertThat(result.recoverable()).isTrue();
+        assertThat(result.lockHolderLabel()).isEqualTo("alice @ studio-mac");
+        assertThat(ProjectHealthScanner.isRecoverable(projectDir, later)).isTrue();
+    }
+
+    private void writeXmlProject(String name, Instant lastModified) throws IOException {
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <daw-project version="1">
+                    <metadata>
+                        <name>%s</name>
+                        <created-at>2026-01-01T00:00:00Z</created-at>
+                        <last-modified>%s</last-modified>
+                    </metadata>
+                </daw-project>
+                """.formatted(name, lastModified);
+        Files.writeString(projectDir.resolve("project.daw"), xml);
+    }
+
+    private static void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/NewProjectPromptsForLocationTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/NewProjectPromptsForLocationTest.java
@@ -1,0 +1,143 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.persistence.AutoSaveConfig;
+import com.benesquivelmusic.daw.core.persistence.CheckpointManager;
+import com.benesquivelmusic.daw.core.persistence.ProjectManager;
+import com.benesquivelmusic.daw.core.persistence.RecentProjectsStore;
+import com.benesquivelmusic.daw.core.persistence.archive.ProjectArchiver;
+import com.benesquivelmusic.daw.core.project.DawProject;
+import com.benesquivelmusic.daw.core.undo.UndoManager;
+
+import javafx.application.Platform;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.VBox;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 296 — the New-project flow prompts for a real destination directory
+ * once and writes there, replacing the §8 / §1.1 silent
+ * {@code Files.createTempDirectory} first-save (the "silent first-save into
+ * /tmp" rejection). With a stubbed directory chooser, {@code createProject}
+ * receives the chosen path; cancelling the prompt creates no project at all.
+ *
+ * <p>{@code MainController} is never FXML-loaded in tests, so this exercises
+ * {@link ProjectLifecycleController} directly with an injected location-prompt
+ * seam ({@link ProjectLifecycleController#setNewProjectLocationPrompt}).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class NewProjectPromptsForLocationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void onNewProjectCreatesProjectAtThePromptedLocation() throws Exception {
+        ProjectManager pm = newProjectManager();
+        Path chosenParent = Files.createDirectories(tempDir.resolve("DAW Projects"));
+        AtomicBoolean promptConsulted = new AtomicBoolean(false);
+
+        ProjectLifecycleController controller = buildController(pm);
+        controller.setNewProjectLocationPrompt(() -> {
+            promptConsulted.set(true);
+            return chosenParent;
+        });
+
+        try {
+            runOnFxThread(controller::onNewProject);
+
+            assertThat(promptConsulted)
+                    .as("the New-project flow consults the location prompt")
+                    .isTrue();
+            assertThat(pm.getCurrentProject())
+                    .as("createProject ran for the prompted location")
+                    .isNotNull();
+            assertThat(pm.getCurrentProject().projectPath().getParent())
+                    .as("createProject received the CHOSEN parent directory — not a "
+                            + "Files.createTempDirectory system-temp dir (§8 / §1.1)")
+                    .isEqualTo(chosenParent);
+            assertThat(pm.getCurrentProject().projectPath())
+                    .as("the new project lives under the chosen workspace")
+                    .startsWith(chosenParent);
+        } finally {
+            pm.abandonProject(); // release lock + stop heartbeat/checkpoints
+        }
+    }
+
+    @Test
+    void cancellingTheLocationPromptCreatesNoProjectAndNoTempDir() throws Exception {
+        ProjectManager pm = newProjectManager();
+
+        ProjectLifecycleController controller = buildController(pm);
+        controller.setNewProjectLocationPrompt(() -> null); // user cancels the chooser
+
+        runOnFxThread(controller::onNewProject);
+
+        assertThat(pm.getCurrentProject())
+                .as("cancelling the location prompt creates NO project — the old code "
+                        + "would have silently created one in a temp dir on first save")
+                .isNull();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private ProjectLifecycleController buildController(ProjectManager pm) throws Exception {
+        AtomicReference<ProjectLifecycleController> ref = new AtomicReference<>();
+        runOnFxThread(() -> {
+            DawProject project = new DawProject("Untitled Project", AudioFormat.STUDIO_QUALITY);
+            project.markClean(); // clean → confirmDiscardUnsavedChanges() won't block
+            AtomicReference<DawProject> p = new AtomicReference<>(project);
+            AtomicReference<UndoManager> um = new AtomicReference<>(new UndoManager());
+            var deps = new ProjectLifecycleController.Deps(
+                    p::get, p::set, um::get, um::set,
+                    () -> { }, () -> { }, mixerView -> { }, () -> null, json -> { });
+            ref.set(new ProjectLifecycleController(
+                    pm, new SessionInterchangeController(), new NotificationBar(),
+                    new ProjectOperationProgress(new FxDispatcher()),
+                    new BorderPane(), new VBox(), deps, new ProjectArchiver()));
+        });
+        return ref.get();
+    }
+
+    private static ProjectManager newProjectManager() {
+        Preferences prefs = Preferences.userRoot().node("daw-test-newproj-" + System.nanoTime());
+        return new ProjectManager(
+                new CheckpointManager(AutoSaveConfig.DEFAULT),
+                new RecentProjectsStore(prefs));
+    }
+
+    private static void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectCardStateBindingTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectCardStateBindingTest.java
@@ -1,0 +1,219 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.hub.HealthBadge;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectCard;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectScanResult;
+import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link ProjectCard}'s skin reflects its properties (the
+ * binding-only meta/health labels) and that the {@link HealthBadge} style-class
+ * reconciliation is headless-safe (asserted on {@code getStyleClass()} without
+ * a realized skin).
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ProjectCardStateBindingTest {
+
+    @Test
+    void skinReflectsNameSizeAndSessionProperties() throws Exception {
+        runOnFxThread(() -> {
+            ProjectCard card = new ProjectCard();
+            realize(card);
+
+            card.setName("Midnight Mix");
+            // HubFormat.formatBytes (mirroring SessionStatusStripSkin) renders
+            // the GB band as whole units, so 2 GiB → "2 GB".
+            card.setSizeOnDiskBytes(2L * 1024 * 1024 * 1024); // 2 GB
+            card.setLastOpened(Instant.now());
+            card.setSessionCount(12);
+
+            assertThat(card.nameLabel().getText()).isEqualTo("Midnight Mix");
+            // Meta line: "<relative> · 2 GB · 12 sess."
+            assertThat(card.metaLabel().getText()).contains("2 GB");
+            assertThat(card.metaLabel().getText()).contains("12 sess.");
+        });
+    }
+
+    @Test
+    void metaLineUsesOneDecimalAtTerabyteScale() throws Exception {
+        runOnFxThread(() -> {
+            ProjectCard card = new ProjectCard();
+            realize(card);
+
+            // 1.5 TiB exercises the only one-decimal band of formatBytes.
+            card.setSizeOnDiskBytes((long) (1.5 * 1024 * 1024 * 1024 * 1024));
+
+            assertThat(card.metaLabel().getText()).contains("1.5 TB");
+        });
+    }
+
+    @Test
+    void metaLineOmitsSessionFragmentWhenUnknown() throws Exception {
+        runOnFxThread(() -> {
+            ProjectCard card = new ProjectCard();
+            realize(card);
+
+            card.setSizeOnDiskBytes(-1L);          // unknown size → "—"
+            card.setSessionCount(-1);              // unknown → no "sess." fragment
+
+            assertThat(card.metaLabel().getText()).doesNotContain("sess.");
+            assertThat(card.metaLabel().getText()).contains("—");
+        });
+    }
+
+    @Test
+    void healthLabelShowsMigratedVersionDetail() throws Exception {
+        runOnFxThread(() -> {
+            ProjectCard card = new ProjectCard();
+            realize(card);
+
+            card.setHealth(HealthBadge.MIGRATED);
+            card.setBackupSchemaVersion(3);
+            card.setSchemaVersion(5);
+
+            assertThat(card.healthLabel().getText()).isEqualTo("⚠ migrated v3→v5");
+        });
+    }
+
+    @Test
+    void healthLabelShowsMissingAssetCount() throws Exception {
+        runOnFxThread(() -> {
+            ProjectCard card = new ProjectCard();
+            realize(card);
+
+            card.setHealth(HealthBadge.MISSING_ASSETS);
+            card.setMissingAssetCount(4);
+
+            assertThat(card.healthLabel().getText()).isEqualTo("⚠ 4 missing assets");
+        });
+    }
+
+    @Test
+    void healthBadgeReconcilesStyleClassesHeadlessSafe() throws Exception {
+        // No Scene / skin needed — the style-class flip happens on the control
+        // itself in healthProperty().invalidated().
+        runOnFxThread(() -> {
+            ProjectCard card = new ProjectCard();
+
+            card.setHealth(HealthBadge.MIGRATED);
+            assertThat(card.getStyleClass())
+                    .contains("project-card-migrated")
+                    .doesNotContain("project-card-healthy", "project-card-missing");
+
+            card.setHealth(HealthBadge.MISSING_ASSETS);
+            assertThat(card.getStyleClass())
+                    .contains("project-card-missing")
+                    .doesNotContain("project-card-healthy", "project-card-migrated");
+
+            card.setHealth(HealthBadge.HEALTHY);
+            assertThat(card.getStyleClass())
+                    .contains("project-card-healthy")
+                    .doesNotContain("project-card-migrated", "project-card-missing");
+
+            // null coerces to HEALTHY.
+            card.setHealth(null);
+            assertThat(card.getHealth()).isEqualTo(HealthBadge.HEALTHY);
+            assertThat(card.getStyleClass()).contains("project-card-healthy");
+        });
+    }
+
+    @Test
+    void selectedAndPinnedReconcileStyleClassesHeadlessSafe() throws Exception {
+        runOnFxThread(() -> {
+            ProjectCard card = new ProjectCard();
+
+            assertThat(card.getStyleClass()).doesNotContain("project-card-selected");
+            card.setSelected(true);
+            assertThat(card.getStyleClass()).contains("project-card-selected");
+            card.setSelected(false);
+            assertThat(card.getStyleClass()).doesNotContain("project-card-selected");
+
+            card.setPinned(true);
+            assertThat(card.getStyleClass()).contains("project-card-pinned");
+            card.setPinned(false);
+            assertThat(card.getStyleClass()).doesNotContain("project-card-pinned");
+        });
+    }
+
+    @Test
+    void applyScanResultSetsDocumentedProperties() throws Exception {
+        runOnFxThread(() -> {
+            ProjectCard card = new ProjectCard();
+            realize(card);
+            // Pinned/selected are view state and must be left untouched by apply.
+            card.setPinned(true);
+            card.setSelected(true);
+
+            Instant opened = Instant.parse("2026-05-01T09:00:00Z");
+            ProjectDiskUsage usage = new ProjectDiskUsage(100L, 200L, 700L); // 1000 bytes total
+            ProjectScanResult scan = new ProjectScanResult(
+                    Path.of("ignored"), "Scanned Project", opened, usage,
+                    7, HealthBadge.MIGRATED, 2, 5, 4,
+                    "alice @ studio-mac", true, true, true);
+
+            card.applyScanResult(scan);
+
+            assertThat(card.getName()).isEqualTo("Scanned Project");
+            assertThat(card.getLastOpened()).isEqualTo(opened);
+            assertThat(card.getSizeOnDiskBytes()).isEqualTo(1000L);
+            assertThat(card.getSessionCount()).isEqualTo(7);
+            assertThat(card.getMissingAssetCount()).isEqualTo(2);
+            assertThat(card.getSchemaVersion()).isEqualTo(5);
+            assertThat(card.getBackupSchemaVersion()).isEqualTo(4);
+            assertThat(card.getLockHolderLabel()).isEqualTo("alice @ studio-mac");
+            assertThat(card.isLockStale()).isTrue();
+            assertThat(card.getHealth()).isEqualTo(HealthBadge.MIGRATED);
+            // Untouched view state.
+            assertThat(card.isPinned()).isTrue();
+            assertThat(card.isSelected()).isTrue();
+        });
+    }
+
+    /** Attaches the card to a Scene and realizes its skin so the labels exist. */
+    private static void realize(ProjectCard card) {
+        Scene scene = new Scene(card);
+        card.applyCss();
+        card.layout();
+        // Touch the scene so static analysis doesn't flag it unused; the
+        // attachment is the load-bearing effect (the skin realizes on applyCss).
+        assertThat(scene.getRoot()).isSameAs(card);
+    }
+
+    /**
+     * Runs {@code action} on the FX thread and rethrows any assertion error it
+     * raises (per the headless test discipline — FX would otherwise swallow it).
+     */
+    private static void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectHubViewModeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectHubViewModeTest.java
@@ -1,0 +1,144 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.hub.ProjectCard;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHealthScanner;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHubView;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+
+import javafx.application.Platform;
+import javafx.scene.layout.Region;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-296 {@link ProjectHubView} view-mode regression: the Grid/List toggle
+ * must actually change the layout. Because the centre {@code ScrollPane} is
+ * {@code fitToWidth}, {@code FlowPane.prefWrapLength} is ignored, so the
+ * single-column List layout is forced by binding each card's preferred width to
+ * the grid width — selecting List binds it, selecting Grid releases it.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ProjectHubViewModeTest {
+
+    @TempDir
+    Path tempRoot;
+
+    private FxDispatcher dispatcher;
+
+    @BeforeEach
+    void installDispatcher() throws Exception {
+        dispatcher = new FxDispatcher();
+        FxDispatcher.installDefault(dispatcher);
+        runOnFxThread(dispatcher::start);
+    }
+
+    @AfterEach
+    void disposeDispatcher() throws Exception {
+        runOnFxThread(dispatcher::dispose);
+        FxDispatcher.installDefault(null);
+    }
+
+    @Test
+    void listToggleBindsCardWidthAndGridToggleReleasesIt() throws Exception {
+        List<Path> recent = List.of(writeProject("Song A"), writeProject("Song B"));
+
+        AtomicReference<ProjectHubView> hubRef = new AtomicReference<>();
+        runOnFxThread(() -> hubRef.set(new ProjectHubView(
+                recent,
+                new ProjectHealthScanner(dispatcher),
+                dispatcher,
+                p -> { },
+                p -> { })));
+        ProjectHubView hub = hubRef.get();
+        assertThat(hub).isNotNull();
+
+        // Grid is the default view: card widths are free (unbound).
+        runOnFxThread(() -> {
+            assertThat(hub.recentCards()).isNotEmpty();
+            for (ProjectCard card : hub.recentCards()) {
+                assertThat(card.prefWidthProperty().isBound())
+                        .as("grid mode leaves card width unbound")
+                        .isFalse();
+            }
+        });
+
+        // Switching to List binds each card's preferred width to the grid width
+        // (forcing one card per row).
+        runOnFxThread(() -> {
+            hub.listToggle().setSelected(true);
+            for (ProjectCard card : hub.recentCards()) {
+                assertThat(card.prefWidthProperty().isBound())
+                        .as("list mode binds card width → single column")
+                        .isTrue();
+            }
+        });
+
+        // Switching back to Grid releases the binding and restores the computed
+        // tile width.
+        runOnFxThread(() -> {
+            hub.gridToggle().setSelected(true);
+            for (ProjectCard card : hub.recentCards()) {
+                assertThat(card.prefWidthProperty().isBound())
+                        .as("grid mode releases the list-column binding")
+                        .isFalse();
+                assertThat(card.getPrefWidth()).isEqualTo(Region.USE_COMPUTED_SIZE);
+            }
+        });
+
+        for (Thread scan : hub.pendingScans()) {
+            scan.join(2_000);
+        }
+        runOnFxThread(() -> { /* barrier — let posted scan consumers run */ });
+    }
+
+    private Path writeProject(String name) throws IOException {
+        Path dir = Files.createDirectory(tempRoot.resolve("proj-" + UUID.randomUUID()));
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <daw-project version="1">
+                    <metadata>
+                        <name>%s</name>
+                        <created-at>2026-01-01T00:00:00Z</created-at>
+                        <last-modified>2026-01-01T00:00:00Z</last-modified>
+                    </metadata>
+                </daw-project>
+                """.formatted(name);
+        Files.writeString(dir.resolve("project.daw"), xml);
+        return dir;
+    }
+
+    private static void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectHubViewModeTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectHubViewModeTest.java
@@ -61,7 +61,6 @@ class ProjectHubViewModeTest {
         runOnFxThread(() -> hubRef.set(new ProjectHubView(
                 recent,
                 new ProjectHealthScanner(dispatcher),
-                dispatcher,
                 p -> { },
                 p -> { })));
         ProjectHubView hub = hubRef.get();

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RecentMenuOpensHubTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RecentMenuOpensHubTest.java
@@ -1,0 +1,166 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHubView;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.status.ProjectOperationProgress;
+import com.benesquivelmusic.daw.core.audio.AudioFormat;
+import com.benesquivelmusic.daw.core.persistence.AutoSaveConfig;
+import com.benesquivelmusic.daw.core.persistence.CheckpointManager;
+import com.benesquivelmusic.daw.core.persistence.ProjectManager;
+import com.benesquivelmusic.daw.core.persistence.RecentProjectsStore;
+import com.benesquivelmusic.daw.core.persistence.archive.ProjectArchiver;
+import com.benesquivelmusic.daw.core.project.DawProject;
+import com.benesquivelmusic.daw.core.undo.UndoManager;
+
+import javafx.application.Platform;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.VBox;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 296 — the File-menu "recent projects" entry now opens the §4.2 Project
+ * Hub (a full-window browser) instead of building a filename {@code ContextMenu}
+ * (§1.4; §8 "a Recent Projects menu that is just filenames"). The controller's
+ * {@code onRecentProjects()} routes through an injectable presenter seam, so a
+ * headless test can assert it presented a {@link ProjectHubView} whose Recent
+ * section reflects the {@code RecentProjectsStore}.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class RecentMenuOpensHubTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void onRecentProjectsOpensProjectHubReflectingTheStore() throws Exception {
+        ProjectManager pm = newProjectManager();
+        // Seed two recent projects on disk (newest added last → first in the store).
+        Path alpha = newProjectDir("Alpha");
+        Path beta = newProjectDir("Beta");
+        pm.getRecentProjectsStore().addRecentProject(alpha);
+        pm.getRecentProjectsStore().addRecentProject(beta);
+
+        AtomicReference<ProjectHubView> presented = new AtomicReference<>();
+        ProjectLifecycleController controller = buildController(pm);
+        controller.setProjectHubPresenter(presented::set);
+
+        runOnFxThread(controller::onRecentProjects);
+
+        ProjectHubView hub = presented.get();
+        assertThat(hub)
+                .as("the recent-projects menu entry opens the §4.2 Project Hub, "
+                        + "not a filename ContextMenu")
+                .isNotNull();
+        assertThat(hub.recentCards())
+                .as("the Hub's Recent section renders one card per recent project")
+                .hasSize(2);
+        // Recent order mirrors the store (most-recent-first): Beta then Alpha.
+        assertThat(hub.recentCards().get(0).getName()).isIn("Beta", "Alpha");
+
+        joinScans(hub); // let the per-card background scans finish before @TempDir cleanup
+    }
+
+    @Test
+    void hubClearRecentButtonClearsTheStoreAndEmptiesTheRecentSection() throws Exception {
+        ProjectManager pm = newProjectManager();
+        pm.getRecentProjectsStore().addRecentProject(newProjectDir("Alpha"));
+        pm.getRecentProjectsStore().addRecentProject(newProjectDir("Beta"));
+
+        AtomicReference<ProjectHubView> presented = new AtomicReference<>();
+        ProjectLifecycleController controller = buildController(pm);
+        controller.setProjectHubPresenter(presented::set);
+        runOnFxThread(controller::onRecentProjects);
+
+        ProjectHubView hub = presented.get();
+        assertThat(hub.recentCards()).hasSize(2);
+        joinScans(hub);
+
+        // The Hub's "Clear Recent" affordance (carried over from the old menu's
+        // "Clear Recent Projects" item) clears the store and empties the section.
+        runOnFxThread(() -> hub.clearRecentButton().fire());
+
+        assertThat(pm.getRecentProjectsStore().getRecentProjectPaths())
+                .as("Clear Recent clears the recent-projects store")
+                .isEmpty();
+        AtomicReference<Integer> remaining = new AtomicReference<>();
+        runOnFxThread(() -> remaining.set(hub.recentCards().size()));
+        assertThat(remaining.get())
+                .as("Clear Recent empties the Hub's Recent section in place")
+                .isZero();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private Path newProjectDir(String name) throws Exception {
+        Path dir = Files.createDirectories(tempDir.resolve(name));
+        Files.writeString(dir.resolve("project.daw"),
+                "# DAW Project File\n"
+                        + "name=" + name + "\n"
+                        + "created_at=2026-01-01T00:00:00Z\n"
+                        + "last_modified=2026-01-01T00:00:00Z\n");
+        return dir;
+    }
+
+    private static void joinScans(ProjectHubView hub) throws InterruptedException {
+        for (Thread scan : hub.pendingScans()) {
+            scan.join(2_000);
+        }
+    }
+
+    private ProjectLifecycleController buildController(ProjectManager pm) throws Exception {
+        AtomicReference<ProjectLifecycleController> ref = new AtomicReference<>();
+        runOnFxThread(() -> {
+            DawProject project = new DawProject("Untitled Project", AudioFormat.STUDIO_QUALITY);
+            project.markClean();
+            AtomicReference<DawProject> p = new AtomicReference<>(project);
+            AtomicReference<UndoManager> um = new AtomicReference<>(new UndoManager());
+            var deps = new ProjectLifecycleController.Deps(
+                    p::get, p::set, um::get, um::set,
+                    () -> { }, () -> { }, mixerView -> { }, () -> null, json -> { });
+            ref.set(new ProjectLifecycleController(
+                    pm, new SessionInterchangeController(), new NotificationBar(),
+                    new ProjectOperationProgress(new FxDispatcher()),
+                    new BorderPane(), new VBox(), deps, new ProjectArchiver()));
+        });
+        return ref.get();
+    }
+
+    private static ProjectManager newProjectManager() {
+        Preferences prefs = Preferences.userRoot().node("daw-test-recenthub-" + System.nanoTime());
+        return new ProjectManager(
+                new CheckpointManager(AutoSaveConfig.DEFAULT),
+                new RecentProjectsStore(prefs));
+    }
+
+    private static void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RecentMenuOpensHubTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RecentMenuOpensHubTest.java
@@ -64,10 +64,9 @@ class RecentMenuOpensHubTest {
                         + "not a filename ContextMenu")
                 .isNotNull();
         assertThat(hub.recentCards())
-                .as("the Hub's Recent section renders one card per recent project")
-                .hasSize(2);
-        // Recent order mirrors the store (most-recent-first): Beta then Alpha.
-        assertThat(hub.recentCards().get(0).getName()).isIn("Beta", "Alpha");
+                .as("the Hub's Recent section renders one card per recent project in most-recent-first order")
+                .extracting(card -> card.getName())
+                .containsExactly("Beta", "Alpha");
 
         joinScans(hub); // let the per-card background scans finish before @TempDir cleanup
     }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RecentProjectsStoreFeedsHubTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RecentProjectsStoreFeedsHubTest.java
@@ -106,7 +106,6 @@ class RecentProjectsStoreFeedsHubTest {
         runOnFxThread(() -> hubRef.set(new ProjectHubView(
                 recentPaths,
                 new ProjectHealthScanner(dispatcher),
-                dispatcher,
                 p -> { },
                 p -> { })));
         ProjectHubView hub = hubRef.get();

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RecentProjectsStoreFeedsHubTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RecentProjectsStoreFeedsHubTest.java
@@ -1,0 +1,228 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.hub.ProjectCard;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHealthScanner;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHubView;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.persistence.ProjectMetadata;
+import com.benesquivelmusic.daw.core.persistence.ProjectMetadataReader;
+import com.benesquivelmusic.daw.core.persistence.RecentProjectsStore;
+import com.benesquivelmusic.daw.core.persistence.backup.ProjectDiskUsage;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The story-296 {@code RecentProjectsStoreFeedsHubTest} acceptance criterion:
+ * a {@link RecentProjectsStore} feeds the §4.2 {@link ProjectHubView} Recent
+ * section — one card per stored path, in the store's most-recent-first order,
+ * each carrying its {@link ProjectMetadata} last-opened time and its
+ * {@link ProjectDiskUsage} on-disk size.
+ *
+ * <p>Mirrors {@code HealthScanOffFxThreadTest}: a dedicated, installed
+ * {@link FxDispatcher}; FX-thread work funnelled through {@link #runOnFxThread};
+ * every value captured inside an FX runnable is stashed in an
+ * {@link AtomicReference} and asserted on the test thread (FX swallows an
+ * {@code AssertionError} raised on its own thread —
+ * {@code feedback_javafx_headless_test_pitfalls}).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class RecentProjectsStoreFeedsHubTest {
+
+    @TempDir
+    Path tempRoot;
+
+    private FxDispatcher dispatcher;
+    private Preferences prefsNode;
+    private RecentProjectsStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dispatcher = new FxDispatcher();
+        FxDispatcher.installDefault(dispatcher);
+        runOnFxThread(dispatcher::start);
+
+        // A unique preferences node per test run so concurrent / repeated runs
+        // never collide on the platform-native backing store.
+        prefsNode = Preferences.userRoot().node("test/hub/" + UUID.randomUUID());
+        store = new RecentProjectsStore(prefsNode);
+        store.clear();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        runOnFxThread(dispatcher::dispose);
+        FxDispatcher.installDefault(null);
+        if (prefsNode != null) {
+            try {
+                prefsNode.removeNode();
+            } catch (BackingStoreException | IllegalStateException ignored) {
+                // Best-effort cleanup — the node may already be gone.
+            }
+        }
+    }
+
+    @Test
+    void recentSectionRendersOneCardPerStoreEntryInOrderWithMetadataAndSize() throws Exception {
+        // Three projects with DISTINCT names, last-modified times, and sizes.
+        ProjectFixture vienna = writeProject("Live - Vienna",
+                Instant.parse("2026-03-12T14:22:00Z"), 1);
+        ProjectFixture score = writeProject("Score - Episode 4",
+                Instant.parse("2026-03-08T09:00:00Z"), 2);
+        ProjectFixture sketches = writeProject("Sketches / Synth",
+                Instant.parse("2026-02-19T18:30:00Z"), 3);
+
+        // Add oldest first so the store reports newest first
+        // (sketches < score < vienna chronologically; store is most-recent-first).
+        store.addRecentProject(sketches.dir());
+        store.addRecentProject(score.dir());
+        store.addRecentProject(vienna.dir());
+
+        List<Path> recentPaths = store.getRecentProjectPaths();
+        assertThat(recentPaths).hasSize(3);
+
+        // Build the Hub on the FX thread; capture it for the test thread.
+        AtomicReference<ProjectHubView> hubRef = new AtomicReference<>();
+        runOnFxThread(() -> hubRef.set(new ProjectHubView(
+                recentPaths,
+                new ProjectHealthScanner(dispatcher),
+                dispatcher,
+                p -> { },
+                p -> { })));
+        ProjectHubView hub = hubRef.get();
+        assertThat(hub).isNotNull();
+
+        // Join every scan thread (they run off the FX thread on virtual threads),
+        // then flush the dispatcher's posted consumers with an FX-thread barrier.
+        for (Thread scan : hub.pendingScans()) {
+            scan.join(5_000);
+            assertThat(scan.isAlive()).as("scan thread should finish").isFalse();
+        }
+        runOnFxThread(() -> { /* barrier — lets the posted scan consumers run */ });
+
+        // ── assert on the test thread, reading card facts inside an FX barrier ──
+        AtomicReference<List<String>> namesRef = new AtomicReference<>();
+        AtomicReference<List<Instant>> lastOpenedRef = new AtomicReference<>();
+        AtomicReference<List<Long>> sizesRef = new AtomicReference<>();
+        runOnFxThread(() -> {
+            List<ProjectCard> cards = hub.recentCards();
+            List<String> names = new ArrayList<>();
+            List<Instant> opened = new ArrayList<>();
+            List<Long> sizes = new ArrayList<>();
+            for (ProjectCard card : cards) {
+                names.add(card.getName());
+                opened.add(card.getLastOpened());
+                sizes.add(card.getSizeOnDiskBytes());
+            }
+            namesRef.set(names);
+            lastOpenedRef.set(opened);
+            sizesRef.set(sizes);
+        });
+
+        // One card per store entry, in the SAME (most-recent-first) order.
+        assertThat(namesRef.get())
+                .containsExactly("Live - Vienna", "Score - Episode 4", "Sketches / Synth");
+
+        // Each card's last-opened equals that project's ProjectMetadata last-modified.
+        List<Instant> expectedOpened = List.of(
+                metadataLastModified(vienna.dir()),
+                metadataLastModified(score.dir()),
+                metadataLastModified(sketches.dir()));
+        assertThat(lastOpenedRef.get()).containsExactlyElementsOf(expectedOpened);
+
+        // Each card's size-on-disk equals ProjectDiskUsage.compute(dir).totalBytes().
+        List<Long> expectedSizes = List.of(
+                diskTotal(vienna.dir()),
+                diskTotal(score.dir()),
+                diskTotal(sketches.dir()));
+        assertThat(sizesRef.get()).containsExactlyElementsOf(expectedSizes);
+
+        // Sizes really do differ (the fixtures wrote distinct checkpoint payloads).
+        assertThat(sizesRef.get()).doesNotHaveDuplicates();
+    }
+
+    /** A project directory plus its written name / last-modified, for assertions. */
+    private record ProjectFixture(Path dir, String name, Instant lastModified) {
+    }
+
+    /**
+     * Writes a real {@code project.daw} (XML) under {@code tempRoot} with a
+     * distinct name and last-modified, plus a {@code checkpoints/} payload of
+     * {@code 1024 * sizeUnits} bytes so the three fixtures' sizes differ.
+     */
+    private ProjectFixture writeProject(String name, Instant lastModified, int sizeUnits)
+            throws IOException {
+        Path dir = Files.createDirectory(tempRoot.resolve("proj-" + UUID.randomUUID()));
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <daw-project version="1">
+                    <metadata>
+                        <name>%s</name>
+                        <created-at>2026-01-01T00:00:00Z</created-at>
+                        <last-modified>%s</last-modified>
+                    </metadata>
+                </daw-project>
+                """.formatted(name, lastModified);
+        Files.writeString(dir.resolve("project.daw"), xml);
+
+        Path checkpoints = Files.createDirectory(dir.resolve(ProjectDiskUsage.AUTOSAVES_DIR));
+        Files.write(checkpoints.resolve("cp.bin"), new byte[1024 * sizeUnits]);
+        return new ProjectFixture(dir, name, lastModified);
+    }
+
+    private static Instant metadataLastModified(Path dir) {
+        ProjectMetadata metadata = ProjectMetadataReader.read(dir)
+                .orElseThrow(() -> new AssertionError("no metadata read for " + dir));
+        return metadata.lastModified();
+    }
+
+    private static long diskTotal(Path dir) throws IOException {
+        return ProjectDiskUsage.compute(dir).totalBytes();
+    }
+
+    /**
+     * Runs {@code action} on the FX thread and blocks until it finishes,
+     * re-throwing any {@link Throwable} it raised on the test thread (the
+     * capture-and-rethrow helper — an assertion failing on the FX thread is
+     * otherwise swallowed).
+     */
+    private static void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/WelcomeRecoverBeforeRecentTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/WelcomeRecoverBeforeRecentTest.java
@@ -1,0 +1,156 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHealthScanner;
+import com.benesquivelmusic.daw.app.ui.hub.WelcomeView;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.persistence.ProjectLockManager;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the story-296 §4.1 ordering: with one stale-lock ("did not exit
+ * cleanly") project present, {@link WelcomeView} renders the Recover region
+ * <em>above</em> the Continue region and places the stale project in Recover —
+ * never in Continue. Classification is synchronous (a single lock-file read per
+ * recent path), so placement is asserted with no dispatcher pump.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class WelcomeRecoverBeforeRecentTest {
+
+    /** Lock heartbeat instant; the view's clock is 20 min later (> 10 min stale threshold). */
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    @TempDir
+    Path tempRoot;
+
+    private FxDispatcher dispatcher;
+
+    @BeforeEach
+    void installDispatcher() throws Exception {
+        dispatcher = new FxDispatcher();
+        FxDispatcher.installDefault(dispatcher);
+        runOnFxThread(dispatcher::start);
+    }
+
+    @AfterEach
+    void disposeDispatcher() throws Exception {
+        runOnFxThread(dispatcher::dispose);
+        FxDispatcher.installDefault(null);
+    }
+
+    @Test
+    void recoverRendersAboveContinueAndHoldsTheStaleProject() throws Exception {
+        Path staleDir = Files.createDirectory(tempRoot.resolve("crashed-session"));
+        Path cleanDir = Files.createDirectory(tempRoot.resolve("clean-session"));
+        writeProjectFile(staleDir, "Crashed Song");
+        writeProjectFile(cleanDir, "Clean Song");
+
+        // Write a STALE lock into the stale dir: its lastSeenAt is fixed at T0,
+        // and the view's clock is T0 + 20 min, so ProjectLockManager.isStale is
+        // true (STALE_THRESHOLD = 10 min). forceAcquire writes .project.lock.
+        ProjectLockManager holder =
+                new ProjectLockManager(InstantSource.fixed(T0), "ben", "studio-pc", 123L);
+        holder.forceAcquire(staleDir);
+
+        InstantSource clock = InstantSource.fixed(T0.plus(20, ChronoUnit.MINUTES));
+
+        // Sanity: the scanner classifies the stale dir as recoverable and the
+        // clean dir as not — the same cheap read WelcomeView uses for placement.
+        assertThat(ProjectHealthScanner.isRecoverable(staleDir, clock)).isTrue();
+        assertThat(ProjectHealthScanner.isRecoverable(cleanDir, clock)).isFalse();
+
+        AtomicReference<WelcomeView> viewRef = new AtomicReference<>();
+        runOnFxThread(() -> viewRef.set(new WelcomeView(
+                List.of(staleDir, cleanDir),
+                new ProjectHealthScanner(dispatcher),
+                dispatcher,
+                clock,
+                () -> {},          // onNewProject
+                _ -> {},           // onOpenProject
+                () -> {},          // onOpenFromDisk
+                () -> {},          // onRestoreArchive
+                () -> {})));       // onImportDawproject
+
+        WelcomeView view = viewRef.get();
+        assertThat(view).isNotNull();
+
+        // §4.1: Recover renders above Continue.
+        var children = view.sectionsBox().getChildren();
+        int recoverIndex = children.indexOf(view.recoverSection());
+        int continueIndex = children.indexOf(view.continueSection());
+        assertThat(recoverIndex).isGreaterThanOrEqualTo(0);
+        assertThat(continueIndex).isGreaterThanOrEqualTo(0);
+        assertThat(recoverIndex).isLessThan(continueIndex);
+
+        // The stale project is recoverable, never in Continue; the clean one is.
+        assertThat(view.recoverPaths()).contains(staleDir).doesNotContain(cleanDir);
+        assertThat(view.continuePaths()).contains(cleanDir);
+
+        // Let the per-card background scans finish and clean up the lock so the
+        // @TempDir can be deleted (Windows: release the held lock file handle).
+        joinPendingScans(view);
+        holder.close();
+    }
+
+    private void joinPendingScans(WelcomeView view) throws Exception {
+        for (Thread scan : view.pendingScans()) {
+            scan.join(2_000);
+        }
+        // Flush the FX queue so any posted applyScanResult consumers have run
+        // before teardown disposes the dispatcher.
+        runOnFxThread(() -> { /* barrier */ });
+    }
+
+    private static void writeProjectFile(Path dir, String name) throws IOException {
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <daw-project version="1">
+                    <metadata>
+                        <name>%s</name>
+                        <created-at>2026-01-01T00:00:00Z</created-at>
+                        <last-modified>2026-01-01T00:00:00Z</last-modified>
+                    </metadata>
+                </daw-project>
+                """.formatted(name);
+        Files.writeString(dir.resolve("project.daw"), xml);
+    }
+
+    private static void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/WelcomeViewInteractionTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/WelcomeViewInteractionTest.java
@@ -1,0 +1,214 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.hub.ProjectCard;
+import com.benesquivelmusic.daw.app.ui.hub.ProjectHealthScanner;
+import com.benesquivelmusic.daw.app.ui.hub.WelcomeView;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.persistence.ProjectLockManager;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Button;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-296 {@link WelcomeView} interaction regressions:
+ *
+ * <ul>
+ *   <li>A <b>Continue</b> card actually opens its project on keyboard activation
+ *       (it is wired identically for a primary double-click) — without this the
+ *       launch screen's recent cards are inert and the user cannot return to
+ *       their work.</li>
+ *   <li>At most <b>one</b> Recover row carries the default button, so Enter on
+ *       the Welcome screen recovers a single, deterministic project rather than
+ *       an arbitrary one among several recoverable projects.</li>
+ * </ul>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class WelcomeViewInteractionTest {
+
+    /** Lock heartbeat instant; the view's clock is 20 min later (> 10 min stale threshold). */
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    @TempDir
+    Path tempRoot;
+
+    private FxDispatcher dispatcher;
+
+    @BeforeEach
+    void installDispatcher() throws Exception {
+        dispatcher = new FxDispatcher();
+        FxDispatcher.installDefault(dispatcher);
+        runOnFxThread(dispatcher::start);
+    }
+
+    @AfterEach
+    void disposeDispatcher() throws Exception {
+        runOnFxThread(dispatcher::dispose);
+        FxDispatcher.installDefault(null);
+    }
+
+    @Test
+    void continueCardOpensItsProjectOnKeyboardActivation() throws Exception {
+        Path cleanDir = Files.createDirectory(tempRoot.resolve("clean-session"));
+        writeProjectFile(cleanDir, "Clean Song");
+
+        AtomicReference<Path> opened = new AtomicReference<>();
+        AtomicReference<WelcomeView> viewRef = new AtomicReference<>();
+        runOnFxThread(() -> viewRef.set(new WelcomeView(
+                List.of(cleanDir),
+                new ProjectHealthScanner(dispatcher),
+                dispatcher,
+                InstantSource.fixed(T0.plus(20, ChronoUnit.MINUTES)),
+                () -> {},               // onNewProject
+                opened::set,            // onOpenProject — capture the opened path
+                () -> {},               // onOpenFromDisk
+                () -> {},               // onRestoreArchive
+                () -> {})));            // onImportDawproject
+
+        WelcomeView view = viewRef.get();
+        assertThat(view).isNotNull();
+        assertThat(view.continuePaths()).containsExactly(cleanDir);
+        assertThat(view.continueCards()).hasSize(1);
+
+        // Press Enter on the Continue card: it must open exactly its project.
+        runOnFxThread(() -> {
+            ProjectCard card = view.continueCards().get(0);
+            card.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, KeyEvent.CHAR_UNDEFINED, "",
+                    KeyCode.ENTER, false, false, false, false));
+        });
+
+        assertThat(opened.get())
+                .as("a Continue card is no longer inert — Enter opens its project")
+                .isEqualTo(cleanDir);
+
+        joinPendingScans(view);
+    }
+
+    @Test
+    void atMostOneRecoverRowIsTheDefaultButton() throws Exception {
+        Path crashedA = Files.createDirectory(tempRoot.resolve("crashed-a"));
+        Path crashedB = Files.createDirectory(tempRoot.resolve("crashed-b"));
+        writeProjectFile(crashedA, "Crashed A");
+        writeProjectFile(crashedB, "Crashed B");
+
+        // Two STALE locks → both projects are recoverable (two Recover rows).
+        ProjectLockManager holderA =
+                new ProjectLockManager(InstantSource.fixed(T0), "ben", "studio-pc", 123L);
+        ProjectLockManager holderB =
+                new ProjectLockManager(InstantSource.fixed(T0), "ben", "studio-pc", 124L);
+        holderA.forceAcquire(crashedA);
+        holderB.forceAcquire(crashedB);
+
+        InstantSource clock = InstantSource.fixed(T0.plus(20, ChronoUnit.MINUTES));
+        AtomicReference<WelcomeView> viewRef = new AtomicReference<>();
+        runOnFxThread(() -> viewRef.set(new WelcomeView(
+                List.of(crashedA, crashedB),
+                new ProjectHealthScanner(dispatcher),
+                dispatcher,
+                clock,
+                () -> {}, _ -> {}, () -> {}, () -> {}, () -> {})));
+
+        WelcomeView view = viewRef.get();
+        assertThat(view).isNotNull();
+        assertThat(view.recoverPaths()).containsExactly(crashedA, crashedB);
+
+        AtomicReference<Long> defaultCount = new AtomicReference<>();
+        runOnFxThread(() -> {
+            long defaults = collectButtons(view.recoverSection()).stream()
+                    .filter(Button::isDefaultButton)
+                    .count();
+            defaultCount.set(defaults);
+        });
+
+        assertThat(defaultCount.get())
+                .as("only one default button across multiple Recover rows")
+                .isEqualTo(1L);
+
+        joinPendingScans(view);
+        holderA.close();
+        holderB.close();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static List<Button> collectButtons(Node node) {
+        List<Button> buttons = new ArrayList<>();
+        collectButtons(node, buttons);
+        return buttons;
+    }
+
+    private static void collectButtons(Node node, List<Button> out) {
+        if (node instanceof Button button) {
+            out.add(button);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collectButtons(child, out);
+            }
+        }
+    }
+
+    private void joinPendingScans(WelcomeView view) throws Exception {
+        for (Thread scan : view.pendingScans()) {
+            scan.join(2_000);
+        }
+        runOnFxThread(() -> { /* barrier — let posted scan consumers run */ });
+    }
+
+    private static void writeProjectFile(Path dir, String name) throws IOException {
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <daw-project version="1">
+                    <metadata>
+                        <name>%s</name>
+                        <created-at>2026-01-01T00:00:00Z</created-at>
+                        <last-modified>2026-01-01T00:00:00Z</last-modified>
+                    </metadata>
+                </daw-project>
+                """.formatted(name);
+        Files.writeString(dir.resolve("project.daw"), xml);
+    }
+
+    private static void runOnFxThread(Runnable action) throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Timed out waiting for JavaFX action to complete");
+        }
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+    }
+}

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectLockManager.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectLockManager.java
@@ -317,6 +317,26 @@ public final class ProjectLockManager implements AutoCloseable {
         return Duration.between(lock.lastSeenAt(), now).compareTo(STALE_THRESHOLD) > 0;
     }
 
+    /**
+     * Reads the {@code .project.lock} sidecar in {@code projectDir} WITHOUT
+     * acquiring, writing, or modifying anything (unlike {@link #tryAcquire}).
+     * Returns the parsed holder lock, or empty when no lock file is present or
+     * it cannot be parsed. The story-296 Welcome/Hub recover-scan uses this +
+     * {@link #isStale(ProjectLock, Instant)} to classify "did not exit cleanly"
+     * without the side effect of {@code tryAcquire}.
+     *
+     * @param projectDir the project directory whose lock sidecar to peek
+     * @return the on-disk holder lock, or empty when absent / unparseable
+     */
+    public static Optional<ProjectLock> peekLock(Path projectDir) {
+        Objects.requireNonNull(projectDir, "projectDir must not be null");
+        try {
+            return Optional.ofNullable(readLock(projectDir.resolve(LOCK_FILE_NAME)));
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
     /** Reads and parses a lock file, returning {@code null} if it cannot be parsed. */
     static ProjectLock readLock(Path lockFile) throws IOException {
         if (!Files.exists(lockFile)) {

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectLockManager.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectLockManager.java
@@ -332,7 +332,7 @@ public final class ProjectLockManager implements AutoCloseable {
         Objects.requireNonNull(projectDir, "projectDir must not be null");
         try {
             return Optional.ofNullable(readLock(projectDir.resolve(LOCK_FILE_NAME)));
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             return Optional.empty();
         }
     }

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectManager.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectManager.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.persistence.migration.MigrationReport;
 import com.benesquivelmusic.daw.core.project.DawProject;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -139,6 +140,13 @@ public final class ProjectManager {
     /**
      * Creates a new project in the specified directory.
      *
+     * <p>The project folder is created under {@code parentDirectory} from the
+     * sanitized name; if that directory already exists it is <em>not</em>
+     * overwritten — a numeric suffix is appended ({@code "Untitled Project 2"},
+     * {@code "Untitled Project 3"}, …). Two new projects created with the same
+     * default name into the same workspace therefore land in distinct
+     * directories instead of the second silently clobbering the first.</p>
+     *
      * @param name             the project name
      * @param parentDirectory  the parent directory where the project folder will be created
      * @return metadata for the new project
@@ -148,8 +156,7 @@ public final class ProjectManager {
         Objects.requireNonNull(name, "name must not be null");
         Objects.requireNonNull(parentDirectory, "parentDirectory must not be null");
 
-        Path projectDir = parentDirectory.resolve(sanitizeDirectoryName(name));
-        Files.createDirectories(projectDir);
+        Path projectDir = createUniqueProjectDirectory(parentDirectory, sanitizeDirectoryName(name));
         Files.createDirectories(projectDir.resolve(AUDIO_DIR_NAME));
 
         ProjectMetadata metadata = ProjectMetadata.createNew(name).withPath(projectDir);
@@ -160,11 +167,39 @@ public final class ProjectManager {
         readOnly = false;
         recentProjects.put(projectDir.toString(), metadata);
         recordRecentProject(projectDir);
-        // A brand-new project directory cannot already be in use, so unconditionally take the lock.
+        // createUniqueProjectDirectory() atomically created a brand-new folder, so
+        // the directory cannot already be locked — unconditionally take it.
         lockManager.forceAcquire(projectDir);
         lockManager.startHeartbeat();
         checkpointManager.start(projectDir);
         return metadata;
+    }
+
+    /**
+     * Atomically creates and returns a fresh child directory under {@code parent}:
+     * {@code base}, else {@code "base 2"}, {@code "base 3"}, … . Each candidate is
+     * claimed with {@link Files#createDirectory(Path, java.nio.file.attribute.FileAttribute[])}
+     * — which fails if the directory already exists — rather than an
+     * {@link Files#exists} check followed by a separate {@code createDirectories},
+     * closing the time-of-check/time-of-use gap: two processes (or threads)
+     * creating a same-named project into the same workspace can never both resolve
+     * the same name and have the loser silently merge into the winner's directory.
+     * Creating a new project therefore never overwrites — nor co-occupies — an
+     * existing project directory, an irreversible action the Project Manager design
+     * book reserves for an explicit confirmation, never a silent default.
+     */
+    private static Path createUniqueProjectDirectory(Path parent, String base) throws IOException {
+        Files.createDirectories(parent);
+        int suffix = 1;
+        Path candidate = parent.resolve(base);
+        while (true) {
+            try {
+                return Files.createDirectory(candidate);
+            } catch (FileAlreadyExistsException e) {
+                suffix++;
+                candidate = parent.resolve(base + " " + suffix);
+            }
+        }
     }
 
     /**

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectMetadataReader.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectMetadataReader.java
@@ -1,0 +1,212 @@
+package com.benesquivelmusic.daw.core.persistence;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Side-effect-free reader of a project's {@code project.daw} metadata — the
+ * cheap, lock-free, migration-free name/timestamp peek the story-296
+ * Welcome/Hub project cards use to populate a card without opening the project
+ * (no {@link ProjectLockManager#tryAcquire lock}, no
+ * {@link com.benesquivelmusic.daw.core.persistence.migration.MigrationRegistry
+ * migration}, no {@link DawProject} deserialization).
+ *
+ * <p>JavaFX-free (this is {@code daw-core}). The full
+ * {@link ProjectDeserializer} reads the same {@code <metadata>} block but also
+ * runs migrations and rebuilds the entire project graph; this reader does the
+ * minimum a hub tile needs and is robust to malformed content (it never throws
+ * for bad input — it returns {@link Optional#empty()} or a best-effort
+ * {@link ProjectMetadata}).</p>
+ *
+ * <h2>Format detection</h2>
+ *
+ * <p>Mirrors {@link ProjectManager#openProject(Path)}: if the file content
+ * starts with {@code <?xml} or {@code <daw-project} it is parsed as XML (the
+ * {@code <metadata><name>/<created-at>/<last-modified></metadata>} elements,
+ * exactly as {@link ProjectDeserializer} reads them); otherwise it is parsed as
+ * the legacy text format ({@code name=}/{@code created_at=}/{@code last_modified=}
+ * lines, exactly as {@link ProjectManager}'s legacy {@code parseProjectFile}
+ * does).</p>
+ */
+public final class ProjectMetadataReader {
+
+    private static final String PROJECT_FILE_NAME = "project.daw";
+
+    private ProjectMetadataReader() {
+        // Static utility — no instances.
+    }
+
+    /**
+     * Reads the {@code project.daw} metadata in {@code projectDir} without any
+     * side effect. Returns the parsed {@link ProjectMetadata} (with
+     * {@code projectPath} set to {@code projectDir}), or {@link Optional#empty()}
+     * when {@code project.daw} is missing or unreadable.
+     *
+     * <p>The returned metadata's {@code name} falls back to the directory's
+     * file name when the file carries no usable name; {@code createdAt} /
+     * {@code lastModified} fall back to the {@code project.daw} file's
+     * last-modified time when the file carries no parseable timestamp (and only
+     * to {@link Instant#now()} when even that is unreadable) — so a card's
+     * "last opened" reflects the file on disk rather than the moment of the scan.
+     * Malformed content never throws.</p>
+     *
+     * @param projectDir the project directory to read; must not be {@code null}
+     * @return the project metadata, or empty when no readable {@code project.daw} exists
+     */
+    public static Optional<ProjectMetadata> read(Path projectDir) {
+        Objects.requireNonNull(projectDir, "projectDir must not be null");
+        Path projectFile = projectDir.resolve(PROJECT_FILE_NAME);
+        if (!Files.isRegularFile(projectFile)) {
+            return Optional.empty();
+        }
+        String content;
+        try {
+            content = Files.readString(projectFile);
+        } catch (IOException | RuntimeException e) {
+            // Unreadable / undecodable — treated as "no metadata available".
+            return Optional.empty();
+        }
+
+        String stripped = content.strip();
+        Parsed parsed = (stripped.startsWith("<?xml") || stripped.startsWith("<daw-project"))
+                ? parseXml(content)
+                : parseLegacyText(content);
+
+        String name = (parsed.name == null || parsed.name.isBlank())
+                ? fileNameOf(projectDir)
+                : parsed.name.strip();
+        // When the content has no parseable timestamp, prefer the file's own
+        // last-modified time over Instant.now() so the card's "last opened" tracks
+        // the project on disk instead of the instant this scan happened to run.
+        Instant fileModified = fileLastModified(projectFile);
+        Instant createdAt = firstNonNull(parsed.createdAt, fileModified);
+        Instant lastModified = firstNonNull(parsed.lastModified, fileModified);
+        return Optional.of(new ProjectMetadata(name, createdAt, lastModified, projectDir));
+    }
+
+    /** Best-effort parse holder — any field may be {@code null} (use a fallback). */
+    private record Parsed(String name, Instant createdAt, Instant lastModified) {
+    }
+
+    private static Parsed parseXml(String xml) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // Same hardening as ProjectDeserializer — no external DTD entities.
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document document = builder.parse(
+                    new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            document.getDocumentElement().normalize();
+
+            Element root = document.getDocumentElement();
+            List<Element> metadataElements = directChildren(root, "metadata");
+            if (metadataElements.isEmpty()) {
+                return new Parsed(null, null, null);
+            }
+            Element metadata = metadataElements.get(0);
+            String name = firstChildText(metadata, "name");
+            Instant createdAt = parseInstant(firstChildText(metadata, "created-at"));
+            Instant lastModified = parseInstant(firstChildText(metadata, "last-modified"));
+            return new Parsed(name, createdAt, lastModified);
+        } catch (ParserConfigurationException | SAXException | IOException | RuntimeException e) {
+            // Malformed XML — best-effort empty parse, fallbacks fill in.
+            return new Parsed(null, null, null);
+        }
+    }
+
+    private static Parsed parseLegacyText(String content) {
+        String name = null;
+        Instant createdAt = null;
+        Instant lastModified = null;
+        for (String line : content.split("\n")) {
+            if (line.startsWith("name=")) {
+                name = line.substring("name=".length()).strip();
+            } else if (line.startsWith("created_at=")) {
+                createdAt = parseInstant(line.substring("created_at=".length()).strip());
+            } else if (line.startsWith("last_modified=")) {
+                lastModified = parseInstant(line.substring("last_modified=".length()).strip());
+            }
+        }
+        return new Parsed(name, createdAt, lastModified);
+    }
+
+    /**
+     * The first non-{@code null} of {@code parsed} (the content timestamp) then
+     * {@code fileModified} (the file's mtime), falling back to {@link Instant#now()}
+     * only when both are absent.
+     */
+    private static Instant firstNonNull(Instant parsed, Instant fileModified) {
+        if (parsed != null) {
+            return parsed;
+        }
+        return fileModified != null ? fileModified : Instant.now();
+    }
+
+    /** The {@code project.daw} file's last-modified instant, or {@code null} if unreadable. */
+    private static Instant fileLastModified(Path projectFile) {
+        try {
+            return Files.getLastModifiedTime(projectFile).toInstant();
+        } catch (IOException | RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static Instant parseInstant(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(raw.strip());
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private static List<Element> directChildren(Element parent, String tagName) {
+        List<Element> result = new ArrayList<>();
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE && tagName.equals(node.getNodeName())) {
+                result.add((Element) node);
+            }
+        }
+        return result;
+    }
+
+    private static String firstChildText(Element parent, String tagName) {
+        List<Element> elements = directChildren(parent, tagName);
+        if (elements.isEmpty()) {
+            return null;
+        }
+        String text = elements.get(0).getTextContent();
+        return (text == null || text.isBlank()) ? null : text.strip();
+    }
+
+    // Core-side base-name helper; intentionally mirrors the daw-app
+    // HubFormat.baseName semantics (full-path fallback for a root path) so the
+    // hub and this reader agree on a card's seeded name. daw-core cannot depend
+    // on daw-app, hence the small duplicate.
+    private static String fileNameOf(Path projectDir) {
+        Path fileName = projectDir.getFileName();
+        return fileName != null ? fileName.toString() : projectDir.toString();
+    }
+}

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectMetadataReader.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectMetadataReader.java
@@ -9,6 +9,7 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -50,6 +51,13 @@ public final class ProjectMetadataReader {
 
     private static final String PROJECT_FILE_NAME = "project.daw";
 
+    /**
+     * Maximum number of characters to read from project.daw. The metadata block
+     * is always near the top of the file, so 8 KB is more than sufficient to
+     * capture it without loading the potentially large full project graph.
+     */
+    private static final int READ_LIMIT = 8192;
+
     private ProjectMetadataReader() {
         // Static utility — no instances.
     }
@@ -59,6 +67,10 @@ public final class ProjectMetadataReader {
      * side effect. Returns the parsed {@link ProjectMetadata} (with
      * {@code projectPath} set to {@code projectDir}), or {@link Optional#empty()}
      * when {@code project.daw} is missing or unreadable.
+     *
+     * <p>Only the first {@value #READ_LIMIT} characters of the file are read —
+     * enough to capture the {@code <metadata>} block (or legacy header) without
+     * allocating the full project graph into memory.</p>
      *
      * <p>The returned metadata's {@code name} falls back to the directory's
      * file name when the file carries no usable name; {@code createdAt} /
@@ -79,7 +91,7 @@ public final class ProjectMetadataReader {
         }
         String content;
         try {
-            content = Files.readString(projectFile);
+            content = readPrefix(projectFile);
         } catch (IOException | RuntimeException e) {
             // Unreadable / undecodable — treated as "no metadata available".
             return Optional.empty();
@@ -100,6 +112,25 @@ public final class ProjectMetadataReader {
         Instant createdAt = firstNonNull(parsed.createdAt, fileModified);
         Instant lastModified = firstNonNull(parsed.lastModified, fileModified);
         return Optional.of(new ProjectMetadata(name, createdAt, lastModified, projectDir));
+    }
+
+    /**
+     * Reads at most {@link #READ_LIMIT} characters from the beginning of the
+     * file — enough to capture the metadata header without loading the full
+     * project graph.
+     */
+    private static String readPrefix(Path file) throws IOException {
+        char[] buffer = new char[READ_LIMIT];
+        int totalRead;
+        try (BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            totalRead = 0;
+            int n;
+            while (totalRead < READ_LIMIT
+                    && (n = reader.read(buffer, totalRead, READ_LIMIT - totalRead)) != -1) {
+                totalRead += n;
+            }
+        }
+        return new String(buffer, 0, totalRead);
     }
 
     /** Best-effort parse holder — any field may be {@code null} (use a fallback). */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectMetadataReader.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/persistence/ProjectMetadataReader.java
@@ -41,10 +41,10 @@ import java.util.Optional;
  * <p>Mirrors {@link ProjectManager#openProject(Path)}: if the file content
  * starts with {@code <?xml} or {@code <daw-project} it is parsed as XML (the
  * {@code <metadata><name>/<created-at>/<last-modified></metadata>} elements,
- * exactly as {@link ProjectDeserializer} reads them); otherwise it is parsed as
- * the legacy text format ({@code name=}/{@code created_at=}/{@code last_modified=}
- * lines, exactly as {@link ProjectManager}'s legacy {@code parseProjectFile}
- * does).</p>
+ * consistent with {@link ProjectDeserializer}; otherwise it parses the legacy
+ * text keys ({@code name=}/{@code created_at=}/{@code last_modified=}) used by
+ * {@link ProjectManager}'s legacy {@code parseProjectFile}, but with this
+ * reader's own fallback semantics (dir name / file mtime) documented below.</p>
  */
 public final class ProjectMetadataReader {
 

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/persistence/ProjectLockManagerPeekTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/persistence/ProjectLockManagerPeekTest.java
@@ -1,0 +1,87 @@
+package com.benesquivelmusic.daw.core.persistence;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ProjectLockManager#peekLock(Path)} — the side-effect-free
+ * lock peek the story-296 Welcome/Hub recover-scan uses. A new file (the
+ * existing {@code ProjectLockManagerTest} is left untouched).
+ */
+class ProjectLockManagerPeekTest {
+
+    @TempDir
+    Path projectDir;
+
+    /** A controllable {@link InstantSource}, mirroring ProjectLockManagerTest's helper. */
+    private static final class FakeClock implements InstantSource {
+        private Instant now;
+        FakeClock(Instant start) { this.now = start; }
+        @Override public Instant instant() { return now; }
+        void advance(Duration by) { now = now.plus(by); }
+    }
+
+    @Test
+    void peekReturnsHolderForPresentLock() throws IOException {
+        FakeClock clock = new FakeClock(Instant.parse("2026-01-01T00:00:00Z"));
+        ProjectLockManager holder = new ProjectLockManager(clock, "alice", "studio-mac", 4242L);
+        holder.tryAcquire(projectDir);
+
+        Optional<ProjectLock> peeked = ProjectLockManager.peekLock(projectDir);
+
+        assertThat(peeked).isPresent();
+        assertThat(peeked.get().user()).isEqualTo("alice");
+        assertThat(peeked.get().hostname()).isEqualTo("studio-mac");
+        assertThat(peeked.get().pid()).isEqualTo(4242L);
+    }
+
+    @Test
+    void peekReturnsEmptyForUnlockedDirectoryAndCreatesNoLockFile() {
+        Optional<ProjectLock> peeked = ProjectLockManager.peekLock(projectDir);
+
+        assertThat(peeked).isEmpty();
+        // The peek must NOT have written a sidecar (unlike tryAcquire).
+        assertThat(projectDir.resolve(ProjectLockManager.LOCK_FILE_NAME))
+                .doesNotExist();
+    }
+
+    @Test
+    void peekDoesNotAlterAnExistingLock() throws IOException {
+        FakeClock clock = new FakeClock(Instant.parse("2026-01-01T00:00:00Z"));
+        ProjectLockManager holder = new ProjectLockManager(clock, "bob", "edit-suite", 7L);
+        holder.tryAcquire(projectDir);
+
+        Path lockFile = projectDir.resolve(ProjectLockManager.LOCK_FILE_NAME);
+        byte[] before = Files.readAllBytes(lockFile);
+
+        ProjectLockManager.peekLock(projectDir);
+        ProjectLockManager.peekLock(projectDir);
+
+        // Peeking is read-only: the sidecar's bytes are unchanged.
+        assertThat(Files.readAllBytes(lockFile)).isEqualTo(before);
+    }
+
+    @Test
+    void peekedLockIsClassifiableAsStale() throws IOException {
+        FakeClock clock = new FakeClock(Instant.parse("2026-01-01T00:00:00Z"));
+        ProjectLockManager holder = new ProjectLockManager(clock, "carol", "tracking-rig", 9L);
+        holder.tryAcquire(projectDir);
+
+        clock.advance(Duration.ofMinutes(11)); // past the 10-minute threshold
+
+        Optional<ProjectLock> peeked = ProjectLockManager.peekLock(projectDir);
+
+        assertThat(peeked).isPresent();
+        assertThat(ProjectLockManager.isStale(peeked.get(), clock.instant())).isTrue();
+    }
+}

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/persistence/ProjectManagerTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/persistence/ProjectManagerTest.java
@@ -49,6 +49,29 @@ class ProjectManagerTest {
     }
 
     @Test
+    void createProjectWithDuplicateNameDoesNotOverwriteExisting() throws IOException {
+        ProjectManager manager = createProjectManager();
+
+        ProjectMetadata first = manager.createProject("Untitled Project", tempDir);
+        Path firstDir = first.projectPath();
+        Files.writeString(firstDir.resolve("marker.txt"), "first project's data");
+        manager.abandonProject(); // release the lock so a second create can run
+
+        ProjectMetadata second = manager.createProject("Untitled Project", tempDir);
+        Path secondDir = second.projectPath();
+
+        assertThat(secondDir)
+                .as("a second same-named new project gets its own directory, never "
+                        + "silently overwriting the first")
+                .isNotEqualTo(firstDir);
+        assertThat(firstDir).isDirectory();
+        assertThat(firstDir.resolve("marker.txt"))
+                .as("the first project's contents are left intact")
+                .exists();
+        assertThat(secondDir.resolve("project.daw")).exists();
+    }
+
+    @Test
     void shouldHaveCurrentProjectAfterCreate() throws IOException {
         ProjectManager manager = createProjectManager();
 

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/persistence/ProjectMetadataReaderTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/persistence/ProjectMetadataReaderTest.java
@@ -1,0 +1,144 @@
+package com.benesquivelmusic.daw.core.persistence;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ProjectMetadataReader} — the side-effect-free name/timestamp
+ * peek used by the story-296 Project Hub. Covers the XML format, the legacy
+ * text format, and the missing-file empty case.
+ */
+class ProjectMetadataReaderTest {
+
+    @TempDir
+    Path projectDir;
+
+    @Test
+    void readsXmlMetadata() throws IOException {
+        Instant created = Instant.parse("2026-01-02T03:04:05Z");
+        Instant modified = Instant.parse("2026-02-03T04:05:06Z");
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <daw-project version="1">
+                    <metadata>
+                        <name>My XML Song</name>
+                        <created-at>%s</created-at>
+                        <last-modified>%s</last-modified>
+                    </metadata>
+                </daw-project>
+                """.formatted(created, modified);
+        Files.writeString(projectDir.resolve("project.daw"), xml);
+
+        Optional<ProjectMetadata> result = ProjectMetadataReader.read(projectDir);
+
+        assertThat(result).isPresent();
+        ProjectMetadata metadata = result.get();
+        assertThat(metadata.name()).isEqualTo("My XML Song");
+        assertThat(metadata.createdAt()).isEqualTo(created);
+        assertThat(metadata.lastModified()).isEqualTo(modified);
+        assertThat(metadata.projectPath()).isEqualTo(projectDir);
+    }
+
+    @Test
+    void readsLegacyTextMetadata() throws IOException {
+        Instant created = Instant.parse("2025-06-01T10:00:00Z");
+        Instant modified = Instant.parse("2025-06-15T18:30:00Z");
+        String text = """
+                # DAW Project File
+                name=Legacy Tune
+                created_at=%s
+                last_modified=%s
+                """.formatted(created, modified);
+        Files.writeString(projectDir.resolve("project.daw"), text);
+
+        Optional<ProjectMetadata> result = ProjectMetadataReader.read(projectDir);
+
+        assertThat(result).isPresent();
+        ProjectMetadata metadata = result.get();
+        assertThat(metadata.name()).isEqualTo("Legacy Tune");
+        assertThat(metadata.createdAt()).isEqualTo(created);
+        assertThat(metadata.lastModified()).isEqualTo(modified);
+        assertThat(metadata.projectPath()).isEqualTo(projectDir);
+    }
+
+    @Test
+    void returnsEmptyWhenProjectFileMissing() {
+        // projectDir exists (the @TempDir) but contains no project.daw.
+        Optional<ProjectMetadata> result = ProjectMetadataReader.read(projectDir);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void fallsBackToDirectoryNameWhenNameBlank() throws IOException {
+        // XML with no <name> element — name should fall back to the dir name.
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <daw-project version="1">
+                    <metadata>
+                        <created-at>2026-01-01T00:00:00Z</created-at>
+                    </metadata>
+                </daw-project>
+                """;
+        Files.writeString(projectDir.resolve("project.daw"), xml);
+
+        Optional<ProjectMetadata> result = ProjectMetadataReader.read(projectDir);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().name())
+                .isEqualTo(projectDir.getFileName().toString());
+    }
+
+    @Test
+    void lastModifiedFallsBackToFileMtimeNotNowWhenContentHasNoTimestamp() throws IOException {
+        // XML with a name but NO <last-modified>/<created-at>: the timestamp must
+        // come from the file on disk, not the instant the scan happens to run.
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <daw-project version="1">
+                    <metadata>
+                        <name>No Timestamp Song</name>
+                    </metadata>
+                </daw-project>
+                """;
+        Path file = projectDir.resolve("project.daw");
+        Files.writeString(file, xml);
+        // Stamp a known mtime well in the past so a (regressed) Instant.now()
+        // fallback would be obviously wrong.
+        Files.setLastModifiedTime(file, FileTime.from(Instant.parse("2024-07-01T12:00:00Z")));
+
+        Optional<ProjectMetadata> result = ProjectMetadataReader.read(projectDir);
+
+        assertThat(result).isPresent();
+        // Read the mtime back so the assertion tolerates filesystem time resolution.
+        Instant expected = Files.getLastModifiedTime(file).toInstant();
+        assertThat(result.get().lastModified())
+                .as("missing-timestamp project.daw falls back to the file's mtime")
+                .isEqualTo(expected);
+        assertThat(result.get().lastModified())
+                .as("the past mtime, not a fresh Instant.now()")
+                .isBefore(Instant.now().minusSeconds(60));
+    }
+
+    @Test
+    void returnsBestEffortForMalformedXmlWithoutThrowing() throws IOException {
+        // Truncated XML — must not throw; name falls back to the dir name.
+        Files.writeString(projectDir.resolve("project.daw"),
+                "<?xml version=\"1.0\"?><daw-project><metadata><name>oops");
+
+        Optional<ProjectMetadata> result = ProjectMetadataReader.read(projectDir);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().name())
+                .isEqualTo(projectDir.getFileName().toString());
+    }
+}


### PR DESCRIPTION
# Project Hub and Welcome Screen with a ProjectCard Control

## Motivation

This is **Stage 2** of the Project Manager Design Book §7 migration path. It replaces the single worst surface in today's project management with the §4.1 Welcome screen and the §4.2 Project Hub, fixing two §1 problems and one §8 rejection:

- **§1.4 (recent-projects is a flat list with no judgement).** `onRecentProjects()` (`ProjectLifecycleController.java:179`) builds a `ContextMenu` of **bare filenames**. It shows no last-opened time (though `ProjectMetadata` carries it), no size on disk (though `ProjectDiskUsage` exists and is unused by the menu), no health flag, no search, no pin, no grouping. The book's verdict: "it gives them less information than `ls -lt`." It is the user's only way back into their work.
- **§2.3 / §1 crash framing (recoverable sessions must come first).** On launch the user may be returning from a crash; the §4.1 Welcome screen shows a **Recover** region *before* Continue and Start, so the user does not hunt for the project name after losing work.
- **§8 rejection — "a Recent Projects menu that is just filenames"** and **"silent first-save into /tmp."** The menu becomes a shortcut that opens the Project Hub; the new-project flow prompts for a real location once (killing the §1.1 `Files.createTempDirectory` first-save).

The fix is the §4.2 Project Hub (a full-window browser, `⌘P` / File ▸ Project Hub) plus the §4.1 Welcome screen, both built from a reusable **`ProjectCard`** `Control` (§4.2: "the grid view uses `Control` + `Skin` for the project card"). Stage 2 is still data-format-neutral (§7 Stage 2: "no data-format change") — it reads `RecentProjectsStore` plus a fast on-open health/size scan.

## Goals

- **Build `ProjectCard` as a `Control` + `Skin`** (`javafx-application-design` §3, §4.2): the state (name, last-opened, size-on-disk, session count, health badge, schema, lock holder, pinned) lives on the control; the visual lives on `ProjectCardSkin`. One card type serves both the Welcome grid and the Project Hub grid so themes restyle once.
- **Build `ProjectHubView`** (full-window, reachable via File ▸ Project Hub and `⌘P`) per the §4.2 mockup: Pinned / Recent / Archived (`.dawz`) sections, search field, Grid/List toggle, Sort control, and the **detail strip** (the §1.4 fix) listing every fact the model carries about the selected project — path, schema, size-on-disk broken down (audio / checkpoints / journal / snapshots), session count + most-recent session, sample rate, and lock holder + freshness — with **Reveal** (open OS file browser at the directory) and **Open** actions.
- **Build `WelcomeView`** (shown on launch when no project is open) per §4.1: **Recover** region first (projects whose `.project.lock` shows the prior process did not exit cleanly), then **Continue** (recent projects as cards), then **Start** (four tiles: New, Open, Restore archive, Import DAWproject). Footer shows Workspace selector and the §1.8 disk line ("Free disk: 412 GB ≈ 38 h record").
- **Compute health/size on a background virtual thread.** The card badge ("✓ healthy", "⚠ migrated v3→v5", "⚠ N missing assets") and size come from a quick scan the moment the surface appears — existence of `.project.lock` (stale → recoverable), pre-migration backup presence, missing assets — run via `Thread.ofVirtual()` (story 205) and published to cards through story 289's Control-Sync `FxDispatcher`. The FX thread never walks the project tree (`javafx-application-design` §11; book §2.1).
- **Recover-scan reuses existing lock APIs.** The Recover region derives "did not exit cleanly" from `ProjectLockManager` staleness (Appendix A: `isStale(ProjectLock, Instant)` / the acquisition staleness result) plus journal presence — it does not invent a new crash flag. (The recovery *dialog* and journal replay are story 298; Stage 2 only surfaces the candidates and routes "Recover" to that flow.)
- **Kill the /tmp first-save.** "New project" prompts for a destination directory once (default under the §3.1 Workspace root, e.g. `~/DAW Projects`), then `projectManager.createProject(...)` writes there — no `Files.createTempDirectory` (§8; §1.1). Existing `createProject` / save paths are reused unchanged.
- **Demote the old menu.** Replace the `onRecentProjects()` `ContextMenu` body (`ProjectLifecycleController.java:179`) with a single "Project Hub…" item that opens `ProjectHubView` (Appendix A: "menu retains a 'Project Hub…' item").
- **Open is undoable-friendly, switch is never silent.** Switching Workspace closes the current project cleanly first (§4.4 Workspace cell; §6.5 "never silent").
- Tests:
  - `ProjectCardStateBindingTest` (new): set each `ProjectCard` property, assert the skin reflects it; assert health badge maps to the documented style-class token (headless-safe style-class assertion, `feedback_javafx_headless_test_pitfalls.md`).
  - `RecentProjectsStoreFeedsHubTest` (new): seed `RecentProjectsStore`, assert `ProjectHubView` Recent section renders one card per entry ordered by last-opened, each carrying `ProjectMetadata` last-opened + `ProjectDiskUsage` size.
  - `WelcomeRecoverBeforeRecentTest` (new): with one stale-lock project present, assert the Recover region renders above Continue and contains that project (§4.1 ordering).
  - `HealthScanOffFxThreadTest` (new): assert the size/health scan runs on a virtual (non-FX) thread and that cards update via the dispatcher (capture the executing thread; no assertions inside a swallowed FX runnable).
  - `NewProjectPromptsForLocationTest` (new): invoke the New-project flow with a stubbed directory chooser, assert `createProject` receives the chosen path and that `Files.createTempDirectory` is never called (no /tmp first-save).
  - `RecentMenuOpensHubTest` (new): assert the File menu's recent-projects entry now opens `ProjectHubView` rather than building a filename `ContextMenu`.

## Non-Goals

- **No journal, recovery replay, or `sessions/` manifests.** The Recover region only *lists* candidates and routes to the story 298 recovery dialog; the navigable session history is story 297; snapshots/migration-log are story 299. Stage 2 adds no files to the project directory (§7 Stage 2 risk: "low, no data-format change").
- **No archive / restore *engine* changes.** The Archived (`.dawz`) section lists archives and offers Restore, but the actual pack/restore worker and the per-asset missing-assets dialog are unchanged here (the enriched per-asset dialog is story 299, §4.7). `ProjectArchiver` is consumed as-is.
- **No migration *log*.** A migrated card shows the "⚠ migrated" badge and the detail strip shows current schema, but the scrollable migration history and diff/roll-back live in story 299 (§4.6.2). The one-shot `MigrationReportDialog` (story 247) is untouched.
- **No workspace *settings* surface.** §3.1 workspaces are selectable here; their per-workspace defaults editor is out of scope.
- **No Session Status Strip work.** That is story 295; the Hub/Welcome consume `ProjectOperationProgress` where useful but do not build it.

## Technical Notes

- Files: new `daw-app/.../ui/hub/ProjectCard.java` + `ProjectCardSkin.java`, `daw-app/.../ui/hub/ProjectHubView.java`, `daw-app/.../ui/hub/WelcomeView.java`, a small `ProjectHealthScanner` (virtual-thread scan → `FxDispatcher`); edits to `daw-app/.../ui/ProjectLifecycleController.java` (replace `onRecentProjects()` body at :179 with a Hub launcher; route New-project through a directory prompt); `styles.css` (card + hub tokens). Sources: `RecentProjectsStore` (`daw-core/.../persistence/RecentProjectsStore.java`), `ProjectDiskUsage` (`daw-core/.../persistence/backup/ProjectDiskUsage.java`), `ProjectMetadata` (`daw-core/.../persistence/ProjectMetadata.java`), `ProjectLockManager` (`daw-core/.../persistence/ProjectLockManager.java`).
- `ProjectCard` and the Hub/Welcome views are `Control`+`Skin` so the card's state is testable off-toolkit and the visual is theme-swappable (`javafx-application-design` §3; mirrors the §4.2 directive). Construct card *state* (records / properties) off the FX thread and assert without a toolkit extension (`feedback_javafx_headless_test_pitfalls.md`).
- Threading: the on-appear scan fans nothing out — it is per-card single tasks on virtual threads; cross to FX only via the `FxDispatcher`. (Restore, which *does* fan out unzip + rewrite-xml + seed-checkpoint, is story 299 and uses `DawScope.openShutdownOnFailure`.)
- Tokens not hex: badge colours (healthy / migrated / missing-assets) are derived role tokens in `styles.css`, consumed by `ProjectCardSkin` via forwarded local properties (`feedback_control_css_role_token_forwarding.md`, `feedback_iconnode_tint_from_resolved_css.md` for any tinted glyph). IconNode SVG glyphs are tinted in Java from a resolved ancestor property, paired with `applyCss()` + deterministic re-tint.
- `daw-core` stays JavaFX-free: all new UI lives in `daw-app`; the Hub reads plain values and never pulls JavaFX into core (`project_daw_app_non_modular.md`).
- Reference: Project Manager Design Book §1.1, §1.4, §2.3, §3.1, §4.1, §4.2, §7 Stage 2, §8 (recent-menu + /tmp rejections), Appendix A (the `onRecentProjects` mapping); Control Synchronization Design Book §2; user story 289 (`FxDispatcher`), 292 (`ProjectVM` — the Hub binds project-open state), 295 (`ProjectOperationProgress` / Session Status Strip — sibling Stage 1), 205 (virtual threads), 019 (project save/load/autosave), 189 (project archive zip — the Archived section's source). SKILLs: `javafx-application-design` (§3 Control/Skin, §4 Properties, §10 overflow/tooltip, §11 threading, §15 anti-patterns), `java-26.agent.md` Project Loom (virtual threads for I/O), `research-daw` §3 (project file format — names match the ecosystem).
