### PR TITLE
300-plugineditorfactory-sdk-contract-pluginmanifest-and-deprecation-o…

### DIFF
--- a/daw-sdk/pom.xml
+++ b/daw-sdk/pom.xml
@@ -16,4 +16,13 @@
 
     <name>DAW SDK</name>
     <description>Public SDK for developing plugins for the Digital Audio Workstation</description>
+
+    <dependencies>
+        <!-- The editor SDK package returns/consumes JavaFX types (Region, Color,
+             GraphicsContext, ObservableValue). Version managed by daw-parent. -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/CanvasSurface.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/CanvasSurface.java
@@ -1,0 +1,52 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import javafx.scene.canvas.GraphicsContext;
+
+/**
+ * A minimal facade over the drawing surface the host provides to a
+ * {@link PluginEditorFactory.Canvas} plugin (Plugin View Design Book §4.1).
+ * The host owns the surface — it is backed by a JavaFX {@code Canvas} today and
+ * may be backed by a GPU canvas in future — so the plugin draws <em>into</em>
+ * it but never constructs, sizes, or reparents it (§2.2, §6.3).
+ *
+ * <p><strong>Threading (§4.7):</strong> every method here is called on the
+ * JavaFX Application Thread, from inside the host's fault harness. Drawing
+ * should not allocate and must not block.</p>
+ */
+public interface CanvasSurface {
+
+    /**
+     * Returns the current drawable width in pixels. May change between frames
+     * when the host resizes the editor; a plugin should read it each frame
+     * rather than cache it.
+     *
+     * @return the surface width in pixels
+     */
+    double width();
+
+    /**
+     * Returns the current drawable height in pixels.
+     *
+     * @return the surface height in pixels
+     */
+    double height();
+
+    /**
+     * Returns the {@link GraphicsContext} the plugin draws with. The host
+     * clips drawing to the surface bounds, so a misbehaving plugin cannot paint
+     * over the host chrome (§6.3). Valid only between
+     * {@link PluginEditorFactory.Canvas#attach(CanvasSurface)} and
+     * {@link PluginEditorFactory.Canvas#detach()}.
+     *
+     * @return the graphics context for this surface, never {@code null}
+     */
+    GraphicsContext graphicsContext();
+
+    /**
+     * Asks the host to schedule another {@link PluginEditorFactory.Canvas#render(RenderTick)}
+     * on the next pulse. Use this from an event handler (a knob turn, a data
+     * update) to repaint on demand; the host coalesces repeated requests within
+     * a single frame.
+     */
+    void requestRender();
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/ChromePolicy.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/ChromePolicy.java
@@ -1,0 +1,35 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+/**
+ * How much host chrome (breadcrumb header, preset/meter footer, A/B bar,
+ * fault banner) surrounds a plugin editor surface.
+ *
+ * <p>A plugin declares its preferred chrome through {@link EditorHints#chrome()};
+ * the host owns and renders the chrome in every mode (Plugin View Design Book
+ * §2.1, §2.2). This enum only selects <em>how much</em> of that host chrome is
+ * shown, never lets the plugin draw the chrome itself.</p>
+ *
+ * @see EditorHints
+ */
+public enum ChromePolicy {
+
+    /**
+     * Full host chrome: breadcrumb header, preset + I/O meter footer, and the
+     * A/B compare bar are all shown around the plugin surface (§5.A, §6.1–§6.5).
+     * The default for declarative and panel editors.
+     */
+    STANDARD,
+
+    /**
+     * Collapse to a title bar only — for tiny utilities (three knobs or fewer)
+     * that do not warrant a full editor frame (§5.C compact strip).
+     */
+    MINIMAL,
+
+    /**
+     * The chrome reveals on hover and retracts after a short period of pointer
+     * inactivity, so a full-surface tool (spectrum analyzer, oscilloscope,
+     * match-EQ) owns every pixel the rest of the time (§5.D immersive canvas).
+     */
+    IMMERSIVE
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/EditorContext.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/EditorContext.java
@@ -1,0 +1,89 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import javafx.beans.value.ObservableValue;
+
+/**
+ * The narrow set of host services a plugin editor may call (Plugin View Design
+ * Book §4.1). Handed to {@link PluginEditorFactory.Panel#createPanel(EditorContext)}
+ * and available to a {@link PluginEditorFactory.Canvas} through the surface the
+ * host attaches.
+ *
+ * <p>This interface is deliberately kept small (§9 rejection #2 — no god-object
+ * {@code EditorContext}): it exposes only theme, the parameter store, the
+ * sample rate, resize / redraw requests, and fault reporting. Anything richer
+ * (for example observing an automation lane's state) is intended to arrive
+ * later as a dedicated sub-interface reached through this one, not by growing
+ * this type.</p>
+ *
+ * <p><strong>Threading (§4.7):</strong> every method here is called on the
+ * JavaFX Application Thread. The store returned by {@link #parameterStore()} is
+ * the one exception — it is the thread-safe bridge to the audio thread (see
+ * {@link PluginParameterStore}).</p>
+ */
+public interface EditorContext {
+
+    /**
+     * Returns the current audio sample rate in Hz.
+     *
+     * @return the sample rate in Hz
+     */
+    double sampleRate();
+
+    /**
+     * Returns the resolved theme colours the editor should draw with right now.
+     * Prefer {@link #themeProperty()} to react to live theme changes.
+     *
+     * @return the current resolved theme, never {@code null}
+     */
+    Theme theme();
+
+    /**
+     * Returns an observable of the resolved theme so a panel can re-style, and
+     * a canvas can re-tint, when the user switches the DAW theme. Read-only —
+     * a plugin observes the palette, it cannot set it (§9 rejection #6).
+     *
+     * @return an observable theme value, never {@code null}
+     */
+    ObservableValue<Theme> themeProperty();
+
+    /**
+     * Returns the host-owned, real-time-safe parameter store. This is the only
+     * channel between the editor (FX thread) and the audio processor (audio
+     * thread); the editor cannot reach the {@code AudioProcessor} directly
+     * (§2.6).
+     *
+     * @return the parameter store, never {@code null}
+     */
+    PluginParameterStore parameterStore();
+
+    /**
+     * Asks the host to resize the editor to the given content size, subject to
+     * the editor's {@link EditorHints#resize()} policy and the host layout. The
+     * host enforces the constraints and may coerce the request; the plugin
+     * cannot resize itself (§6.3).
+     *
+     * @param width  the requested content width in pixels
+     * @param height the requested content height in pixels
+     */
+    void requestResize(int width, int height);
+
+    /**
+     * Asks the host to schedule a repaint of the editor surface on the next
+     * pulse. Repeated requests within a frame are coalesced.
+     */
+    void requestRender();
+
+    /**
+     * Reports a recoverable fault from the plugin. The host routes it to the
+     * in-surface fault banner (§6.6) and the plugin fault log, without tearing
+     * the editor down. Use this for problems the plugin catches itself; faults
+     * thrown out of a host-invoked callback are captured by the host's fault
+     * harness automatically (§2.7).
+     *
+     * @param error the throwable that occurred; must not be {@code null}
+     * @param hint  a short, user-facing description of what failed (for example
+     *              {@code "failed to load impulse response"}); must not be
+     *              {@code null}
+     */
+    void postFault(Throwable error, String hint);
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/EditorHints.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/EditorHints.java
@@ -1,0 +1,84 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.Objects;
+
+/**
+ * What a plugin editor asks the host for: a preferred content size and the
+ * resize / chrome policies the host should apply (Plugin View Design Book
+ * §4.1). These are <em>hints</em> — the host obeys them where it can and
+ * coerces them where it cannot (for example the embedded Workshop pane fixes
+ * the width, so a {@link ResizePolicy#BOTH} hint behaves as
+ * {@link ResizePolicy#VERTICAL} until the editor is detached to a floating
+ * window §5.A/§5.B).
+ *
+ * @param preferredWidth  the preferred content width in pixels (must be &gt; 0)
+ * @param preferredHeight the preferred content height in pixels (must be &gt; 0)
+ * @param resize          which axes the host may resize (never {@code null})
+ * @param chrome          how much host chrome to show (never {@code null})
+ */
+public record EditorHints(
+        int preferredWidth,
+        int preferredHeight,
+        ResizePolicy resize,
+        ChromePolicy chrome) {
+
+    public EditorHints {
+        if (preferredWidth <= 0) {
+            throw new IllegalArgumentException(
+                    "preferredWidth must be > 0, got " + preferredWidth);
+        }
+        if (preferredHeight <= 0) {
+            throw new IllegalArgumentException(
+                    "preferredHeight must be > 0, got " + preferredHeight);
+        }
+        Objects.requireNonNull(resize, "resize must not be null");
+        Objects.requireNonNull(chrome, "chrome must not be null");
+    }
+
+    /**
+     * A compact editor with standard chrome — the default for a declarative
+     * plugin generated from {@code getParameters()} (§4.2). Reflows its
+     * parameter grid horizontally as the pane width changes (§6.2).
+     *
+     * @return compact hints, never {@code null}
+     */
+    public static EditorHints compact() {
+        return new EditorHints(360, 240, ResizePolicy.BOTH, ChromePolicy.STANDARD);
+    }
+
+    /**
+     * A roomier editor with standard chrome — a sensible default for a
+     * {@link PluginEditorFactory.Panel} that ships a custom layout.
+     *
+     * @return standard hints, never {@code null}
+     */
+    public static EditorHints standard() {
+        return new EditorHints(640, 420, ResizePolicy.BOTH, ChromePolicy.STANDARD);
+    }
+
+    /**
+     * A full-surface editor whose chrome retracts on inactivity — a sensible
+     * default for a {@link PluginEditorFactory.Canvas} analyzer or scope that
+     * wants the chrome out of the way (§5.D).
+     *
+     * @return immersive hints, never {@code null}
+     */
+    public static EditorHints immersive() {
+        return new EditorHints(720, 480, ResizePolicy.BOTH, ChromePolicy.IMMERSIVE);
+    }
+
+    /** Returns a copy of these hints with the given chrome policy. */
+    public EditorHints withChrome(ChromePolicy newChrome) {
+        return new EditorHints(preferredWidth, preferredHeight, resize, newChrome);
+    }
+
+    /** Returns a copy of these hints with the given resize policy. */
+    public EditorHints withResize(ResizePolicy newResize) {
+        return new EditorHints(preferredWidth, preferredHeight, newResize, chrome);
+    }
+
+    /** Returns a copy of these hints with the given preferred content size. */
+    public EditorHints withSize(int newPreferredWidth, int newPreferredHeight) {
+        return new EditorHints(newPreferredWidth, newPreferredHeight, resize, chrome);
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginCategory.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginCategory.java
@@ -1,0 +1,58 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+/**
+ * Categorises a plugin for the plugin browser (Plugin View Design Book §4.4,
+ * §6.7). The category drives which section of the browser a plugin appears in
+ * and replaces the keyword-sniffing heuristic the legacy install dialog used
+ * to guess a plugin's kind from its name.
+ *
+ * <p>Declared on {@link com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor}
+ * and carried in the {@code META-INF/daw-plugin.json} manifest
+ * ({@link PluginManifest}). A plugin that does not declare a category defaults
+ * to {@link #UTILITY}.</p>
+ */
+public enum PluginCategory {
+
+    /** Compressors, limiters, gates, expanders, transient shapers. */
+    DYNAMICS("Dynamics"),
+
+    /** Parametric / graphic EQs and filters. */
+    EQ_AND_FILTER("EQ & Filter"),
+
+    /** Chorus, flanger, phaser, tremolo and other modulation effects. */
+    MODULATION("Modulation"),
+
+    /** Reverbs, delays and other time-based effects. */
+    REVERB_AND_DELAY("Reverb & Delay"),
+
+    /** Panners, binaural / immersive and mid-side tools. */
+    SPATIAL("Spatial"),
+
+    /** Gain, dither, meters and general-purpose utilities. Default category. */
+    UTILITY("Utility"),
+
+    /** Spectrum analyzers, oscilloscopes, loudness and correlation meters. */
+    ANALYZER("Analyzer"),
+
+    /** Virtual instruments that generate audio. */
+    INSTRUMENT("Instrument"),
+
+    /** MIDI effects (arpeggiators, chord generators, note filters). */
+    MIDI_EFFECT("MIDI Effect");
+
+    private final String displayName;
+
+    PluginCategory(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * Returns the human-readable label for this category (for example
+     * {@code "EQ & Filter"}), suitable for a browser section header.
+     *
+     * @return the display name, never {@code null}
+     */
+    public String displayName() {
+        return displayName;
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginEditorFactory.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginEditorFactory.java
@@ -1,0 +1,199 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.List;
+import java.util.Objects;
+
+import javafx.scene.layout.Region;
+
+import com.benesquivelmusic.daw.sdk.annotation.Internal;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+
+/**
+ * The single, typed entry point a plugin returns from
+ * {@link com.benesquivelmusic.daw.sdk.plugin.DawPlugin#editorFactory()} to
+ * describe <em>how</em> its editor is produced (Plugin View Design Book §2.1,
+ * §4.1). A {@code PluginEditorFactory} is one of exactly four permitted shapes:
+ *
+ * <ul>
+ *   <li>{@link Declarative} — "no GUI, just my parameter list"; the host renders
+ *       a parameter grid from the carried parameters laid out per {@link #hints()}
+ *       (§6.2).</li>
+ *   <li>{@link Panel} — "I will hand you a {@link Region}"; the host embeds it in
+ *       its standard frame (§6.3).</li>
+ *   <li>{@link Canvas} — "I will draw into your surface"; the host owns the
+ *       canvas and drives the render loop (§5.D, §6.3).</li>
+ *   <li>{@link Faulted} — an {@linkplain Internal internal} variant the host
+ *       swaps in when a factory throws, so the user still sees an editor with a
+ *       fault banner and a Reload affordance, never a void (§2.7, §4.8, §6.6).</li>
+ * </ul>
+ *
+ * <p>The type is {@code sealed}: the four permitted subtypes are closed, so the
+ * host can pattern-match exhaustively over the modes without a {@code default}.
+ * Plugin authors implement {@link Panel} or {@link Canvas} (both
+ * {@code non-sealed}), or return a {@link Declarative}; they never implement
+ * {@code PluginEditorFactory} directly.</p>
+ *
+ * <h2>Threading (§4.7)</h2>
+ * <p>{@link Panel#createPanel(EditorContext)}, {@link Canvas#attach(CanvasSurface)},
+ * {@link Canvas#render(RenderTick)} and {@link Canvas#detach()} are all called on
+ * the JavaFX Application Thread, each inside the host's fault harness (§2.7). None
+ * may block; {@code render} should not allocate. The audio side
+ * ({@code AudioProcessor#process(...)}) runs on the real-time audio thread and
+ * must be real-time-safe; the editor never touches the processor directly — both
+ * sides talk to the {@link PluginParameterStore} (§2.6).</p>
+ *
+ * @see com.benesquivelmusic.daw.sdk.plugin.DawPlugin#editorFactory()
+ * @see EditorContext
+ * @see EditorHints
+ */
+public sealed interface PluginEditorFactory
+        permits PluginEditorFactory.Declarative,
+                PluginEditorFactory.Panel,
+                PluginEditorFactory.Canvas,
+                PluginEditorFactory.Faulted {
+
+    /**
+     * The size, resize and chrome hints the host reads to frame this editor
+     * (§4.1). Every mode reports hints: {@link Declarative} carries them as a
+     * component; {@link Panel} and {@link Canvas} provide sensible defaults a
+     * plugin may override.
+     *
+     * @return the editor hints, never {@code null}
+     */
+    EditorHints hints();
+
+    /**
+     * "No GUI — just my parameter list." The host generates a parameter grid
+     * (§6.2) from {@link #parameters()} laid out per {@link #hints()}. This is
+     * the default an ordinary plugin gets for free from
+     * {@link com.benesquivelmusic.daw.sdk.plugin.DawPlugin#editorFactory()} when
+     * it overrides only {@code getParameters()} (§4.2).
+     *
+     * @param parameters the parameters to render (copied defensively; never
+     *                   {@code null})
+     * @param hints      the layout hints (never {@code null})
+     */
+    record Declarative(List<PluginParameter> parameters, EditorHints hints)
+            implements PluginEditorFactory {
+        public Declarative {
+            Objects.requireNonNull(parameters, "parameters must not be null");
+            Objects.requireNonNull(hints, "hints must not be null");
+            parameters = List.copyOf(parameters);
+        }
+    }
+
+    /**
+     * "I will hand you a {@link Region} when you ask." The host calls
+     * {@link #createPanel(EditorContext)} once on the FX thread and embeds the
+     * returned region inside its standard frame (§6.3). The plugin owns only the
+     * region's contents; the host owns the chrome, sizing and clipping (§2.2).
+     *
+     * <p><strong>Threading (§4.7):</strong> {@code createPanel} runs on the
+     * JavaFX Application Thread inside the host's fault harness; it may allocate
+     * but must not block.</p>
+     */
+    non-sealed interface Panel extends PluginEditorFactory {
+
+        /**
+         * Builds this plugin's editor region. Called once, on the FX thread.
+         *
+         * @param context the narrow host services the editor may use (never
+         *               {@code null})
+         * @return the editor's root region; must not be {@code null}
+         */
+        Region createPanel(EditorContext context);
+
+        /**
+         * {@inheritDoc}
+         *
+         * <p>Defaults to {@link EditorHints#standard()}; override to request a
+         * different preferred size, resize policy, or chrome.</p>
+         */
+        @Override
+        default EditorHints hints() {
+            return EditorHints.standard();
+        }
+    }
+
+    /**
+     * "I will draw inside your canvas." The host provides and owns a
+     * {@link CanvasSurface}; the plugin draws into it and never constructs, sizes
+     * or reparents it (§2.2, §6.3). Suits spectrum analyzers, oscilloscopes and
+     * other full-surface tools (§5.D).
+     *
+     * <p><strong>Threading (§4.7):</strong> {@link #attach(CanvasSurface)},
+     * {@link #render(RenderTick)} and {@link #detach()} all run on the JavaFX
+     * Application Thread inside the host's fault harness. {@code render} should
+     * not allocate and must not block.</p>
+     */
+    non-sealed interface Canvas extends PluginEditorFactory {
+
+        /**
+         * Called once, on the FX thread, when the host has created the surface
+         * and is about to start the render loop. Cache the surface reference for
+         * use in {@link #render(RenderTick)}.
+         *
+         * @param surface the host-owned drawing surface (never {@code null})
+         */
+        void attach(CanvasSurface surface);
+
+        /**
+         * Draws one frame. Called on the FX thread for every frame the host needs
+         * to repaint (parameter change, resize, theme change, or an animation
+         * tick the plugin opted into). Should not allocate; must not block.
+         *
+         * @param tick the per-frame payload — elapsed time, frame index and the
+         *            resolved {@link Theme} tokens (never {@code null})
+         */
+        void render(RenderTick tick);
+
+        /**
+         * Called once, on the FX thread, when the editor is being torn down.
+         * Release any resources acquired in {@link #attach(CanvasSurface)}.
+         */
+        void detach();
+
+        /**
+         * {@inheritDoc}
+         *
+         * <p>Defaults to {@link EditorHints#immersive()} — a full surface whose
+         * chrome retracts on inactivity; override to request different hints.</p>
+         */
+        @Override
+        default EditorHints hints() {
+            return EditorHints.immersive();
+        }
+    }
+
+    /**
+     * An {@linkplain Internal internal} editor the host substitutes when a
+     * plugin's {@code editorFactory()} — or one of its FX-thread callbacks —
+     * throws (Plugin View Design Book §2.7, §4.8, §6.6). The user still sees an
+     * editor: a fault banner describing {@link #cause()} / {@link #hint()} plus a
+     * placeholder body and a Reload affordance, never a blank void. Plugin
+     * authors never construct this; it exists so a thrown factory degrades to a
+     * recoverable surface instead of a missing one.
+     *
+     * @param cause the throwable the plugin raised (never {@code null})
+     * @param hint  a short, user-facing description of what failed (never
+     *             {@code null})
+     */
+    @Internal
+    record Faulted(Throwable cause, String hint) implements PluginEditorFactory {
+        public Faulted {
+            Objects.requireNonNull(cause, "cause must not be null");
+            Objects.requireNonNull(hint, "hint must not be null");
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * <p>A faulted editor is framed compactly with standard chrome so the
+         * banner and Reload affordance are visible.</p>
+         */
+        @Override
+        public EditorHints hints() {
+            return EditorHints.compact();
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifest.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifest.java
@@ -1,0 +1,31 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.Objects;
+
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+
+/**
+ * The parsed form of a plugin's {@code META-INF/daw-plugin.json} manifest
+ * (Plugin View Design Book §4.5). A manifest declares everything a
+ * {@link PluginDescriptor} exposes plus the fully-qualified name of the
+ * {@link com.benesquivelmusic.daw.sdk.plugin.DawPlugin} implementation class, so
+ * the host can install a plugin from a dropped JAR without the user ever typing a
+ * class name (§1.4, §6.8).
+ *
+ * <p>Read with {@link PluginManifestReader}, written with
+ * {@link PluginManifestWriter}. This Phase-1 story defines and round-trips the
+ * manifest; the install UX that consumes it is Phase 4 (story 303).</p>
+ *
+ * @param pluginClass the fully-qualified class name of the {@code DawPlugin}
+ *                    implementation (never {@code null} or blank)
+ * @param descriptor  the plugin metadata this manifest declares (never {@code null})
+ */
+public record PluginManifest(String pluginClass, PluginDescriptor descriptor) {
+    public PluginManifest {
+        Objects.requireNonNull(pluginClass, "pluginClass must not be null");
+        Objects.requireNonNull(descriptor, "descriptor must not be null");
+        if (pluginClass.isBlank()) {
+            throw new IllegalArgumentException("pluginClass must not be blank");
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReader.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReader.java
@@ -1,0 +1,306 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+/**
+ * Finds, parses and validates a plugin's {@code META-INF/daw-plugin.json}
+ * manifest (Plugin View Design Book §4.5). Never throws for a malformed or
+ * missing manifest — every problem is reported as a {@link Result.Invalid} with
+ * human-readable reasons, so a bad JAR drop degrades gracefully rather than
+ * escaping an exception into the install flow (§1.4, §6.8).
+ *
+ * <p>The reader deliberately embeds a tiny JSON parser for a <em>flat object of
+ * string values</em> rather than depend on a JSON library: {@code daw-sdk} is the
+ * project's dependency-free API floor.</p>
+ */
+public final class PluginManifestReader {
+
+    /** The JAR entry path the manifest is expected at. */
+    public static final String MANIFEST_ENTRY = "META-INF/daw-plugin.json";
+
+    static final String KEY_PLUGIN_CLASS = "pluginClass";
+    static final String KEY_ID = "id";
+    static final String KEY_NAME = "name";
+    static final String KEY_VERSION = "version";
+    static final String KEY_VENDOR = "vendor";
+    static final String KEY_TYPE = "type";
+    static final String KEY_CATEGORY = "category";
+    static final String KEY_ICON_HINT = "iconHint";
+
+    /**
+     * The outcome of a read/parse attempt: either a valid {@link PluginManifest}
+     * or a non-empty list of validation errors.
+     */
+    public sealed interface Result permits Result.Valid, Result.Invalid {
+
+        /** A successful parse. */
+        record Valid(PluginManifest value) implements Result {
+            public Valid {
+                Objects.requireNonNull(value, "value must not be null");
+            }
+        }
+
+        /** A failed parse: one or more human-readable reasons. */
+        record Invalid(List<String> errors) implements Result {
+            public Invalid {
+                Objects.requireNonNull(errors, "errors must not be null");
+                errors = List.copyOf(errors);
+                if (errors.isEmpty()) {
+                    throw new IllegalArgumentException("errors must not be empty");
+                }
+            }
+        }
+
+        /** @return {@code true} if this is a {@link Valid} result. */
+        default boolean isValid() {
+            return this instanceof Valid;
+        }
+
+        /** @return the manifest if valid, otherwise empty. */
+        default Optional<PluginManifest> manifest() {
+            return this instanceof Valid v ? Optional.of(v.value()) : Optional.empty();
+        }
+    }
+
+    /**
+     * Reads and validates the manifest inside the given JAR file.
+     *
+     * @param jarFile the plugin JAR (never {@code null})
+     * @return a {@link Result.Valid} or {@link Result.Invalid}; never throws for a
+     *         missing/malformed manifest or an unreadable JAR
+     */
+    public Result readFromJar(Path jarFile) {
+        Objects.requireNonNull(jarFile, "jarFile must not be null");
+        try (JarFile jar = new JarFile(jarFile.toFile())) {
+            ZipEntry entry = jar.getEntry(MANIFEST_ENTRY);
+            if (entry == null) {
+                return new Result.Invalid(List.of("no " + MANIFEST_ENTRY + " entry in " + jarFile));
+            }
+            try (InputStream in = jar.getInputStream(entry)) {
+                return parse(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        } catch (IOException | RuntimeException e) {
+            return new Result.Invalid(List.of("could not read " + jarFile + ": " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Parses and validates manifest JSON read from the given stream (UTF-8). Does
+     * not close the stream.
+     *
+     * @param jsonStream the manifest content (never {@code null})
+     * @return a validation result; never throws for malformed content
+     */
+    public Result parse(InputStream jsonStream) {
+        Objects.requireNonNull(jsonStream, "jsonStream must not be null");
+        try {
+            return parse(new String(jsonStream.readAllBytes(), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            return new Result.Invalid(List.of("could not read manifest stream: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Parses and validates the given manifest JSON text.
+     *
+     * @param json the manifest document (never {@code null})
+     * @return a validation result; never throws for malformed content
+     */
+    public Result parse(String json) {
+        Objects.requireNonNull(json, "json must not be null");
+        Map<String, String> fields;
+        try {
+            fields = JsonObject.parse(json);
+        } catch (RuntimeException e) {
+            return new Result.Invalid(List.of("malformed JSON: " + e.getMessage()));
+        }
+
+        List<String> errors = new ArrayList<>();
+        String pluginClass = required(fields, KEY_PLUGIN_CLASS, errors);
+        String id = required(fields, KEY_ID, errors);
+        String name = required(fields, KEY_NAME, errors);
+        String version = required(fields, KEY_VERSION, errors);
+        String vendor = required(fields, KEY_VENDOR, errors);
+        String typeName = required(fields, KEY_TYPE, errors);
+
+        PluginType type = null;
+        if (typeName != null) {
+            try {
+                type = PluginType.valueOf(typeName);
+            } catch (IllegalArgumentException e) {
+                errors.add("unknown type: " + typeName);
+            }
+        }
+
+        PluginCategory category = PluginCategory.UTILITY;
+        String categoryName = fields.get(KEY_CATEGORY);
+        if (categoryName != null && !categoryName.isBlank()) {
+            try {
+                category = PluginCategory.valueOf(categoryName);
+            } catch (IllegalArgumentException e) {
+                errors.add("unknown category: " + categoryName);
+            }
+        }
+
+        String iconHint = fields.getOrDefault(KEY_ICON_HINT, "");
+
+        if (!errors.isEmpty()) {
+            return new Result.Invalid(errors);
+        }
+
+        try {
+            PluginDescriptor descriptor =
+                    new PluginDescriptor(id, name, version, vendor, type, category, iconHint);
+            return new Result.Valid(new PluginManifest(pluginClass, descriptor));
+        } catch (RuntimeException e) {
+            return new Result.Invalid(List.of("invalid manifest fields: " + e.getMessage()));
+        }
+    }
+
+    private static String required(Map<String, String> fields, String key, List<String> errors) {
+        String value = fields.get(key);
+        if (value == null || value.isBlank()) {
+            errors.add("missing required field: " + key);
+            return null;
+        }
+        return value;
+    }
+
+    /**
+     * A deliberately tiny JSON reader for a <em>flat object of string values</em>
+     * — all a {@code daw-plugin.json} manifest needs. Rejects anything that is not
+     * a flat {@code {"key":"value", ...}} object (nested objects/arrays, or
+     * number/boolean/null values) by throwing, which the caller converts into a
+     * {@link Result.Invalid}.
+     */
+    private static final class JsonObject {
+        private final String s;
+        private int i;
+
+        private JsonObject(String s) {
+            this.s = s;
+        }
+
+        static Map<String, String> parse(String json) {
+            JsonObject p = new JsonObject(json);
+            Map<String, String> out = p.parseObject();
+            p.skipWs();
+            if (p.i != p.s.length()) {
+                throw new IllegalArgumentException("trailing content at index " + p.i);
+            }
+            return out;
+        }
+
+        private Map<String, String> parseObject() {
+            Map<String, String> out = new LinkedHashMap<>();
+            skipWs();
+            expect('{');
+            skipWs();
+            if (peek() == '}') {
+                i++;
+                return out;
+            }
+            while (true) {
+                skipWs();
+                String key = parseString();
+                skipWs();
+                expect(':');
+                skipWs();
+                String value = parseString();
+                out.put(key, value);
+                skipWs();
+                char c = next();
+                if (c == '}') {
+                    return out;
+                }
+                if (c != ',') {
+                    throw new IllegalArgumentException("expected ',' or '}' at index " + (i - 1));
+                }
+            }
+        }
+
+        private String parseString() {
+            expect('"');
+            StringBuilder sb = new StringBuilder();
+            while (true) {
+                if (i >= s.length()) {
+                    throw new IllegalArgumentException("unterminated string");
+                }
+                char c = s.charAt(i++);
+                if (c == '"') {
+                    return sb.toString();
+                }
+                if (c == '\\') {
+                    char e = next();
+                    switch (e) {
+                        case '"' -> sb.append('"');
+                        case '\\' -> sb.append('\\');
+                        case '/' -> sb.append('/');
+                        case 'n' -> sb.append('\n');
+                        case 'r' -> sb.append('\r');
+                        case 't' -> sb.append('\t');
+                        case 'b' -> sb.append('\b');
+                        case 'f' -> sb.append('\f');
+                        case 'u' -> {
+                            if (i + 4 > s.length()) {
+                                throw new IllegalArgumentException("bad \\u escape");
+                            }
+                            sb.append((char) Integer.parseInt(s.substring(i, i + 4), 16));
+                            i += 4;
+                        }
+                        default -> throw new IllegalArgumentException("bad escape \\" + e);
+                    }
+                } else {
+                    sb.append(c);
+                }
+            }
+        }
+
+        private void skipWs() {
+            while (i < s.length()) {
+                char c = s.charAt(i);
+                if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+                    i++;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        private char peek() {
+            if (i >= s.length()) {
+                throw new IllegalArgumentException("unexpected end of input");
+            }
+            return s.charAt(i);
+        }
+
+        private char next() {
+            if (i >= s.length()) {
+                throw new IllegalArgumentException("unexpected end of input");
+            }
+            return s.charAt(i++);
+        }
+
+        private void expect(char c) {
+            char actual = next();
+            if (actual != c) {
+                throw new IllegalArgumentException(
+                        "expected '" + c + "' at index " + (i - 1) + " but got '" + actual + "'");
+            }
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReader.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReader.java
@@ -265,6 +265,10 @@ public final class PluginManifestReader {
                         default -> throw new IllegalArgumentException("bad escape \\" + e);
                     }
                 } else {
+                    if (c < 0x20) {
+                        throw new IllegalArgumentException(
+                                "unescaped control character in string at index " + (i - 1));
+                    }
                     sb.append(c);
                 }
             }

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriter.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriter.java
@@ -1,0 +1,114 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+
+/**
+ * Serialises a {@link PluginManifest} to the JSON form stored at
+ * {@code META-INF/daw-plugin.json} (Plugin View Design Book §4.5). The output
+ * round-trips through {@link PluginManifestReader} to an equal manifest.
+ *
+ * <p>This is the library type only; the Maven goal that emits the manifest at
+ * build time is out of scope for this story (§7.1/§7.3 — the book scopes the
+ * plugin code out).</p>
+ */
+public final class PluginManifestWriter {
+
+    /**
+     * Renders the manifest as a pretty-printed JSON object string. The
+     * {@code iconHint} key is omitted when the descriptor's icon hint is empty;
+     * every other field is always written.
+     *
+     * @param manifest the manifest to serialise (never {@code null})
+     * @return the JSON document, never {@code null}
+     */
+    public String toJson(PluginManifest manifest) {
+        Objects.requireNonNull(manifest, "manifest must not be null");
+        PluginDescriptor d = manifest.descriptor();
+
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put(PluginManifestReader.KEY_PLUGIN_CLASS, manifest.pluginClass());
+        fields.put(PluginManifestReader.KEY_ID, d.id());
+        fields.put(PluginManifestReader.KEY_NAME, d.name());
+        fields.put(PluginManifestReader.KEY_VERSION, d.version());
+        fields.put(PluginManifestReader.KEY_VENDOR, d.vendor());
+        fields.put(PluginManifestReader.KEY_TYPE, d.type().name());
+        fields.put(PluginManifestReader.KEY_CATEGORY, d.category().name());
+        if (!d.iconHint().isEmpty()) {
+            fields.put(PluginManifestReader.KEY_ICON_HINT, d.iconHint());
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        int i = 0;
+        for (Map.Entry<String, String> e : fields.entrySet()) {
+            sb.append("  ");
+            appendQuoted(sb, e.getKey());
+            sb.append(": ");
+            appendQuoted(sb, e.getValue());
+            if (++i < fields.size()) {
+                sb.append(',');
+            }
+            sb.append('\n');
+        }
+        sb.append("}\n");
+        return sb.toString();
+    }
+
+    /**
+     * Writes the manifest as a standalone {@code daw-plugin.json} file (UTF-8).
+     *
+     * @param manifest the manifest to write (never {@code null})
+     * @param jsonFile the destination file path (never {@code null})
+     * @throws IOException if writing fails
+     */
+    public void writeToFile(PluginManifest manifest, Path jsonFile) throws IOException {
+        Objects.requireNonNull(jsonFile, "jsonFile must not be null");
+        Files.writeString(jsonFile, toJson(manifest), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Writes the manifest JSON to the given stream (UTF-8). Does not close the
+     * stream.
+     *
+     * @param manifest the manifest to write (never {@code null})
+     * @param out      the destination stream (never {@code null})
+     * @throws IOException if writing fails
+     */
+    public void writeTo(PluginManifest manifest, OutputStream out) throws IOException {
+        Objects.requireNonNull(out, "out must not be null");
+        out.write(toJson(manifest).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void appendQuoted(StringBuilder sb, String value) {
+        sb.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append("\\u").append(String.format("%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        sb.append('"');
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginParameterStore.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginParameterStore.java
@@ -1,0 +1,303 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+
+/**
+ * The real-time-safe parameter store the host owns and a plugin editor
+ * reads / writes through {@link EditorContext#parameterStore()} (Plugin View
+ * Design Book §4.6). It is the enforcement seam behind Principle §2.6: a
+ * plugin's editor cannot reach its {@code AudioProcessor} directly — both the
+ * FX side (a knob turn) and the audio side (an internal envelope follower)
+ * talk only to this store.
+ *
+ * <h2>Coherence and threading (§4.7)</h2>
+ * <ul>
+ *   <li>Every parameter has an authoritative value stored in a lock-free
+ *       {@link AtomicLongArray} (as raw {@code double} bits). {@link #value(int)}
+ *       returns a coherent, allocation-free snapshot from either thread.</li>
+ *   <li>{@link #writeFromUi(int, double)} runs on the FX thread: it clamps and
+ *       publishes the new value, then posts the parameter's index onto a
+ *       single-producer / single-consumer ring the audio thread drains in
+ *       {@code process(...)} via {@link #drainToAudio(IndexConsumer)}.</li>
+ *   <li>{@link #writeFromAudio(int, double)} runs on the audio thread and is
+ *       {@link RealTimeSafe}: it clamps and publishes, then posts onto a
+ *       <em>separate</em> ring the FX thread drains via
+ *       {@link #drainToUi(IndexConsumer)} for display update.</li>
+ * </ul>
+ *
+ * <p>The rings carry only the changed parameter <em>index</em>; the value is
+ * read back from the coherent atomic array by the draining side. Both rings are
+ * fixed-capacity and non-blocking: if a producer outruns its consumer the
+ * oldest pending notification is dropped, never blocked — the atomic array
+ * still holds the latest value, so a dropped notification only delays a
+ * downstream apply / repaint until the next change. This keeps the audio-thread
+ * path free of allocation, locking and unbounded work.</p>
+ *
+ * <p>Indices are dense ({@code 0 .. parameterCount()-1}) in the order the store
+ * was constructed. {@link #indexOf(int)} maps a {@link PluginParameter#id()} to
+ * its index; that lookup is for setup / FX-side code only — the audio-thread
+ * methods take an index so they never touch the map.</p>
+ */
+public final class PluginParameterStore {
+
+    /**
+     * Allocation-free callback for draining a change ring. Receives the dense
+     * index of a parameter whose value changed; read the new value with
+     * {@link PluginParameterStore#value(int)}.
+     */
+    @FunctionalInterface
+    public interface IndexConsumer {
+        void accept(int parameterIndex);
+    }
+
+    private final PluginParameter[] parameters;
+    private final int[] parameterIds;
+    private final Map<Integer, Integer> idToIndex;
+    private final AtomicLongArray values;
+    private final IntRing uiToAudio;
+    private final IntRing audioToUi;
+
+    /**
+     * Creates a store for the given ordered parameter list. Each parameter's
+     * value is seeded to its {@link PluginParameter#defaultValue()}.
+     *
+     * @param parameters the plugin's parameters, in a stable order; must not be
+     *                   {@code null} and must not contain duplicate ids
+     * @throws IllegalArgumentException if two parameters share an id
+     */
+    public PluginParameterStore(List<PluginParameter> parameters) {
+        Objects.requireNonNull(parameters, "parameters must not be null");
+        int n = parameters.size();
+        this.parameters = parameters.toArray(new PluginParameter[0]);
+        this.parameterIds = new int[n];
+        this.idToIndex = new HashMap<>(Math.max(1, (n * 4 + 2) / 3));
+        this.values = new AtomicLongArray(n);
+        for (int i = 0; i < n; i++) {
+            PluginParameter p = Objects.requireNonNull(
+                    this.parameters[i], "parameters must not contain null");
+            parameterIds[i] = p.id();
+            if (idToIndex.putIfAbsent(p.id(), i) != null) {
+                throw new IllegalArgumentException("duplicate parameter id: " + p.id());
+            }
+            values.set(i, Double.doubleToRawLongBits(p.defaultValue()));
+        }
+        int capacity = ringCapacity(n);
+        this.uiToAudio = new IntRing(capacity);
+        this.audioToUi = new IntRing(capacity);
+    }
+
+    /**
+     * Returns the number of parameters in this store.
+     *
+     * @return the parameter count
+     */
+    public int parameterCount() {
+        return parameters.length;
+    }
+
+    /**
+     * Returns the parameter descriptor at the given dense index.
+     *
+     * @param index a dense index in {@code [0, parameterCount())}
+     * @return the parameter descriptor
+     */
+    public PluginParameter parameter(int index) {
+        return parameters[index];
+    }
+
+    /**
+     * Maps a {@link PluginParameter#id()} to its dense index. For setup /
+     * FX-side use only — not for the audio thread.
+     *
+     * @param parameterId the parameter id
+     * @return the dense index of that parameter
+     * @throws IllegalArgumentException if no parameter has that id
+     */
+    public int indexOf(int parameterId) {
+        Integer index = idToIndex.get(parameterId);
+        if (index == null) {
+            throw new IllegalArgumentException("unknown parameter id: " + parameterId);
+        }
+        return index;
+    }
+
+    /**
+     * Returns the {@link PluginParameter#id()} of the parameter at the given
+     * dense index.
+     *
+     * @param index a dense index in {@code [0, parameterCount())}
+     * @return the parameter id at that index
+     */
+    public int parameterIdAt(int index) {
+        return parameterIds[index];
+    }
+
+    /**
+     * Returns the current value of the parameter at the given index. Coherent
+     * and allocation-free — safe to call from any thread, including the audio
+     * thread.
+     *
+     * @param index a dense index in {@code [0, parameterCount())}
+     * @return the current value
+     */
+    @RealTimeSafe
+    public double value(int index) {
+        return Double.longBitsToDouble(values.get(index));
+    }
+
+    /**
+     * Returns the current value of the parameter with the given id. Convenience
+     * for FX-side code; performs an id-to-index lookup so it is <em>not</em>
+     * for the audio thread — use {@link #value(int)} there.
+     *
+     * @param parameterId the parameter id
+     * @return the current value
+     * @throws IllegalArgumentException if no parameter has that id
+     */
+    public double valueById(int parameterId) {
+        return value(indexOf(parameterId));
+    }
+
+    /**
+     * FX-thread write (a knob turn): clamps the value into the parameter's
+     * declared range, publishes it as the new coherent value, and notifies the
+     * audio thread. Drain the notification on the audio thread with
+     * {@link #drainToAudio(IndexConsumer)}.
+     *
+     * @param index a dense index in {@code [0, parameterCount())}
+     * @param value the requested value (clamped to the parameter's range)
+     */
+    public void writeFromUi(int index, double value) {
+        values.set(index, Double.doubleToRawLongBits(clamp(index, value)));
+        uiToAudio.offer(index);
+    }
+
+    /**
+     * FX-thread write addressed by parameter id. Equivalent to
+     * {@code writeFromUi(indexOf(parameterId), value)}.
+     *
+     * @param parameterId the parameter id
+     * @param value       the requested value (clamped to the parameter's range)
+     * @throws IllegalArgumentException if no parameter has that id
+     */
+    public void writeFromUiById(int parameterId, double value) {
+        writeFromUi(indexOf(parameterId), value);
+    }
+
+    /**
+     * Audio-thread write (for example an internal envelope follower the plugin
+     * wants to display): clamps and publishes the new coherent value, then
+     * notifies the FX thread. Drain the notification on the FX thread with
+     * {@link #drainToUi(IndexConsumer)}. Real-time safe — no allocation, no
+     * locking, no blocking.
+     *
+     * @param index a dense index in {@code [0, parameterCount())}
+     * @param value the value (clamped to the parameter's range)
+     */
+    @RealTimeSafe
+    public void writeFromAudio(int index, double value) {
+        values.set(index, Double.doubleToRawLongBits(clamp(index, value)));
+        audioToUi.offer(index);
+    }
+
+    /**
+     * Audio-thread drain of FX-side writes. Invokes {@code sink} once per
+     * pending change with the changed parameter's index (read the value with
+     * {@link #value(int)}), and returns the number of changes drained.
+     * Real-time safe as long as {@code sink} is (the store allocates nothing).
+     *
+     * @param sink the per-change callback
+     * @return the number of changes drained
+     */
+    @RealTimeSafe
+    public int drainToAudio(IndexConsumer sink) {
+        return uiToAudio.drain(sink);
+    }
+
+    /**
+     * FX-thread drain of audio-side writes. Invokes {@code sink} once per
+     * pending change with the changed parameter's index, and returns the number
+     * of changes drained. Call this from an FX pulse / animation tick to refresh
+     * the editor's controls.
+     *
+     * @param sink the per-change callback
+     * @return the number of changes drained
+     */
+    public int drainToUi(IndexConsumer sink) {
+        return audioToUi.drain(sink);
+    }
+
+    @RealTimeSafe
+    private double clamp(int index, double value) {
+        PluginParameter p = parameters[index];
+        double min = p.minValue();
+        double max = p.maxValue();
+        if (value < min) {
+            return min;
+        }
+        if (value > max) {
+            return max;
+        }
+        return value;
+    }
+
+    /** Smallest power of two that comfortably buffers {@code n} parameters. */
+    private static int ringCapacity(int n) {
+        int wanted = Math.max(64, n * 4);
+        int cap = 1;
+        while (cap < wanted) {
+            cap <<= 1;
+        }
+        return cap;
+    }
+
+    /**
+     * A single-producer / single-consumer, lock-free, fixed-capacity ring of
+     * {@code int} values. The producer ({@link #offer(int)}) and consumer
+     * ({@link #drain(IndexConsumer)}) each run on exactly one thread. Neither
+     * allocates; a full ring drops the incoming value rather than blocking.
+     */
+    private static final class IntRing {
+        private final int[] buffer;
+        private final int mask;
+        private final AtomicLong head = new AtomicLong(); // consumer position
+        private final AtomicLong tail = new AtomicLong(); // producer position
+
+        IntRing(int capacityPowerOfTwo) {
+            this.buffer = new int[capacityPowerOfTwo];
+            this.mask = capacityPowerOfTwo - 1;
+        }
+
+        @RealTimeSafe
+        void offer(int value) {
+            long t = tail.get();
+            if (t - head.get() >= buffer.length) {
+                return; // full — drop; the coherent atomic value still holds truth
+            }
+            buffer[(int) (t & mask)] = value;
+            tail.set(t + 1); // release: publishes the buffer write to the consumer
+        }
+
+        @RealTimeSafe
+        int drain(IndexConsumer sink) {
+            long h = head.get();
+            long t = tail.get(); // acquire: sees buffer writes up to t
+            int count = 0;
+            while (h < t) {
+                sink.accept(buffer[(int) (h & mask)]);
+                h++;
+                count++;
+            }
+            head.set(h);
+            return count;
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginParameterStore.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginParameterStore.java
@@ -36,9 +36,9 @@ import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
  * <p>The rings carry only the changed parameter <em>index</em>; the value is
  * read back from the coherent atomic array by the draining side. Both rings are
  * fixed-capacity and non-blocking: if a producer outruns its consumer the
- * oldest pending notification is dropped, never blocked — the atomic array
- * still holds the latest value, so a dropped notification only delays a
- * downstream apply / repaint until the next change. This keeps the audio-thread
+ * incoming notification is dropped, never blocked — the atomic array still
+ * holds the latest value, so a dropped notification only delays a downstream
+ * apply / repaint until the next change. This keeps the audio-thread
  * path free of allocation, locking and unbounded work.</p>
  *
  * <p>Indices are dense ({@code 0 .. parameterCount()-1}) in the order the store

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/RenderTick.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/RenderTick.java
@@ -1,0 +1,37 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.Objects;
+
+/**
+ * The per-frame payload the host passes to
+ * {@link PluginEditorFactory.Canvas#render(RenderTick)} (Plugin View Design
+ * Book §4.1). A canvas plugin reads the elapsed time to advance its own
+ * animation and reads {@link #tokens()} so its drawing tracks the active
+ * theme.
+ *
+ * <p>{@code render(RenderTick)} runs on the JavaFX Application Thread and
+ * should not allocate and must not block (§4.7). Because a fresh
+ * {@code RenderTick} is created for every frame the host repaints, keep this
+ * record small.</p>
+ *
+ * @param deltaSeconds seconds elapsed since the previous render tick
+ *                     (&ge; 0, finite)
+ * @param frameIndex   a monotonically increasing frame counter for this editor
+ *                     (&ge; 0)
+ * @param tokens       the resolved theme colours for this frame (never
+ *                     {@code null})
+ */
+public record RenderTick(double deltaSeconds, long frameIndex, Theme tokens) {
+
+    public RenderTick {
+        if (!Double.isFinite(deltaSeconds) || deltaSeconds < 0.0) {
+            throw new IllegalArgumentException(
+                    "deltaSeconds must be finite and >= 0, got " + deltaSeconds);
+        }
+        if (frameIndex < 0) {
+            throw new IllegalArgumentException(
+                    "frameIndex must be >= 0, got " + frameIndex);
+        }
+        Objects.requireNonNull(tokens, "tokens must not be null");
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/ResizePolicy.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/ResizePolicy.java
@@ -1,0 +1,29 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+/**
+ * How a plugin editor surface may be resized by the host.
+ *
+ * <p>A plugin declares its preferred policy through {@link EditorHints#resize()}.
+ * The host <em>enforces</em> the policy — a plugin cannot resize itself
+ * (Plugin View Design Book §2.2, §6.3). The policy constrains which axes the
+ * host's resize grip acts on; the host is free to coerce a request it cannot
+ * honour (for example, width is inherited from the Workshop right pane in the
+ * default {@code Workbench} concept §5.A, so a {@link #HORIZONTAL} request is
+ * ignored while embedded but honoured once detached to a floating window).</p>
+ *
+ * @see EditorHints
+ */
+public enum ResizePolicy {
+
+    /** The editor is a fixed size on both axes; the host shows no resize grip. */
+    FIXED,
+
+    /** Only the width may change; height is fixed. */
+    HORIZONTAL,
+
+    /** Only the height may change; width is fixed. */
+    VERTICAL,
+
+    /** The editor may be resized freely on both axes. */
+    BOTH
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/Theme.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/Theme.java
@@ -1,0 +1,62 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.Objects;
+
+import javafx.scene.paint.Color;
+
+/**
+ * Resolved role-token colour values for the active theme, handed to a
+ * {@link PluginEditorFactory.Canvas} plugin so its custom drawing tracks the
+ * host palette (Plugin View Design Book §2.5, §4.1).
+ *
+ * <p>The host resolves these values from CSS (the {@code .root-pane} role
+ * tokens surfaced by {@code ThemeManager}, story 277) — they are <em>never</em>
+ * a hard-coded hex mirror of a shipped theme. A canvas plugin must draw with
+ * these colours rather than its own literals so that switching the DAW theme
+ * re-tints the plugin without the plugin doing anything (§9 rejection #6:
+ * plugins consume host tokens, they cannot override them).</p>
+ *
+ * @param background the surface background colour
+ * @param foreground the primary text / line colour on {@code background}
+ * @param accent     the single accent colour used for focus and active state
+ * @param meterSafe  the "nominal" meter colour (green band)
+ * @param meterWarn  the "warning" meter colour (amber band)
+ * @param meterClip  the "critical" meter colour (red / clip band)
+ */
+public record Theme(
+        Color background,
+        Color foreground,
+        Color accent,
+        Color meterSafe,
+        Color meterWarn,
+        Color meterClip) {
+
+    public Theme {
+        Objects.requireNonNull(background, "background must not be null");
+        Objects.requireNonNull(foreground, "foreground must not be null");
+        Objects.requireNonNull(accent, "accent must not be null");
+        Objects.requireNonNull(meterSafe, "meterSafe must not be null");
+        Objects.requireNonNull(meterWarn, "meterWarn must not be null");
+        Objects.requireNonNull(meterClip, "meterClip must not be null");
+    }
+
+    /**
+     * A neutral greyscale fallback palette used <em>only</em> when the host has
+     * not yet supplied resolved role tokens — for example inside SDK unit tests
+     * or before the first theme resolution completes. This is deliberately
+     * <strong>not</strong> a mirror of any shipped DAW theme: the host always
+     * replaces it with values resolved from CSS. It exists so a canvas plugin
+     * always has a coherent, non-null palette to draw with.
+     *
+     * @return a neutral fallback theme, never {@code null}
+     */
+    public static Theme neutral() {
+        return new Theme(
+                Color.gray(0.12),
+                Color.gray(0.88),
+                Color.web("#4a9eff"),
+                Color.web("#3ecf5b"),
+                Color.web("#e0b93a"),
+                Color.web("#e05a4a"));
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/package-info.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/package-info.java
@@ -1,0 +1,52 @@
+/**
+ * The plugin <strong>editor</strong> contract (Plugin View Design Book §4) — the
+ * typed seam a third-party plugin uses to ship a GUI without ever touching
+ * {@code daw-app}. Introduced by Phase 1 of the §8 migration path (SDK additions,
+ * no removals); the host begins honouring it in story 301.
+ *
+ * <h2>The one entry point</h2>
+ * <p>A plugin returns a
+ * {@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory} from
+ * {@link com.benesquivelmusic.daw.sdk.plugin.DawPlugin#editorFactory()}, choosing
+ * exactly one of three modes (§2.1): a
+ * {@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory.Declarative}
+ * parameter list, a {@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory.Panel}
+ * that ships a {@link javafx.scene.layout.Region}, or a
+ * {@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory.Canvas} that draws
+ * into a host-owned {@link com.benesquivelmusic.daw.sdk.editor.CanvasSurface}.</p>
+ *
+ * <p>The host owns all chrome (breadcrumb, A/B, preset bar, meters, fault banner,
+ * resize grip, detach/close) in every mode; the plugin owns only what is between
+ * them (§2.1, §2.2). A plugin never overrides host tokens — a
+ * {@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory.Canvas} plugin is
+ * handed the resolved {@link com.benesquivelmusic.daw.sdk.editor.Theme} so its
+ * drawing tracks the active palette (§2.5, §9 rejection #6).</p>
+ *
+ * <h2>Real-time safety (§2.6)</h2>
+ * <p>An editor cannot reach its {@code AudioProcessor} directly. Both the FX side
+ * (a knob turn) and the audio side (an internal follower) talk only to the
+ * host-owned {@link com.benesquivelmusic.daw.sdk.editor.PluginParameterStore},
+ * which bridges the two threads over lock-free rings.</p>
+ *
+ * <h2>Threading (§4.7)</h2>
+ * <table class="striped">
+ *   <caption>Which thread each callback runs on</caption>
+ *   <thead>
+ *     <tr><th>Callback</th><th>Thread</th><th>May allocate?</th><th>May block?</th></tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr><td>{@code AudioProcessor#process(...)}</td><td>Audio</td><td>no</td><td>no</td></tr>
+ *     <tr><td>{@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory.Panel#createPanel(com.benesquivelmusic.daw.sdk.editor.EditorContext)}</td><td>FX</td><td>yes</td><td>no</td></tr>
+ *     <tr><td>{@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory.Canvas#attach(com.benesquivelmusic.daw.sdk.editor.CanvasSurface)} / detach</td><td>FX</td><td>yes</td><td>no</td></tr>
+ *     <tr><td>{@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory.Canvas#render(com.benesquivelmusic.daw.sdk.editor.RenderTick)}</td><td>FX</td><td>preferably no</td><td>no</td></tr>
+ *   </tbody>
+ * </table>
+ * <p>The host wraps every plugin-facing callback in a fault harness that catches
+ * {@link java.lang.Throwable} and routes it to the in-surface fault banner (§2.7,
+ * §6.6); a plugin may also self-report via
+ * {@link com.benesquivelmusic.daw.sdk.editor.EditorContext#postFault(java.lang.Throwable, java.lang.String)}.</p>
+ *
+ * @see com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory
+ * @see com.benesquivelmusic.daw.sdk.plugin.DawPlugin
+ */
+package com.benesquivelmusic.daw.sdk.editor;

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/plugin/DawPlugin.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/plugin/DawPlugin.java
@@ -1,6 +1,8 @@
 package com.benesquivelmusic.daw.sdk.plugin;
 
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.EditorHints;
+import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 
 import java.util.List;
 import java.util.Optional;
@@ -93,6 +95,36 @@ public interface DawPlugin {
      */
     default List<PluginParameter> getParameters() {
         return List.of();
+    }
+
+    /**
+     * Returns the factory that produces this plugin's editor surface (Plugin
+     * View Design Book §2.1, §4.2). The host calls this on the JavaFX
+     * Application Thread when the user focuses the plugin, and frames the result
+     * in its own chrome (breadcrumb, A/B, preset bar, meters, fault banner) — the
+     * plugin owns only the surface between them (§2.2).
+     *
+     * <p>The default is <em>backwards-compatible</em>: a plugin that overrides
+     * only {@link #getParameters()} gets a host-generated parameter-grid editor
+     * ({@link PluginEditorFactory.Declarative}) for free; a plugin that overrides
+     * nothing gets an empty declarative editor (still better than the silence of
+     * the pre-{@code editorFactory} SDK). A plugin that wants a custom GUI
+     * overrides this method to return a {@link PluginEditorFactory.Panel} (ship a
+     * {@link javafx.scene.layout.Region}) or a {@link PluginEditorFactory.Canvas}
+     * (draw into a host-owned surface).</p>
+     *
+     * <p><strong>Threading (§4.7):</strong> this method and the panel/canvas
+     * callbacks it leads to run on the FX thread, each inside the host's fault
+     * harness (§2.7) — a factory that throws degrades to a recoverable
+     * {@link PluginEditorFactory.Faulted} editor rather than crashing the host.
+     * The editor never touches the {@code AudioProcessor} directly; it reads and
+     * writes parameters through the host's real-time-safe
+     * {@link com.benesquivelmusic.daw.sdk.editor.PluginParameterStore} (§2.6).</p>
+     *
+     * @return this plugin's editor factory, never {@code null}
+     */
+    default PluginEditorFactory editorFactory() {
+        return new PluginEditorFactory.Declarative(getParameters(), EditorHints.compact());
     }
 
     /**

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/plugin/PluginDescriptor.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/plugin/PluginDescriptor.java
@@ -17,7 +17,8 @@ import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
  *                 constructor
  * @param iconHint a stable iconographic hint the host maps to its own icon pack
  *                 (e.g. {@code "compressor"}, {@code "reverb"}); the empty string
- *                 when the plugin declares none (§4.4)
+ *                 when the plugin declares none (§4.4). A blank or whitespace-only
+ *                 hint is normalised to the empty string.
  */
 public record PluginDescriptor(
         String id,
@@ -36,6 +37,10 @@ public record PluginDescriptor(
         Objects.requireNonNull(type, "type must not be null");
         Objects.requireNonNull(category, "category must not be null");
         Objects.requireNonNull(iconHint, "iconHint must not be null");
+
+        if (iconHint.isBlank()) {
+            iconHint = "";
+        }
 
         if (id.isBlank()) {
             throw new IllegalArgumentException("id must not be blank");

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/plugin/PluginDescriptor.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/plugin/PluginDescriptor.java
@@ -2,21 +2,31 @@ package com.benesquivelmusic.daw.sdk.plugin;
 
 import java.util.Objects;
 
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+
 /**
  * Immutable descriptor containing metadata about a DAW plugin.
  *
- * @param id      unique identifier for the plugin (e.g., {@code "com.example.reverb"})
- * @param name    human-readable name of the plugin
- * @param version version string (e.g., {@code "1.0.0"})
- * @param vendor  vendor or author name
- * @param type    the type of plugin
+ * @param id       unique identifier for the plugin (e.g., {@code "com.example.reverb"})
+ * @param name     human-readable name of the plugin
+ * @param version  version string (e.g., {@code "1.0.0"})
+ * @param vendor   vendor or author name
+ * @param type     the type of plugin
+ * @param category the browser category (Plugin View Design Book §4.4); defaults
+ *                 to {@link PluginCategory#UTILITY} via the legacy five-argument
+ *                 constructor
+ * @param iconHint a stable iconographic hint the host maps to its own icon pack
+ *                 (e.g. {@code "compressor"}, {@code "reverb"}); the empty string
+ *                 when the plugin declares none (§4.4)
  */
 public record PluginDescriptor(
         String id,
         String name,
         String version,
         String vendor,
-        PluginType type
+        PluginType type,
+        PluginCategory category,
+        String iconHint
 ) {
     public PluginDescriptor {
         Objects.requireNonNull(id, "id must not be null");
@@ -24,6 +34,8 @@ public record PluginDescriptor(
         Objects.requireNonNull(version, "version must not be null");
         Objects.requireNonNull(vendor, "vendor must not be null");
         Objects.requireNonNull(type, "type must not be null");
+        Objects.requireNonNull(category, "category must not be null");
+        Objects.requireNonNull(iconHint, "iconHint must not be null");
 
         if (id.isBlank()) {
             throw new IllegalArgumentException("id must not be blank");
@@ -31,5 +43,22 @@ public record PluginDescriptor(
         if (name.isBlank()) {
             throw new IllegalArgumentException("name must not be blank");
         }
+    }
+
+    /**
+     * Legacy five-argument constructor, preserved for backwards compatibility
+     * (Plugin View Design Book §4.4, §8.1.3). Defaults {@link #category()} to
+     * {@link PluginCategory#UTILITY} and {@link #iconHint()} to the empty string,
+     * so every existing {@code new PluginDescriptor(id, name, version, vendor,
+     * type)} call site keeps compiling unchanged.
+     *
+     * @param id      unique identifier for the plugin
+     * @param name    human-readable name of the plugin
+     * @param version version string
+     * @param vendor  vendor or author name
+     * @param type    the type of plugin
+     */
+    public PluginDescriptor(String id, String name, String version, String vendor, PluginType type) {
+        this(id, name, version, vendor, type, PluginCategory.UTILITY, "");
     }
 }

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/ui/PluginUI.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/ui/PluginUI.java
@@ -17,7 +17,7 @@ package com.benesquivelmusic.daw.sdk.ui;
  * @see com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory
  * @see com.benesquivelmusic.daw.sdk.plugin.DawPlugin#editorFactory()
  */
-@Deprecated(since = "<next>", forRemoval = true)
+@Deprecated(forRemoval = true)
 public interface PluginUI {
 
     /**

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/ui/PluginUI.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/ui/PluginUI.java
@@ -6,7 +6,18 @@ package com.benesquivelmusic.daw.sdk.ui;
  * <p>Implementations create and manage the visual representation of a plugin
  * within the DAW window. The DAW calls {@link #createUI()} to obtain the
  * root UI node when the user opens the plugin editor.</p>
+ *
+ * @deprecated Superseded by the typed
+ *     {@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory} editor
+ *     contract (Plugin View Design Book §1.2, §1.3, §4.3). This interface was
+ *     never consumed by the host and returns an untyped {@code Object} with no
+ *     compile-time contract; a plugin now ships its GUI by overriding
+ *     {@link com.benesquivelmusic.daw.sdk.plugin.DawPlugin#editorFactory()}.
+ *     Scheduled for removal after two release cycles (Phase 5 / story 304).
+ * @see com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory
+ * @see com.benesquivelmusic.daw.sdk.plugin.DawPlugin#editorFactory()
  */
+@Deprecated(since = "<next>", forRemoval = true)
 public interface PluginUI {
 
     /**

--- a/daw-sdk/src/main/java/module-info.java
+++ b/daw-sdk/src/main/java/module-info.java
@@ -36,6 +36,7 @@ module daw.sdk {
     // EditorContext a javafx.beans ObservableValue (Plugin View Design Book §9
     // rejection #3). Non-transitive so downstream modules do not automatically
     // read `javafx.graphics`; it is still required to resolve daw.sdk at runtime.
+    requires javafx.graphics;
 
     // ---------------------------------------------------------------------
     // Public API + SPI exports

--- a/daw-sdk/src/main/java/module-info.java
+++ b/daw-sdk/src/main/java/module-info.java
@@ -34,8 +34,8 @@ module daw.sdk {
     // JavaFX dependency: Panel#createPanel returns a javafx.scene.layout.Region,
     // Theme exposes javafx.scene.paint.Color, CanvasSurface a GraphicsContext,
     // EditorContext a javafx.beans ObservableValue (Plugin View Design Book §9
-    // rejection #3). Non-transitive on purpose so daw-core stays JavaFX-free.
-    requires javafx.graphics;
+    // rejection #3). Non-transitive so downstream modules do not automatically
+    // read `javafx.graphics`; it is still required to resolve daw.sdk at runtime.
 
     // ---------------------------------------------------------------------
     // Public API + SPI exports

--- a/daw-sdk/src/main/java/module-info.java
+++ b/daw-sdk/src/main/java/module-info.java
@@ -30,6 +30,13 @@ module daw.sdk {
     requires transitive java.desktop;
     requires java.logging;
 
+    // The editor package (com.benesquivelmusic.daw.sdk.editor) takes a hard
+    // JavaFX dependency: Panel#createPanel returns a javafx.scene.layout.Region,
+    // Theme exposes javafx.scene.paint.Color, CanvasSurface a GraphicsContext,
+    // EditorContext a javafx.beans ObservableValue (Plugin View Design Book §9
+    // rejection #3). Non-transitive on purpose so daw-core stays JavaFX-free.
+    requires javafx.graphics;
+
     // ---------------------------------------------------------------------
     // Public API + SPI exports
     //
@@ -48,6 +55,7 @@ module daw.sdk {
     exports com.benesquivelmusic.daw.sdk.audio;
     exports com.benesquivelmusic.daw.sdk.audio.performance;
     exports com.benesquivelmusic.daw.sdk.edit;
+    exports com.benesquivelmusic.daw.sdk.editor;
     exports com.benesquivelmusic.daw.sdk.event;
     exports com.benesquivelmusic.daw.sdk.export;
     exports com.benesquivelmusic.daw.sdk.mastering;

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/DawPluginDefaultEditorFactoryTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/DawPluginDefaultEditorFactoryTest.java
@@ -1,0 +1,76 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the backwards-compatible default of
+ * {@link DawPlugin#editorFactory()}: a plugin that only overrides
+ * {@code getParameters()} gets a host-generated declarative editor carrying
+ * exactly those parameters (Plugin View Design Book §4.2).
+ */
+class DawPluginDefaultEditorFactoryTest {
+
+    @Test
+    void defaultEditorFactoryCarriesOverriddenParameters() {
+        List<PluginParameter> params = List.of(
+                new PluginParameter(0, "Gain", 0.0, 1.0, 0.5),
+                new PluginParameter(1, "Mix", 0.0, 1.0, 1.0));
+        DawPlugin plugin = new ParametricPlugin(params);
+
+        PluginEditorFactory factory = plugin.editorFactory();
+
+        assertThat(factory).isInstanceOf(PluginEditorFactory.Declarative.class);
+        assertThat(((PluginEditorFactory.Declarative) factory).parameters())
+                .isEqualTo(params);
+    }
+
+    @Test
+    void defaultEditorFactoryForBarePluginIsEmptyDeclarative() {
+        DawPlugin plugin = new MinimalPlugin();
+
+        PluginEditorFactory factory = plugin.editorFactory();
+
+        assertThat(factory).isInstanceOf(PluginEditorFactory.Declarative.class);
+        assertThat(((PluginEditorFactory.Declarative) factory).parameters()).isEmpty();
+    }
+
+    /** Lifecycle + descriptor only; inherits the default (empty) {@code getParameters()}. */
+    private static class MinimalPlugin implements DawPlugin {
+
+        @Override
+        public PluginDescriptor getDescriptor() {
+            return new PluginDescriptor(
+                    "test.plugin", "Test", "1.0", "Tests", PluginType.EFFECT);
+        }
+
+        @Override public void initialize(PluginContext context) {}
+        @Override public void activate() {}
+        @Override public void deactivate() {}
+        @Override public void dispose() {}
+    }
+
+    /** Overrides only {@code getParameters()} — the discriminating case for the default factory. */
+    private static final class ParametricPlugin extends MinimalPlugin {
+
+        private final List<PluginParameter> parameters;
+
+        ParametricPlugin(List<PluginParameter> parameters) {
+            this.parameters = parameters;
+        }
+
+        @Override
+        public List<PluginParameter> getParameters() {
+            return parameters;
+        }
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginEditorFactorySealedTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginEditorFactorySealedTest.java
@@ -1,0 +1,53 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Structural guardrails for {@link PluginEditorFactory}: it must stay sealed over
+ * exactly the four permitted modes so the host can pattern-match exhaustively
+ * (Plugin View Design Book §2.1, §4.1).
+ */
+class PluginEditorFactorySealedTest {
+
+    @Test
+    void factoryIsSealedOverExactlyFourModes() {
+        assertThat(PluginEditorFactory.class.isSealed()).isTrue();
+
+        List<String> permitted =
+                Arrays.stream(PluginEditorFactory.class.getPermittedSubclasses())
+                        .map(Class::getSimpleName)
+                        .toList();
+
+        assertThat(permitted)
+                .containsExactlyInAnyOrder("Declarative", "Panel", "Canvas", "Faulted");
+    }
+
+    @Test
+    void panelAndCanvasAreInterfacesDeclarativeAndFaultedAreRecords() {
+        assertThat(PluginEditorFactory.Panel.class.isInterface()).isTrue();
+        assertThat(PluginEditorFactory.Canvas.class.isInterface()).isTrue();
+        assertThat(PluginEditorFactory.Declarative.class.isRecord()).isTrue();
+        assertThat(PluginEditorFactory.Faulted.class.isRecord()).isTrue();
+    }
+
+    @Test
+    void declarativeRoundTripsParametersAndHints() {
+        List<PluginParameter> params = List.of(
+                new PluginParameter(0, "Gain", 0.0, 1.0, 0.5),
+                new PluginParameter(1, "Mix", 0.0, 1.0, 1.0));
+        EditorHints hints = EditorHints.standard();
+
+        PluginEditorFactory.Declarative declarative =
+                new PluginEditorFactory.Declarative(params, hints);
+
+        assertThat(declarative.parameters()).isEqualTo(params);
+        assertThat(declarative.hints()).isEqualTo(hints);
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReaderTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReaderTest.java
@@ -1,0 +1,150 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies {@link PluginManifestReader} (Plugin View Design Book §4.5): a
+ * well-formed {@code META-INF/daw-plugin.json} parses to a valid
+ * {@link PluginManifest}, optional fields default sensibly, and every malformed or
+ * missing input degrades to a {@link PluginManifestReader.Result.Invalid} rather
+ * than throwing (§1.4, §6.8).
+ */
+class PluginManifestReaderTest {
+
+    /** Minimal document carrying only the six required fields (type {@code EFFECT}). */
+    private static final String MINIMAL_JSON = """
+            {
+              "pluginClass": "com.acme.MinimalPlugin",
+              "id": "com.acme.minimal",
+              "name": "Acme Minimal",
+              "version": "1.0.0",
+              "vendor": "Acme Audio",
+              "type": "EFFECT"
+            }
+            """;
+
+    private final PluginManifestReader reader = new PluginManifestReader();
+
+    @Test
+    void parsesWellFormedManifest() {
+        String json = """
+                {
+                  "pluginClass": "com.acme.ReverbPlugin",
+                  "id": "com.acme.reverb",
+                  "name": "Acme Reverb",
+                  "version": "1.0.0",
+                  "vendor": "Acme Audio",
+                  "type": "EFFECT",
+                  "category": "DYNAMICS",
+                  "iconHint": "compressor"
+                }
+                """;
+
+        PluginManifestReader.Result result = reader.parse(json);
+
+        assertThat(result.isValid()).isTrue();
+        PluginManifest manifest = result.manifest().orElseThrow();
+        assertThat(manifest.pluginClass()).isEqualTo("com.acme.ReverbPlugin");
+        assertThat(manifest.descriptor().type()).isEqualTo(PluginType.EFFECT);
+        assertThat(manifest.descriptor().category()).isEqualTo(PluginCategory.DYNAMICS);
+        assertThat(manifest.descriptor().iconHint()).isEqualTo("compressor");
+    }
+
+    @Test
+    void missingIconHintDefaultsToEmpty() {
+        PluginManifestReader.Result result = reader.parse(MINIMAL_JSON);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.manifest().orElseThrow().descriptor().iconHint()).isEmpty();
+    }
+
+    @Test
+    void missingCategoryDefaultsToUtility() {
+        PluginManifestReader.Result result = reader.parse(MINIMAL_JSON);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.manifest().orElseThrow().descriptor().category())
+                .isEqualTo(PluginCategory.UTILITY);
+    }
+
+    @Test
+    void malformedJsonReportedAsInvalid() {
+        PluginManifestReader.Result result = reader.parse("{ not json ");
+
+        assertThat(result).isInstanceOf(PluginManifestReader.Result.Invalid.class);
+        assertThat(result.isValid()).isFalse();
+    }
+
+    @Test
+    void missingRequiredFieldReportedAsInvalid() {
+        PluginManifestReader.Result result = reader.parse("{\"name\":\"x\"}");
+
+        assertThat(result).isInstanceOf(PluginManifestReader.Result.Invalid.class);
+        assertThat(result.isValid()).isFalse();
+    }
+
+    @Test
+    void unknownTypeReportedAsInvalid() {
+        String json = """
+                {
+                  "pluginClass": "com.acme.BogusPlugin",
+                  "id": "com.acme.bogus",
+                  "name": "Acme Bogus",
+                  "version": "1.0.0",
+                  "vendor": "Acme Audio",
+                  "type": "BOGUS"
+                }
+                """;
+
+        PluginManifestReader.Result result = reader.parse(json);
+
+        assertThat(result).isInstanceOf(PluginManifestReader.Result.Invalid.class);
+        assertThat(result.isValid()).isFalse();
+    }
+
+    @Test
+    void readsWellFormedManifestFromJar(@TempDir Path tempDir) throws IOException {
+        Path jar = writeJar(tempDir, "plugin.jar",
+                PluginManifestReader.MANIFEST_ENTRY, MINIMAL_JSON.getBytes(StandardCharsets.UTF_8));
+
+        PluginManifestReader.Result result = reader.readFromJar(jar);
+
+        assertThat(result.isValid()).isTrue();
+        PluginManifest manifest = result.manifest().orElseThrow();
+        assertThat(manifest.pluginClass()).isEqualTo("com.acme.MinimalPlugin");
+        assertThat(manifest.descriptor().category()).isEqualTo(PluginCategory.UTILITY);
+    }
+
+    @Test
+    void missingManifestInJarReportedAsInvalid(@TempDir Path tempDir) throws IOException {
+        Path jar = writeJar(tempDir, "no-manifest.jar",
+                "com/acme/MinimalPlugin.class", new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE});
+
+        PluginManifestReader.Result result = reader.readFromJar(jar);
+
+        assertThat(result).isInstanceOf(PluginManifestReader.Result.Invalid.class);
+        assertThat(result.isValid()).isFalse();
+    }
+
+    private static Path writeJar(Path dir, String jarName, String entryName, byte[] content) throws IOException {
+        Path jar = dir.resolve(jarName);
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar))) {
+            jos.putNextEntry(new JarEntry(entryName));
+            jos.write(content);
+            jos.closeEntry();
+        }
+        return jar;
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriterRoundTripTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriterRoundTripTest.java
@@ -1,0 +1,60 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import org.junit.jupiter.api.Test;
+
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link PluginManifestWriter} output round-trips through
+ * {@link PluginManifestReader} to an equal {@link PluginManifest} (Plugin View
+ * Design Book §4.5), including non-default {@code category}/{@code iconHint} and
+ * strings that require JSON escaping.
+ */
+class PluginManifestWriterRoundTripTest {
+
+    private final PluginManifestWriter writer = new PluginManifestWriter();
+    private final PluginManifestReader reader = new PluginManifestReader();
+
+    @Test
+    void roundTripsFullManifest() {
+        PluginManifest manifest = new PluginManifest(
+                "com.acme.TubeWarmth",
+                new PluginDescriptor(
+                        "com.acme.tubewarmth", "TubeWarmth", "1.2.0", "Acme Audio",
+                        PluginType.EFFECT, PluginCategory.DYNAMICS, "compressor"));
+
+        PluginManifest roundTripped = reader.parse(writer.toJson(manifest)).manifest().orElseThrow();
+
+        assertThat(roundTripped).isEqualTo(manifest);
+    }
+
+    @Test
+    void roundTripsManifestWithDefaults() {
+        PluginManifest manifest = new PluginManifest(
+                "com.acme.SynthPlugin",
+                new PluginDescriptor(
+                        "com.acme.synth", "Acme Synth", "1.0.0", "Acme Audio", PluginType.INSTRUMENT));
+
+        PluginManifest roundTripped = reader.parse(writer.toJson(manifest)).manifest().orElseThrow();
+
+        assertThat(roundTripped).isEqualTo(manifest);
+        assertThat(roundTripped.descriptor().category()).isEqualTo(PluginCategory.UTILITY);
+        assertThat(roundTripped.descriptor().iconHint()).isEmpty();
+    }
+
+    @Test
+    void escapesSpecialCharacters() {
+        PluginManifest manifest = new PluginManifest(
+                "com.acme.WeirdPlugin",
+                new PluginDescriptor(
+                        "com.acme.weird", "A \"quoted\" \\ name\nwith\ttabs", "1.0.0", "Acme Audio",
+                        PluginType.EFFECT, PluginCategory.UTILITY, ""));
+
+        PluginManifest roundTripped = reader.parse(writer.toJson(manifest)).manifest().orElseThrow();
+
+        assertThat(roundTripped).isEqualTo(manifest);
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriterRoundTripTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriterRoundTripTest.java
@@ -46,6 +46,20 @@ class PluginManifestWriterRoundTripTest {
     }
 
     @Test
+    void omitsIconHintKeyForWhitespaceOnlyHint() {
+        PluginManifest manifest = new PluginManifest(
+                "com.acme.SynthPlugin",
+                new PluginDescriptor(
+                        "com.acme.synth", "Acme Synth", "1.0.0", "Acme Audio",
+                        PluginType.INSTRUMENT, PluginCategory.UTILITY, "  \t"));
+
+        String json = writer.toJson(manifest);
+
+        assertThat(json).doesNotContain("iconHint");
+        assertThat(reader.parse(json).manifest().orElseThrow().descriptor().iconHint()).isEmpty();
+    }
+
+    @Test
     void escapesSpecialCharacters() {
         PluginManifest manifest = new PluginManifest(
                 "com.acme.WeirdPlugin",

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginUiDeprecatedForRemovalTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginUiDeprecatedForRemovalTest.java
@@ -1,0 +1,28 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import org.junit.jupiter.api.Test;
+
+import com.benesquivelmusic.daw.sdk.ui.PluginUI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the deprecation contract of the orphaned {@code PluginUI}: it must be
+ * annotated {@code @Deprecated(forRemoval = true)} now that the typed
+ * {@link PluginEditorFactory} supersedes it (Plugin View Design Book §1.2, §4.3).
+ * Story 304 removes it after two release cycles.
+ */
+class PluginUiDeprecatedForRemovalTest {
+
+    @Test
+    void pluginUiIsDeprecatedForRemoval() {
+        Deprecated deprecated = PluginUI.class.getAnnotation(Deprecated.class);
+
+        assertThat(deprecated)
+                .as("PluginUI must be @Deprecated in favour of PluginEditorFactory")
+                .isNotNull();
+        assertThat(deprecated.forRemoval())
+                .as("PluginUI deprecation must be forRemoval = true")
+                .isTrue();
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/plugin/PluginDescriptorBackCompatTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/plugin/PluginDescriptorBackCompatTest.java
@@ -1,0 +1,63 @@
+package com.benesquivelmusic.daw.sdk.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies the backwards-compatible widening of {@link PluginDescriptor} with the
+ * {@code category} and {@code iconHint} components (Plugin View Design Book §4.4,
+ * §8.1.3): the legacy five-argument constructor still compiles and defaults the
+ * new fields, while the seven-argument constructor round-trips non-default values.
+ */
+class PluginDescriptorBackCompatTest {
+
+    @Test
+    void legacyConstructorDefaultsCategoryToUtilityAndIconHintToEmpty() {
+        PluginDescriptor descriptor = new PluginDescriptor(
+                "com.example.reverb", "Reverb", "1.0.0", "Example Audio", PluginType.EFFECT);
+
+        assertThat(descriptor.category()).isEqualTo(PluginCategory.UTILITY);
+        assertThat(descriptor.iconHint()).isEmpty();
+    }
+
+    @Test
+    void sevenArgConstructorRoundTripsNonDefaultCategoryAndIconHint() {
+        PluginDescriptor descriptor = new PluginDescriptor(
+                "com.example.comp", "Compressor", "2.1.0", "Example Audio",
+                PluginType.EFFECT, PluginCategory.DYNAMICS, "compressor");
+
+        assertThat(descriptor.category()).isEqualTo(PluginCategory.DYNAMICS);
+        assertThat(descriptor.iconHint()).isEqualTo("compressor");
+    }
+
+    @Test
+    void legacyDescriptorEqualsExplicitSevenArgWithDefaults() {
+        PluginDescriptor legacy = new PluginDescriptor(
+                "id", "Name", "1.0", "Vendor", PluginType.EFFECT);
+        PluginDescriptor explicit = new PluginDescriptor(
+                "id", "Name", "1.0", "Vendor", PluginType.EFFECT, PluginCategory.UTILITY, "");
+
+        assertThat(legacy).isEqualTo(explicit);
+        assertThat(legacy.hashCode()).isEqualTo(explicit.hashCode());
+    }
+
+    @Test
+    void rejectsNullCategory() {
+        assertThatThrownBy(() -> new PluginDescriptor(
+                "id", "Name", "1.0", "Vendor", PluginType.EFFECT, null, ""))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("category");
+    }
+
+    @Test
+    void rejectsNullIconHint() {
+        assertThatThrownBy(() -> new PluginDescriptor(
+                "id", "Name", "1.0", "Vendor", PluginType.EFFECT, PluginCategory.UTILITY, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("iconHint");
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/plugin/PluginDescriptorTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/plugin/PluginDescriptorTest.java
@@ -2,6 +2,8 @@ package com.benesquivelmusic.daw.sdk.plugin;
 
 import org.junit.jupiter.api.Test;
 
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -74,6 +76,14 @@ class PluginDescriptorTest {
             PluginDescriptor descriptor = new PluginDescriptor("id", "Test", "1.0", "Vendor", type);
             assertThat(descriptor.type()).isEqualTo(type);
         }
+    }
+
+    @Test
+    void shouldNormalizeWhitespaceOnlyIconHintToEmpty() {
+        PluginDescriptor descriptor = new PluginDescriptor(
+                "id", "Name", "1.0", "Vendor", PluginType.EFFECT, PluginCategory.UTILITY, "  \t");
+
+        assertThat(descriptor.iconHint()).isEmpty();
     }
 
     @Test

--- a/daw-sdk/src/test/resources/META-INF/api-packages.allowlist
+++ b/daw-sdk/src/test/resources/META-INF/api-packages.allowlist
@@ -14,6 +14,7 @@ com.benesquivelmusic.daw.sdk.annotation
 com.benesquivelmusic.daw.sdk.audio
 com.benesquivelmusic.daw.sdk.audio.performance
 com.benesquivelmusic.daw.sdk.edit
+com.benesquivelmusic.daw.sdk.editor
 com.benesquivelmusic.daw.sdk.event
 com.benesquivelmusic.daw.sdk.export
 com.benesquivelmusic.daw.sdk.mastering


### PR DESCRIPTION
# PluginEditorFactory SDK Contract, PluginManifest, and Deprecation of the Orphaned PluginUI

## Motivation

The Plugin View Design Book opens with a frank inventory of why "hook in developer-made plugins" is confusing today (`docs/design/PLUGIN_VIEW_DESIGN_BOOK.md` §1). Two of those problems are SDK-shaped and must be fixed at the seam before any host or UI work can follow:

- **§1.2 — the SDK has no plugin-view contract.** `daw-sdk/.../ui/PluginUI.java` declares exactly two methods (`Object createUI()`, `void disposeUI()`) and **nothing in the codebase calls `createUI()`** — verified: the only references to `createUI` are its own declaration and Javadoc in `PluginUI.java:7,21`; there is no caller in `daw-app`. The one mechanism the host actually honours for "show this plugin's editor" is the hard-coded `switch` over plugin id in `PluginViewController.openBuiltInPluginView()` (`daw-app/.../ui/PluginViewController.java:161-183`), which only accepts `BuiltInDawPlugin`. A third party has no path to a custom editor at all.
- **§1.3 — `Object createUI()` is a non-contract.** The return type is `Object` "to avoid a hard JavaFX dependency in the SDK module itself" (`PluginUI.java:15-17`). The host would have to `instanceof Node` the result with no compile-time guarantee, and the SDK can never ask the plugin "how big do you want to be?", "do you resize?", "do you want host chrome?".
- **§1.4 — no discoverability.** The install path (`PluginManagerDialog`, story below in Phase 4) is "type a fully-qualified class name into a text field" (`PluginManagerDialog.java:98-99`, `classNameField`), the exact friction the `DawPlugin` Javadoc claims to remove (`DawPlugin.java:13-15`, "no `META-INF/services` configuration required").

This is **Phase 1 of the §8 migration path** — *SDK additions, no removals* (§8.1). It defines the contract end-to-end so the host (story 301), the built-in migration (story 302), and the install flow (story 303) have something real to build on. No app behaviour changes; existing tests keep passing; third-party plugins built against the old SDK still load.

## Goals

- **New package `com.benesquivelmusic.daw.sdk.editor`** (§4.1) so the contract does not collide with the existing `daw-sdk/.../ui` package (which keeps `PluginUI`, `PanelState`, `Rectangle2D`, `Workspace`). The package contains, per the §4.1 table:
  - `PluginEditorFactory` — a **sealed interface**. Three of its permitted subtypes are the §2.1 modes (`Declarative` / `Panel` / `Canvas`); a fourth, `Faulted` (below), is an internal variant the host swaps in — **four permitted subtypes in total**, which is what `PluginEditorFactorySealedTest` asserts.
  - `PluginEditorFactory.Declarative` — a **record** carrying `List<PluginParameter>` plus an `EditorHints` layout hint ("no GUI, just my parameter list").
  - `PluginEditorFactory.Panel` — an **interface** with one method `javafx.scene.layout.Region createPanel(EditorContext)` (**not** `Object` — see Non-Goals and §9 rejection #3).
  - `PluginEditorFactory.Canvas` — an **interface** with `attach(CanvasSurface)`, `render(RenderTick)`, `detach()`.
  - `PluginEditorFactory.Faulted` — an internal sealed variant the host swaps in when a factory throws, so the user still sees an editor with a fault banner and a Reload affordance, never a void (§4.8, §6.6).
  - Supporting types: `EditorContext`, `CanvasSurface`, `RenderTick` (record `(double deltaSeconds, long frameIndex, Theme tokens)`), `Theme` (resolved role-token record), `EditorHints` (record `(int preferredWidth, int preferredHeight, ResizePolicy resize, ChromePolicy chrome)`), `ResizePolicy` (`FIXED`/`HORIZONTAL`/`VERTICAL`/`BOTH`), `ChromePolicy` (`STANDARD`/`MINIMAL`/`IMMERSIVE`), and `PluginParameterStore` (§4.6).
- **Augment `DawPlugin` with one default method** (§4.2) so the change is backwards-compatible:
  ```java
  default PluginEditorFactory editorFactory() {
      return new PluginEditorFactory.Declarative(getParameters(), EditorHints.compact());
  }
  ```
  A plugin that overrides only `getParameters()` (`DawPlugin.java:94-96`) gets a parameter-grid editor for free; a plugin that overrides nothing gets an empty editor (still better than today's silence); a plugin that wants a custom GUI overrides `editorFactory()` to return `Panel` or `Canvas`.
- **Augment `PluginDescriptor`** (§4.4) with two optional fields, `category` (a new `PluginCategory` enum: Dynamics, EQ & Filter, Modulation, Reverb & Delay, Spatial, Utility, Analyzer, Instrument, MIDI Effect) and `iconHint` (`String`). Add them via a **builder or secondary canonical constructor that preserves the existing 5-arg record constructor** `PluginDescriptor(id, name, version, vendor, type)` (`PluginDescriptor.java:14-20`) so no current caller breaks.
- **`PluginManifest` + reader + writer** (§4.5): a `PluginManifest` record (parsed form of `META-INF/daw-plugin.json`), a `PluginManifestReader` that finds and validates the manifest in a JAR, and a `PluginManifestWriter`. The manifest declares everything `PluginDescriptor` exposes plus the fully-qualified plugin class name — the data Phase 4 reads on JAR drop so the user never types a class name.
- **Deprecate `PluginUI`** with `@Deprecated(since = "<next>", forRemoval = true)` and a Javadoc `@see PluginEditorFactory` (§4.3, §8.1.5). Risk-free: nothing calls it. (Actual removal is Phase 5 / story 304.)
- **Codify the §4.7 threading rules in SDK Javadoc**: `AudioProcessor#process(...)` is `@RealTimeSafe` (no alloc, no block); `createPanel(...)`, `Canvas#attach/detach`, and `Canvas#render(RenderTick)` run on the FX thread; `render` should not allocate and must not block. The Javadoc states the host wraps every callback in a fault harness (§2.7).
- Tests:
  - `PluginEditorFactorySealedTest` (new): assert `PluginEditorFactory` is `sealed` and its permitted subtypes are exactly `Declarative`, `Panel`, `Canvas`, `Faulted` (reflective `getPermittedSubclasses()` check).
  - `DawPluginDefaultEditorFactoryTest` (new): a plugin overriding only `getParameters()` yields a `Declarative` factory whose parameter list equals `getParameters()`; a plugin overriding nothing yields a `Declarative` factory with an empty list — proves §4.2 backwards-compatibility.
  - `PluginDescriptorBackCompatTest` (new): the legacy 5-arg constructor still compiles and runs; the new constructor/builder defaults `category`/`iconHint` to a sensible value; round-trips both.
  - `PluginManifestReaderTest` (new): a well-formed `META-INF/daw-plugin.json` parses into a `PluginManifest` with the declared class name and descriptor fields; a malformed/missing manifest is reported as a validation failure, not an exception that escapes.
  - `PluginManifestWriterRoundTripTest` (new): `PluginManifestWriter` emits JSON that `PluginManifestReader` parses back to an equal `PluginManifest`.
  - `PluginUiDeprecatedForRemovalTest` (new): reflectively assert `PluginUI` carries `@Deprecated(forRemoval = true)` — pins the Phase 5 contract.

## Non-Goals

- **No host wiring.** `PluginViewController` is untouched this phase; the `switch` (`PluginViewController.java:161-183`) stays, the built-ins keep their current floating windows. Honouring `editorFactory()` is story 301 (Phase 2).
- **No built-in migration.** None of the thirteen `*PluginView.java` classes change here. That is story 302 (Phase 3).
- **No install-flow change.** `PluginManagerDialog` keeps its class-name field this phase; the manifest is *defined and parseable* but not yet consumed by the install UX (story 303, Phase 4).
- **No `PluginUI` removal.** Deprecation only; removal is story 304 (Phase 5), after two release cycles.
- **No `Object` return types** anywhere in the new contract — `Panel#createPanel(...)` returns `javafx.scene.layout.Region` directly (§9 rejection #3).
- **No Maven archetype / `daw-plugin-maven-plugin` code.** §7.1/§7.3 describe a scaffold archetype and a manifest-emitting Maven goal; this story ships the `PluginManifestWriter` library type only, not the build plugin (book scopes the plugin code out).

## Technical Notes

- **The SDK takes a hard JavaFX dependency** (§9 rejection #3): add `requires javafx.graphics;` to `daw-sdk/.../module-info.java` and `exports com.benesquivelmusic.daw.sdk.editor;`. Panel mode returns a real `javafx.scene.layout.Region`; Canvas mode's `CanvasSurface` is a minimal facade over the FX `Canvas` (or a future GPU canvas). The cost — one `requires` line — is dwarfed by the typed, navigable, compile-time-safe contract.
- **`daw-core` stays JavaFX-free.** The editor types live in `daw-sdk` (which may take the JavaFX dep) and are consumed in `daw-app`; nothing JavaFX leaks into `daw-core`. The audio side (`AudioProcessor#process`, `DawProject`, parameter model in `daw-core/.../plugin/parameter`) is unaffected.
- **`PluginParameterStore` is the §2.6 enforcement seam.** The plugin's `Editor` cannot reach its `AudioProcessor` directly; both sides talk to the store. FX-thread writes (a knob turn) post to a lock-free ring the audio thread drains in `process(...)`; audio-thread writes (an internal envelope follower) post to a separate ring the FX thread drains for display. This is the type that later (story 301, cross-referencing the Control-Sync single-writer binding) retires the `PluginParameterEditorPanel.refreshControls()` feedback loop (`PluginParameterEditorPanel.java:160-176`) and the per-view `suppressNotification` flags.
- **`Theme` sources resolved role tokens from `ThemeManager`** (story 277, `daw-app/.../ui/theme/ThemeManager.java`) — background, foreground, accent, meterSafe/meterWarn/meterClip — so a Canvas-mode plugin's custom drawing tracks the active palette (§2.5). Per `feedback_control_css_role_token_forwarding.md`, the resolved values come from CSS, never a hard-coded hex mirror.
- **A/B compare** already exists as `ABComparison` in `daw-core/.../plugin/parameter/ABComparison.java` (verified: `Slot { A, B }`, `toggle()`, `copyActiveToInactive()`, `getSlotValues(Slot)`); the new contract reuses it rather than re-inventing per-view A/B (§6.5).
- **Discovery is `ServiceLoader`-based, not sealed-`permits`.** `DawPlugin.java:13-14` documents `java.util.ServiceLoader` discovery; built-ins are `ServiceLoader` providers declared in `daw-core/.../module-info.java`. The `dawg-annotations-reflection` SKILL §1/§2 is **stale** on this point (it still describes sealed-`permits` discovery) — do not cite sealed-`permits` for plugin discovery in this work.
- Files: new `daw-sdk/.../editor/` package (`PluginEditorFactory.java`, `EditorContext.java`, `CanvasSurface.java`, `RenderTick.java`, `Theme.java`, `EditorHints.java`, `ResizePolicy.java`, `ChromePolicy.java`, `PluginManifest.java`, `PluginManifestReader.java`, `PluginManifestWriter.java`, `PluginParameterStore.java`, `PluginCategory.java`); edits to `daw-sdk/.../plugin/DawPlugin.java` (add `editorFactory()`), `daw-sdk/.../plugin/PluginDescriptor.java` (add `category`/`iconHint`), `daw-sdk/.../ui/PluginUI.java` (deprecate), `daw-sdk/.../module-info.java` (`requires javafx.graphics`, `exports …editor`).
- Reference: Plugin View Design Book §1.2/§1.3/§1.4 (the problems), §2.1 (three modes), §2.6 (RT-safety as separated types), §3 (information model), §4 (the whole contract), §8.1 (this phase), §9 rejections #1/#2/#3 (no second `PluginUI`, no god-object `EditorContext`, no `Object` returns); user story 030 (plugin parameter UI — the model `Declarative` reuses), user story 089 (plugin audio-processing contract — the `process`/editor boundary), user story 034 (CLAP hosting — a future external host that benefits from a real editor contract), user stories 107/108 (annotation-driven parameter discovery / reflective registry), user story 079 (built-in plugin discovery — now `ServiceLoader`); `daw-sdk/README.md` (the §7.7 getting-started deliverable this contract enables). SKILLs: `javafx-application-design` (§4 Properties for `EditorContext` observables, §6 Canvas for Canvas mode, §11 threading for the §4.7 table, §12 typed events), `dawg-annotations-reflection` (ServiceLoader discovery — note the SKILL is stale on sealed-permits), `research-daw`.
