### PR TITLE
301-host-honours-the-editor-contract-standard-chrome-around-declarati…

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DawMenuBarController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/DawMenuBarController.java
@@ -1,8 +1,10 @@
 package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.core.plugin.BuiltInDawPlugin;
+import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
 import javafx.scene.control.MenuBar;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Logger;
@@ -110,6 +112,40 @@ public final class DawMenuBarController {
          */
         default void onOpenBackupSettings() { }
         void onActivateBuiltInPlugin(Class<? extends BuiltInDawPlugin> pluginClass);
+
+        /**
+         * Story 301 §8.2.1 — one entry in the Plugins ▸ External submenu: a
+         * loaded third-party plugin the user can activate into the
+         * contract-driven editor frame.
+         *
+         * @param entry       the registry entry identifying the plugin
+         * @param displayName the label shown in the menu (the descriptor
+         *                    name, or a defensive fallback when the
+         *                    descriptor read throws)
+         */
+        record ExternalPluginMenuItem(ExternalPluginEntry entry, String displayName) {
+        }
+
+        /**
+         * Story 301 §8.2.1 — the loaded external plugins to list in the
+         * Plugins ▸ External submenu, re-read every time the Plugins menu is
+         * shown so the list tracks the registry. Default empty for tests /
+         * hosts without a plugin registry.
+         *
+         * @return the current external-plugin menu entries, never {@code null}
+         */
+        default List<ExternalPluginMenuItem> externalPluginMenuItems() {
+            return List.of();
+        }
+
+        /**
+         * Story 301 §8.2.1 — activate a loaded external plugin and open its
+         * contract-driven editor. Default no-op for tests.
+         *
+         * @param entry the registry entry the user picked
+         */
+        default void onActivateExternalPlugin(ExternalPluginEntry entry) {
+        }
 
         // Window actions
         void onSwitchView(DawView view);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -1615,6 +1615,10 @@ public final class MainController {
         // Story 294 — direct functional deps replace PluginViewController.Host (§4.2/§9).
         // project/sampleRate/bufferSize read the swappable project field live; dirty
         // routes through DawProject.markDirty() (the §1.2 "one dirty bit").
+        // Story 301 — the three contract-editor services: the Workshop pane
+        // host, a live supervisor read (pluginSupervisor is constructed after
+        // this controller in initializePluginFaultIsolation), and the fault-log
+        // opener behind the §6.6 banner's [ⓘ] action.
         pluginViewController = new PluginViewController(new PluginViewController.Deps(
                 () -> project.getFormat().sampleRate(),
                 () -> project.getFormat().bufferSize(),
@@ -1623,7 +1627,14 @@ public final class MainController {
                 () -> viewNavigationController.switchView(DawView.MASTERING),
                 this::status,
                 (level, message) -> notificationBar.show(level, message),
-                this::showTelemetryPanel));
+                this::showTelemetryPanel,
+                (segments, node) -> viewNavigationController.showEditorInWorkshopPane(segments, node),
+                () -> pluginSupervisor,
+                () -> {
+                    if (pluginFaultUiController != null) {
+                        pluginFaultUiController.openFaultLog();
+                    }
+                }));
     }
 
     /**
@@ -2324,6 +2335,35 @@ public final class MainController {
                     @Override public void onOpenBackupSettings() { MainController.this.onOpenBackupSettings(); }
                     @Override public void onActivateBuiltInPlugin(Class<? extends BuiltInDawPlugin> pluginClass) {
                         pluginViewController.onActivateBuiltInPlugin(pluginClass);
+                    }
+                    // Story 301 §8.2.1 — Plugins ▸ External submenu: list the
+                    // registry's loaded third-party plugins and route an
+                    // activation into the contract-driven editor path.
+                    @Override public List<ExternalPluginMenuItem> externalPluginMenuItems() {
+                        var items = new java.util.ArrayList<ExternalPluginMenuItem>();
+                        for (var loaded : pluginRegistry.getLoadedPlugins().entrySet()) {
+                            String displayName;
+                            try {
+                                displayName = loaded.getValue().getDescriptor().name();
+                            } catch (RuntimeException e) {
+                                // Defensive — a third-party descriptor read can
+                                // throw; the menu must still build.
+                                displayName = loaded.getKey().className();
+                            }
+                            items.add(new ExternalPluginMenuItem(loaded.getKey(), displayName));
+                        }
+                        return items;
+                    }
+                    @Override public void onActivateExternalPlugin(
+                            com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry entry) {
+                        com.benesquivelmusic.daw.sdk.plugin.DawPlugin plugin =
+                                pluginRegistry.getPlugin(entry);
+                        if (plugin == null) {
+                            notificationBar.show(NotificationLevel.ERROR,
+                                    "Plugin is not loaded: " + entry.className());
+                            return;
+                        }
+                        pluginViewController.onActivateExternalPlugin(plugin);
                     }
                     @Override public void onSwitchView(DawView view) { viewNavigationController.switchView(view); }
                     @Override public void onToggleBrowser() {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MenuConstructionService.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MenuConstructionService.java
@@ -12,9 +12,12 @@ import javafx.scene.input.KeyCombination;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.MissingResourceException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.ResourceBundle;
 
 /**
  * Builds the JavaFX menu hierarchy (File, Edit, Tracks, Plugins, Window,
@@ -37,6 +40,15 @@ final class MenuConstructionService {
 
     /** Icon size for menu-item graphics. */
     static final double MENU_ICON_SIZE = DawMenuBarController.MENU_ICON_SIZE;
+
+    /**
+     * Chrome strings for the story-301 External submenu (Skill §14) —
+     * {@code Locale.ROOT}, the EditorFrameSkin idiom. The legacy menu labels
+     * predate the bundle and stay inline; new user-facing strings flow
+     * through here.
+     */
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
 
     private final DawMenuBarController.MenuActions host;
     private final KeyBindingManager keyBindingManager;
@@ -305,11 +317,61 @@ final class MenuConstructionService {
             pluginsMenu.getItems().add(new SeparatorMenuItem());
         }
 
+        // Story 301 \u00a78.2.1 \u2014 External submenu: the user-visible activation
+        // path for loaded third-party plugins (routed to editorFactory() and
+        // the contract-driven editor frame). The registry contents change at
+        // runtime (Plugin Manager loads/unloads JARs), so this one submenu
+        // repopulates on every Plugins-menu showing; everything else in the
+        // menu stays one-shot construction.
+        Menu externalMenu = new Menu(msg("menu.plugins.external"));
+        externalMenu.getStyleClass().add("daw-menu");
+        externalMenu.setGraphic(IconNode.of(DawIcon.KNOB, MENU_ICON_SIZE));
+        populateExternalPluginsMenu(externalMenu);
+        pluginsMenu.setOnShowing(_ -> populateExternalPluginsMenu(externalMenu));
+        // No extra separator: External shares the trailing plugin-management
+        // block with Plugin Manager\u2026, preserving the documented separator
+        // structure (one per category group + one before this block).
+        pluginsMenu.getItems().add(externalMenu);
+
         MenuItem managePlugins = menuItem("Plugin Manager\u2026", DawIcon.EQ,
                 null, host::onManagePlugins);
         pluginsMenu.getItems().add(managePlugins);
 
         return pluginsMenu;
+    }
+
+    /**
+     * (Re)populates the Plugins \u25b8 External submenu from
+     * {@link DawMenuBarController.MenuActions#externalPluginMenuItems()} \u2014
+     * one item per loaded third-party plugin, or a single disabled
+     * placeholder when none are installed (story 301 \u00a78.2.1).
+     */
+    private void populateExternalPluginsMenu(Menu externalMenu) {
+        externalMenu.getItems().clear();
+        List<DawMenuBarController.MenuActions.ExternalPluginMenuItem> items =
+                host.externalPluginMenuItems();
+        if (items.isEmpty()) {
+            MenuItem none = new MenuItem(msg("menu.plugins.external.none"));
+            none.setDisable(true);
+            externalMenu.getItems().add(none);
+            return;
+        }
+        for (var item : items) {
+            externalMenu.getItems().add(menuItem(item.displayName(), null,
+                    null, () -> host.onActivateExternalPlugin(item.entry())));
+        }
+    }
+
+    /**
+     * Resolves a chrome string from the shared bundle, falling back to the
+     * raw key if absent (mirrors {@code EditorFrameSkin#msg(String)}).
+     */
+    private static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (MissingResourceException e) {
+            return key;
+        }
     }
 
     // ── Window Menu ──────────────────────────────────────────────────────────

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginParameterEditorPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginParameterEditorPanel.java
@@ -28,6 +28,16 @@ import java.util.function.BiConsumer;
  *
  * <p>Parameter changes are reported via the {@code onParameterChanged}
  * callback, allowing real-time wiring to the effects chain.</p>
+ *
+ * <p><strong>Superseded for contract-driven editors</strong> (story 301,
+ * Plugin View Design Book §6.2): the host-generated body for a
+ * {@code PluginEditorFactory.Declarative} editor is now
+ * {@link com.benesquivelmusic.daw.app.ui.plugin.ParameterGridPanel}, rendered
+ * inside the standard {@code EditorFrame} chrome with the single-writer
+ * binding discipline. This class remains the built-in insert-effect path
+ * ({@code InsertEffectRack} / {@code WorkshopSelectionHostController} /
+ * {@code InnerChainEditor}) until the built-ins migrate onto the contract in
+ * story 302.</p>
  */
 public final class PluginParameterEditorPanel extends VBox {
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginViewController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginViewController.java
@@ -3,18 +3,26 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.display.SpectrumDisplayWindow;
 import com.benesquivelmusic.daw.app.ui.display.TunerDisplayWindow;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginEditorSession;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.plugin.*;
 import com.benesquivelmusic.daw.core.project.DawProject;
 import com.benesquivelmusic.daw.core.spatial.binaural.HrtfImportController;
 import com.benesquivelmusic.daw.core.spatial.binaural.HrtfProfileLibrary;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.DoubleSupplier;
 import java.util.function.IntSupplier;
@@ -44,6 +52,16 @@ final class PluginViewController {
      * {@link Runnable}s ({@code markProjectDirty} routes through
      * {@code DawProject.markDirty()} now — the §1.2 "one dirty bit"); status and
      * notification are {@link BiConsumer} sinks.
+     *
+     * <p>Story 301 (Plugin View Design Book §8.2) appends the contract-editor
+     * services: {@code showEditorInWorkshopPane} hosts an {@code EditorFrame}
+     * in the Workshop right pane's stable-identity container (§8.2.2 —
+     * breadcrumb segments plus the editor node; a {@code null} node clears the
+     * pane); {@code faultSupervisor} is a live {@link Supplier} (the
+     * {@link PluginInvocationSupervisor} is constructed after this controller
+     * at startup) feeding the §6.6 editor fault harness; and
+     * {@code openPluginFaultLog} backs the fault banner's {@code [ⓘ]}
+     * action.</p>
      */
     record Deps(
             DoubleSupplier sampleRate,
@@ -53,7 +71,10 @@ final class PluginViewController {
             Runnable switchToMasteringView,
             BiConsumer<String, DawIcon> updateStatusBar,
             BiConsumer<NotificationLevel, String> showNotification,
-            Runnable showTelemetryPanel) {
+            Runnable showTelemetryPanel,
+            BiConsumer<List<String>, Node> showEditorInWorkshopPane,
+            Supplier<PluginInvocationSupervisor> faultSupervisor,
+            Runnable openPluginFaultLog) {
     }
 
     private final Deps deps;
@@ -82,6 +103,23 @@ final class PluginViewController {
     private Stage midSideWrapperStage;
     private MidSideWrapperPluginView midSideWrapperView;
     private final HrtfProfileLibrary hrtfProfileLibrary = new HrtfProfileLibrary();
+
+    /**
+     * The single live contract-editor session (story 301 §8.2). Opening
+     * another plugin's editor disposes the previous session first — the
+     * Workshop right pane hosts one focused editor at a time (§5.A).
+     */
+    private PluginEditorSession activeEditorSession;
+
+    /**
+     * External plugins this controller has already {@code initialize(...)}d
+     * (story 301 — initialise-once, identity-keyed: two registry entries that
+     * load the same instance must not double-initialise it). Activation and
+     * editor opening repeat per request; disposal stays with the
+     * {@link PluginRegistry}, which owns the external-plugin lifecycle.
+     */
+    private final Set<DawPlugin> initializedExternalPlugins =
+            Collections.newSetFromMap(new IdentityHashMap<>());
 
     PluginViewController(Deps deps) {
         this.deps = deps;
@@ -112,7 +150,7 @@ final class PluginViewController {
             });
             deps.updateStatusBar().accept("Activating " + plugin.getMenuLabel() + "...", null);
             plugin.activate();
-            openBuiltInPluginView(plugin);
+            openEditor(plugin);
             deps.updateStatusBar().accept(plugin.getMenuLabel() + " activated", null);
             LOG.fine("Activated built-in plugin: " + plugin.getMenuLabel());
         } catch (RuntimeException e) {
@@ -120,6 +158,43 @@ final class PluginViewController {
             deps.updateStatusBar().accept("Failed to activate " + pluginClass.getSimpleName(), null);
             deps.showNotification().accept(NotificationLevel.ERROR,
                     "Failed to activate " + pluginClass.getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Activates an external (third-party) plugin from the registry and opens
+     * its contract-driven editor (story 301 §8.2.1 — "third-party plugins now
+     * have editors"). Mirrors {@link #onActivateBuiltInPlugin}: first
+     * activation initialises the plugin with the same anonymous
+     * {@code PluginContext} shape (initialise-once, identity-keyed), every
+     * activation calls {@code activate()} then routes through
+     * {@link #openEditor(DawPlugin)}. The registry keeps ownership of the
+     * plugin's lifecycle — this controller never disposes it.
+     *
+     * @param plugin the loaded external plugin to activate; must not be
+     *               {@code null}
+     */
+    void onActivateExternalPlugin(DawPlugin plugin) {
+        try {
+            if (initializedExternalPlugins.add(plugin)) {
+                PluginContext pluginContext = new PluginContext() {
+                    @Override public double getSampleRate() { return deps.sampleRate().getAsDouble(); }
+                    @Override public int getBufferSize() { return deps.bufferSize().getAsInt(); }
+                    @Override public void log(String message) { LOG.info(message); }
+                };
+                plugin.initialize(pluginContext);
+            }
+            String label = plugin.getDescriptor().name();
+            deps.updateStatusBar().accept("Activating " + label + "...", null);
+            plugin.activate();
+            openEditor(plugin);
+            deps.updateStatusBar().accept(label + " activated", null);
+            LOG.fine("Activated external plugin: " + label);
+        } catch (RuntimeException e) {
+            LOG.log(Level.WARNING, "Failed to activate external plugin: " + plugin.getClass().getName(), e);
+            deps.updateStatusBar().accept("Failed to activate " + plugin.getClass().getSimpleName(), null);
+            deps.showNotification().accept(NotificationLevel.ERROR,
+                    "Failed to activate " + plugin.getClass().getSimpleName() + ": " + e.getMessage());
         }
     }
 
@@ -154,6 +229,13 @@ final class PluginViewController {
         if (midSideWrapperStage != null) {
             midSideWrapperStage.hide();
         }
+        // Story 301 — tear down the live contract-editor session. External
+        // plugins themselves are NOT disposed here: the PluginRegistry owns
+        // their lifecycle.
+        if (activeEditorSession != null) {
+            activeEditorSession.dispose();
+            activeEditorSession = null;
+        }
         try {
             for (BuiltInDawPlugin plugin : builtInPluginCache.values()) {
                 try {
@@ -168,7 +250,36 @@ final class PluginViewController {
         }
     }
 
-    private void openBuiltInPluginView(BuiltInDawPlugin plugin) {
+    /**
+     * Opens a plugin's editor through the story-301 §8.2.1 dispatch rule:
+     * the legacy built-in {@code switch}
+     * ({@link #openLegacyBuiltInView(BuiltInDawPlugin)}) keeps its arms
+     * unchanged and still wins for every id it knows — the documented §2.3
+     * internal escape hatch until the built-ins migrate in story 302 — and
+     * <em>every other plugin</em> routes to {@code editorFactory()} and is
+     * rendered in the standard {@link com.benesquivelmusic.daw.app.ui.plugin.EditorFrame}
+     * chrome ({@link #openContractEditor(DawPlugin)}).
+     *
+     * @param plugin the activated plugin to open an editor for
+     */
+    void openEditor(DawPlugin plugin) {
+        if (plugin instanceof BuiltInDawPlugin builtIn && openLegacyBuiltInView(builtIn)) {
+            return;
+        }
+        openContractEditor(plugin);
+    }
+
+    /**
+     * The legacy built-in view {@code switch} (Plugin View Design Book §2.3
+     * escape hatch — story 301 keeps its arms byte-for-byte; story 302
+     * deletes it). Returns whether an arm matched, so
+     * {@link #openEditor(DawPlugin)} can fall through to the §8.2.1 contract
+     * path for ids the switch does not know.
+     *
+     * @param plugin the activated built-in plugin
+     * @return {@code true} when a legacy arm handled the plugin
+     */
+    private boolean openLegacyBuiltInView(BuiltInDawPlugin plugin) {
         String pluginId = plugin.getDescriptor().id();
         switch (pluginId) {
             case VirtualKeyboardPlugin.PLUGIN_ID -> openVirtualKeyboardWindow((VirtualKeyboardPlugin) plugin);
@@ -188,8 +299,64 @@ final class PluginViewController {
             case ParametricEqPlugin.PLUGIN_ID,
                  CompressorPlugin.PLUGIN_ID,
                  ReverbPlugin.PLUGIN_ID -> deps.switchToMasteringView().run();
-            default -> LOG.fine("No associated built-in view mapping for plugin id: " + pluginId);
+            default -> {
+                LOG.fine("No associated built-in view mapping for plugin id: " + pluginId);
+                return false;
+            }
         }
+        return true;
+    }
+
+    /**
+     * Story 301 §8.2 — opens the contract-driven editor: disposes any
+     * previous session, runs the plugin's {@code editorFactory()} pipeline
+     * through {@link PluginEditorSession#open} (never throws for
+     * plugin-caused failures — faults degrade to the §6.6 banner), wires the
+     * controller-owned close intent (the one frame callback the session
+     * deliberately leaves to its host), and places the framed editor in the
+     * Workshop right pane's stable-identity container (§8.2.2).
+     */
+    private void openContractEditor(DawPlugin plugin) {
+        if (activeEditorSession != null) {
+            activeEditorSession.dispose();
+            activeEditorSession = null;
+        }
+        PluginEditorSession session = PluginEditorSession.open(plugin, null,
+                new PluginEditorSession.Deps(
+                        deps.sampleRate(),
+                        deps.faultSupervisor(),
+                        deps.openPluginFaultLog(),
+                        deps.showNotification()));
+        activeEditorSession = session;
+        // §6.1 [×] close — focus-only: the session is torn down and the pane
+        // cleared, but the plugin stays registered and activated.
+        session.frame().setOnCloseRequested(() -> {
+            session.dispose();
+            if (activeEditorSession == session) {
+                activeEditorSession = null;
+            }
+            deps.showEditorInWorkshopPane().accept(List.of(), null);
+        });
+        List<String> segments = new ArrayList<>(2);
+        addSegmentIfPresent(segments, session.frame().getVendor());
+        addSegmentIfPresent(segments, session.frame().getPluginName());
+        deps.showEditorInWorkshopPane().accept(segments, session.frame());
+        deps.updateStatusBar().accept(
+                "Opened editor for " + session.frame().getPluginName(), null);
+    }
+
+    private static void addSegmentIfPresent(List<String> segments, String value) {
+        if (value != null && !value.isBlank()) {
+            segments.add(value);
+        }
+    }
+
+    /**
+     * @return the live contract-editor session, or {@code null} — test seam
+     *         (story 301)
+     */
+    PluginEditorSession activeEditorSessionForTest() {
+        return activeEditorSession;
     }
 
     private void openVirtualKeyboardWindow(VirtualKeyboardPlugin plugin) {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ViewNavigationController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/ViewNavigationController.java
@@ -15,6 +15,7 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.layout.BorderPane;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
@@ -337,6 +338,33 @@ final class ViewNavigationController {
             onViewChanged.run();
         }
         LOG.fine(() -> "Switched to view: " + view);
+    }
+
+    /**
+     * Story 301 §8.2.2 — hosts a contract-driven plugin editor in the
+     * Workshop right pane's stable-identity {@code PluginViewContainer}
+     * (the story-281 invariant: switching the focused plugin swaps the
+     * container's inner content, never the container itself). A non-null
+     * {@code editorNode} first switches to (and lazily builds) the Workshop
+     * view so the editor is visible immediately; clearing ({@code null})
+     * only empties the focused-plugin slot and does <em>not</em> force a
+     * view switch — closing an editor from another view must not yank the
+     * user into Workshop.
+     *
+     * @param segments   the §6.1 breadcrumb segments (e.g. vendor ▸ plugin
+     *                   name); may be {@code null}/empty to clear the crumb
+     * @param editorNode the framed editor to focus, or {@code null} to clear
+     *                   the pane back to its empty placeholder
+     */
+    public void showEditorInWorkshopPane(List<String> segments, Node editorNode) {
+        if (editorNode == null) {
+            if (workshopView != null) {
+                workshopView.clearFocusedPlugin();
+            }
+            return;
+        }
+        switchView(DawView.WORKSHOP);
+        workshopView.setFocusedPlugin(segments, editorNode);
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/EditorFrame.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/EditorFrame.java
@@ -1,0 +1,722 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.core.plugin.parameter.ABComparison;
+import com.benesquivelmusic.daw.sdk.editor.ChromePolicy;
+import com.benesquivelmusic.daw.sdk.editor.ResizePolicy;
+import com.benesquivelmusic.daw.sdk.editor.Theme;
+import com.benesquivelmusic.daw.sdk.plugin.PluginMeterSnapshot;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.css.CssMetaData;
+import javafx.css.StyleConverter;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
+import javafx.scene.AccessibleRole;
+import javafx.scene.Node;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Host-side plugin-editor frame {@link Control} — the standard chrome that
+ * wraps every contract-driven plugin editor (story 301, Plugin View Design
+ * Book §5.A "Workbench" / §5.D "Immersive canvas" / §6.1–§6.6).
+ *
+ * <p>Phase 2 of the §8 migration path: story 300 gave the SDK the
+ * {@code PluginEditorFactory} contract; this control is how the host
+ * honours it. The frame renders, for <em>every</em> editor mode
+ * (declarative / panel / canvas):</p>
+ *
+ * <ul>
+ *   <li>the <strong>breadcrumb header</strong> (§6.1) — vendor mark ▸ plugin
+ *       name ▸ insert location, plus the four host actions
+ *       {@code [Bypass] [A|B] [↗] [×]} on a single line that never wraps;</li>
+ *   <li>the <strong>A/B compare bar</strong> (§6.5), revealed by the header
+ *       {@code [A|B]} toggle and backed by the existing
+ *       {@link ABComparison} machinery (this control carries display state
+ *       only — see {@link #abActiveSlotProperty()});</li>
+ *   <li>the <strong>fault banner</strong> (§6.6) — inline above the body,
+ *       never modal, shown whenever {@link #faultMessageProperty()} is
+ *       non-blank;</li>
+ *   <li>the clipped <strong>body host</strong> (§6.3) — the mode-specific
+ *       editor node installed via {@link #bodyProperty()}; the host enforces
+ *       {@link ResizePolicy} (see {@link #applyResizePolicy}), the plugin
+ *       cannot resize itself or paint outside its bounds;</li>
+ *   <li>the <strong>footer</strong> (§6.4) — preset selector + Save /
+ *       Save As, and always-present IN/OUT meters fed from
+ *       {@link #metersProperty()}.</li>
+ * </ul>
+ *
+ * <p>Design principle §2.2 — <em>"the plugin is a guest, not a
+ * tenant"</em> — is structural: all chrome is host-rendered, the plugin can
+ * neither add nor remove header actions, and {@link ChromePolicy} only
+ * selects <em>how much</em> of the host chrome is shown
+ * ({@code STANDARD} full, {@code MINIMAL} title-bar-ish per §5.C,
+ * {@code IMMERSIVE} auto-retracting per §5.D).</p>
+ *
+ * <h2>Role-token forwarding (§2.5)</h2>
+ *
+ * <p>The six {@code -editor-frame-*} styleable colour properties mirror the
+ * component structure of the SDK {@link Theme} record. The application
+ * stylesheet forwards the resolved role tokens
+ * ({@code -surface-1}/{@code -text}/{@code -accent}/{@code -meter-*}) into
+ * them, and the host builds the {@link Theme} handed to canvas plugins from
+ * the <em>resolved</em> values ({@link #getEditorBackground()} et al.) —
+ * per the story technical note, colours are derived from resolved CSS,
+ * never a mirrored hex literal. The Java-side defaults are the component
+ * values of {@link Theme#neutral()}: the SDK's deliberately-neutral
+ * fallback palette, replaced by resolved CSS the moment the frame is
+ * styled — <strong>not</strong> a mirror of any shipped theme.</p>
+ *
+ * <p>Following the {@code controls}-package convention ({@code LevelMeter}
+ * story 267, {@code Knob} story 268, {@code StatusStripCell} story 295)
+ * this is the observable-state half of a Control/Skin split; the visuals
+ * and interaction live in {@link EditorFrameSkin}.</p>
+ *
+ * @see EditorFrameSkin
+ */
+public final class EditorFrame extends Control {
+
+    /** Stable style class — selectable as {@code .editor-frame} in CSS. */
+    public static final String STYLE_CLASS = "editor-frame";
+
+    // ── SDK neutral fallbacks (Theme.neutral()) ───────────────────────────
+    // Defaults for the styleable -editor-frame-* colour properties. These
+    // are the SDK's neutral greyscale fallback palette — NOT a mirror of
+    // any shipped DAW theme — and are replaced by resolved CSS the moment
+    // the frame is styled (story 301 technical note: "derive colours from
+    // resolved CSS, never mirror a hex literal").
+    private static final Theme NEUTRAL_THEME = Theme.neutral();
+    private static final Color FALLBACK_BACKGROUND = NEUTRAL_THEME.background();
+    private static final Color FALLBACK_FOREGROUND = NEUTRAL_THEME.foreground();
+    private static final Color FALLBACK_ACCENT = NEUTRAL_THEME.accent();
+    private static final Color FALLBACK_METER_SAFE = NEUTRAL_THEME.meterSafe();
+    private static final Color FALLBACK_METER_WARN = NEUTRAL_THEME.meterWarn();
+    private static final Color FALLBACK_METER_CLIP = NEUTRAL_THEME.meterClip();
+
+    // ── Identity (breadcrumb §6.1) ────────────────────────────────────────
+
+    private final StringProperty pluginName =
+            new SimpleStringProperty(this, "pluginName", "");
+    private final StringProperty vendor =
+            new SimpleStringProperty(this, "vendor", "");
+    private final StringProperty insertLocation =
+            new SimpleStringProperty(this, "insertLocation", "");
+
+    // ── Policy (host enforces; §6.3) ──────────────────────────────────────
+
+    private final ObjectProperty<ChromePolicy> chromePolicy =
+            new SimpleObjectProperty<>(this, "chromePolicy", ChromePolicy.STANDARD) {
+                @Override
+                public void set(ChromePolicy newValue) {
+                    super.set(Objects.requireNonNull(newValue, "chromePolicy"));
+                }
+            };
+    private final ObjectProperty<ResizePolicy> resizePolicy =
+            new SimpleObjectProperty<>(this, "resizePolicy", ResizePolicy.BOTH) {
+                @Override
+                public void set(ResizePolicy newValue) {
+                    super.set(Objects.requireNonNull(newValue, "resizePolicy"));
+                }
+            };
+    private final DoubleProperty preferredBodyWidth =
+            new SimpleDoubleProperty(this, "preferredBodyWidth", 360.0);
+    private final DoubleProperty preferredBodyHeight =
+            new SimpleDoubleProperty(this, "preferredBodyHeight", 240.0);
+
+    // ── State ─────────────────────────────────────────────────────────────
+
+    private final BooleanProperty bypassed =
+            new SimpleBooleanProperty(this, "bypassed", false);
+    private final BooleanProperty abBarVisible =
+            new SimpleBooleanProperty(this, "abBarVisible", false);
+    private final ObjectProperty<ABComparison.Slot> abActiveSlot =
+            new SimpleObjectProperty<>(this, "abActiveSlot", ABComparison.Slot.A) {
+                @Override
+                public void set(ABComparison.Slot newValue) {
+                    // Display-only slot indicator — a null is coerced to the
+                    // A default (StatusStripCell severity precedent) so the
+                    // skin never has to branch on a missing slot.
+                    super.set(newValue == null ? ABComparison.Slot.A : newValue);
+                }
+            };
+    private final ObjectProperty<PluginMeterSnapshot> meters =
+            new SimpleObjectProperty<>(this, "meters", PluginMeterSnapshot.SILENT) {
+                @Override
+                public void set(PluginMeterSnapshot newValue) {
+                    // Never null: a null write is coerced to SILENT so the
+                    // footer meters always have a coherent snapshot (§6.4
+                    // "I/O meters always present").
+                    super.set(newValue == null ? PluginMeterSnapshot.SILENT : newValue);
+                }
+            };
+    private final StringProperty faultMessage =
+            new SimpleStringProperty(this, "faultMessage", "");
+    private final ObjectProperty<Node> body =
+            new SimpleObjectProperty<>(this, "body", null);
+    private final ObservableList<String> presetItems =
+            FXCollections.observableArrayList();
+    private final StringProperty selectedPreset =
+            new SimpleStringProperty(this, "selectedPreset", null);
+
+    // ── Momentary action callbacks (all nullable) ─────────────────────────
+    // Plain fields per the codebase precedent (AudioEditorView,
+    // SessionStatusStrip, TaskProgressIndicator) — invoked by the skin's
+    // buttons / key handlers; a null callback is simply a no-op.
+
+    private Runnable onCloseRequested;
+    private Runnable onDetachRequested;
+    private Runnable onReloadRequested;
+    private Runnable onFaultDetailsRequested;
+    private Runnable onAbToggleRequested;
+    private Runnable onAbCopyRequested;
+    private Runnable onSavePresetRequested;
+    private Runnable onSaveAsPresetRequested;
+    private Consumer<String> onPresetSelected;
+
+    /**
+     * Creates an editor frame with defaults: {@link ChromePolicy#STANDARD},
+     * {@link ResizePolicy#BOTH}, preferred body 360 × 240, not bypassed,
+     * A/B bar hidden, slot {@code A} active, {@link PluginMeterSnapshot#SILENT}
+     * meters, no fault, no body.
+     */
+    public EditorFrame() {
+        getStyleClass().add(STYLE_CLASS);
+        setAccessibleRole(AccessibleRole.NODE);
+        setAccessibleRoleDescription("Plugin editor");
+        // Focus traversability makes the §6.1 keyboard contract (B bypass,
+        // Cmd+\ A/B, Cmd+D detach, Cmd+W close) reachable when the frame
+        // itself is focused, not only while a child control has focus
+        // (mirrors the Knob rationale — otherwise the keyboard contract
+        // is unobservable).
+        setFocusTraversable(true);
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new EditorFrameSkin(this);
+    }
+
+    // ── pluginName ────────────────────────────────────────────────────────
+
+    /** @return the plugin display-name property (breadcrumb §6.1, from {@code PluginDescriptor#name}). */
+    public final StringProperty pluginNameProperty() { return pluginName; }
+    /** @return the plugin display name. */
+    public final String getPluginName() { return pluginName.get(); }
+    /** @param v the plugin display name; a blank/null value omits the crumb. */
+    public final void setPluginName(String v) { pluginName.set(v); }
+
+    // ── vendor ────────────────────────────────────────────────────────────
+
+    /** @return the vendor-mark property (breadcrumb §6.1, from {@code PluginDescriptor#vendor}). */
+    public final StringProperty vendorProperty() { return vendor; }
+    /** @return the vendor mark. */
+    public final String getVendor() { return vendor.get(); }
+    /** @param v the vendor mark; a blank/null value omits the crumb. */
+    public final void setVendor(String v) { vendor.set(v); }
+
+    // ── insertLocation ────────────────────────────────────────────────────
+
+    /**
+     * @return the insert-location property (breadcrumb §6.1 — e.g.
+     *         {@code "Drum Bus / Insert 2"}). A {@code null} or blank value
+     *         omits the crumb entirely.
+     */
+    public final StringProperty insertLocationProperty() { return insertLocation; }
+    /** @return the insert location, possibly {@code null}/blank (crumb omitted). */
+    public final String getInsertLocation() { return insertLocation.get(); }
+    /** @param v the insert location; {@code null}/blank omits the crumb. */
+    public final void setInsertLocation(String v) { insertLocation.set(v); }
+
+    // ── chromePolicy ──────────────────────────────────────────────────────
+
+    /**
+     * @return the chrome-policy property (default
+     *         {@link ChromePolicy#STANDARD}). The host owns the chrome in
+     *         every mode (§2.2); the policy only selects how much is shown:
+     *         {@code STANDARD} = full chrome, {@code MINIMAL} = header +
+     *         fault banner only (§5.C), {@code IMMERSIVE} = chrome retracts
+     *         after 2 s of pointer inactivity (§5.D). Writes of {@code null}
+     *         are rejected with a {@link NullPointerException}.
+     */
+    public final ObjectProperty<ChromePolicy> chromePolicyProperty() { return chromePolicy; }
+    /** @return the current chrome policy (never {@code null}). */
+    public final ChromePolicy getChromePolicy() { return chromePolicy.get(); }
+    /** @param v the chrome policy; must not be {@code null}. */
+    public final void setChromePolicy(ChromePolicy v) {
+        chromePolicy.set(Objects.requireNonNull(v, "chromePolicy"));
+    }
+
+    // ── resizePolicy ──────────────────────────────────────────────────────
+
+    /**
+     * @return the resize-policy property (default {@link ResizePolicy#BOTH}).
+     *         Enforced by the host via {@link #applyResizePolicy} — the
+     *         plugin cannot resize itself (§6.3). Writes of {@code null} are
+     *         rejected with a {@link NullPointerException}.
+     */
+    public final ObjectProperty<ResizePolicy> resizePolicyProperty() { return resizePolicy; }
+    /** @return the current resize policy (never {@code null}). */
+    public final ResizePolicy getResizePolicy() { return resizePolicy.get(); }
+    /** @param v the resize policy; must not be {@code null}. */
+    public final void setResizePolicy(ResizePolicy v) {
+        resizePolicy.set(Objects.requireNonNull(v, "resizePolicy"));
+    }
+
+    // ── preferredBodyWidth / preferredBodyHeight ──────────────────────────
+
+    /** @return the preferred body width property in px (default 360) — the plugin's declared editor width. */
+    public final DoubleProperty preferredBodyWidthProperty() { return preferredBodyWidth; }
+    /** @return the preferred body width (px). */
+    public final double getPreferredBodyWidth() { return preferredBodyWidth.get(); }
+    /** @param v the preferred body width (px). */
+    public final void setPreferredBodyWidth(double v) { preferredBodyWidth.set(v); }
+
+    /** @return the preferred body height property in px (default 240) — the plugin's declared editor height. */
+    public final DoubleProperty preferredBodyHeightProperty() { return preferredBodyHeight; }
+    /** @return the preferred body height (px). */
+    public final double getPreferredBodyHeight() { return preferredBodyHeight.get(); }
+    /** @param v the preferred body height (px). */
+    public final void setPreferredBodyHeight(double v) { preferredBodyHeight.set(v); }
+
+    // ── bypassed ──────────────────────────────────────────────────────────
+
+    /**
+     * @return the bypass-state property (§6.1 — a state toggle, also wired
+     *         to the mixer slot by the hosting controller). The skin's
+     *         {@code [Bypass]} header toggle and the {@code B} key both
+     *         write it.
+     */
+    public final BooleanProperty bypassedProperty() { return bypassed; }
+    /** @return whether the plugin is bypassed. */
+    public final boolean isBypassed() { return bypassed.get(); }
+    /** @param v whether the plugin is bypassed. */
+    public final void setBypassed(boolean v) { bypassed.set(v); }
+
+    // ── abBarVisible ──────────────────────────────────────────────────────
+
+    /**
+     * @return whether the §6.5 A/B compare bar is revealed (default
+     *         {@code false}). Toggled by the header {@code [A|B]} button.
+     *         Under {@link ChromePolicy#MINIMAL} the bar stays hidden
+     *         regardless of this flag; under {@link ChromePolicy#IMMERSIVE}
+     *         it retracts with the rest of the chrome.
+     */
+    public final BooleanProperty abBarVisibleProperty() { return abBarVisible; }
+    /** @return whether the A/B compare bar is revealed. */
+    public final boolean isAbBarVisible() { return abBarVisible.get(); }
+    /** @param v whether the A/B compare bar is revealed. */
+    public final void setAbBarVisible(boolean v) { abBarVisible.set(v); }
+
+    // ── abActiveSlot ──────────────────────────────────────────────────────
+
+    /**
+     * @return the display-only active A/B slot property (default
+     *         {@link ABComparison.Slot#A}). The hosting controller mirrors
+     *         the real {@link ABComparison#getActiveSlot()} into this;
+     *         swapping slots is requested via
+     *         {@link #setOnAbToggleRequested(Runnable)}, never by writing
+     *         this property from the skin. A {@code null} write is coerced
+     *         to {@code A}.
+     */
+    public final ObjectProperty<ABComparison.Slot> abActiveSlotProperty() { return abActiveSlot; }
+    /** @return the active A/B slot (never {@code null}). */
+    public final ABComparison.Slot getAbActiveSlot() { return abActiveSlot.get(); }
+    /** @param v the active A/B slot; {@code null} is coerced to {@link ABComparison.Slot#A}. */
+    public final void setAbActiveSlot(ABComparison.Slot v) { abActiveSlot.set(v); }
+
+    // ── meters ────────────────────────────────────────────────────────────
+
+    /**
+     * @return the footer I/O meter snapshot property (§6.4 — "I/O meters
+     *         always present"), default {@link PluginMeterSnapshot#SILENT},
+     *         never {@code null} (a {@code null} write is coerced to
+     *         {@code SILENT}). The hosting controller taps the parameter
+     *         store's audio-side snapshot and mirrors it here on the FX
+     *         thread; {@link Double#NEGATIVE_INFINITY} levels render as an
+     *         empty meter, not a clip.
+     */
+    public final ObjectProperty<PluginMeterSnapshot> metersProperty() { return meters; }
+    /** @return the current meter snapshot (never {@code null}). */
+    public final PluginMeterSnapshot getMeters() { return meters.get(); }
+    /** @param v the meter snapshot; {@code null} is coerced to {@link PluginMeterSnapshot#SILENT}. */
+    public final void setMeters(PluginMeterSnapshot v) { meters.set(v); }
+
+    // ── faultMessage ──────────────────────────────────────────────────────
+
+    /**
+     * @return the fault-banner message property (§6.6). A {@code null} or
+     *         blank value hides the banner; any other text shows the inline
+     *         (never modal) banner above the body with its {@code [Reload]}
+     *         and {@code [ⓘ]} actions.
+     */
+    public final StringProperty faultMessageProperty() { return faultMessage; }
+    /** @return the fault message, possibly {@code null}/blank (banner hidden). */
+    public final String getFaultMessage() { return faultMessage.get(); }
+    /** @param v the fault message; {@code null}/blank hides the banner. */
+    public final void setFaultMessage(String v) { faultMessage.set(v); }
+
+    // ── body ──────────────────────────────────────────────────────────────
+
+    /**
+     * @return the mode-specific editor body the session installs — the
+     *         host-generated parameter grid (declarative), the plugin's
+     *         {@link Region} (panel), or the host-owned canvas region
+     *         (canvas). May be {@code null} (empty body host). The skin
+     *         clips the body to its bounds (§6.3 — a misbehaving plugin
+     *         cannot paint over the breadcrumb or footer) and, when the
+     *         node is a {@link Region}, applies {@link #applyResizePolicy}.
+     */
+    public final ObjectProperty<Node> bodyProperty() { return body; }
+    /** @return the current editor body node, or {@code null}. */
+    public final Node getBody() { return body.get(); }
+    /** @param v the editor body node, or {@code null} to empty the body host. */
+    public final void setBody(Node v) { body.set(v); }
+
+    // ── presets ───────────────────────────────────────────────────────────
+
+    /**
+     * @return the live observable preset-name list backing the footer's
+     *         preset selector (§6.4). The hosting controller populates it
+     *         from the {@code PluginParameterStore} snapshots; mutations
+     *         are reflected by the skin's {@code ComboBox} directly.
+     */
+    public final ObservableList<String> getPresetItems() { return presetItems; }
+
+    /**
+     * @return the selected preset-name property, kept in two-way sync with
+     *         the footer selector by the skin (listener + setter guard —
+     *         never {@code bind()}). May be {@code null} (no selection).
+     */
+    public final StringProperty selectedPresetProperty() { return selectedPreset; }
+    /** @return the selected preset name, or {@code null}. */
+    public final String getSelectedPreset() { return selectedPreset.get(); }
+    /** @param v the selected preset name, or {@code null} to clear. */
+    public final void setSelectedPreset(String v) { selectedPreset.set(v); }
+
+    // ── Momentary action callbacks ────────────────────────────────────────
+
+    /** @param v callback for the {@code [×]} close action / {@code Cmd+W} (§6.1 — focus only, does not unload); nullable. */
+    public final void setOnCloseRequested(Runnable v) { onCloseRequested = v; }
+    /** @return the close-requested callback, or {@code null}. */
+    public final Runnable getOnCloseRequested() { return onCloseRequested; }
+
+    /** @param v callback for the {@code [↗]} detach action / {@code Cmd+D} (§6.1 — fires the plugin-detach intent); nullable. */
+    public final void setOnDetachRequested(Runnable v) { onDetachRequested = v; }
+    /** @return the detach-requested callback, or {@code null}. */
+    public final Runnable getOnDetachRequested() { return onDetachRequested; }
+
+    /** @param v callback for the fault banner's {@code [Reload]} action (§6.6 — re-invokes {@code editorFactory()}); nullable. */
+    public final void setOnReloadRequested(Runnable v) { onReloadRequested = v; }
+    /** @return the reload-requested callback, or {@code null}. */
+    public final Runnable getOnReloadRequested() { return onReloadRequested; }
+
+    /** @param v callback for the fault banner's {@code [ⓘ]} action (§6.6 — opens {@code PluginFaultLogDialog}); nullable. */
+    public final void setOnFaultDetailsRequested(Runnable v) { onFaultDetailsRequested = v; }
+    /** @return the fault-details callback, or {@code null}. */
+    public final Runnable getOnFaultDetailsRequested() { return onFaultDetailsRequested; }
+
+    /** @param v callback for an A/B slot swap request (§6.5 {@code [Swap]} / {@code Cmd+\}); nullable. */
+    public final void setOnAbToggleRequested(Runnable v) { onAbToggleRequested = v; }
+    /** @return the A/B-toggle callback, or {@code null}. */
+    public final Runnable getOnAbToggleRequested() { return onAbToggleRequested; }
+
+    /** @param v callback for the §6.5 {@code [Copy A▸B]} action (copy active slot to inactive); nullable. */
+    public final void setOnAbCopyRequested(Runnable v) { onAbCopyRequested = v; }
+    /** @return the A/B-copy callback, or {@code null}. */
+    public final Runnable getOnAbCopyRequested() { return onAbCopyRequested; }
+
+    /** @param v callback for the footer {@code [Save…]} preset action (§6.4); nullable. */
+    public final void setOnSavePresetRequested(Runnable v) { onSavePresetRequested = v; }
+    /** @return the save-preset callback, or {@code null}. */
+    public final Runnable getOnSavePresetRequested() { return onSavePresetRequested; }
+
+    /** @param v callback for the footer {@code [Save As…]} preset action (§6.4); nullable. */
+    public final void setOnSaveAsPresetRequested(Runnable v) { onSaveAsPresetRequested = v; }
+    /** @return the save-as-preset callback, or {@code null}. */
+    public final Runnable getOnSaveAsPresetRequested() { return onSaveAsPresetRequested; }
+
+    /**
+     * @param v callback invoked with the preset name when the user picks
+     *          one in the footer selector (§6.4). Not invoked for
+     *          programmatic {@link #setSelectedPreset(String)} writes;
+     *          nullable.
+     */
+    public final void setOnPresetSelected(Consumer<String> v) { onPresetSelected = v; }
+    /** @return the preset-selected callback, or {@code null}. */
+    public final Consumer<String> getOnPresetSelected() { return onPresetSelected; }
+
+    // ── Resize-policy enforcement (§6.3) ──────────────────────────────────
+
+    /**
+     * Applies a {@link ResizePolicy} to a plugin body {@link Region} by
+     * pinning / freeing its min / pref / max constraints. This is the pure,
+     * statically-testable seam behind §6.3 — <em>"the plugin region honours
+     * {@code EditorHints.resize()}; host enforces, plugin cannot resize
+     * itself"</em> ({@code EditorHintsResizePolicyTest} asserts on it).
+     *
+     * <p>Per-policy mapping:</p>
+     * <ul>
+     *   <li>{@link ResizePolicy#FIXED} — both axes pinned:
+     *       {@code min = pref = max = (prefW, prefH)}. The host shows no
+     *       resize grip.</li>
+     *   <li>{@link ResizePolicy#HORIZONTAL} — height pinned
+     *       ({@code min = pref = max height = prefH}), width free
+     *       ({@code minWidth = USE_COMPUTED_SIZE}, {@code prefWidth = prefW},
+     *       {@code maxWidth = Double.MAX_VALUE}).</li>
+     *   <li>{@link ResizePolicy#VERTICAL} — mirror image: width pinned
+     *       ({@code min = pref = max width = prefW}), height free
+     *       ({@code minHeight = USE_COMPUTED_SIZE}, {@code prefHeight = prefH},
+     *       {@code maxHeight = Double.MAX_VALUE}).</li>
+     *   <li>{@link ResizePolicy#BOTH} — freely resizable:
+     *       {@code pref = (prefW, prefH)}, {@code max = Double.MAX_VALUE} on
+     *       both axes, min left computed ({@code USE_COMPUTED_SIZE}).</li>
+     * </ul>
+     *
+     * @param body   the plugin body region to constrain; must not be {@code null}
+     * @param policy the resize policy to enforce; must not be {@code null}
+     * @param prefW  the plugin's preferred body width (px)
+     * @param prefH  the plugin's preferred body height (px)
+     */
+    public static void applyResizePolicy(Region body, ResizePolicy policy,
+            double prefW, double prefH) {
+        Objects.requireNonNull(body, "body");
+        Objects.requireNonNull(policy, "policy");
+        switch (policy) {
+            case FIXED -> {
+                body.setMinSize(prefW, prefH);
+                body.setPrefSize(prefW, prefH);
+                body.setMaxSize(prefW, prefH);
+            }
+            case HORIZONTAL -> {
+                body.setMinWidth(Region.USE_COMPUTED_SIZE);
+                body.setPrefWidth(prefW);
+                body.setMaxWidth(Double.MAX_VALUE);
+                body.setMinHeight(prefH);
+                body.setPrefHeight(prefH);
+                body.setMaxHeight(prefH);
+            }
+            case VERTICAL -> {
+                body.setMinWidth(prefW);
+                body.setPrefWidth(prefW);
+                body.setMaxWidth(prefW);
+                body.setMinHeight(Region.USE_COMPUTED_SIZE);
+                body.setPrefHeight(prefH);
+                body.setMaxHeight(Double.MAX_VALUE);
+            }
+            case BOTH -> {
+                body.setMinWidth(Region.USE_COMPUTED_SIZE);
+                body.setMinHeight(Region.USE_COMPUTED_SIZE);
+                body.setPrefSize(prefW, prefH);
+                body.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
+            }
+        }
+    }
+
+    // ── Styleable role-token colour properties (§2.5) ─────────────────────
+    // Six StyleableObjectProperty<Color> mirroring the SDK Theme record's
+    // components. styles.css forwards -surface-1/-text/-accent/-meter-* into
+    // these; the host reads the RESOLVED values to build the Theme handed to
+    // canvas plugins (never a hex mirror). Pattern copied from Knob.
+
+    private final StyleableObjectProperty<Color> editorBackground =
+            new StyleableObjectProperty<>(FALLBACK_BACKGROUND) {
+                @Override public Object getBean() { return EditorFrame.this; }
+                @Override public String getName() { return "editorBackground"; }
+                @Override public CssMetaData<EditorFrame, Color> getCssMetaData() {
+                    return StyleableProperties.BACKGROUND;
+                }
+            };
+    private final StyleableObjectProperty<Color> editorForeground =
+            new StyleableObjectProperty<>(FALLBACK_FOREGROUND) {
+                @Override public Object getBean() { return EditorFrame.this; }
+                @Override public String getName() { return "editorForeground"; }
+                @Override public CssMetaData<EditorFrame, Color> getCssMetaData() {
+                    return StyleableProperties.FOREGROUND;
+                }
+            };
+    private final StyleableObjectProperty<Color> editorAccent =
+            new StyleableObjectProperty<>(FALLBACK_ACCENT) {
+                @Override public Object getBean() { return EditorFrame.this; }
+                @Override public String getName() { return "editorAccent"; }
+                @Override public CssMetaData<EditorFrame, Color> getCssMetaData() {
+                    return StyleableProperties.ACCENT;
+                }
+            };
+    private final StyleableObjectProperty<Color> editorMeterSafe =
+            new StyleableObjectProperty<>(FALLBACK_METER_SAFE) {
+                @Override public Object getBean() { return EditorFrame.this; }
+                @Override public String getName() { return "editorMeterSafe"; }
+                @Override public CssMetaData<EditorFrame, Color> getCssMetaData() {
+                    return StyleableProperties.METER_SAFE;
+                }
+            };
+    private final StyleableObjectProperty<Color> editorMeterWarn =
+            new StyleableObjectProperty<>(FALLBACK_METER_WARN) {
+                @Override public Object getBean() { return EditorFrame.this; }
+                @Override public String getName() { return "editorMeterWarn"; }
+                @Override public CssMetaData<EditorFrame, Color> getCssMetaData() {
+                    return StyleableProperties.METER_WARN;
+                }
+            };
+    private final StyleableObjectProperty<Color> editorMeterClip =
+            new StyleableObjectProperty<>(FALLBACK_METER_CLIP) {
+                @Override public Object getBean() { return EditorFrame.this; }
+                @Override public String getName() { return "editorMeterClip"; }
+                @Override public CssMetaData<EditorFrame, Color> getCssMetaData() {
+                    return StyleableProperties.METER_CLIP;
+                }
+            };
+
+    /** @return the {@code -editor-frame-background} styleable colour property. */
+    public final ObjectProperty<Color> editorBackgroundProperty() { return editorBackground; }
+    /** @return the resolved editor background colour ({@link Theme#background()} role). */
+    public final Color getEditorBackground() { return editorBackground.get(); }
+    /** @param v the editor background colour. */
+    public final void setEditorBackground(Color v) { editorBackground.set(v); }
+
+    /** @return the {@code -editor-frame-foreground} styleable colour property. */
+    public final ObjectProperty<Color> editorForegroundProperty() { return editorForeground; }
+    /** @return the resolved editor foreground colour ({@link Theme#foreground()} role). */
+    public final Color getEditorForeground() { return editorForeground.get(); }
+    /** @param v the editor foreground colour. */
+    public final void setEditorForeground(Color v) { editorForeground.set(v); }
+
+    /** @return the {@code -editor-frame-accent} styleable colour property. */
+    public final ObjectProperty<Color> editorAccentProperty() { return editorAccent; }
+    /** @return the resolved editor accent colour ({@link Theme#accent()} role). */
+    public final Color getEditorAccent() { return editorAccent.get(); }
+    /** @param v the editor accent colour. */
+    public final void setEditorAccent(Color v) { editorAccent.set(v); }
+
+    /** @return the {@code -editor-frame-meter-safe} styleable colour property. */
+    public final ObjectProperty<Color> editorMeterSafeProperty() { return editorMeterSafe; }
+    /** @return the resolved nominal-band meter colour ({@link Theme#meterSafe()} role). */
+    public final Color getEditorMeterSafe() { return editorMeterSafe.get(); }
+    /** @param v the nominal-band meter colour. */
+    public final void setEditorMeterSafe(Color v) { editorMeterSafe.set(v); }
+
+    /** @return the {@code -editor-frame-meter-warn} styleable colour property. */
+    public final ObjectProperty<Color> editorMeterWarnProperty() { return editorMeterWarn; }
+    /** @return the resolved warning-band meter colour ({@link Theme#meterWarn()} role). */
+    public final Color getEditorMeterWarn() { return editorMeterWarn.get(); }
+    /** @param v the warning-band meter colour. */
+    public final void setEditorMeterWarn(Color v) { editorMeterWarn.set(v); }
+
+    /** @return the {@code -editor-frame-meter-clip} styleable colour property. */
+    public final ObjectProperty<Color> editorMeterClipProperty() { return editorMeterClip; }
+    /** @return the resolved clip-band meter colour ({@link Theme#meterClip()} role). */
+    public final Color getEditorMeterClip() { return editorMeterClip.get(); }
+    /** @param v the clip-band meter colour. */
+    public final void setEditorMeterClip(Color v) { editorMeterClip.set(v); }
+
+    // ── CssMetaData ───────────────────────────────────────────────────────
+
+    private static final class StyleableProperties {
+
+        static final CssMetaData<EditorFrame, Color> BACKGROUND =
+                new CssMetaData<>("-editor-frame-background",
+                        StyleConverter.getColorConverter(), FALLBACK_BACKGROUND) {
+                    @Override public boolean isSettable(EditorFrame f) {
+                        return !f.editorBackground.isBound();
+                    }
+                    @Override public StyleableProperty<Color> getStyleableProperty(EditorFrame f) {
+                        return f.editorBackground;
+                    }
+                };
+        static final CssMetaData<EditorFrame, Color> FOREGROUND =
+                new CssMetaData<>("-editor-frame-foreground",
+                        StyleConverter.getColorConverter(), FALLBACK_FOREGROUND) {
+                    @Override public boolean isSettable(EditorFrame f) {
+                        return !f.editorForeground.isBound();
+                    }
+                    @Override public StyleableProperty<Color> getStyleableProperty(EditorFrame f) {
+                        return f.editorForeground;
+                    }
+                };
+        static final CssMetaData<EditorFrame, Color> ACCENT =
+                new CssMetaData<>("-editor-frame-accent",
+                        StyleConverter.getColorConverter(), FALLBACK_ACCENT) {
+                    @Override public boolean isSettable(EditorFrame f) {
+                        return !f.editorAccent.isBound();
+                    }
+                    @Override public StyleableProperty<Color> getStyleableProperty(EditorFrame f) {
+                        return f.editorAccent;
+                    }
+                };
+        static final CssMetaData<EditorFrame, Color> METER_SAFE =
+                new CssMetaData<>("-editor-frame-meter-safe",
+                        StyleConverter.getColorConverter(), FALLBACK_METER_SAFE) {
+                    @Override public boolean isSettable(EditorFrame f) {
+                        return !f.editorMeterSafe.isBound();
+                    }
+                    @Override public StyleableProperty<Color> getStyleableProperty(EditorFrame f) {
+                        return f.editorMeterSafe;
+                    }
+                };
+        static final CssMetaData<EditorFrame, Color> METER_WARN =
+                new CssMetaData<>("-editor-frame-meter-warn",
+                        StyleConverter.getColorConverter(), FALLBACK_METER_WARN) {
+                    @Override public boolean isSettable(EditorFrame f) {
+                        return !f.editorMeterWarn.isBound();
+                    }
+                    @Override public StyleableProperty<Color> getStyleableProperty(EditorFrame f) {
+                        return f.editorMeterWarn;
+                    }
+                };
+        static final CssMetaData<EditorFrame, Color> METER_CLIP =
+                new CssMetaData<>("-editor-frame-meter-clip",
+                        StyleConverter.getColorConverter(), FALLBACK_METER_CLIP) {
+                    @Override public boolean isSettable(EditorFrame f) {
+                        return !f.editorMeterClip.isBound();
+                    }
+                    @Override public StyleableProperty<Color> getStyleableProperty(EditorFrame f) {
+                        return f.editorMeterClip;
+                    }
+                };
+
+        static final List<CssMetaData<? extends Styleable, ?>> CSS_META_DATA;
+
+        static {
+            List<CssMetaData<? extends Styleable, ?>> list =
+                    new ArrayList<>(Control.getClassCssMetaData());
+            Collections.addAll(list,
+                    BACKGROUND, FOREGROUND, ACCENT,
+                    METER_SAFE, METER_WARN, METER_CLIP);
+            CSS_META_DATA = Collections.unmodifiableList(list);
+        }
+
+        private StyleableProperties() {
+        }
+    }
+
+    /**
+     * @return the {@link CssMetaData} for this control type, combined with
+     *         {@link Control}'s.
+     */
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return StyleableProperties.CSS_META_DATA;
+    }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getControlCssMetaData() {
+        return getClassCssMetaData();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/EditorFrameSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/EditorFrameSkin.java
@@ -1,0 +1,954 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.controls.BreadcrumbBar;
+import com.benesquivelmusic.daw.app.ui.controls.LevelMeter;
+import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
+import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.core.plugin.parameter.ABComparison;
+import com.benesquivelmusic.daw.sdk.editor.ChromePolicy;
+import com.benesquivelmusic.daw.sdk.editor.ResizePolicy;
+import com.benesquivelmusic.daw.sdk.plugin.PluginMeterSnapshot;
+
+import javafx.animation.FadeTransition;
+import javafx.animation.Interpolator;
+import javafx.animation.PauseTransition;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
+import javafx.event.EventHandler;
+import javafx.geometry.Orientation;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.Tooltip;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.shape.Rectangle;
+import javafx.util.Duration;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * Skin for {@link EditorFrame} — renders the story-301 host chrome
+ * (Plugin View Design Book §5.A / §5.D, §6.1–§6.6) and wires the §6.1
+ * keyboard / pointer interaction contract.
+ *
+ * <h2>Structure (top to bottom, a single {@link VBox})</h2>
+ *
+ * <ol>
+ *   <li><strong>Header</strong> {@code .editor-frame-header} (§6.1) — a
+ *       {@link BreadcrumbBar} deriving its segments from vendor / plugin
+ *       name / insert location (blank segments skipped), a growing spacer,
+ *       then the four host actions in order: bypass toggle, A/B toggle,
+ *       detach, close. Single line, never wraps; the plugin cannot add to
+ *       or remove from this row.</li>
+ *   <li><strong>A/B compare bar</strong> {@code .editor-ab-bar} (§6.5) —
+ *       revealed by the header {@code [A|B]} toggle; slot indicator labels
+ *       (the active one carries {@code .editor-ab-active}) plus
+ *       {@code [Copy A▸B]} and {@code [Swap]}.</li>
+ *   <li><strong>Fault banner</strong> {@code .editor-fault-banner} (§6.6) —
+ *       shown while {@link EditorFrame#faultMessageProperty()} is
+ *       non-blank; inline above the body, never modal, and <em>never</em>
+ *       auto-hidden by the immersive chrome retraction.</li>
+ *   <li><strong>Body host</strong> {@code .editor-frame-body} (§6.3) — a
+ *       {@link StackPane} holding {@link EditorFrame#bodyProperty()},
+ *       clipped to its own bounds so a misbehaving plugin cannot paint
+ *       over the breadcrumb or footer. When the body is a {@link Region}
+ *       the host enforces {@link EditorFrame#applyResizePolicy}.</li>
+ *   <li><strong>Footer</strong> {@code .editor-frame-footer} (§6.4) —
+ *       preset selector + Save / Save As, then IN / OUT
+ *       {@link LevelMeter}s fed from {@link EditorFrame#metersProperty()}
+ *       ({@link Double#NEGATIVE_INFINITY} renders empty — it normalises
+ *       below the meter's −60 dB floor, never as a clip).</li>
+ * </ol>
+ *
+ * <h2>Chrome policy (§5.C / §5.D)</h2>
+ *
+ * <p>{@code STANDARD}: header + footer visible, A/B bar per
+ * {@code abBarVisible}, banner per fault. {@code MINIMAL}: footer and A/B
+ * bar hidden — the frame collapses toward a title bar; header and fault
+ * banner remain. {@code IMMERSIVE}: all chrome starts visible; after 2 s
+ * of pointer inactivity over the frame the header / footer / A/B bar
+ * retract (the fault banner never auto-hides — a fault must stay
+ * visible), and any {@code MOUSE_MOVED} / mouse-enter over the frame or a
+ * focus gain reveals them again. Retraction / reveal fades opacity over
+ * 180 ms ({@link Interpolator#EASE_BOTH}) and then flips
+ * {@code visible}/{@code managed} so the body reclaims the pixels.</p>
+ *
+ * <p>The fade is motion-gated per story 279: the skin captures
+ * {@link MotionManager#getDefault()} once in a final field and, when
+ * Reduce Motion is on, snaps {@code visible}/{@code managed} with no fade
+ * — Reduce Motion removes the <em>motion</em>, not the behaviour. The
+ * global flag is observed through a strong listener field wrapped in a
+ * {@link WeakChangeListener} so the process-lifetime singleton never pins
+ * this skin (the {@code KnobSkin}/story-277 sanctioned pattern).</p>
+ *
+ * <h2>Keyboard map (§6.1)</h2>
+ *
+ * <p>Registered on the control, ignoring events targeted at text-input
+ * controls: {@code B} toggles bypass, {@code Shortcut+\} requests an A/B
+ * swap, {@code Shortcut+D} requests detach, {@code Shortcut+W} requests
+ * close. Handled events are consumed.</p>
+ *
+ * <h2>Two-way syncs</h2>
+ *
+ * <p>The bypass toggle ↔ {@code bypassedProperty}, A/B toggle ↔
+ * {@code abBarVisibleProperty} and preset combo ↔
+ * {@code selectedPresetProperty} pairs are synced via listener + setter
+ * with a reentrancy guard — never {@code bind()}, because a two-way
+ * control's own property must stay writable from both sides
+ * ({@code feedback_bind_two_way_control_property}).</p>
+ */
+public final class EditorFrameSkin extends SkinBase<EditorFrame> {
+
+    /** Chrome retract / reveal fade duration (§5.D, 180 ms motion budget). */
+    private static final Duration CHROME_FADE = Duration.millis(180);
+    /** §5.D pointer-inactivity period before the immersive chrome retracts. */
+    private static final Duration IMMERSIVE_INACTIVITY = Duration.seconds(2);
+    /** Header / fault-banner icon size (px). */
+    private static final int ICON_SIZE = 16;
+
+    /** Chrome strings (Skill §14) — {@code Locale.ROOT}, BrowserPanel idiom. */
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
+
+    // ── Nodes ─────────────────────────────────────────────────────────────
+
+    private final VBox root;
+    private final HBox header;
+    private final BreadcrumbBar breadcrumb;
+    private final ToggleButton bypassButton;
+    private final ToggleButton abButton;
+    private final Button detachButton;
+    private final Button closeButton;
+    private final HBox abBar;
+    private final Label slotALabel;
+    private final Label slotBLabel;
+    private final HBox faultBanner;
+    private final Label faultMessageLabel;
+    private final StackPane bodyHost;
+    private final Rectangle bodyClip;
+    private final HBox footer;
+    private final ComboBox<String> presetCombo;
+    private final LevelMeter inMeter;
+    private final LevelMeter outMeter;
+
+    // ── Motion (story 279) ────────────────────────────────────────────────
+    // Captured ONCE at construction so the weak registration and every
+    // later isAnimationAllowed() read the SAME MotionManager — a
+    // getDefault() swap mid-life (setDefaultForTest) cannot make them
+    // diverge (feedback_capture_swappable_singleton_reference).
+    private final MotionManager motionManager = MotionManager.getDefault();
+    // Strong field — lives exactly as long as this skin; registered via a
+    // WeakChangeListener so the singleton never pins the skin.
+    private final ChangeListener<Boolean> reduceMotionListener;
+    private final WeakChangeListener<Boolean> weakReduceMotionListener;
+
+    private final PauseTransition inactivityTimer;
+    /** Per-node running chrome fade — stopped before any new state apply. */
+    private final Map<Node, FadeTransition> runningFades = new HashMap<>();
+
+    // ── Listeners on control properties (removed in dispose()) ───────────
+
+    private final ChangeListener<String> breadcrumbListener;
+    private final ChangeListener<Boolean> bypassedListener;
+    private final ChangeListener<Boolean> abBarVisibleListener;
+    private final ChangeListener<ABComparison.Slot> abSlotListener;
+    private final ChangeListener<ChromePolicy> chromePolicyListener;
+    private final ChangeListener<ResizePolicy> resizePolicyListener;
+    private final ChangeListener<Number> bodySizeListener;
+    private final ChangeListener<PluginMeterSnapshot> metersListener;
+    private final ChangeListener<String> faultListener;
+    private final ChangeListener<Node> bodyListener;
+    private final ChangeListener<String> selectedPresetListener;
+    private final ChangeListener<Boolean> focusListener;
+    private final EventHandler<KeyEvent> keyHandler;
+    private final EventHandler<MouseEvent> pointerActivityFilter;
+
+    // ── Listeners on skin-owned nodes (detached in dispose()) ────────────
+
+    private final ChangeListener<Boolean> bypassButtonListener;
+    private final ChangeListener<Boolean> abButtonListener;
+    private final ChangeListener<String> presetComboListener;
+
+    // ── Reentrancy guards (never bind() a two-way control property) ──────
+
+    private boolean syncingBypass;
+    private boolean syncingAbBar;
+    private boolean syncingPreset;
+
+    /** {@code true} while the §5.D immersive chrome is retracted. */
+    private boolean chromeRetracted;
+    private boolean disposed;
+
+    /**
+     * Builds the full §6 chrome around the given frame and applies the
+     * current control state (breadcrumb, toggles, fault banner, body,
+     * meters, chrome-policy visibility).
+     *
+     * @param control the {@link EditorFrame} this skin renders
+     */
+    public EditorFrameSkin(EditorFrame control) {
+        super(control);
+
+        // ── 1. Header (§6.1) ─────────────────────────────────────────────
+        breadcrumb = new BreadcrumbBar();
+        breadcrumb.getStyleClass().add("editor-frame-breadcrumb");
+
+        Region headerSpacer = new Region();
+        HBox.setHgrow(headerSpacer, Priority.ALWAYS);
+
+        bypassButton = new ToggleButton();
+        bypassButton.setGraphic(IconNode.of(DawIcon.POWER, ICON_SIZE));
+        bypassButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-frame-bypass");
+        bypassButton.setTooltip(new Tooltip(msg("editor.frame.bypass.tooltip")));
+        bypassButton.setAccessibleText(msg("editor.frame.bypass.accessible"));
+
+        abButton = new ToggleButton();
+        abButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-frame-ab");
+        abButton.setTooltip(new Tooltip(msg("editor.frame.ab.tooltip")));
+
+        detachButton = new Button();
+        detachButton.setGraphic(IconNode.of(DawIcon.EXPAND, ICON_SIZE));
+        detachButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-frame-detach");
+        detachButton.setTooltip(new Tooltip(msg("editor.frame.detach.tooltip")));
+        detachButton.setAccessibleText(msg("editor.frame.detach.accessible"));
+        detachButton.setOnAction(e -> {
+            runCallback(getSkinnable().getOnDetachRequested());
+            e.consume();
+        });
+
+        closeButton = new Button();
+        closeButton.setGraphic(IconNode.of(DawIcon.CLOSE, ICON_SIZE));
+        closeButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-frame-close");
+        closeButton.setTooltip(new Tooltip(msg("editor.frame.close.tooltip")));
+        closeButton.setAccessibleText(msg("editor.frame.close.accessible"));
+        closeButton.setOnAction(e -> {
+            runCallback(getSkinnable().getOnCloseRequested());
+            e.consume();
+        });
+
+        header = new HBox(breadcrumb, headerSpacer,
+                bypassButton, abButton, detachButton, closeButton);
+        header.getStyleClass().add("editor-frame-header");
+        header.setAlignment(Pos.CENTER_LEFT);
+
+        // ── 2. A/B compare bar (§6.5) ────────────────────────────────────
+        slotALabel = new Label(ABComparison.Slot.A.name());
+        slotALabel.getStyleClass().add("editor-ab-slot");
+        slotBLabel = new Label(ABComparison.Slot.B.name());
+        slotBLabel.getStyleClass().add("editor-ab-slot");
+
+        Button abCopyButton = new Button(msg("editor.frame.ab.copy"));
+        abCopyButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-ab-copy");
+        abCopyButton.setTooltip(new Tooltip(msg("editor.frame.ab.copy.tooltip")));
+        abCopyButton.setAccessibleText(msg("editor.frame.ab.copy"));
+        abCopyButton.setOnAction(e -> {
+            runCallback(getSkinnable().getOnAbCopyRequested());
+            e.consume();
+        });
+
+        Button abSwapButton = new Button(msg("editor.frame.ab.swap"));
+        abSwapButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-ab-swap");
+        abSwapButton.setTooltip(new Tooltip(msg("editor.frame.ab.swap.tooltip")));
+        abSwapButton.setAccessibleText(msg("editor.frame.ab.swap"));
+        abSwapButton.setOnAction(e -> {
+            runCallback(getSkinnable().getOnAbToggleRequested());
+            e.consume();
+        });
+
+        Region abSpacer = new Region();
+        HBox.setHgrow(abSpacer, Priority.ALWAYS);
+        abBar = new HBox(slotALabel, slotBLabel, abSpacer, abCopyButton, abSwapButton);
+        abBar.getStyleClass().add("editor-ab-bar");
+        abBar.setAlignment(Pos.CENTER_LEFT);
+
+        // ── 3. Fault banner (§6.6) ───────────────────────────────────────
+        faultMessageLabel = new Label();
+        faultMessageLabel.getStyleClass().add("editor-fault-message");
+        faultMessageLabel.setWrapText(true);
+
+        Button reloadButton = new Button(msg("editor.frame.reload.label"));
+        reloadButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-fault-reload");
+        reloadButton.setTooltip(new Tooltip(msg("editor.frame.reload.tooltip")));
+        reloadButton.setAccessibleText(msg("editor.frame.reload.accessible"));
+        reloadButton.setOnAction(e -> {
+            runCallback(getSkinnable().getOnReloadRequested());
+            e.consume();
+        });
+
+        Button faultInfoButton = new Button();
+        faultInfoButton.setGraphic(IconNode.of(DawIcon.INFO_CIRCLE, ICON_SIZE));
+        faultInfoButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-fault-info");
+        faultInfoButton.setTooltip(new Tooltip(msg("editor.frame.faultInfo.tooltip")));
+        faultInfoButton.setAccessibleText(msg("editor.frame.faultInfo.accessible"));
+        faultInfoButton.setOnAction(e -> {
+            runCallback(getSkinnable().getOnFaultDetailsRequested());
+            e.consume();
+        });
+
+        Region faultSpacer = new Region();
+        HBox.setHgrow(faultSpacer, Priority.ALWAYS);
+        HBox.setHgrow(faultMessageLabel, Priority.SOMETIMES);
+        faultBanner = new HBox(IconNode.of(DawIcon.WARNING, ICON_SIZE),
+                faultMessageLabel, faultSpacer, reloadButton, faultInfoButton);
+        faultBanner.getStyleClass().add("editor-fault-banner");
+        faultBanner.setAlignment(Pos.CENTER_LEFT);
+
+        // ── 4. Body host (§6.3) ──────────────────────────────────────────
+        bodyHost = new StackPane();
+        bodyHost.getStyleClass().add("editor-frame-body");
+        // Clip to the host's own bounds — a misbehaving plugin cannot paint
+        // over the breadcrumb or footer (§6.3). A Region's layout bounds
+        // are (0, 0, width, height), so binding the rectangle to the
+        // width/height properties tracks the layout bounds exactly.
+        bodyClip = new Rectangle();
+        bodyClip.widthProperty().bind(bodyHost.widthProperty());
+        bodyClip.heightProperty().bind(bodyHost.heightProperty());
+        bodyHost.setClip(bodyClip);
+        VBox.setVgrow(bodyHost, Priority.ALWAYS);
+
+        // ── 5. Footer (§6.4) ─────────────────────────────────────────────
+        Label presetLabel = new Label(msg("editor.frame.preset.label"));
+        presetLabel.getStyleClass().add("editor-frame-preset-label");
+
+        presetCombo = new ComboBox<>();
+        presetCombo.getStyleClass().add("editor-frame-preset");
+        presetCombo.setItems(control.getPresetItems());
+        presetCombo.setAccessibleText(msg("editor.frame.preset.label"));
+
+        Button saveButton = new Button(msg("editor.frame.preset.save"));
+        saveButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-frame-preset-save");
+        saveButton.setTooltip(new Tooltip(msg("editor.frame.preset.save.tooltip")));
+        saveButton.setAccessibleText(msg("editor.frame.preset.save"));
+        saveButton.setOnAction(e -> {
+            runCallback(getSkinnable().getOnSavePresetRequested());
+            e.consume();
+        });
+
+        Button saveAsButton = new Button(msg("editor.frame.preset.saveAs"));
+        saveAsButton.getStyleClass().addAll("dawg-button", "size-compact", "editor-frame-preset-save-as");
+        saveAsButton.setTooltip(new Tooltip(msg("editor.frame.preset.saveAs.tooltip")));
+        saveAsButton.setAccessibleText(msg("editor.frame.preset.saveAs"));
+        saveAsButton.setOnAction(e -> {
+            runCallback(getSkinnable().getOnSaveAsPresetRequested());
+            e.consume();
+        });
+
+        Label inCaption = new Label(msg("editor.frame.meter.in"));
+        inCaption.getStyleClass().add("editor-frame-meter-caption");
+        inMeter = LevelMeter.create()
+                .channels(1)
+                .orientation(Orientation.HORIZONTAL)
+                .build();
+        inMeter.getStyleClass().add("editor-frame-meter-in");
+
+        Label outCaption = new Label(msg("editor.frame.meter.out"));
+        outCaption.getStyleClass().add("editor-frame-meter-caption");
+        outMeter = LevelMeter.create()
+                .channels(1)
+                .orientation(Orientation.HORIZONTAL)
+                .build();
+        outMeter.getStyleClass().add("editor-frame-meter-out");
+
+        Region footerSpacer = new Region();
+        HBox.setHgrow(footerSpacer, Priority.ALWAYS);
+        footer = new HBox(presetLabel, presetCombo, saveButton, saveAsButton,
+                footerSpacer, inCaption, inMeter, outCaption, outMeter);
+        footer.getStyleClass().add("editor-frame-footer");
+        footer.setAlignment(Pos.CENTER_LEFT);
+
+        root = new VBox(header, abBar, faultBanner, bodyHost, footer);
+        getChildren().add(root);
+
+        // ── Two-way syncs (listener + setter guard — never bind()) ───────
+        bypassButton.setSelected(control.isBypassed());
+        bypassedListener = (obs, was, now) -> {
+            if (disposed || syncingBypass) {
+                return;
+            }
+            syncingBypass = true;
+            try {
+                bypassButton.setSelected(now);
+            } finally {
+                syncingBypass = false;
+            }
+        };
+        bypassButtonListener = (obs, was, now) -> {
+            if (disposed || syncingBypass) {
+                return;
+            }
+            syncingBypass = true;
+            try {
+                getSkinnable().setBypassed(now);
+            } finally {
+                syncingBypass = false;
+            }
+        };
+
+        abButton.setSelected(control.isAbBarVisible());
+        abBarVisibleListener = (obs, was, now) -> {
+            if (disposed) {
+                return;
+            }
+            if (!syncingAbBar) {
+                syncingAbBar = true;
+                try {
+                    abButton.setSelected(now);
+                } finally {
+                    syncingAbBar = false;
+                }
+            }
+            applyChromeVisibility(false);
+        };
+        abButtonListener = (obs, was, now) -> {
+            if (disposed || syncingAbBar) {
+                return;
+            }
+            syncingAbBar = true;
+            try {
+                getSkinnable().setAbBarVisible(now);
+            } finally {
+                syncingAbBar = false;
+            }
+        };
+
+        presetCombo.setValue(control.getSelectedPreset());
+        selectedPresetListener = (obs, was, now) -> {
+            if (disposed || syncingPreset) {
+                return;
+            }
+            syncingPreset = true;
+            try {
+                presetCombo.setValue(now);
+            } finally {
+                syncingPreset = false;
+            }
+        };
+        presetComboListener = (obs, was, now) -> {
+            if (disposed || syncingPreset) {
+                return;
+            }
+            syncingPreset = true;
+            try {
+                getSkinnable().setSelectedPreset(now);
+            } finally {
+                syncingPreset = false;
+            }
+            // A combo value change with the guard off is a user pick —
+            // programmatic control-side writes route through the guarded
+            // selectedPresetListener above and do NOT re-enter here.
+            var callback = getSkinnable().getOnPresetSelected();
+            if (callback != null) {
+                callback.accept(now);
+            }
+        };
+
+        // ── One-way state listeners ──────────────────────────────────────
+        breadcrumbListener = (obs, was, now) -> {
+            if (!disposed) {
+                rebuildBreadcrumb();
+            }
+        };
+        abSlotListener = (obs, was, now) -> {
+            if (!disposed) {
+                updateAbSlot();
+            }
+        };
+        faultListener = (obs, was, now) -> {
+            if (!disposed) {
+                updateFaultBanner();
+            }
+        };
+        bodyListener = (obs, was, now) -> {
+            if (!disposed) {
+                applyBody(now);
+            }
+        };
+        metersListener = (obs, was, now) -> {
+            if (!disposed) {
+                applyMeters(now);
+            }
+        };
+        resizePolicyListener = (obs, was, now) -> {
+            if (!disposed) {
+                reapplyBodyPolicy();
+            }
+        };
+        bodySizeListener = (obs, was, now) -> {
+            if (!disposed) {
+                reapplyBodyPolicy();
+            }
+        };
+
+        // ── Chrome policy + §5.D immersive machinery ─────────────────────
+        inactivityTimer = new PauseTransition(IMMERSIVE_INACTIVITY);
+        inactivityTimer.setOnFinished(e -> onImmersiveInactivity());
+
+        chromePolicyListener = (obs, was, now) -> {
+            if (disposed) {
+                return;
+            }
+            // Leaving IMMERSIVE stops the timer and restores chrome fully;
+            // entering it starts the countdown with the chrome visible.
+            inactivityTimer.stop();
+            chromeRetracted = false;
+            if (now == ChromePolicy.IMMERSIVE) {
+                inactivityTimer.playFromStart();
+            }
+            applyChromeVisibility(false);
+        };
+
+        pointerActivityFilter = e -> onPointerActivity();
+        focusListener = (obs, was, now) -> {
+            if (!disposed && now) {
+                onPointerActivity();
+            }
+        };
+
+        // Reduce Motion flipping ON mid-fade: stop the fades and snap the
+        // chrome to its target state (story 279 — the hide still happens,
+        // only the motion is removed).
+        reduceMotionListener = (obs, was, now) -> {
+            if (!disposed && now) {
+                applyChromeVisibility(false);
+            }
+        };
+        weakReduceMotionListener = new WeakChangeListener<>(reduceMotionListener);
+        motionManager.reduceMotionProperty().addListener(weakReduceMotionListener);
+
+        // ── Keyboard map (§6.1) ──────────────────────────────────────────
+        keyHandler = this::onKeyPressed;
+        control.addEventHandler(KeyEvent.KEY_PRESSED, keyHandler);
+        // Filters (not handlers) so a child consuming the event still
+        // counts as pointer activity over the frame. MOUSE_ENTERED_TARGET
+        // is the bubbling super-type of MOUSE_ENTERED, so one registration
+        // sees enters of the frame and of any child.
+        control.addEventFilter(MouseEvent.MOUSE_MOVED, pointerActivityFilter);
+        control.addEventFilter(MouseEvent.MOUSE_ENTERED_TARGET, pointerActivityFilter);
+        control.focusedProperty().addListener(focusListener);
+
+        // ── Register control-property listeners ──────────────────────────
+        control.pluginNameProperty().addListener(breadcrumbListener);
+        control.vendorProperty().addListener(breadcrumbListener);
+        control.insertLocationProperty().addListener(breadcrumbListener);
+        control.bypassedProperty().addListener(bypassedListener);
+        control.abBarVisibleProperty().addListener(abBarVisibleListener);
+        control.abActiveSlotProperty().addListener(abSlotListener);
+        control.chromePolicyProperty().addListener(chromePolicyListener);
+        control.resizePolicyProperty().addListener(resizePolicyListener);
+        control.preferredBodyWidthProperty().addListener(bodySizeListener);
+        control.preferredBodyHeightProperty().addListener(bodySizeListener);
+        control.metersProperty().addListener(metersListener);
+        control.faultMessageProperty().addListener(faultListener);
+        control.bodyProperty().addListener(bodyListener);
+        control.selectedPresetProperty().addListener(selectedPresetListener);
+        bypassButton.selectedProperty().addListener(bypassButtonListener);
+        abButton.selectedProperty().addListener(abButtonListener);
+        presetCombo.valueProperty().addListener(presetComboListener);
+
+        // ── Apply the initial control state ──────────────────────────────
+        rebuildBreadcrumb();
+        updateAbSlot();
+        updateFaultBanner();
+        applyBody(control.getBody());
+        applyMeters(control.getMeters());
+        applyChromeVisibility(false);
+        if (control.getChromePolicy() == ChromePolicy.IMMERSIVE) {
+            inactivityTimer.playFromStart();
+        }
+    }
+
+    // ── Test seams (package-private) ──────────────────────────────────────
+
+    /** @return whether {@link #dispose()} has run (test seam). */
+    boolean isDisposed() {
+        return disposed;
+    }
+
+    /** @return whether the §5.D immersive chrome is currently retracted (test seam). */
+    boolean isChromeRetracted() {
+        return chromeRetracted;
+    }
+
+    /** @return the §6.1 header row (test seam). */
+    HBox header() {
+        return header;
+    }
+
+    /** @return the §6.5 A/B compare bar (test seam). */
+    HBox abBar() {
+        return abBar;
+    }
+
+    /** @return the §6.6 fault banner (test seam). */
+    HBox faultBanner() {
+        return faultBanner;
+    }
+
+    /** @return the clipped §6.3 body host (test seam). */
+    StackPane bodyHost() {
+        return bodyHost;
+    }
+
+    /** @return the §6.4 footer row (test seam). */
+    HBox footer() {
+        return footer;
+    }
+
+    /** @return the header breadcrumb (test seam). */
+    BreadcrumbBar breadcrumb() {
+        return breadcrumb;
+    }
+
+    /** @return the footer preset selector (test seam). */
+    ComboBox<String> presetCombo() {
+        return presetCombo;
+    }
+
+    /** @return the footer IN meter (test seam). */
+    LevelMeter inMeter() {
+        return inMeter;
+    }
+
+    /** @return the footer OUT meter (test seam). */
+    LevelMeter outMeter() {
+        return outMeter;
+    }
+
+    // ── Breadcrumb (§6.1) ─────────────────────────────────────────────────
+
+    /**
+     * Derives the breadcrumb segments from vendor ▸ plugin name ▸ insert
+     * location, skipping {@code null}/blank segments (a missing insert
+     * location simply omits the crumb).
+     */
+    private void rebuildBreadcrumb() {
+        EditorFrame c = getSkinnable();
+        List<String> segments = new ArrayList<>(3);
+        addSegmentIfPresent(segments, c.getVendor());
+        addSegmentIfPresent(segments, c.getPluginName());
+        addSegmentIfPresent(segments, c.getInsertLocation());
+        breadcrumb.setSegments(segments);
+    }
+
+    private static void addSegmentIfPresent(List<String> segments, String value) {
+        if (value != null && !value.isBlank()) {
+            segments.add(value);
+        }
+    }
+
+    // ── A/B (§6.5) ────────────────────────────────────────────────────────
+
+    /**
+     * Reflects the display-only active slot: the header toggle's text
+     * renders the active slot letter upper-case and the inactive one
+     * lower-case (a text-only affordance — the full §6.5 bar carries the
+     * richer marking), and the bar's active slot label gains
+     * {@code .editor-ab-active}.
+     */
+    private void updateAbSlot() {
+        ABComparison.Slot slot = getSkinnable().getAbActiveSlot();
+        boolean aActive = slot == ABComparison.Slot.A;
+        abButton.setText(aActive ? "A|b" : "a|B");
+        abButton.setAccessibleText(String.format(Locale.ROOT,
+                msg("editor.frame.ab.accessibleFormat"), slot.name()));
+        markActive(slotALabel, aActive);
+        markActive(slotBLabel, !aActive);
+    }
+
+    private static void markActive(Label slotLabel, boolean active) {
+        slotLabel.getStyleClass().remove("editor-ab-active");
+        if (active) {
+            slotLabel.getStyleClass().add("editor-ab-active");
+        }
+    }
+
+    // ── Fault banner (§6.6) ───────────────────────────────────────────────
+
+    /**
+     * Shows the banner while the fault message is non-blank and mirrors the
+     * message into the banner's accessible text (the test-visible seam).
+     * Deliberately independent of the chrome policy — a fault must stay
+     * visible even under {@code IMMERSIVE} retraction.
+     */
+    private void updateFaultBanner() {
+        String message = getSkinnable().getFaultMessage();
+        boolean show = message != null && !message.isBlank();
+        faultMessageLabel.setText(show ? message : "");
+        faultBanner.setAccessibleText(show ? message : null);
+        faultBanner.setVisible(show);
+        faultBanner.setManaged(show);
+    }
+
+    // ── Body (§6.3) ───────────────────────────────────────────────────────
+
+    private void applyBody(Node newBody) {
+        bodyHost.getChildren().clear();
+        if (newBody != null) {
+            bodyHost.getChildren().add(newBody);
+            reapplyBodyPolicy();
+        }
+    }
+
+    /**
+     * Enforces the host-owned resize policy on a {@link Region} body
+     * (§6.3 — the plugin cannot resize itself); re-run whenever the body,
+     * the policy, or the preferred size changes. Non-{@code Region} bodies
+     * (e.g. a bare canvas) are sized by the {@link StackPane} host alone.
+     */
+    private void reapplyBodyPolicy() {
+        EditorFrame c = getSkinnable();
+        if (c.getBody() instanceof Region region) {
+            EditorFrame.applyResizePolicy(region, c.getResizePolicy(),
+                    c.getPreferredBodyWidth(), c.getPreferredBodyHeight());
+        }
+    }
+
+    // ── Meters (§6.4) ─────────────────────────────────────────────────────
+
+    /**
+     * Feeds the footer meters from the snapshot (peak and RMS share the
+     * single dB reading — the snapshot carries one level per direction).
+     * {@link Double#NEGATIVE_INFINITY} normalises below the meter's
+     * −60 dB floor and renders as an empty meter, never a clip.
+     */
+    private void applyMeters(PluginMeterSnapshot snapshot) {
+        inMeter.submitLevels(snapshot.inputLevelDb(), snapshot.inputLevelDb());
+        outMeter.submitLevels(snapshot.outputLevelDb(), snapshot.outputLevelDb());
+    }
+
+    // ── Chrome policy + immersive retraction (§5.C / §5.D) ───────────────
+
+    /**
+     * Applies the effective chrome visibility for the current policy /
+     * A/B-bar flag / retraction state. The fault banner is handled solely
+     * by {@link #updateFaultBanner()} — it never retracts.
+     *
+     * @param animate whether this change may fade (only the §5.D immersive
+     *                retract / reveal passes {@code true}); further gated
+     *                by the story-279 Reduce Motion flag
+     */
+    private void applyChromeVisibility(boolean animate) {
+        EditorFrame c = getSkinnable();
+        ChromePolicy policy = c.getChromePolicy();
+        boolean immersiveHidden = policy == ChromePolicy.IMMERSIVE && chromeRetracted;
+        boolean headerShown = !immersiveHidden;
+        boolean footerShown = policy != ChromePolicy.MINIMAL && !immersiveHidden;
+        boolean abShown = c.isAbBarVisible()
+                && policy != ChromePolicy.MINIMAL && !immersiveHidden;
+        boolean fade = animate && motionManager.isAnimationAllowed();
+        applyNodeVisibility(header, headerShown, fade);
+        applyNodeVisibility(footer, footerShown, fade);
+        applyNodeVisibility(abBar, abShown, fade);
+    }
+
+    /**
+     * Shows / hides one chrome row. When animating, opacity fades over
+     * 180 ms ({@link Interpolator#EASE_BOTH}) and the {@code visible}/
+     * {@code managed} flip happens after the fade-out so the body reclaims
+     * the pixels only once the row has visually gone; a reveal flips the
+     * flags first and fades in. When not animating (Reduce Motion, policy
+     * swaps, initial apply) the flags snap with opacity reset to 1.
+     */
+    private void applyNodeVisibility(Node node, boolean shown, boolean animate) {
+        FadeTransition running = runningFades.remove(node);
+        if (running != null) {
+            running.stop();
+        }
+        if (!animate) {
+            node.setOpacity(1.0);
+            node.setVisible(shown);
+            node.setManaged(shown);
+            return;
+        }
+        if (shown) {
+            if (!node.isVisible()) {
+                node.setOpacity(0.0);
+                node.setVisible(true);
+                node.setManaged(true);
+            }
+            if (node.getOpacity() >= 1.0) {
+                return;
+            }
+            FadeTransition fade = new FadeTransition(CHROME_FADE, node);
+            fade.setToValue(1.0);
+            fade.setInterpolator(Interpolator.EASE_BOTH);
+            fade.setOnFinished(e -> {
+                runningFades.remove(node);
+                node.setOpacity(1.0);
+            });
+            runningFades.put(node, fade);
+            fade.play();
+        } else {
+            if (!node.isVisible()) {
+                node.setOpacity(1.0);
+                return;
+            }
+            FadeTransition fade = new FadeTransition(CHROME_FADE, node);
+            fade.setToValue(0.0);
+            fade.setInterpolator(Interpolator.EASE_BOTH);
+            fade.setOnFinished(e -> {
+                runningFades.remove(node);
+                node.setVisible(false);
+                node.setManaged(false);
+                // Reset so the next (possibly snap) reveal is fully opaque.
+                node.setOpacity(1.0);
+            });
+            runningFades.put(node, fade);
+            fade.play();
+        }
+    }
+
+    /** §5.D: the 2 s inactivity countdown elapsed — retract the chrome. */
+    private void onImmersiveInactivity() {
+        if (disposed || getSkinnable().getChromePolicy() != ChromePolicy.IMMERSIVE) {
+            return;
+        }
+        chromeRetracted = true;
+        applyChromeVisibility(true);
+    }
+
+    /**
+     * §5.D: pointer movement / enter over the frame (or a focus gain)
+     * reveals retracted chrome and restarts the inactivity countdown.
+     * A no-op outside {@code IMMERSIVE}.
+     */
+    private void onPointerActivity() {
+        if (disposed || getSkinnable().getChromePolicy() != ChromePolicy.IMMERSIVE) {
+            return;
+        }
+        if (chromeRetracted) {
+            chromeRetracted = false;
+            applyChromeVisibility(true);
+        }
+        inactivityTimer.playFromStart();
+    }
+
+    // ── Keyboard (§6.1) ───────────────────────────────────────────────────
+
+    /**
+     * §6.1 keyboard map: {@code B} toggles bypass, {@code Shortcut+\}
+     * requests an A/B swap, {@code Shortcut+D} detach, {@code Shortcut+W}
+     * close. Events targeted at a text-input control are ignored (typing a
+     * {@code b} into a plugin's text field must not bypass it); handled
+     * events are consumed.
+     */
+    private void onKeyPressed(KeyEvent e) {
+        if (disposed || e.getTarget() instanceof TextInputControl) {
+            return;
+        }
+        EditorFrame c = getSkinnable();
+        switch (e.getCode()) {
+            case B -> {
+                if (hasNoModifiers(e)) {
+                    c.setBypassed(!c.isBypassed());
+                    e.consume();
+                }
+            }
+            case BACK_SLASH -> {
+                if (e.isShortcutDown()) {
+                    runCallback(c.getOnAbToggleRequested());
+                    e.consume();
+                }
+            }
+            case D -> {
+                if (e.isShortcutDown()) {
+                    runCallback(c.getOnDetachRequested());
+                    e.consume();
+                }
+            }
+            case W -> {
+                if (e.isShortcutDown()) {
+                    runCallback(c.getOnCloseRequested());
+                    e.consume();
+                }
+            }
+            default -> {
+                // Not part of the §6.1 map — leave for other handlers.
+            }
+        }
+    }
+
+    private static boolean hasNoModifiers(KeyEvent e) {
+        return !e.isShiftDown() && !e.isControlDown() && !e.isAltDown()
+                && !e.isMetaDown() && !e.isShortcutDown();
+    }
+
+    private static void runCallback(Runnable callback) {
+        if (callback != null) {
+            callback.run();
+        }
+    }
+
+    /**
+     * Resolves a chrome string from the shared bundle, falling back to the
+     * raw key if absent (mirrors {@code BrowserPanel#msg(String)}).
+     */
+    private static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (MissingResourceException e) {
+            return key;
+        }
+    }
+
+    // ── Dispose ───────────────────────────────────────────────────────────
+
+    @Override
+    public void dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        inactivityTimer.stop();
+        for (FadeTransition fade : runningFades.values()) {
+            fade.stop();
+        }
+        runningFades.clear();
+        EditorFrame c = getSkinnable();
+        if (c != null) {
+            c.removeEventHandler(KeyEvent.KEY_PRESSED, keyHandler);
+            c.removeEventFilter(MouseEvent.MOUSE_MOVED, pointerActivityFilter);
+            c.removeEventFilter(MouseEvent.MOUSE_ENTERED_TARGET, pointerActivityFilter);
+            c.focusedProperty().removeListener(focusListener);
+            c.pluginNameProperty().removeListener(breadcrumbListener);
+            c.vendorProperty().removeListener(breadcrumbListener);
+            c.insertLocationProperty().removeListener(breadcrumbListener);
+            c.bypassedProperty().removeListener(bypassedListener);
+            c.abBarVisibleProperty().removeListener(abBarVisibleListener);
+            c.abActiveSlotProperty().removeListener(abSlotListener);
+            c.chromePolicyProperty().removeListener(chromePolicyListener);
+            c.resizePolicyProperty().removeListener(resizePolicyListener);
+            c.preferredBodyWidthProperty().removeListener(bodySizeListener);
+            c.preferredBodyHeightProperty().removeListener(bodySizeListener);
+            c.metersProperty().removeListener(metersListener);
+            c.faultMessageProperty().removeListener(faultListener);
+            c.bodyProperty().removeListener(bodyListener);
+            c.selectedPresetProperty().removeListener(selectedPresetListener);
+        }
+        bypassButton.selectedProperty().removeListener(bypassButtonListener);
+        abButton.selectedProperty().removeListener(abButtonListener);
+        presetCombo.valueProperty().removeListener(presetComboListener);
+        motionManager.reduceMotionProperty().removeListener(weakReduceMotionListener);
+        bodyClip.widthProperty().unbind();
+        bodyClip.heightProperty().unbind();
+        super.dispose();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/FxCanvasSurface.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/FxCanvasSurface.java
@@ -1,0 +1,72 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.sdk.editor.CanvasSurface;
+import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
+
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+
+import java.util.Objects;
+
+/**
+ * Host-side {@link CanvasSurface} implementation backing a
+ * {@link PluginEditorFactory.Canvas} editor with a JavaFX {@link Canvas}
+ * (story 301, Plugin View Design Book §4.1, §6.3).
+ *
+ * <p>The host owns the surface (§2.2): {@link PluginEditorSession} creates the
+ * backing {@code Canvas} inside its {@code editor-canvas-host} wrapper, sizes
+ * it to follow the wrapper's layout bounds, and hands the plugin only this
+ * facade — the plugin draws <em>into</em> the surface but never constructs,
+ * sizes or reparents it. Clipping is enforced one level up: the
+ * {@code EditorFrame} skin clips the whole body host to its bounds (§6.3), so
+ * a misbehaving plugin cannot paint over the breadcrumb or footer and this
+ * facade needs no clip of its own.</p>
+ *
+ * <p>{@link #requestRender()} routes to the session's coalesced render
+ * scheduler ({@code FxDispatcher} keyed latest-wins, §6.3 "the host coalesces
+ * repeated requests within a single frame") — the same path
+ * {@code EditorContext#requestRender()} takes, so an event-handler repaint and
+ * a context repaint collapse into one {@code render(RenderTick)} per pulse.</p>
+ *
+ * <p>Every method here is called on the JavaFX Application Thread, from inside
+ * the session's fault harness (§4.7).</p>
+ *
+ * @see PluginEditorSession
+ */
+final class FxCanvasSurface implements CanvasSurface {
+
+    private final Canvas canvas;
+    private final Runnable renderRequester;
+
+    /**
+     * @param canvas          the host-owned backing canvas; must not be
+     *                        {@code null}
+     * @param renderRequester the session's coalesced render scheduler; must
+     *                        not be {@code null}
+     */
+    FxCanvasSurface(Canvas canvas, Runnable renderRequester) {
+        this.canvas = Objects.requireNonNull(canvas, "canvas must not be null");
+        this.renderRequester = Objects.requireNonNull(
+                renderRequester, "renderRequester must not be null");
+    }
+
+    @Override
+    public double width() {
+        return canvas.getWidth();
+    }
+
+    @Override
+    public double height() {
+        return canvas.getHeight();
+    }
+
+    @Override
+    public GraphicsContext graphicsContext() {
+        return canvas.getGraphicsContext2D();
+    }
+
+    @Override
+    public void requestRender() {
+        renderRequester.run();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/HostEditorContext.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/HostEditorContext.java
@@ -1,0 +1,106 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.sdk.editor.EditorContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginParameterStore;
+import com.benesquivelmusic.daw.sdk.editor.ResizePolicy;
+import com.benesquivelmusic.daw.sdk.editor.Theme;
+
+import javafx.beans.value.ObservableValue;
+
+import java.util.Objects;
+import java.util.function.DoubleSupplier;
+
+/**
+ * Host-side {@link EditorContext} implementation — the narrow set of host
+ * services a contract-driven plugin editor may call (story 301, Plugin View
+ * Design Book §4.1). One instance per {@link PluginEditorSession}; every
+ * method delegates to the owning session so a reload that rebuilds the
+ * store / body keeps this context valid (the plugin holds the context, the
+ * session holds the truth).
+ *
+ * <p>Per §9 rejection #2 this stays deliberately small: theme, the parameter
+ * store, the sample rate, resize / redraw / animation requests and fault
+ * reporting — nothing more.</p>
+ *
+ * <ul>
+ *   <li>{@link #requestResize(int, int)} is coerced by the session per the
+ *       <em>current</em> {@link ResizePolicy} — the host enforces, the plugin
+ *       cannot resize itself (§6.3).</li>
+ *   <li>{@link #requestRender()} and {@link #requestAnimationTimer(double)}
+ *       drive the session's coalesced canvas render / opted-in fps loop
+ *       (§6.3); both are no-ops for non-canvas editors.</li>
+ *   <li>{@link #postFault(Throwable, String)} is the §4.8 <em>recoverable</em>
+ *       fault channel: banner + fault log, the editor keeps running — unlike a
+ *       fault thrown out of a host-invoked callback, which the session's
+ *       harness substitutes with the §6.6 placeholder.</li>
+ * </ul>
+ *
+ * <p>Threading (§4.7): every method here is called on the JavaFX Application
+ * Thread; the store returned by {@link #parameterStore()} is the one
+ * thread-safe exception (§2.6).</p>
+ *
+ * @see PluginEditorSession
+ */
+final class HostEditorContext implements EditorContext {
+
+    /**
+     * Sample-rate fallback when the host supplied no
+     * {@link PluginEditorSession.Deps#sampleRate()} (the Deps contract
+     * tolerates {@code null} members) — CD-quality, the same default the
+     * audio format layer assumes.
+     */
+    private static final double FALLBACK_SAMPLE_RATE = 44_100.0;
+
+    private final PluginEditorSession session;
+    private final DoubleSupplier sampleRate;
+
+    /**
+     * @param session    the owning session; must not be {@code null}
+     * @param sampleRate the host's live sample-rate read, or {@code null} to
+     *                   fall back to {@value #FALLBACK_SAMPLE_RATE}
+     */
+    HostEditorContext(PluginEditorSession session, DoubleSupplier sampleRate) {
+        this.session = Objects.requireNonNull(session, "session must not be null");
+        this.sampleRate = sampleRate;
+    }
+
+    @Override
+    public double sampleRate() {
+        return sampleRate == null ? FALLBACK_SAMPLE_RATE : sampleRate.getAsDouble();
+    }
+
+    @Override
+    public Theme theme() {
+        return session.currentTheme();
+    }
+
+    @Override
+    public ObservableValue<Theme> themeProperty() {
+        return session.themeProperty();
+    }
+
+    @Override
+    public PluginParameterStore parameterStore() {
+        return session.store();
+    }
+
+    @Override
+    public void requestResize(int width, int height) {
+        session.requestResize(width, height);
+    }
+
+    @Override
+    public void requestRender() {
+        session.scheduleRender();
+    }
+
+    @Override
+    public void requestAnimationTimer(double framesPerSecond) {
+        session.setAnimationFps(framesPerSecond);
+    }
+
+    @Override
+    public void postFault(Throwable error, String hint) {
+        session.postFault(error, hint);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/ParameterGridPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/ParameterGridPanel.java
@@ -1,0 +1,559 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.controls.Knob;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+
+import javafx.geometry.HPos;
+import javafx.geometry.Pos;
+import javafx.geometry.VPos;
+import javafx.scene.control.Label;
+import javafx.scene.control.Toggle;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.DoubleConsumer;
+
+/**
+ * Host-generated §6.2 parameter grid (story 301) — the editor body the host
+ * renders when a plugin returned {@code PluginEditorFactory.Declarative}.
+ *
+ * <p>Plugin View Design Book §6.2: knobs flow in a 16-px-gridded responsive
+ * grid where one knob cell is 96&nbsp;×&nbsp;96&nbsp;px and the container
+ * width drives the column count — always one of 1&nbsp;/&nbsp;2&nbsp;/
+ * 4&nbsp;/&nbsp;6&nbsp;/&nbsp;8, never an arbitrary count, so columns stay
+ * aligned to the design grid. This panel supersedes the legacy
+ * {@code PluginParameterEditorPanel} slider list for host-generated editors:
+ * sliders become {@link Knob}s, halving per-row height so the auto-generated
+ * editor visually matches a hand-built one.</p>
+ *
+ * <h2>Control-type heuristics</h2>
+ *
+ * <p>{@link PluginParameter} carries no boolean/enum metadata yet (it is a
+ * five-component record: id, name, min, max, default), so control types are
+ * inferred, checked in this order:</p>
+ * <ol>
+ *   <li><b>Boolean</b> — the legacy panel's deliberately conservative
+ *       heuristic, kept verbatim: {@code min == 0 && max == 1}, the default
+ *       is exactly 0 or 1, <em>and</em> the lowercase name contains
+ *       {@code "toggle"}. The name guard is load-bearing: a continuous
+ *       0..1 "Mix" or "Level" parameter must render as a knob, not
+ *       collapse into an ON/OFF toggle — without SDK metadata, range alone
+ *       cannot distinguish the two. Renders as the §6.2 "labelled toggle"
+ *       (ON/OFF {@link ToggleButton}).</li>
+ *   <li><b>Discrete</b> — min, max and default are all mathematically
+ *       integral and {@code (max - min)} is between 1 and 7 inclusive
+ *       (i.e. 2–8 states, matching §6.2 "max ≤ 8 with integer steps").
+ *       Renders as a §6.2 segmented selector — one {@link ToggleButton}
+ *       per integer value in a shared {@link ToggleGroup}. The §6.2
+ *       mockup's two-state SIDECHAIN (off/EXT) is exactly such a
+ *       parameter. Deliberately narrow: any non-integral endpoint or
+ *       default, or a span above 7, falls through to a knob.</li>
+ *   <li><b>Continuous</b> — everything else: a 96×96 {@link Knob}
+ *       configured from the descriptor, with a numeric readout below using
+ *       the legacy panel's formatting rules ({@code |v| >= 1000} → one
+ *       decimal, otherwise two).</li>
+ * </ol>
+ *
+ * <h2>Single-writer discipline (story 301 technical note)</h2>
+ *
+ * <p>Exactly one path reports user gestures out of this panel: the
+ * {@link ValueSink}. Model→control echo ({@link #updateValue(int, double)} /
+ * {@link #setAllValues(Map)} — audio-side drains, A/B swaps, preset loads)
+ * moves the controls inside a single panel-wide reentrancy guard so the
+ * controls' own change listeners do not re-fire the sink. There is no
+ * {@code refreshControls()} re-push feedback loop and no per-control
+ * suppress flag — one guard field, one rule.</p>
+ *
+ * <h2>Responsive layout</h2>
+ *
+ * <p>This is a plain {@link Region} with custom {@link #layoutChildren()}
+ * (not a {@code FlowPane}: a FlowPane's {@code prefWrapLength} is ignored
+ * under a {@code fitToWidth} ScrollPane — known project pitfall), placing
+ * cells in {@link #computeColumns(double)} columns with {@link #GRID_GAP}
+ * gaps and centring the used block horizontally.
+ * {@link #computePrefHeight(double)} reports {@code rows × rowHeight +
+ * gaps} for the column count at the given width so ScrollPane/VBox hosts
+ * size the grid correctly; pref width is a sensible 4-column default and
+ * min width is one column.</p>
+ *
+ * <p>All styling comes from style classes ({@value #STYLE_CLASS},
+ * {@code parameter-grid-cell}, {@code parameter-name},
+ * {@code parameter-value}, {@code numeric-caption},
+ * {@code segmented-selector}) — no hard-coded colors here.</p>
+ */
+public final class ParameterGridPanel extends Region {
+
+    /** Stable style class — selectable as {@code .parameter-grid} in CSS. */
+    public static final String STYLE_CLASS = "parameter-grid";
+
+    /** §6.2 — one knob cell is 96 × 96 px. */
+    public static final double CELL_WIDTH = 96;
+
+    /** §6.2 — the grid is 16-px gridded. */
+    public static final double GRID_GAP = 16;
+
+    /** Allowed column counts (§6.2) — checked widest-first. */
+    private static final int[] ALLOWED_COLUMN_COUNTS = {8, 6, 4, 2};
+
+    /** Pref-width default column count (§6.2 mid-size layout). */
+    private static final int PREF_COLUMNS = 4;
+
+    /** Legacy reset affordance, kept verbatim from the panel this supersedes. */
+    private static final String RESET_TOOLTIP = "Double-click to reset to default";
+
+    private static final String LABEL_ON = "ON";
+    private static final String LABEL_OFF = "OFF";
+
+    /** Vertical spacing inside a cell (name / control / readout) — 4-px grid. */
+    private static final double CELL_SPACING = 4;
+
+    /**
+     * FX-side single-writer sink: the ONE place a user gesture reports a
+     * new value. Echo entering through {@link #updateValue(int, double)} or
+     * {@link #setAllValues(Map)} never reaches this sink.
+     */
+    @FunctionalInterface
+    public interface ValueSink {
+
+        /**
+         * A user gesture changed a parameter's value.
+         *
+         * @param parameterId the {@link PluginParameter#id()} of the
+         *        changed parameter
+         * @param newValue the new value, inside the descriptor's
+         *        {@code [min, max]}
+         */
+        void valueChanged(int parameterId, double newValue);
+    }
+
+    /** Cells in descriptor order — also this Region's children. */
+    private final List<VBox> cells = new ArrayList<>();
+
+    /**
+     * Echo appliers by parameter id — how {@link #updateValue(int, double)}
+     * moves each cell's control. Callers are responsible for wrapping the
+     * call in the reentrancy guard. If two descriptors share an id (not a
+     * supported configuration, tolerated like the legacy panel), both cells
+     * render but the last-registered one receives the echo.
+     */
+    private final Map<Integer, DoubleConsumer> echoByParameterId = new LinkedHashMap<>();
+
+    private final ValueSink sink;
+
+    /**
+     * THE single reentrancy guard (story 301): {@code true} while this
+     * panel is writing values into its own controls (echo, deselection
+     * restore, initial selection), so the controls' change listeners do
+     * not report those programmatic writes to the {@link #sink}.
+     */
+    private boolean syncingFromModel;
+
+    /**
+     * Builds a grid with one cell per descriptor, in list order.
+     *
+     * <p>Every control starts at its descriptor's
+     * {@link PluginParameter#defaultValue()}; construction reports nothing
+     * to the sink.</p>
+     *
+     * @param parameters the parameter descriptors to generate cells for;
+     *        may be empty (an empty grid — no crash)
+     * @param sink the single-writer gesture sink
+     * @throws NullPointerException if {@code parameters}, any of its
+     *         elements, or {@code sink} is {@code null}
+     */
+    public ParameterGridPanel(List<PluginParameter> parameters, ValueSink sink) {
+        Objects.requireNonNull(parameters, "parameters must not be null");
+        this.sink = Objects.requireNonNull(sink, "sink must not be null");
+        getStyleClass().add(STYLE_CLASS);
+        for (PluginParameter parameter : parameters) {
+            Objects.requireNonNull(parameter, "parameters must not contain null");
+            VBox cell = buildCell(parameter);
+            cells.add(cell);
+            getChildren().add(cell);
+        }
+    }
+
+    // ── Echo (model → control) ────────────────────────────────────────────
+
+    /**
+     * Model→control echo (audio-side drain / A/B / preset load): moves the
+     * control rendering {@code parameterId} to {@code value}.
+     *
+     * <p>MUST NOT re-fire the sink — and does not: the write happens inside
+     * the panel's reentrancy guard. Unknown parameter ids are tolerated and
+     * ignored (a stale drain must not throw). Out-of-range values are
+     * coerced by the receiving control (the knob clamps at the property
+     * level; toggles threshold at 0.5; segments clamp to the nearest
+     * segment).</p>
+     *
+     * @param parameterId the {@link PluginParameter#id()} to update
+     * @param value the authoritative model value
+     */
+    public void updateValue(int parameterId, double value) {
+        DoubleConsumer echo = echoByParameterId.get(parameterId);
+        if (echo == null) {
+            return;
+        }
+        runSyncing(() -> echo.accept(value));
+    }
+
+    /**
+     * Bulk echo — same no-re-fire guarantee as
+     * {@link #updateValue(int, double)}, applied to every entry under one
+     * guard. Unknown ids and {@code null} values are skipped.
+     *
+     * @param valuesById model values keyed by {@link PluginParameter#id()}
+     * @throws NullPointerException if {@code valuesById} is {@code null}
+     */
+    public void setAllValues(Map<Integer, Double> valuesById) {
+        Objects.requireNonNull(valuesById, "valuesById must not be null");
+        runSyncing(() -> {
+            for (Map.Entry<Integer, Double> entry : valuesById.entrySet()) {
+                DoubleConsumer echo = echoByParameterId.get(entry.getKey());
+                Double value = entry.getValue();
+                if (echo != null && value != null) {
+                    echo.accept(value);
+                }
+            }
+        });
+    }
+
+    /** Runs {@code write} with the single reentrancy guard raised. */
+    private void runSyncing(Runnable write) {
+        boolean was = syncingFromModel;
+        syncingFromModel = true;
+        try {
+            write.run();
+        } finally {
+            syncingFromModel = was;
+        }
+    }
+
+    /**
+     * The ONE call site discipline: every gesture handler reports through
+     * here, and echo (guard raised) is silently swallowed.
+     */
+    private void fireSink(int parameterId, double newValue) {
+        if (!syncingFromModel) {
+            sink.valueChanged(parameterId, newValue);
+        }
+    }
+
+    // ── Column math (§6.2) ────────────────────────────────────────────────
+
+    /**
+     * Pure column math, unit-testable with no toolkit: the largest of
+     * {@code {8, 6, 4, 2, 1}} such that
+     * {@code n * CELL_WIDTH + (n - 1) * GRID_GAP <= availableWidth} —
+     * never an arbitrary count (§6.2). Returns 1 for anything too narrow
+     * (including zero and negative widths).
+     *
+     * @param availableWidth the width available for cells, in px
+     * @return the §6.2 column count: 8, 6, 4, 2 or 1
+     */
+    public static int computeColumns(double availableWidth) {
+        for (int columns : ALLOWED_COLUMN_COUNTS) {
+            if (blockWidth(columns) <= availableWidth) {
+                return columns;
+            }
+        }
+        return 1;
+    }
+
+    /** @return the width of {@code columns} cells plus the gaps between them. */
+    private static double blockWidth(int columns) {
+        return columns * CELL_WIDTH + (columns - 1) * GRID_GAP;
+    }
+
+    // ── Responsive layout ─────────────────────────────────────────────────
+
+    @Override
+    protected void layoutChildren() {
+        if (cells.isEmpty()) {
+            return;
+        }
+        double left = snappedLeftInset();
+        double top = snappedTopInset();
+        double contentWidth = getWidth() - left - snappedRightInset();
+        int columns = computeColumns(contentWidth);
+        double rowHeight = maxCellPrefHeight();
+        // Centre the used block horizontally (§6.2 — the grid floats in
+        // the editor body rather than hugging the left edge).
+        double xOrigin = left + Math.max(0.0, (contentWidth - blockWidth(columns)) / 2.0);
+        for (int i = 0; i < cells.size(); i++) {
+            int column = i % columns;
+            int row = i / columns;
+            double x = xOrigin + column * (CELL_WIDTH + GRID_GAP);
+            double y = top + row * (rowHeight + GRID_GAP);
+            layoutInArea(cells.get(i), x, y, CELL_WIDTH, rowHeight,
+                    0, HPos.CENTER, VPos.TOP);
+        }
+    }
+
+    @Override
+    protected double computePrefWidth(double height) {
+        // A sensible 4-column default (§6.2 mid-size layout), shrunk to the
+        // cell count when the grid holds fewer than four cells.
+        int columns = Math.max(1, Math.min(PREF_COLUMNS, cells.size()));
+        return snappedLeftInset() + snappedRightInset() + blockWidth(columns);
+    }
+
+    @Override
+    protected double computeMinWidth(double height) {
+        // One column — the grid never renders narrower than a single cell.
+        return snappedLeftInset() + snappedRightInset() + CELL_WIDTH;
+    }
+
+    @Override
+    protected double computePrefHeight(double width) {
+        double verticalInsets = snappedTopInset() + snappedBottomInset();
+        if (cells.isEmpty()) {
+            return verticalInsets;
+        }
+        // Report rows × rowHeight + gaps for the column count at THIS width
+        // so fitToWidth ScrollPane / VBox hosts size the grid correctly as
+        // it re-wraps. A negative width means "unconstrained" — use the
+        // pref-width column count.
+        int columns = width < 0
+                ? Math.max(1, Math.min(PREF_COLUMNS, cells.size()))
+                : computeColumns(width - snappedLeftInset() - snappedRightInset());
+        int rows = (cells.size() + columns - 1) / columns;
+        return verticalInsets + rows * maxCellPrefHeight() + (rows - 1) * GRID_GAP;
+    }
+
+    /** @return the uniform row height: the tallest cell's pref height at cell width. */
+    private double maxCellPrefHeight() {
+        double max = 0.0;
+        for (VBox cell : cells) {
+            max = Math.max(max, cell.prefHeight(CELL_WIDTH));
+        }
+        return max;
+    }
+
+    // ── Cell construction ─────────────────────────────────────────────────
+
+    private VBox buildCell(PluginParameter parameter) {
+        VBox cell = new VBox(CELL_SPACING);
+        cell.getStyleClass().add("parameter-grid-cell");
+        cell.setAlignment(Pos.TOP_CENTER);
+        cell.setMinWidth(CELL_WIDTH);
+        cell.setPrefWidth(CELL_WIDTH);
+        cell.setMaxWidth(CELL_WIDTH);
+
+        Label name = new Label(parameter.name());
+        name.getStyleClass().add("parameter-name");
+        name.setMaxWidth(CELL_WIDTH); // long names truncate with ellipsis
+        cell.getChildren().add(name);
+
+        if (isBooleanParameter(parameter)) {
+            buildToggleCell(cell, parameter);
+        } else if (isDiscreteParameter(parameter)) {
+            buildSegmentedCell(cell, parameter);
+        } else {
+            buildKnobCell(cell, parameter);
+        }
+        return cell;
+    }
+
+    /**
+     * Continuous parameter → 96×96 {@link Knob} plus a numeric readout.
+     *
+     * <p>Sized in code ({@code setMinSize/setPrefSize/setMaxSize}) — the
+     * {@code .size-*} style classes top out at 48 px and {@code KnobSkin}
+     * caps its computed max at 64 px, so explicit overrides are required
+     * for the §6.2 96-px cell. {@code KnobSkin} renders the formatted
+     * value only into the accessible text, not as a visible readout, so
+     * the readout is a separate {@code parameter-value} Label; the knob's
+     * own formatter is aligned with it so screen-reader narration matches
+     * the visible text. Double-click reset to default is built into
+     * {@code KnobSkin} (as is Ctrl/Cmd-click and the {@code 0} key).</p>
+     */
+    private void buildKnobCell(VBox cell, PluginParameter parameter) {
+        Knob knob = Knob.create()
+                .min(parameter.minValue())
+                .max(parameter.maxValue())
+                .defaultValue(parameter.defaultValue())
+                .build();
+        knob.setMinSize(CELL_WIDTH, CELL_WIDTH);
+        knob.setPrefSize(CELL_WIDTH, CELL_WIDTH);
+        knob.setMaxSize(CELL_WIDTH, CELL_WIDTH);
+        knob.setValueFormatter(ParameterGridPanel::formatContinuous);
+        knob.setTooltip(new Tooltip(RESET_TOOLTIP));
+
+        Label value = new Label(formatContinuous(parameter.defaultValue()));
+        // Literal class names (story 266 numeric-typography audit friendly):
+        // parameter values are inline numeric readouts and use tabular
+        // figures so they don't jiggle as the user drags the knob.
+        value.getStyleClass().addAll("parameter-value", "numeric-caption");
+
+        knob.valueProperty().addListener((obs, oldValue, newValue) -> {
+            double v = newValue.doubleValue();
+            // The readout tracks EVERY change (gesture and echo alike);
+            // only genuine gestures pass the guard inside fireSink.
+            value.setText(formatContinuous(v));
+            fireSink(parameter.id(), v);
+        });
+
+        cell.getChildren().addAll(knob, value);
+        echoByParameterId.put(parameter.id(), knob::setValue);
+    }
+
+    /**
+     * Boolean parameter → §6.2 "labelled toggle": an ON/OFF
+     * {@link ToggleButton}. Selected ⇒ 1.0, deselected ⇒ 0.0. Double-click
+     * resets to the descriptor default (legacy semantics kept verbatim).
+     */
+    private void buildToggleCell(VBox cell, PluginParameter parameter) {
+        boolean initiallyOn = parameter.defaultValue() >= 0.5;
+        ToggleButton toggle = new ToggleButton(initiallyOn ? LABEL_ON : LABEL_OFF);
+        toggle.setSelected(initiallyOn);
+        toggle.setTooltip(new Tooltip(RESET_TOOLTIP));
+        toggle.setOnAction(e -> {
+            boolean on = toggle.isSelected();
+            toggle.setText(on ? LABEL_ON : LABEL_OFF);
+            fireSink(parameter.id(), on ? 1.0 : 0.0);
+        });
+        toggle.setOnMouseClicked(e -> {
+            if (e.getClickCount() == 2) {
+                // setSelected does not fire onAction, so report explicitly
+                // (same shape as the legacy panel's double-click reset).
+                boolean on = parameter.defaultValue() >= 0.5;
+                toggle.setSelected(on);
+                toggle.setText(on ? LABEL_ON : LABEL_OFF);
+                fireSink(parameter.id(), parameter.defaultValue());
+            }
+        });
+
+        cell.getChildren().add(toggle);
+        echoByParameterId.put(parameter.id(), v -> {
+            boolean on = v >= 0.5;
+            toggle.setSelected(on);
+            toggle.setText(on ? LABEL_ON : LABEL_OFF);
+        });
+    }
+
+    /**
+     * Discrete parameter → §6.2 segmented selector: one
+     * {@link ToggleButton} per integer value {@code min..max} in a single
+     * {@link ToggleGroup}, labelled with the value.
+     *
+     * <p>All sink reporting flows through the group's selected-toggle
+     * listener, so each actual value change is reported exactly once. The
+     * listener also guards the standard ToggleGroup pitfall: clicking the
+     * already-selected segment tries to deselect it (selected toggle →
+     * {@code null}) — the guard re-selects it inside the reentrancy guard,
+     * keeping one segment always active without re-reporting. Double-click
+     * selects the default segment (the selection listener reports the
+     * change if there is one).</p>
+     */
+    private void buildSegmentedCell(VBox cell, PluginParameter parameter) {
+        long lo = Math.round(parameter.minValue());
+        long hi = Math.round(parameter.maxValue());
+
+        ToggleGroup group = new ToggleGroup();
+        HBox selector = new HBox();
+        selector.getStyleClass().add("segmented-selector");
+        selector.setAlignment(Pos.CENTER);
+
+        List<ToggleButton> segments = new ArrayList<>();
+        for (long v = lo; v <= hi; v++) {
+            ToggleButton segment = new ToggleButton(Long.toString(v));
+            segment.setToggleGroup(group);
+            segment.setUserData((double) v);
+            segment.setTooltip(new Tooltip(RESET_TOOLTIP));
+            segment.setOnMouseClicked(e -> {
+                if (e.getClickCount() == 2) {
+                    // Reset to default — reported (once) by the selection
+                    // listener iff the selection actually changes.
+                    selectSegment(segments, lo, parameter.defaultValue());
+                }
+            });
+            segments.add(segment);
+            selector.getChildren().add(segment);
+        }
+
+        group.selectedToggleProperty().addListener((obs, oldToggle, newToggle) -> {
+            if (newToggle == null) {
+                // Deselection guard: clicking the selected segment must
+                // keep it selected. Restore inside the reentrancy guard so
+                // the restore is not reported as a gesture.
+                if (oldToggle != null) {
+                    runSyncing(() -> group.selectToggle(oldToggle));
+                }
+                return;
+            }
+            fireSink(parameter.id(), (Double) newToggle.getUserData());
+        });
+
+        // Initial selection = default, silently (construction reports nothing).
+        runSyncing(() -> selectSegment(segments, lo, parameter.defaultValue()));
+
+        cell.getChildren().add(selector);
+        echoByParameterId.put(parameter.id(), v -> selectSegment(segments, lo, v));
+    }
+
+    /** Selects the segment nearest {@code value} (clamped into the range). */
+    private static void selectSegment(List<ToggleButton> segments, long lo, double value) {
+        long index = Math.round(value) - lo;
+        index = Math.max(0, Math.min(segments.size() - 1, index));
+        Toggle segment = segments.get((int) index);
+        segment.setSelected(true);
+    }
+
+    // ── Heuristics & formatting (legacy PluginParameterEditorPanel) ───────
+
+    /**
+     * The legacy panel's deliberately conservative boolean heuristic, kept
+     * verbatim: unit range, integral default, AND the name mentions
+     * "toggle". Without the name guard a continuous 0..1 parameter that
+     * happens to default to 0 or 1 (a "Mix", a "Level") would silently
+     * collapse into an ON/OFF toggle — the SDK has no boolean metadata yet
+     * to decide otherwise.
+     */
+    private static boolean isBooleanParameter(PluginParameter parameter) {
+        return parameter.minValue() == 0.0 && parameter.maxValue() == 1.0
+                && (parameter.defaultValue() == 0.0 || parameter.defaultValue() == 1.0)
+                && parameter.name().toLowerCase(Locale.ROOT).contains("toggle");
+    }
+
+    /**
+     * Discrete heuristic (§6.2 "max ≤ 8 with integer steps"), applied only
+     * when {@link #isBooleanParameter(PluginParameter)} said no: all three
+     * range values are mathematically integral and the span covers 2–8
+     * integer states. A heuristic by necessity — the SDK has no enum
+     * metadata yet.
+     */
+    private static boolean isDiscreteParameter(PluginParameter parameter) {
+        double span = parameter.maxValue() - parameter.minValue();
+        return isIntegral(parameter.minValue())
+                && isIntegral(parameter.maxValue())
+                && isIntegral(parameter.defaultValue())
+                && span >= 1.0 && span <= 7.0;
+    }
+
+    private static boolean isIntegral(double v) {
+        return Double.isFinite(v) && v == Math.rint(v);
+    }
+
+    /**
+     * The legacy panel's continuous formatting rules: {@code |v| >= 1000}
+     * → one decimal, otherwise two ({@link Locale#ROOT}, matching the
+     * controls-package formatter convention).
+     */
+    private static String formatContinuous(double value) {
+        if (Math.abs(value) >= 1000) {
+            return String.format(Locale.ROOT, "%.1f", value);
+        }
+        return String.format(Locale.ROOT, "%.2f", value);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginEditorSession.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginEditorSession.java
@@ -1,0 +1,1024 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.NotificationLevel;
+import com.benesquivelmusic.daw.app.ui.marshal.FxAnimationTimerAllowed;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+import com.benesquivelmusic.daw.app.ui.views.DetachPluginRequestedEvent;
+import com.benesquivelmusic.daw.core.plugin.PluginInvocationSupervisor;
+import com.benesquivelmusic.daw.core.plugin.parameter.ABComparison;
+import com.benesquivelmusic.daw.core.plugin.parameter.ParameterPreset;
+import com.benesquivelmusic.daw.core.plugin.parameter.ParameterPresetManager;
+import com.benesquivelmusic.daw.core.plugin.parameter.PluginParameterState;
+import com.benesquivelmusic.daw.sdk.editor.EditorHints;
+import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
+import com.benesquivelmusic.daw.sdk.editor.PluginParameterStore;
+import com.benesquivelmusic.daw.sdk.editor.RenderTick;
+import com.benesquivelmusic.daw.sdk.editor.Theme;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginMeterSnapshot;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+
+import javafx.animation.AnimationTimer;
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextInputDialog;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import java.util.function.BiConsumer;
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * One live host↔plugin editor session (story 301, Plugin View Design Book
+ * §8.2) — the host-side machinery that honours the story-300
+ * {@link PluginEditorFactory} contract. {@link #open} invokes the plugin's
+ * {@code editorFactory()} inside the §2.7 fault harness, frames the resulting
+ * editor in the standard {@link EditorFrame} chrome (§6.1–§6.6), and drives
+ * everything the contract promises the plugin:
+ *
+ * <ul>
+ *   <li><strong>Declarative</strong> — a host-generated
+ *       {@link ParameterGridPanel} (§6.2) wired through the single-writer
+ *       {@link ParameterGridPanel.ValueSink} into the session's
+ *       {@link PluginParameterState} mirror and the real-time-safe
+ *       {@link PluginParameterStore} (§2.6);</li>
+ *   <li><strong>Panel</strong> — the plugin's {@link Region} from
+ *       {@code createPanel(EditorContext)}, embedded and clipped by the frame
+ *       (§6.3);</li>
+ *   <li><strong>Canvas</strong> — a host-owned {@link Canvas} inside an
+ *       {@code editor-canvas-host} wrapper; the session owns the render loop
+ *       and calls {@code render(RenderTick)} on parameter change, resize,
+ *       theme change, {@code requestRender()} and an opted-in
+ *       {@code requestAnimationTimer(fps)} tick (§5.D, §6.3), all coalesced
+ *       per frame through the {@link FxDispatcher} keyed latest-wins seam
+ *       (§6.3 / story 289);</li>
+ *   <li><strong>Faulted</strong> — the §6.6 placeholder body plus the inline
+ *       fault banner, never a void.</li>
+ * </ul>
+ *
+ * <h2>Fault harness (§2.7, §4.7, §6.6)</h2>
+ *
+ * <p>Every plugin-facing call — {@code editorFactory()}, {@code hints()},
+ * {@code getParameters()}, {@code createPanel}, {@code attach},
+ * {@code render}, {@code detach} — runs inside a {@link Throwable}-catching
+ * harness. On a fault the session routes the trace to
+ * {@link PluginInvocationSupervisor#reportUiFault} (editor faults never
+ * quarantine the audio processor — §6.6 "only the editor is disabled"),
+ * shows the fault banner, and — when the fault killed the body — swaps in the
+ * {@code editor-fault-placeholder} so the user always sees an editor. A fault
+ * during a canvas {@code render} substitutes the body exactly once (guarded,
+ * never per-tick spam), stops the fps loop and best-effort-detaches the
+ * canvas. {@code EditorContext#postFault} (§4.8) is the deliberate exception:
+ * a plugin-<em>reported</em> recoverable fault shows the banner and logs, but
+ * neither substitutes the body nor stops the editor.</p>
+ *
+ * <h2>Callback ownership</h2>
+ *
+ * <p>The session wires every {@link EditorFrame} callback <em>except</em>
+ * {@link EditorFrame#setOnCloseRequested(Runnable)}: close-intent placement
+ * (clearing the Workshop pane, nulling the active-session field) is the
+ * hosting {@code PluginViewController}'s concern, so the controller sets that
+ * one callback after {@link #open} returns. Reload, fault details, detach
+ * (fires the existing typed {@link DetachPluginRequestedEvent} — story 288's
+ * panel-dock machinery is explicitly out of scope), A/B (backed by the
+ * existing {@link ABComparison}, §6.5), and the §6.4 preset footer (persisted
+ * via {@link ParameterPresetManager} under
+ * {@code ~/.daw/plugin-presets/<sanitized-plugin-id>}, the
+ * {@code BackupRetentionController}/{@code RenderQueue} home-directory
+ * convention) are all session-owned.</p>
+ *
+ * <h2>Bypass (§6.1)</h2>
+ *
+ * <p>The frame's bypass toggle is recorded in {@link #isBypassed()} only:
+ * story 301 opens editors for <em>registered</em> plugins with no live insert
+ * slot behind them, so there is no engine hookup for the bypass state yet —
+ * wiring it to a live insert chain is the inserts / story-302+ domain.</p>
+ *
+ * <h2>Threading (§4.7)</h2>
+ *
+ * <p>{@link #open}, {@link #dispose()} and every frame callback run on the
+ * JavaFX Application Thread. The session's single {@link AnimationTimer}
+ * (sanctioned below) runs only while the frame is in a {@link Scene}; per
+ * tick it drains the store's audio→UI ring into the grid / a canvas repaint,
+ * mirrors the latest {@link PluginMeterSnapshot} into the frame's §6.4
+ * meters (reference-compared — the meter channel is latest-wins), and paces
+ * the opted-in canvas fps. Per-tick work is allocation-light: the drain sink
+ * and render runnable are pre-allocated fields.</p>
+ *
+ * <h2>Theme bridge (§2.5)</h2>
+ *
+ * <p>The SDK {@link Theme} handed to canvas plugins is built from the frame's
+ * six resolved {@code -editor-frame-*} styleable colours (styles.css forwards
+ * {@code -surface-1}/{@code -text}/{@code -accent}/{@code -meter-*} into
+ * them) — colours derive from resolved CSS, never a mirrored hex literal.
+ * One invalidation listener over all six rebuilds the theme and schedules a
+ * canvas repaint; entering a scene first forces {@code applyCss()} so the
+ * initial read is resolved, not the neutral fallback.</p>
+ *
+ * @see EditorFrame
+ * @see HostEditorContext
+ * @see FxCanvasSurface
+ */
+@FxAnimationTimerAllowed("Per-editor drain/meter/fps loop owned by this session: "
+        + "drains the parameter store's audio-to-UI ring into the editor, mirrors "
+        + "the meter snapshot and paces an opted-in canvas frame rate, running "
+        + "only while the frame is in a scene (javafx-application-design §6 "
+        + "control-owns-timer); not a cross-thread seam — story 289 sentinel.")
+public final class PluginEditorSession {
+
+    private static final Logger LOG = Logger.getLogger(PluginEditorSession.class.getName());
+
+    /** Chrome strings (Skill §14) — {@code Locale.ROOT}, EditorFrameSkin idiom. */
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
+
+    /** Bounds the host clamps an opted-in animation rate into (§6.3). */
+    private static final double MIN_FPS = 1.0;
+    private static final double MAX_FPS = 60.0;
+
+    /**
+     * Host services the session consumes. Supplier results and nullable
+     * members are tolerated as {@code null} — a missing service degrades to
+     * a sensible fallback (default sample rate, no fault-log routing, no
+     * notification) rather than an error, so headless tests can open a
+     * session with {@code new Deps(null, null, null, null)}.
+     *
+     * @param sampleRate       live sample-rate read for
+     *                         {@code EditorContext#sampleRate()}; nullable
+     * @param faultSupervisor  live supplier of the
+     *                         {@link PluginInvocationSupervisor} the §6.6
+     *                         fault harness reports into (a supplier because
+     *                         the supervisor is constructed after the plugin
+     *                         controller at startup); nullable, and a
+     *                         {@code null} supplier result is tolerated
+     * @param openPluginFaultLog opens the plugin fault log (the banner's
+     *                         {@code [ⓘ]} action, §6.6); nullable
+     * @param showNotification the toast sink for host-side failures (e.g. a
+     *                         preset that cannot be written, §6.4); nullable
+     */
+    public record Deps(DoubleSupplier sampleRate,
+                       Supplier<PluginInvocationSupervisor> faultSupervisor,
+                       Runnable openPluginFaultLog,
+                       BiConsumer<NotificationLevel, String> showNotification) {
+    }
+
+    // ── Immutable session identity / services ────────────────────────────
+
+    private final DawPlugin plugin;
+    private final Deps deps;
+    private final EditorFrame frame = new EditorFrame();
+    private final HostEditorContext context;
+
+    /**
+     * The marshalling seam, captured ONCE at open — never re-read, so a
+     * {@code FxDispatcher.installDefault} swap mid-life cannot split the
+     * session across two dispatchers (the "capture swappable singleton
+     * reference once" discipline). May be {@code null} in a pure-unit
+     * context; renders then run immediately instead of coalesced.
+     */
+    private final FxDispatcher dispatcher;
+
+    /** Theme manager captured ONCE at open (same discipline as above). */
+    private final ThemeManager themeManager;
+
+    /** Fault-log id: {@code descriptor.id()}, or the class name fallback. */
+    private final String faultReportId;
+    /** Banner display name: {@code descriptor.name()}, or the class simple name. */
+    private final String displayName;
+
+    private final ParameterPresetManager presetManager;
+    /** Loaded presets by name — backs the §6.4 footer selector. */
+    private final Map<String, ParameterPreset> presetsByName = new LinkedHashMap<>();
+
+    // ── Timer / render plumbing (pre-allocated — per-tick work stays light) ─
+
+    private final SessionTimer timer = new SessionTimer();
+    /** Session-unique coalescing key for {@link FxDispatcher#onFx(Object, Runnable)}. */
+    private final Object renderKey = new Object();
+    private final Runnable renderRunnable = this::renderNow;
+    private final PluginParameterStore.IndexConsumer drainSink = this::onStoreIndexDrained;
+
+    // ── Theme bridge (§2.5) ───────────────────────────────────────────────
+
+    private final ReadOnlyObjectWrapper<Theme> theme;
+    // this-qualified reads: a lambda in an instance-variable initializer may
+    // not forward-reference a later field by simple name (JLS §8.3.3).
+    private final InvalidationListener themeTokensListener = obs -> {
+        if (!this.disposed) {
+            rebuildTheme();
+        }
+    };
+    private final ChangeListener<Scene> sceneListener = this::onSceneChanged;
+    private final ChangeListener<Boolean> bypassListener =
+            (obs, was, now) -> this.bypassed = now;
+
+    // ── Per-build editor state (replaced wholesale by a reload) ──────────
+
+    private PluginParameterStore store;
+    private PluginParameterState state;
+    private ABComparison abComparison;
+    /** Non-null only in Declarative mode — the echo target for drains / A/B / presets. */
+    private ParameterGridPanel grid;
+    /** Non-null only in Canvas mode. */
+    private PluginEditorFactory.Canvas canvasFactory;
+    private FxCanvasSurface surface;
+    private Canvas canvas;
+    private boolean canvasAttached;
+
+    /** §6.6 swap-once guard: the placeholder is substituted at most once per build. */
+    private boolean bodyFaulted;
+    /** Set by the drain sink when a drained change needs a canvas repaint this tick. */
+    private boolean drainRenderNeeded;
+    /** Opted-in canvas animation rate (§6.3); {@code 0} = event-driven only. */
+    private double animationFps;
+    /** {@code System.nanoTime()} of the previous render; {@code 0} = none yet. */
+    private long lastRenderNanos;
+    /** Monotonic {@link RenderTick#frameIndex()} counter for this editor. */
+    private long frameIndex;
+
+    private boolean bypassed;
+    private boolean disposed;
+
+    private PluginEditorSession(DawPlugin plugin, String insertLocation, Deps deps) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin must not be null");
+        this.deps = Objects.requireNonNull(deps, "deps must not be null");
+        this.dispatcher = FxDispatcher.getDefault();
+        this.themeManager = ThemeManager.getDefault();
+        this.context = new HostEditorContext(this, deps.sampleRate());
+
+        // Identity — getDescriptor() is plugin code; a throw degrades to the
+        // class name so the session (and its fault reporting) still works.
+        String id;
+        String name;
+        String vendor;
+        Throwable descriptorFault = null;
+        try {
+            PluginDescriptor descriptor = Objects.requireNonNull(
+                    plugin.getDescriptor(), "getDescriptor() returned null");
+            id = descriptor.id();
+            name = descriptor.name();
+            vendor = descriptor.vendor();
+        } catch (Throwable t) {
+            id = plugin.getClass().getName();
+            name = plugin.getClass().getSimpleName();
+            vendor = "";
+            descriptorFault = t;
+        }
+        this.faultReportId = id;
+        this.displayName = name;
+        if (descriptorFault != null) {
+            reportToSupervisor(descriptorFault);
+        }
+        frame.setVendor(vendor);
+        frame.setPluginName(name);
+        frame.setInsertLocation(insertLocation);
+
+        this.presetManager = new ParameterPresetManager(presetRoot(id));
+        this.theme = new ReadOnlyObjectWrapper<>(this, "theme", readThemeFromFrame());
+
+        // §2.5 — ONE invalidation listener over all six forwarded role-token
+        // colours; a change rebuilds the SDK Theme and repaints the canvas.
+        frame.editorBackgroundProperty().addListener(themeTokensListener);
+        frame.editorForegroundProperty().addListener(themeTokensListener);
+        frame.editorAccentProperty().addListener(themeTokensListener);
+        frame.editorMeterSafeProperty().addListener(themeTokensListener);
+        frame.editorMeterWarnProperty().addListener(themeTokensListener);
+        frame.editorMeterClipProperty().addListener(themeTokensListener);
+        frame.sceneProperty().addListener(sceneListener);
+        frame.bypassedProperty().addListener(bypassListener);
+        bypassed = frame.isBypassed();
+
+        // Frame callbacks — everything EXCEPT onCloseRequested, which the
+        // hosting PluginViewController owns (see the class Javadoc).
+        frame.setOnReloadRequested(this::reload);
+        frame.setOnFaultDetailsRequested(this::openFaultLog);
+        frame.setOnDetachRequested(
+                () -> frame.fireEvent(new DetachPluginRequestedEvent()));
+        frame.setOnAbToggleRequested(this::onAbToggle);
+        frame.setOnAbCopyRequested(this::onAbCopy);
+        frame.setOnPresetSelected(this::onPresetSelected);
+        frame.setOnSavePresetRequested(this::onSavePreset);
+        frame.setOnSaveAsPresetRequested(this::onSaveAsPreset);
+
+        buildEditor();
+        loadPresetsIntoFrame();
+
+        if (frame.getScene() != null) {
+            onSceneChanged(frame.sceneProperty(), null, frame.getScene());
+        }
+    }
+
+    /**
+     * Opens an editor session for the given plugin: runs the §8.2 factory
+     * pipeline ({@code editorFactory()} → hints → store → mode body) inside
+     * the fault harness and returns the framed result.
+     *
+     * <p>FX thread only. Never throws for plugin-caused failures — a plugin
+     * that throws anywhere in the pipeline degrades to the §6.6 fault banner
+     * plus placeholder body, and the returned session is fully functional
+     * (Reload re-attempts the pipeline).</p>
+     *
+     * @param plugin         the plugin whose editor to open; must not be
+     *                       {@code null}
+     * @param insertLocation the §6.1 insert-location crumb (e.g.
+     *                       {@code "Drum Bus / Insert 2"}); {@code null} or
+     *                       blank omits the crumb
+     * @param deps           host services; must not be {@code null} (its
+     *                       members may be)
+     * @return the open session, never {@code null}
+     */
+    public static PluginEditorSession open(DawPlugin plugin, String insertLocation,
+            Deps deps) {
+        return new PluginEditorSession(plugin, insertLocation, deps);
+    }
+
+    /** @return the framed editor — the node the host places in the Workshop pane. */
+    public EditorFrame frame() {
+        return frame;
+    }
+
+    /**
+     * @return the session's real-time-safe parameter store — the §2.6 bridge
+     *         both the editor and (in later stories) the audio processor talk
+     *         to. Exposed as a test seam; a Reload that re-runs the factory
+     *         pipeline replaces the instance, so callers should not cache it.
+     */
+    public PluginParameterStore store() {
+        return store;
+    }
+
+    /**
+     * @return the frame's current bypass state (§6.1). Story 301 records the
+     *         toggle only — these editors open for registered plugins with no
+     *         live insert slot, so wiring bypass into an engine chain is the
+     *         inserts / story-302+ domain.
+     */
+    public boolean isBypassed() {
+        return bypassed;
+    }
+
+    /**
+     * Tears the session down: stops the timer, best-effort-detaches a canvas
+     * editor (harnessed), and removes every listener / callback the session
+     * installed on the frame ({@code onCloseRequested} is deliberately left —
+     * the hosting controller owns it). Idempotent.
+     */
+    public void dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        timer.stop();
+        teardownCanvas();
+        grid = null;
+        frame.sceneProperty().removeListener(sceneListener);
+        frame.bypassedProperty().removeListener(bypassListener);
+        frame.editorBackgroundProperty().removeListener(themeTokensListener);
+        frame.editorForegroundProperty().removeListener(themeTokensListener);
+        frame.editorAccentProperty().removeListener(themeTokensListener);
+        frame.editorMeterSafeProperty().removeListener(themeTokensListener);
+        frame.editorMeterWarnProperty().removeListener(themeTokensListener);
+        frame.editorMeterClipProperty().removeListener(themeTokensListener);
+        frame.setOnReloadRequested(null);
+        frame.setOnFaultDetailsRequested(null);
+        frame.setOnDetachRequested(null);
+        frame.setOnAbToggleRequested(null);
+        frame.setOnAbCopyRequested(null);
+        frame.setOnPresetSelected(null);
+        frame.setOnSavePresetRequested(null);
+        frame.setOnSaveAsPresetRequested(null);
+    }
+
+    // ── Factory pipeline (§8.2, §2.7) ─────────────────────────────────────
+
+    /**
+     * The whole factory pipeline: invoke {@code editorFactory()} (harnessed;
+     * a throw substitutes {@link PluginEditorFactory.Faulted} per §2.7), read
+     * {@code hints()} (harnessed; {@link EditorHints#compact()} fallback),
+     * build the store / state / A/B from the resolved parameter list, apply
+     * the hints to the frame, and build the mode-specific body. Run once at
+     * open and again on every Reload.
+     */
+    private void buildEditor() {
+        bodyFaulted = false;
+
+        PluginEditorFactory factory;
+        try {
+            factory = Objects.requireNonNull(
+                    plugin.editorFactory(), "editorFactory() returned null");
+        } catch (Throwable t) {
+            factory = new PluginEditorFactory.Faulted(t, "editorFactory");
+        }
+
+        EditorHints hints;
+        try {
+            hints = Objects.requireNonNull(factory.hints(), "hints() returned null");
+        } catch (Throwable t) {
+            faultBanner("hints", t);
+            hints = EditorHints.compact();
+        }
+
+        // §2.6 — the store is the only bridge to the audio side. For a
+        // Declarative editor it must carry the FACTORY's list (the record may
+        // differ from getParameters()); an empty factory list falls back to
+        // getParameters(). The store constructor rejects duplicate ids —
+        // plugin-caused, so that too degrades via the harness.
+        List<PluginParameter> parameters = resolveParameters(factory);
+        try {
+            store = new PluginParameterStore(parameters);
+        } catch (Throwable t) {
+            faultBanner("getParameters", t);
+            parameters = List.of();
+            store = new PluginParameterStore(parameters);
+        }
+        state = new PluginParameterState(parameters);
+        abComparison = new ABComparison(state);
+        frame.setAbActiveSlot(abComparison.getActiveSlot());
+
+        // §6.3 — the host applies (and enforces) the size / resize / chrome
+        // hints; the plugin cannot resize itself.
+        frame.setPreferredBodyWidth(hints.preferredWidth());
+        frame.setPreferredBodyHeight(hints.preferredHeight());
+        frame.setResizePolicy(hints.resize());
+        frame.setChromePolicy(hints.chrome());
+
+        switch (factory) {
+            case PluginEditorFactory.Declarative _ -> buildDeclarativeBody(parameters);
+            case PluginEditorFactory.Panel p -> buildPanelBody(p);
+            case PluginEditorFactory.Canvas c -> buildCanvasBody(c);
+            case PluginEditorFactory.Faulted f -> buildFaultedBody(f);
+        }
+    }
+
+    /**
+     * The parameter list the store / state / grid are built from: a
+     * Declarative factory's own (non-empty) list wins, everything else reads
+     * {@code getParameters()} (harnessed — a throw degrades to an empty
+     * list, banner shown, editor still built).
+     */
+    private List<PluginParameter> resolveParameters(PluginEditorFactory factory) {
+        if (factory instanceof PluginEditorFactory.Declarative d
+                && !d.parameters().isEmpty()) {
+            return d.parameters();
+        }
+        try {
+            return Objects.requireNonNull(
+                    plugin.getParameters(), "getParameters() returned null");
+        } catch (Throwable t) {
+            faultBanner("getParameters", t);
+            return List.of();
+        }
+    }
+
+    /**
+     * §6.2 — the host-generated grid. The sink is the session's single-writer
+     * entry: a user gesture lands in the {@link PluginParameterState} mirror
+     * (the A/B / preset snapshot source) and the store's UI→audio ring; echo
+     * re-entry is already guarded inside the grid.
+     */
+    private void buildDeclarativeBody(List<PluginParameter> parameters) {
+        grid = new ParameterGridPanel(parameters, this::onGridGesture);
+        frame.setBody(grid);
+    }
+
+    private void onGridGesture(int parameterId, double newValue) {
+        state.setValue(parameterId, newValue);
+        store.writeFromUiById(parameterId, newValue);
+    }
+
+    /** §6.3 — the plugin's own region, harnessed; a {@code null} return is a fault. */
+    private void buildPanelBody(PluginEditorFactory.Panel panel) {
+        Region body;
+        try {
+            body = panel.createPanel(context);
+            if (body == null) {
+                throw new NullPointerException("createPanel returned null");
+            }
+        } catch (Throwable t) {
+            faultAndSubstitute("createPanel", t);
+            return;
+        }
+        frame.setBody(body);
+    }
+
+    /**
+     * §5.D / §6.3 — the host-owned canvas. {@link Canvas} is not a
+     * {@link Region}, so it cannot be resized by layout: the wrapper hosts it
+     * and listeners mirror the wrapper's size onto the canvas (then request a
+     * render). Harnessed {@code attach} followed by exactly one synchronous
+     * initial render; all further renders are event-driven / fps-paced.
+     */
+    private void buildCanvasBody(PluginEditorFactory.Canvas factory) {
+        canvas = new Canvas();
+        Pane host = new Pane(canvas);
+        host.getStyleClass().add("editor-canvas-host");
+        host.widthProperty().addListener((obs, was, now) -> {
+            canvas.setWidth(now.doubleValue());
+            scheduleRender();
+        });
+        host.heightProperty().addListener((obs, was, now) -> {
+            canvas.setHeight(now.doubleValue());
+            scheduleRender();
+        });
+        surface = new FxCanvasSurface(canvas, this::scheduleRender);
+        canvasFactory = factory;
+        frame.setBody(host);
+        try {
+            factory.attach(surface);
+            canvasAttached = true;
+        } catch (Throwable t) {
+            faultAndSubstitute("attach", t);
+            return;
+        }
+        renderNow();
+    }
+
+    /** §6.6 — the host-substituted faulted editor: banner + placeholder, never a void. */
+    private void buildFaultedBody(PluginEditorFactory.Faulted faulted) {
+        bodyFaulted = true;
+        faultBanner(faulted.hint(), faulted.cause());
+        frame.setBody(buildFaultPlaceholder());
+    }
+
+    private Node buildFaultPlaceholder() {
+        Label label = new Label(msg("editor.frame.fault.placeholder"));
+        label.setWrapText(true);
+        VBox placeholder = new VBox(label);
+        placeholder.getStyleClass().add("editor-fault-placeholder");
+        placeholder.setAlignment(Pos.CENTER);
+        return placeholder;
+    }
+
+    // ── Fault harness (§2.7, §4.7, §6.6) ─────────────────────────────────
+
+    /**
+     * A fault that killed the body: banner + substitute the placeholder +
+     * (canvas-side) stop the fps loop and best-effort detach. Substitutes at
+     * most once per build — a render fault inside the timer swaps once,
+     * never per-tick spam; repeats are still routed to the fault log.
+     */
+    private void faultAndSubstitute(String phase, Throwable t) {
+        if (bodyFaulted) {
+            reportToSupervisor(t);
+            return;
+        }
+        bodyFaulted = true;
+        faultBanner(phase, t);
+        frame.setBody(buildFaultPlaceholder());
+        grid = null;
+        teardownCanvas();
+    }
+
+    /**
+     * Banner + fault-log routing without substituting the body — for faults
+     * with a viable fallback (hints, getParameters) and the §4.8 posted-fault
+     * channel.
+     */
+    private void faultBanner(String phase, Throwable t) {
+        reportToSupervisor(t);
+        frame.setFaultMessage(String.format(Locale.ROOT,
+                msg("editor.frame.fault.bannerFormat"),
+                displayName, t.getClass().getSimpleName(), phase));
+    }
+
+    /**
+     * Routes a fault to the {@link PluginInvocationSupervisor} (§6.6 — editor
+     * faults are logged and published but never quarantine the audio side).
+     * Tolerates a missing supervisor: the deps member and its supplier result
+     * may both be {@code null}.
+     */
+    private void reportToSupervisor(Throwable t) {
+        PluginInvocationSupervisor supervisor =
+                deps.faultSupervisor() == null ? null : deps.faultSupervisor().get();
+        if (supervisor != null) {
+            supervisor.reportUiFault(faultReportId, t);
+        }
+        LOG.log(Level.WARNING, "Plugin editor fault [" + faultReportId + "]", t);
+    }
+
+    /**
+     * §4.8 — a plugin-reported <em>recoverable</em> fault
+     * ({@code EditorContext#postFault}): banner + fault log, but the body is
+     * NOT substituted and the editor keeps running.
+     */
+    void postFault(Throwable error, String hint) {
+        Objects.requireNonNull(error, "error must not be null");
+        Objects.requireNonNull(hint, "hint must not be null");
+        reportToSupervisor(error);
+        frame.setFaultMessage(String.format(Locale.ROOT,
+                msg("editor.frame.fault.postedFormat"),
+                hint, error.getClass().getSimpleName()));
+    }
+
+    /** §6.6 {@code [Reload]} — tear the body down and re-run the whole pipeline. */
+    private void reload() {
+        if (disposed) {
+            return;
+        }
+        teardownCanvas();
+        grid = null;
+        frame.setFaultMessage("");
+        buildEditor();
+    }
+
+    private void openFaultLog() {
+        if (deps.openPluginFaultLog() != null) {
+            deps.openPluginFaultLog().run();
+        }
+    }
+
+    /**
+     * Stops the fps loop and best-effort-detaches an attached canvas factory.
+     * The detach is itself harnessed (report-only — no banner, no recursive
+     * substitution on failure). A no-op outside Canvas mode.
+     */
+    private void teardownCanvas() {
+        animationFps = 0.0;
+        if (canvasFactory != null && canvasAttached) {
+            try {
+                canvasFactory.detach();
+            } catch (Throwable t) {
+                reportToSupervisor(t);
+            }
+        }
+        canvasAttached = false;
+        canvasFactory = null;
+        surface = null;
+        canvas = null;
+        lastRenderNanos = 0;
+    }
+
+    // ── A/B (§6.5) ────────────────────────────────────────────────────────
+
+    /**
+     * §6.5 swap. Panel / Canvas editors write to the store directly, so the
+     * {@link PluginParameterState} mirror is refreshed from the store at
+     * every snapshot point before {@link ABComparison} captures / loads;
+     * afterwards the loaded slot is pushed back into the store and echoed
+     * into the grid.
+     */
+    private void onAbToggle() {
+        if (disposed) {
+            return;
+        }
+        refreshStateFromStore();
+        abComparison.toggle();
+        frame.setAbActiveSlot(abComparison.getActiveSlot());
+        pushStateToStoreAndGrid();
+    }
+
+    /** §6.5 {@code [Copy A▸B]} — snapshot the store, copy active → inactive. */
+    private void onAbCopy() {
+        if (disposed) {
+            return;
+        }
+        refreshStateFromStore();
+        abComparison.copyActiveToInactive();
+    }
+
+    /** Snapshot point: mirror every store value into the A/B / preset state. */
+    private void refreshStateFromStore() {
+        for (int i = 0; i < store.parameterCount(); i++) {
+            state.setValue(store.parameterIdAt(i), store.value(i));
+        }
+    }
+
+    /**
+     * Pushes every state value into the store (the audio side sees the swap /
+     * preset), echoes the grid in one guarded bulk write, and schedules a
+     * canvas repaint (a UI-side value change never travels the audio→UI ring,
+     * so the canvas must be repainted explicitly).
+     */
+    private void pushStateToStoreAndGrid() {
+        Map<Integer, Double> values = state.getAllValues();
+        for (Map.Entry<Integer, Double> entry : values.entrySet()) {
+            store.writeFromUiById(entry.getKey(), entry.getValue());
+        }
+        if (grid != null) {
+            grid.setAllValues(values);
+        }
+        scheduleRender();
+    }
+
+    // ── Presets (§6.4) ────────────────────────────────────────────────────
+
+    private void loadPresetsIntoFrame() {
+        presetsByName.clear();
+        try {
+            for (ParameterPreset preset : presetManager.loadAllPresets()) {
+                presetsByName.put(preset.name(), preset);
+            }
+        } catch (IOException e) {
+            LOG.fine(() -> "Could not load presets for " + faultReportId + ": " + e);
+        }
+        frame.getPresetItems().setAll(presetsByName.keySet());
+    }
+
+    private void onPresetSelected(String name) {
+        if (disposed || name == null) {
+            return;
+        }
+        ParameterPreset preset = presetsByName.get(name);
+        if (preset == null) {
+            return;
+        }
+        state.loadValues(preset.values());
+        pushStateToStoreAndGrid();
+        frame.setSelectedPreset(name);
+    }
+
+    /** §6.4 {@code [Save…]} — overwrite the selected preset, else fall through to Save As. */
+    private void onSavePreset() {
+        if (disposed) {
+            return;
+        }
+        refreshStateFromStore();
+        String selected = frame.getSelectedPreset();
+        if (selected == null || selected.isBlank()) {
+            promptAndSavePresetAs();
+            return;
+        }
+        savePreset(selected);
+    }
+
+    /** §6.4 {@code [Save As…]} — prompt for a name, then persist. */
+    private void onSaveAsPreset() {
+        if (disposed) {
+            return;
+        }
+        refreshStateFromStore();
+        promptAndSavePresetAs();
+    }
+
+    private void promptAndSavePresetAs() {
+        TextInputDialog dialog = new TextInputDialog();
+        dialog.setTitle(msg("editor.frame.preset.saveAs.title"));
+        dialog.setHeaderText(msg("editor.frame.preset.saveAs.header"));
+        dialog.setContentText(msg("editor.frame.preset.saveAs.prompt"));
+        themeManager.applyTo(dialog.getDialogPane());
+        dialog.showAndWait()
+                .map(String::strip)
+                .filter(name -> !name.isEmpty())
+                .ifPresent(this::savePreset);
+    }
+
+    private void savePreset(String name) {
+        ParameterPreset preset = ParameterPreset.user(name, state.getAllValues());
+        try {
+            presetManager.savePreset(preset);
+        } catch (IOException e) {
+            LOG.log(Level.WARNING,
+                    "Failed to save preset '" + name + "' for " + faultReportId, e);
+            if (deps.showNotification() != null) {
+                deps.showNotification().accept(NotificationLevel.ERROR,
+                        String.format(Locale.ROOT,
+                                msg("editor.frame.preset.saveError"), e.getMessage()));
+            }
+            return;
+        }
+        presetsByName.put(name, preset);
+        if (!frame.getPresetItems().contains(name)) {
+            frame.getPresetItems().add(name);
+        }
+        frame.setSelectedPreset(name);
+    }
+
+    /**
+     * Per-plugin preset home: {@code ~/.daw/plugin-presets/<sanitized-id>}
+     * (the {@code ~/.daw} convention shared with autosaves and the render
+     * queue). Sanitising replaces any character outside
+     * {@code [a-zA-Z0-9._-]} with {@code _} so an arbitrary plugin id is
+     * always a valid directory name.
+     */
+    private static Path presetRoot(String pluginId) {
+        return Path.of(System.getProperty("user.home", "."),
+                ".daw", "plugin-presets", sanitizeDirectoryName(pluginId));
+    }
+
+    private static String sanitizeDirectoryName(String pluginId) {
+        return pluginId.replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+
+    // ── Host services reached through HostEditorContext ─────────────────
+
+    /** @return the current resolved SDK theme (§2.5). */
+    Theme currentTheme() {
+        return theme.get();
+    }
+
+    /** @return the read-only observable theme handed to plugin editors (§2.5). */
+    ObservableValue<Theme> themeProperty() {
+        return theme.getReadOnlyProperty();
+    }
+
+    /**
+     * §6.3 — coerces a plugin resize request per the CURRENT resize policy
+     * (the host enforces; the plugin cannot resize itself): {@code FIXED}
+     * ignores it, {@code HORIZONTAL}/{@code VERTICAL} honour one axis,
+     * {@code BOTH} honours both. Sizes clamp to ≥ 1 px.
+     */
+    void requestResize(int width, int height) {
+        if (disposed) {
+            return;
+        }
+        double w = Math.max(1, width);
+        double h = Math.max(1, height);
+        switch (frame.getResizePolicy()) {
+            case FIXED -> {
+                // Fixed on both axes — the request is ignored (§6.3).
+            }
+            case HORIZONTAL -> frame.setPreferredBodyWidth(w);
+            case VERTICAL -> frame.setPreferredBodyHeight(h);
+            case BOTH -> {
+                frame.setPreferredBodyWidth(w);
+                frame.setPreferredBodyHeight(h);
+            }
+        }
+    }
+
+    /**
+     * §6.3 — clamps an opted-in animation rate into [{@value MIN_FPS},
+     * {@value MAX_FPS}]; a value {@code <= 0} cancels the loop, returning the
+     * editor to purely event-driven rendering.
+     */
+    void setAnimationFps(double framesPerSecond) {
+        if (framesPerSecond <= 0.0) {
+            animationFps = 0.0;
+            return;
+        }
+        animationFps = Math.clamp(framesPerSecond, MIN_FPS, MAX_FPS);
+    }
+
+    /**
+     * Schedules one coalesced canvas render on the next dispatcher pulse
+     * (§6.3 — N requests within a frame collapse to the latest via the
+     * story-289 keyed seam). A no-op outside Canvas mode; renders immediately
+     * when no dispatcher is installed (pure-unit context).
+     */
+    void scheduleRender() {
+        if (disposed || canvasFactory == null) {
+            return;
+        }
+        if (dispatcher != null) {
+            dispatcher.onFx(renderKey, renderRunnable);
+        } else {
+            renderNow();
+        }
+    }
+
+    // ── Render loop (§5.D, §6.3) ──────────────────────────────────────────
+
+    /**
+     * Renders one frame: builds the {@link RenderTick} (delta from the
+     * previous render, {@code 0.0} first; monotonic frame index; the current
+     * resolved theme) and calls the plugin's {@code render} inside the
+     * harness. The body host clips the canvas region (§6.3), so nothing
+     * extra guards the graphics context here.
+     */
+    private void renderNow() {
+        if (disposed || bodyFaulted || canvasFactory == null || !canvasAttached) {
+            return;
+        }
+        long now = System.nanoTime();
+        double delta = lastRenderNanos == 0
+                ? 0.0
+                : Math.max(0.0, (now - lastRenderNanos) / 1e9);
+        lastRenderNanos = now;
+        RenderTick tick = new RenderTick(delta, frameIndex++, theme.get());
+        try {
+            canvasFactory.render(tick);
+        } catch (Throwable t) {
+            faultAndSubstitute("render", t);
+        }
+    }
+
+    // ── Theme bridge (§2.5) ───────────────────────────────────────────────
+
+    /**
+     * Builds the SDK {@link Theme} from the frame's six RESOLVED styleable
+     * colours — the styles.css role-token forwarding seam — never a mirrored
+     * hex literal. Null-hardened against a degenerate CSS write with the
+     * SDK's own neutral fallback.
+     */
+    private Theme readThemeFromFrame() {
+        Theme neutral = Theme.neutral();
+        return new Theme(
+                orFallback(frame.getEditorBackground(), neutral.background()),
+                orFallback(frame.getEditorForeground(), neutral.foreground()),
+                orFallback(frame.getEditorAccent(), neutral.accent()),
+                orFallback(frame.getEditorMeterSafe(), neutral.meterSafe()),
+                orFallback(frame.getEditorMeterWarn(), neutral.meterWarn()),
+                orFallback(frame.getEditorMeterClip(), neutral.meterClip()));
+    }
+
+    private static <T> T orFallback(T value, T fallback) {
+        return value == null ? fallback : value;
+    }
+
+    private void rebuildTheme() {
+        theme.set(readThemeFromFrame());
+        scheduleRender();
+    }
+
+    /**
+     * Scene lifecycle: entering a scene forces {@code applyCss()} (paired
+     * with the token listeners per the resolved-CSS discipline) so the first
+     * theme read is resolved rather than the neutral fallback, then starts
+     * the per-editor timer; leaving the scene stops it, so a hidden editor
+     * never spins a frame loop.
+     */
+    private void onSceneChanged(ObservableValue<? extends Scene> observable,
+            Scene oldScene, Scene newScene) {
+        if (disposed) {
+            return;
+        }
+        if (newScene != null) {
+            frame.applyCss();
+            rebuildTheme();
+            timer.start();
+        } else {
+            timer.stop();
+        }
+    }
+
+    // ── Session timer ─────────────────────────────────────────────────────
+
+    /**
+     * The session's ONE per-frame loop (class-level
+     * {@code @FxAnimationTimerAllowed} sentinel): (1) drain the store's
+     * audio→UI ring — Declarative echoes into the grid, Canvas marks a
+     * repaint; (2) mirror the latest meter snapshot (reference compare —
+     * meters are a latest-wins channel, §6.4); (3) pace the opted-in canvas
+     * fps. Allocation-light: the sink and runnable are pre-allocated fields.
+     */
+    private void tick(long nowNanos) {
+        if (disposed) {
+            return;
+        }
+        drainRenderNeeded = false;
+        store.drainToUi(drainSink);
+        if (drainRenderNeeded) {
+            renderNow();
+        }
+        PluginMeterSnapshot meters = store.meters();
+        if (meters != frame.getMeters()) {
+            frame.setMeters(meters);
+        }
+        if (canvasFactory != null && animationFps > 0.0
+                && (lastRenderNanos == 0
+                        || nowNanos - lastRenderNanos >= (long) (1e9 / animationFps))) {
+            renderNow();
+        }
+    }
+
+    /** Pre-allocated drain sink — one audio-side change, by dense index. */
+    private void onStoreIndexDrained(int index) {
+        if (grid != null) {
+            grid.updateValue(store.parameterIdAt(index), store.value(index));
+        } else if (canvasFactory != null) {
+            drainRenderNeeded = true;
+        }
+    }
+
+    /** The one timer this session owns; its {@code handle} body is {@link #tick}. */
+    private final class SessionTimer extends AnimationTimer {
+        @Override
+        public void handle(long now) {
+            tick(now);
+        }
+    }
+
+    /**
+     * Resolves a chrome string from the shared bundle, falling back to the
+     * raw key if absent (mirrors {@code EditorFrameSkin#msg(String)}).
+     */
+    private static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (MissingResourceException e) {
+            return key;
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/package-info.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/package-info.java
@@ -1,0 +1,38 @@
+/**
+ * Host-side plugin-editor surface — the standard chrome and mode renderers
+ * that wrap any {@link com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory}
+ * (story 301, Plugin View Design Book §5.A/§5.D and §6).
+ *
+ * <p>Story 300 (Phase 1 of the §8 migration path) defined the SDK-side
+ * editor contract; this package is Phase 2 — <em>the host honours it</em>
+ * (§8.2). The centrepiece is
+ * {@link com.benesquivelmusic.daw.app.ui.plugin.EditorFrame}, a
+ * {@code Control} that renders the host-owned chrome around every editor
+ * mode:</p>
+ *
+ * <ul>
+ *   <li>the <strong>breadcrumb header</strong> (§6.1) — vendor ▸ plugin ▸
+ *       insert location plus the four host actions
+ *       {@code [Bypass] [A|B] [↗ detach] [× close]};</li>
+ *   <li>the <strong>A/B compare bar</strong> (§6.5), backed by
+ *       {@link com.benesquivelmusic.daw.core.plugin.parameter.ABComparison};</li>
+ *   <li>the <strong>fault banner</strong> (§6.6) — inline above the body,
+ *       never modal;</li>
+ *   <li>the clipped <strong>body host</strong> (§6.3) — the mode-specific
+ *       editor node, size-policed by the host
+ *       ({@link com.benesquivelmusic.daw.sdk.editor.ResizePolicy}); and</li>
+ *   <li>the <strong>footer</strong> (§6.4) — preset bar + always-present
+ *       IN/OUT meters fed from
+ *       {@link com.benesquivelmusic.daw.sdk.plugin.PluginMeterSnapshot}.</li>
+ * </ul>
+ *
+ * <p>Design principle §2.2 — "the plugin is a guest, not a tenant" — is
+ * structural here: the chrome is host-rendered in every mode, the plugin
+ * cannot add or remove header actions, and the body region is clipped so a
+ * misbehaving plugin cannot paint over the breadcrumb or footer. Chrome
+ * quantity is selected by
+ * {@link com.benesquivelmusic.daw.sdk.editor.ChromePolicy}
+ * ({@code STANDARD} / {@code MINIMAL} / {@code IMMERSIVE}) but always
+ * host-owned.</p>
+ */
+package com.benesquivelmusic.daw.app.ui.plugin;

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -131,3 +131,60 @@ workshop.breadcrumb.separator=▸
 # reorder or relabel without touching code (Skill §14).
 workshop.breadcrumb.trackFormat=Track %02d
 workshop.breadcrumb.insertFormat=Insert %d
+
+# Plugin editor frame (story 301) -- Plugin View Design Book §5.A/§5.D, §6.
+# Host-owned chrome around every contract-driven plugin editor: the four
+# §6.1 header actions, the §6.5 A/B compare bar, the §6.6 fault banner and
+# the §6.4 preset/meter footer. Breadcrumb segment text is data (vendor /
+# plugin name / insert location) composed in EditorFrameSkin, not chrome
+# strings. Section-scoped prefix per the file convention.
+editor.frame.bypass.tooltip=Bypass plugin (B)
+editor.frame.bypass.accessible=Bypass plugin
+editor.frame.ab.tooltip=A/B compare — reveal the compare bar
+# Accessible-text template for the header [A|B] toggle; %s is the active
+# slot name (A or B).
+editor.frame.ab.accessibleFormat=A/B compare — active slot %s
+editor.frame.ab.copy=Copy A▸B
+editor.frame.ab.copy.tooltip=Copy the active slot into the inactive slot
+editor.frame.ab.swap=Swap
+editor.frame.ab.swap.tooltip=Swap between the A and B parameter states
+editor.frame.detach.tooltip=Detach editor to a floating window
+editor.frame.detach.accessible=Detach editor
+editor.frame.close.tooltip=Close editor (plugin keeps running)
+editor.frame.close.accessible=Close editor
+editor.frame.reload.label=Reload
+editor.frame.reload.tooltip=Reload the plugin editor
+editor.frame.reload.accessible=Reload editor
+editor.frame.faultInfo.tooltip=Open this fault in the plugin fault log
+editor.frame.faultInfo.accessible=Fault details
+editor.frame.preset.label=Preset
+editor.frame.preset.save=Save…
+editor.frame.preset.save.tooltip=Save the current preset
+editor.frame.preset.saveAs=Save As…
+editor.frame.preset.saveAs.tooltip=Save the current state as a new preset
+editor.frame.meter.in=IN
+editor.frame.meter.out=OUT
+# §6.6 placeholder body text shown in place of a faulted editor.
+editor.frame.fault.placeholder=Editor unavailable — see fault log for details.
+# §6.6 fault-banner template (story 301 host session): %1$s = plugin display
+# name, %2$s = the thrown exception's simple class name, %3$s = the
+# plugin-facing phase that faulted (editorFactory, createPanel, attach,
+# render, …).
+editor.frame.fault.bannerFormat=%s threw %s in %s(). The editor was substituted with a safe placeholder.
+# §4.8 plugin-reported recoverable fault (EditorContext.postFault): %1$s =
+# the plugin's own hint, %2$s = the exception's simple class name. The body
+# is NOT substituted for these — the editor keeps running.
+editor.frame.fault.postedFormat=%s (%s)
+# §6.4 Save As… preset naming dialog (story 301 host session).
+editor.frame.preset.saveAs.title=Save Preset As
+editor.frame.preset.saveAs.header=Save the current parameter values as a preset
+editor.frame.preset.saveAs.prompt=Preset name
+# Preset persistence failure notification (§6.4); %s = the I/O error message.
+editor.frame.preset.saveError=Failed to save preset: %s
+
+# Plugins menu — External submenu (story 301 §8.2.1). Lists every loaded
+# third-party plugin from the PluginRegistry so an already-registered
+# DawPlugin has a user-visible activation path into the contract-driven
+# editor frame. Section-scoped prefix per the file convention.
+menu.plugins.external=External
+menu.plugins.external.none=(none installed)

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -2484,15 +2484,17 @@
     -fx-alignment: CENTER;
 }
 
-/* Parameter name above the knob — muted small-caps feel (§6.2). */
-.parameter-grid-cell-name {
+/* Parameter name above the knob — muted small-caps feel (§6.2).
+ * Scoped under .parameter-grid: PluginParameterEditorPanel reuses the
+ * bare parameter-name/parameter-value classes and must not pick this up. */
+.parameter-grid .parameter-name {
     -fx-text-fill: -text-mute;
     -fx-font-size: 10px;
     -fx-font-weight: bold;
 }
 
 /* Formatted value beneath the knob (§6.2). */
-.parameter-grid-cell-value {
+.parameter-grid .parameter-value {
     -fx-text-fill: -text-hi;
     -fx-font-size: 11px;
 }

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -2355,3 +2355,144 @@
     -fx-text-fill: -text-mute;
     -fx-font-size: 12px;
 }
+
+/* ── Plugin editor frame (story 301, Plugin View Design Book §5.A/§5.D, §6) ──
+ * Host-owned chrome around every contract-driven plugin editor: the §6.1
+ * breadcrumb header, §6.5 A/B compare bar, §6.6 fault banner, clipped §6.3
+ * body host and §6.4 preset/meter footer. All spacing on the 4 px grid;
+ * pure token references — no inline colours (TokenValidationTest).
+ *
+ * THIS RULE also forwards the documented .root-pane role tokens into the
+ * frame's -editor-frame-* styleable colour properties (the Knob/LevelMeter
+ * convention). The forwards use distinct source/target names so they are
+ * NOT circular looked-up colours. The host reads the RESOLVED values
+ * (EditorFrame#getEditorBackground() et al.) to build the SDK Theme handed
+ * to Canvas plugins — colours derive from resolved CSS, never a mirrored
+ * hex literal (feedback_control_css_role_token_forwarding); the Java-side
+ * defaults are only the SDK's neutral Theme.neutral() fallback. A theme
+ * re-tints the frame (and every canvas plugin) just by overriding the role
+ * tokens on .root-pane — no per-control duplication needed. */
+.editor-frame {
+    -fx-background-color: -surface-1;
+    -editor-frame-background: -surface-1;
+    -editor-frame-foreground: -text;
+    -editor-frame-accent:     -accent;
+    -editor-frame-meter-safe: -meter-low;
+    -editor-frame-meter-warn: -meter-hi;
+    -editor-frame-meter-clip: -meter-clip;
+}
+
+/* §6.1 breadcrumb header — single line, never wraps; the four host
+ * actions sit right of the growing spacer. */
+.editor-frame-header {
+    -fx-background-color: -surface-2;
+    -fx-padding: 8;
+    -fx-spacing: 8;
+    -fx-border-color: transparent transparent -line-soft transparent;
+    -fx-border-width: 0 0 1 0;
+}
+
+/* The header breadcrumb reuses .breadcrumb-bar (story 281); zero its own
+ * padding so the header's 8 px padding governs the row. */
+.editor-frame-breadcrumb {
+    -fx-padding: 0;
+}
+
+/* §6.5 A/B compare bar — revealed by the header [A|B] toggle; subtle
+ * second-surface strip under the header. */
+.editor-ab-bar {
+    -fx-background-color: -surface-2;
+    -fx-padding: 4 8 4 8;
+    -fx-spacing: 8;
+    -fx-border-color: transparent transparent -line-soft transparent;
+    -fx-border-width: 0 0 1 0;
+}
+
+.editor-ab-slot {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+    -fx-font-weight: bold;
+}
+
+/* Added to the ACTIVE slot label only (single accent, §2.1). */
+.editor-ab-active {
+    -fx-text-fill: -accent;
+}
+
+/* §6.6 fault banner — inline above the body, never modal, never
+ * auto-hidden by the immersive retraction. -warn border carries the
+ * severity; background stays a quiet surface. */
+.editor-fault-banner {
+    -fx-background-color: -surface-2;
+    -fx-border-color: -warn;
+    -fx-border-width: 1;
+    -fx-padding: 8;
+    -fx-spacing: 8;
+}
+
+.editor-fault-message {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 12px;
+}
+
+/* §6.3 body host — plugin-owned pixels, clipped in code so a misbehaving
+ * plugin cannot paint over the breadcrumb or footer. */
+.editor-frame-body {
+    -fx-background-color: -surface-1;
+}
+
+/* §6.4 footer: preset bar + always-present IN/OUT meters. */
+.editor-frame-footer {
+    -fx-background-color: -surface-2;
+    -fx-padding: 8;
+    -fx-spacing: 8;
+    -fx-border-color: -line-soft transparent transparent transparent;
+    -fx-border-width: 1 0 0 0;
+}
+
+.editor-frame-preset {
+    -fx-pref-width: 160;
+}
+
+.editor-frame-preset-label,
+.editor-frame-meter-caption {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10px;
+    -fx-font-weight: bold;
+}
+
+/* Compact horizontal footer meters (dimensions only — the lit-segment
+ * palette forwards via the story-267 .level-meter rule above). */
+.editor-frame-meter-in,
+.editor-frame-meter-out {
+    -fx-pref-width: 72;
+    -fx-pref-height: 8;
+    -fx-min-width: 40;
+    -fx-min-height: 8;
+}
+
+/* §6.2 declarative parameter grid — the host-generated 96 px knob grid
+ * rendered for PluginEditorFactory.Declarative editors. The 16 px gaps
+ * and the 96 px cell column are set in code (ParameterGrid); CSS carries
+ * alignment and text colours only. Grid background transparent so the
+ * .editor-frame-body surface shows through. */
+.parameter-grid {
+    -fx-background-color: transparent;
+}
+
+.parameter-grid-cell {
+    -fx-alignment: CENTER;
+}
+
+/* Parameter name above the knob — muted small-caps feel (§6.2). */
+.parameter-grid-cell-name {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10px;
+    -fx-font-weight: bold;
+}
+
+/* Formatted value beneath the knob (§6.2). */
+.parameter-grid-cell-value {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 11px;
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BuiltInUnchangedInPhase2Test.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/BuiltInUnchangedInPhase2Test.java
@@ -1,0 +1,146 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.core.plugin.BusCompressorPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+
+import javafx.scene.Node;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 301 acceptance — Plugin View Design Book §2.3 / §8.2.1: built-in
+ * plugins are untouched in this phase.
+ *
+ * <p>{@code PluginViewController#openEditor(DawPlugin)} dispatches through
+ * the legacy built-in {@code switch} first (the documented §2.3 internal
+ * escape hatch, kept byte-for-byte until the built-ins migrate in story
+ * 302). Activating a {@code BuiltInDawPlugin} whose id IS in the switch —
+ * here {@link BusCompressorPlugin#PLUGIN_ID} — must still route to the
+ * legacy {@code openBusCompressorWindow(...)} floating-Stage path, and must
+ * NOT open the new story-301 contract editor:</p>
+ *
+ * <ul>
+ *   <li>the {@code showEditorInWorkshopPane} dep is never invoked and no
+ *       contract-editor session is created
+ *       ({@code activeEditorSessionForTest()} stays {@code null});</li>
+ *   <li>a showing {@link Stage} titled {@code "Bus Compressor"} exists —
+ *       the JavaFX 26 headless Glass platform (the repo's standard test
+ *       environment) supports real Stages, so the legacy window is
+ *       directly observable.</li>
+ * </ul>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class BuiltInUnchangedInPhase2Test {
+
+    private static final String LEGACY_WINDOW_TITLE = "Bus Compressor";
+
+    private PluginViewController controller;
+    private BusCompressorPlugin plugin;
+
+    @Test
+    void busCompressorStillRoutesToLegacyFloatingWindowNotContractFrame() {
+        runOnFxThread(() -> {
+            plugin = new BusCompressorPlugin();
+            plugin.initialize(new PluginContext() {
+                @Override public double getSampleRate() { return 48_000.0; }
+                @Override public int getBufferSize() { return 512; }
+                @Override public void log(String message) { }
+            });
+            plugin.activate();
+
+            List<List<String>> workshopInvocations = new ArrayList<>();
+            controller = new PluginViewController(deps(
+                    (segments, node) -> workshopInvocations.add(segments)));
+
+            controller.openEditor(plugin);
+
+            assertThat(workshopInvocations)
+                    .as("a switch-known built-in must never reach the "
+                            + "story-301 contract path — the Workshop-pane "
+                            + "consumer stays uninvoked (§2.3 escape hatch)")
+                    .isEmpty();
+            assertThat(controller.activeEditorSessionForTest())
+                    .as("no contract-editor session is created for a "
+                            + "legacy-routed built-in")
+                    .isNull();
+            assertThat(showingLegacyStages())
+                    .as("the legacy 'Bus Compressor' floating Stage opened "
+                            + "(pre-301 behaviour, unchanged this phase)")
+                    .isNotEmpty();
+            return null;
+        });
+    }
+
+    @AfterEach
+    void cleanup() {
+        runOnFxThread(() -> {
+            if (controller != null) {
+                // dispose() hides the stage; its onHidden handler disposes
+                // the view and deactivates the plugin.
+                controller.dispose();
+                controller = null;
+            }
+            // Best-effort: if dispose alone left the window showing, hide it
+            // directly so the shared toolkit fork stays clean.
+            for (Stage lingering : showingLegacyStages()) {
+                lingering.hide();
+            }
+            assertThat(showingLegacyStages())
+                    .as("no lingering 'Bus Compressor' window remains showing")
+                    .isEmpty();
+            if (plugin != null) {
+                // The plugin is test-constructed (not routed through the
+                // controller's built-in cache), so the test owns disposal.
+                plugin.dispose();
+                plugin = null;
+            }
+            return null;
+        });
+    }
+
+    // ── Harness ───────────────────────────────────────────────────────────
+
+    /** Minimal live {@code Deps}: fixed audio facts and no-op sinks. */
+    private static PluginViewController.Deps deps(
+            BiConsumer<List<String>, Node> showEditorInWorkshopPane) {
+        return new PluginViewController.Deps(
+                () -> 48_000.0,
+                () -> 512,
+                () -> null,
+                () -> { },
+                () -> { },
+                (status, icon) -> { },
+                (level, message) -> { },
+                () -> { },
+                showEditorInWorkshopPane,
+                () -> null,
+                () -> { });
+    }
+
+    /**
+     * All currently-showing Stages titled {@value #LEGACY_WINDOW_TITLE}.
+     * FX thread only ({@link Window#getWindows()} is an FX observable list;
+     * copied before filtering so a concurrent hide cannot break iteration).
+     */
+    private static List<Stage> showingLegacyStages() {
+        List<Stage> stages = new ArrayList<>();
+        for (Window window : List.copyOf(Window.getWindows())) {
+            if (window instanceof Stage stage && stage.isShowing()
+                    && LEGACY_WINDOW_TITLE.equals(stage.getTitle())) {
+                stages.add(stage);
+            }
+        }
+        return stages;
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FocusedEditorDoesNotRebuildContainerTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FocusedEditorDoesNotRebuildContainerTest.java
@@ -1,0 +1,216 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.plugin.EditorFrame;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginEditorSession;
+import com.benesquivelmusic.daw.app.ui.views.PluginViewContainer;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import javafx.beans.value.ChangeListener;
+import javafx.scene.Node;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 301 acceptance — Plugin View Design Book §8.2.2 on top of the
+ * story-281 invariant: swapping the focused plugin updates the
+ * {@link PluginViewContainer}'s content, but the container instance itself
+ * is never unmounted or rebuilt.
+ *
+ * <p>Two fake third-party plugins (different descriptor ids, both relying
+ * on the DEFAULT {@code editorFactory()} — the §4.2 backwards-compatible
+ * Declarative-over-{@code getParameters()} path) are activated in turn
+ * through {@code PluginViewController#onActivateExternalPlugin(DawPlugin)}.
+ * The test pins:</p>
+ *
+ * <ul>
+ *   <li>both activations produce {@link EditorFrame} content and the second
+ *       frame is a different instance ({@code currentContentProperty}
+ *       changed);</li>
+ *   <li>the container object identity is unchanged across the swap (strict
+ *       reference identity, the {@code WorkshopPluginSwitchTest}
+ *       precedent), the swap going through {@code setPluginView} only —
+ *       a {@code currentContentProperty} listener registered before the
+ *       second activation fires exactly once, with the new frame;</li>
+ *   <li>the first session is no longer the active one and the first frame
+ *       is no longer the container's content.</li>
+ * </ul>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class FocusedEditorDoesNotRebuildContainerTest {
+
+    private PluginViewController controller;
+
+    @Test
+    void swappingFocusedPluginTwiceKeepsContainerIdentityWhileContentChanges() {
+        runOnFxThread(() -> {
+            PluginViewContainer container = new PluginViewContainer();
+            controller = new PluginViewController(deps(
+                    (segments, node) -> container.setPluginView(node)));
+
+            FakeThirdPartyPlugin pluginA =
+                    new FakeThirdPartyPlugin("a", "Fake Plugin A");
+            FakeThirdPartyPlugin pluginB =
+                    new FakeThirdPartyPlugin("b", "Fake Plugin B");
+
+            // ── First activation: plugin A ────────────────────────────────
+            controller.onActivateExternalPlugin(pluginA);
+
+            PluginViewContainer containerRef1 = container;
+            int containerIdBefore = System.identityHashCode(container);
+            Node content1 = container.getCurrentContent();
+            PluginEditorSession firstSession =
+                    controller.activeEditorSessionForTest();
+
+            assertThat(content1)
+                    .as("activating plugin A frames its editor in the container")
+                    .isInstanceOf(EditorFrame.class);
+            assertThat(firstSession)
+                    .as("a live session backs plugin A's editor")
+                    .isNotNull();
+
+            // Listen BEFORE the second activation: the swap must surface as
+            // exactly one currentContentProperty change (typed property
+            // observation — never Event.getSource() identity).
+            List<Node> contentChanges = new ArrayList<>();
+            ChangeListener<Node> contentListener =
+                    (obs, was, now) -> contentChanges.add(now);
+            container.currentContentProperty().addListener(contentListener);
+
+            // ── Second activation: plugin B ───────────────────────────────
+            controller.onActivateExternalPlugin(pluginB);
+
+            Node content2 = container.getCurrentContent();
+            assertThat(content2)
+                    .as("activating plugin B frames its editor in the container")
+                    .isInstanceOf(EditorFrame.class);
+            assertThat(content2)
+                    .as("the focused-editor swap replaces the frame instance "
+                            + "(currentContentProperty changed)")
+                    .isNotSameAs(content1);
+
+            // Container identity — the story-281 invariant under the new frame.
+            assertThat(container)
+                    .as("the PluginViewContainer instance is the same object "
+                            + "across focused-plugin swaps — strict reference identity")
+                    .isSameAs(containerRef1);
+            assertThat(System.identityHashCode(container))
+                    .as("the container identity-hash is unchanged after the swap")
+                    .isEqualTo(containerIdBefore);
+
+            assertThat(contentChanges)
+                    .as("the swap fires currentContentProperty exactly once "
+                            + "— one setPluginView, no unmount/rebuild churn")
+                    .hasSize(1);
+            assertThat(contentChanges.get(0))
+                    .as("the single content change carries the new frame")
+                    .isSameAs(content2);
+
+            // Session and content handoff.
+            assertThat(controller.activeEditorSessionForTest())
+                    .as("the first session is no longer the active one")
+                    .isNotNull()
+                    .isNotSameAs(firstSession);
+            assertThat(container.getCurrentContent())
+                    .as("the first frame is no longer the container content")
+                    .isNotSameAs(content1);
+            assertThat(container.getChildren())
+                    .as("the container hosts exactly the new frame — the old "
+                            + "frame was swapped out through setPluginView")
+                    .containsExactly(content2);
+
+            container.currentContentProperty().removeListener(contentListener);
+            return null;
+        });
+    }
+
+    @AfterEach
+    void disposeController() {
+        if (controller != null) {
+            runOnFxThread(() -> {
+                controller.dispose();
+                return null;
+            });
+            controller = null;
+        }
+    }
+
+    // ── Harness ───────────────────────────────────────────────────────────
+
+    /** Minimal live {@code Deps}: fixed audio facts and no-op sinks. */
+    private static PluginViewController.Deps deps(
+            BiConsumer<List<String>, Node> showEditorInWorkshopPane) {
+        return new PluginViewController.Deps(
+                () -> 48_000.0,
+                () -> 512,
+                () -> null,
+                () -> { },
+                () -> { },
+                (status, icon) -> { },
+                (level, message) -> { },
+                () -> { },
+                showEditorInWorkshopPane,
+                () -> null,
+                () -> { });
+    }
+
+    /**
+     * A third-party plugin relying on the DEFAULT {@code editorFactory()}
+     * (§4.2 — Declarative over {@code getParameters()} for free). Each
+     * instance gets its own descriptor id so A and B are distinct plugins.
+     */
+    private static final class FakeThirdPartyPlugin implements DawPlugin {
+
+        private final PluginDescriptor descriptor;
+
+        FakeThirdPartyPlugin(String idSuffix, String name) {
+            this.descriptor = new PluginDescriptor(
+                    "com.test.story301.fake." + idSuffix,
+                    name, "1.0.0", "Test Vendor", PluginType.EFFECT);
+        }
+
+        @Override
+        public PluginDescriptor getDescriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public void initialize(PluginContext context) {
+            // no-op
+        }
+
+        @Override
+        public void activate() {
+            // no-op
+        }
+
+        @Override
+        public void deactivate() {
+            // no-op
+        }
+
+        @Override
+        public void dispose() {
+            // no-op
+        }
+
+        @Override
+        public List<PluginParameter> getParameters() {
+            return List.of(
+                    new PluginParameter(1, "Gain", -24.0, 24.0, 0.0),
+                    new PluginParameter(2, "Mix", 0.0, 1.0, 1.0));
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ThirdPartyPluginGetsEditorTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ThirdPartyPluginGetsEditorTest.java
@@ -1,0 +1,229 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.plugin.EditorFrame;
+import com.benesquivelmusic.daw.app.ui.plugin.ParameterGridPanel;
+import com.benesquivelmusic.daw.app.ui.views.PluginViewContainer;
+import com.benesquivelmusic.daw.sdk.editor.EditorHints;
+import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import javafx.scene.Node;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 301 acceptance — Plugin View Design Book §8.2.1 <em>"third-party
+ * plugins now have editors"</em>.
+ *
+ * <p>A fake third-party {@link DawPlugin} (its descriptor id is NOT in
+ * {@code PluginViewController}'s legacy built-in {@code switch}) overrides
+ * {@code editorFactory()} to return a
+ * {@link PluginEditorFactory.Declarative} over its own parameter list.
+ * Activating it through
+ * {@code PluginViewController#onActivateExternalPlugin(DawPlugin)} must:</p>
+ *
+ * <ul>
+ *   <li>build an {@link EditorFrame} (the standard §6.1–§6.6 host chrome)
+ *       whose body is the host-generated {@link ParameterGridPanel}
+ *       (§6.2), and place it in the Workshop right pane's stable-identity
+ *       {@link PluginViewContainer} via the {@code showEditorInWorkshopPane}
+ *       dep (§8.2.2);</li>
+ *   <li>initialise the plugin exactly once (identity-keyed
+ *       initialise-once) while every activation calls {@code activate()};</li>
+ *   <li>report the §6.1 breadcrumb segments — vendor and plugin name —
+ *       alongside the framed editor;</li>
+ *   <li>leave a live contract-editor session behind
+ *       ({@code activeEditorSessionForTest()} non-null).</li>
+ * </ul>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+final class ThirdPartyPluginGetsEditorTest {
+
+    private PluginViewController controller;
+
+    @Test
+    void activatingThirdPartyPluginBuildsEditorFrameWithParameterGridInContainer() {
+        runOnFxThread(() -> {
+            PluginViewContainer container = new PluginViewContainer();
+            List<List<String>> recordedSegments = new ArrayList<>();
+            List<String> notifications = new ArrayList<>();
+            controller = new PluginViewController(deps(
+                    (segments, node) -> {
+                        recordedSegments.add(segments);
+                        container.setPluginView(node);
+                    },
+                    notifications));
+            FakeThirdPartyPlugin fake = new FakeThirdPartyPlugin("editor");
+
+            controller.onActivateExternalPlugin(fake);
+
+            // onActivateExternalPlugin swallows RuntimeExceptions into the
+            // notification sink — an empty log proves the happy path ran.
+            assertThat(notifications)
+                    .as("activation must not degrade to the error-notification path")
+                    .isEmpty();
+
+            Node content = container.getCurrentContent();
+            assertThat(content)
+                    .as("the host frames the third-party editor in the standard "
+                            + "EditorFrame chrome and sets it on the container (§8.2.1)")
+                    .isNotNull()
+                    .isInstanceOf(EditorFrame.class);
+            EditorFrame frame = (EditorFrame) content;
+            assertThat(frame.getBody())
+                    .as("a Declarative factory yields the host-generated "
+                            + "parameter grid as the frame body (§6.2)")
+                    .isInstanceOf(ParameterGridPanel.class);
+
+            assertThat(fake.initializeCalls())
+                    .as("first activation initialises the plugin exactly once")
+                    .isEqualTo(1);
+            assertThat(fake.activateCalls())
+                    .as("activation calls activate()")
+                    .isEqualTo(1);
+
+            assertThat(recordedSegments)
+                    .as("the framed editor is handed to the Workshop pane once per activation")
+                    .hasSize(1);
+            assertThat(recordedSegments.get(0))
+                    .as("the §6.1 breadcrumb segments carry vendor and plugin name")
+                    .contains("Test Vendor", "Fake Editor Plugin");
+
+            assertThat(controller.activeEditorSessionForTest())
+                    .as("a live contract-editor session backs the framed editor")
+                    .isNotNull();
+
+            // Second activation of the SAME instance: initialise-once
+            // (identity-keyed), activation and editor opening repeat.
+            controller.onActivateExternalPlugin(fake);
+            assertThat(fake.initializeCalls())
+                    .as("a second activation must NOT re-initialise the plugin")
+                    .isEqualTo(1);
+            assertThat(fake.activateCalls())
+                    .as("every activation calls activate()")
+                    .isEqualTo(2);
+            assertThat(controller.activeEditorSessionForTest())
+                    .as("a live session remains after re-activation")
+                    .isNotNull();
+            assertThat(notifications)
+                    .as("re-activation must not degrade to the error-notification path")
+                    .isEmpty();
+            return null;
+        });
+    }
+
+    @AfterEach
+    void disposeController() {
+        if (controller != null) {
+            runOnFxThread(() -> {
+                controller.dispose();
+                return null;
+            });
+            controller = null;
+        }
+    }
+
+    // ── Harness ───────────────────────────────────────────────────────────
+
+    /**
+     * Minimal live {@code Deps}: fixed audio facts, no-op sinks, the
+     * test-provided Workshop-pane consumer, and a notification recorder so a
+     * swallowed activation failure is still visible to assertions.
+     */
+    private static PluginViewController.Deps deps(
+            BiConsumer<List<String>, Node> showEditorInWorkshopPane,
+            List<String> notificationLog) {
+        return new PluginViewController.Deps(
+                () -> 48_000.0,
+                () -> 512,
+                () -> null,
+                () -> { },
+                () -> { },
+                (status, icon) -> { },
+                (level, message) -> notificationLog.add(level + ": " + message),
+                () -> { },
+                showEditorInWorkshopPane,
+                () -> null,
+                () -> { });
+    }
+
+    /**
+     * The story's third-party shape: an id no built-in switch arm knows,
+     * two continuous parameters, and — per the story text — an explicit
+     * {@code editorFactory()} override returning
+     * {@link PluginEditorFactory.Declarative}.
+     */
+    private static final class FakeThirdPartyPlugin implements DawPlugin {
+
+        private final PluginDescriptor descriptor;
+        private int initializeCalls;
+        private int activateCalls;
+
+        FakeThirdPartyPlugin(String idSuffix) {
+            this.descriptor = new PluginDescriptor(
+                    "com.test.story301.fake." + idSuffix,
+                    "Fake Editor Plugin", "1.0.0", "Test Vendor",
+                    PluginType.EFFECT);
+        }
+
+        @Override
+        public PluginDescriptor getDescriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public void initialize(PluginContext context) {
+            initializeCalls++;
+        }
+
+        @Override
+        public void activate() {
+            activateCalls++;
+        }
+
+        @Override
+        public void deactivate() {
+            // no-op
+        }
+
+        @Override
+        public void dispose() {
+            // no-op
+        }
+
+        @Override
+        public List<PluginParameter> getParameters() {
+            return List.of(
+                    new PluginParameter(1, "Gain", -24.0, 24.0, 0.0),
+                    new PluginParameter(2, "Mix", 0.0, 1.0, 1.0));
+        }
+
+        /** Story 301 §8.2.1 — explicitly Declarative over the parameter list. */
+        @Override
+        public PluginEditorFactory editorFactory() {
+            return new PluginEditorFactory.Declarative(
+                    getParameters(), EditorHints.compact());
+        }
+
+        int initializeCalls() {
+            return initializeCalls;
+        }
+
+        int activateCalls() {
+            return activateCalls;
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/EditorFaultHarnessShowsBannerTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/EditorFaultHarnessShowsBannerTest.java
@@ -1,0 +1,261 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.sdk.editor.EditorContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Story 301 acceptance — the §2.7 fault harness (Plugin View Design Book
+ * §2.7, §6.6): a {@link PluginEditorFactory.Panel} whose {@code createPanel}
+ * throws never propagates out of {@link PluginEditorSession#open}. The frame
+ * shows the inline fault banner, the session swaps in the
+ * {@link PluginEditorFactory.Faulted}-style placeholder body, and the user
+ * always sees an editor — never a void. The banner's {@code [ⓘ]} action
+ * routes to the host fault log, and {@code [Reload]} re-runs the whole
+ * factory pipeline, recovering a plugin that succeeds on a later attempt.
+ *
+ * <p>The tests assert via the banner's style class, visibility and
+ * accessible text — the plugin's exception is never caught by the test
+ * itself. All FX work runs through the capture-and-rethrow
+ * {@code FxSnapshotTest.runOnFxThread} helper.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+@DisplayName("Editor fault harness shows the banner, never a void (story 301, §2.7/§6.6)")
+class EditorFaultHarnessShowsBannerTest {
+
+    /** Two continuous parameters (non-integral defaults — knob cells, §6.2). */
+    private static final PluginParameter GAIN =
+            new PluginParameter(1, "Gain", 0.0, 1.0, 0.5);
+    private static final PluginParameter MIX =
+            new PluginParameter(2, "Mix", 0.0, 1.0, 0.25);
+
+    /**
+     * Headless deps. The fault supervisor supplier deliberately yields
+     * {@code null}: the harness must tolerate a missing supervisor while
+     * reporting a fault (asserted implicitly by every open below completing).
+     */
+    private static final PluginEditorSession.Deps DEPS =
+            new PluginEditorSession.Deps(() -> 48_000.0, () -> null, null, null);
+
+    private PluginEditorSession session;
+
+    @AfterEach
+    void disposeSession() {
+        if (session != null) {
+            PluginEditorSession doomed = session;
+            session = null;
+            runOnFxThread(() -> {
+                doomed.dispose();
+                return null;
+            });
+        }
+    }
+
+    // ── createPanel throws → banner + placeholder, never a void (§6.6) ────
+
+    @Test
+    @DisplayName("a throwing createPanel does not propagate; the frame shows the fault banner and a placeholder body")
+    void throwingCreatePanelShowsBannerAndPlaceholderWithoutPropagating() {
+        DawPlugin plugin = new FakeDawPlugin("fault.panel", () -> new ThrowingPanel());
+
+        // The plugin's exception must be swallowed by the host harness — the
+        // test never catches it itself (a null faultSupervisor supplier
+        // result must not throw either; see DEPS).
+        assertThatCode(() -> session = openSession(plugin))
+                .doesNotThrowAnyException();
+
+        EditorFrame frame = session.frame();
+        realize(frame);
+
+        // Banner text names the failing phase and the exception type.
+        assertThat(frame.getFaultMessage())
+                .isNotBlank()
+                .contains("createPanel")
+                .contains(IllegalStateException.class.getSimpleName());
+
+        // The banner node itself: present, visible, and carrying the fault
+        // message as its accessible text (§6.6 test-visible seam).
+        Node banner = frame.lookup(".editor-fault-banner");
+        assertThat(banner).isNotNull();
+        assertThat(banner.isVisible()).isTrue();
+        assertThat(banner.getAccessibleText()).isEqualTo(frame.getFaultMessage());
+
+        // Never a void: the body was substituted with the §6.6 placeholder.
+        assertThat(frame.getBody()).isNotNull();
+        assertThat(frame.lookup(".editor-fault-placeholder")).isNotNull();
+    }
+
+    // ── Banner [ⓘ] routes to the host fault log (§6.6) ────────────────────
+
+    @Test
+    @DisplayName("the banner's fault-details action routes to the deps' openPluginFaultLog")
+    void faultDetailsCallbackRoutesToOpenPluginFaultLog() {
+        AtomicInteger routed = new AtomicInteger();
+        PluginEditorSession.Deps deps = new PluginEditorSession.Deps(
+                () -> 48_000.0, () -> null, routed::incrementAndGet, null);
+
+        session = runOnFxThread(() -> PluginEditorSession.open(
+                new FakeDawPlugin("fault.details", () -> new ThrowingPanel()),
+                "Drum Bus / Insert 2", deps));
+        EditorFrame frame = session.frame();
+
+        assertThat(frame.getOnFaultDetailsRequested()).isNotNull();
+        runOnFxThread(() -> {
+            frame.getOnFaultDetailsRequested().run();
+            return null;
+        });
+
+        assertThat(routed).hasValue(1);
+    }
+
+    // ── [Reload] recovery (§6.6) ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("Reload re-runs the factory pipeline: a first-attempt fault recovers to the real panel")
+    void reloadRecoversAPanelThatSucceedsOnTheSecondAttempt() {
+        AtomicInteger attempts = new AtomicInteger();
+        AtomicReference<Region> stubRef = new AtomicReference<>();
+        PluginEditorFactory.Panel flaky = new PluginEditorFactory.Panel() {
+            @Override
+            public Region createPanel(EditorContext context) {
+                if (attempts.incrementAndGet() == 1) {
+                    throw new IllegalStateException("boom in panel");
+                }
+                Region stub = new Region();
+                stubRef.set(stub);
+                return stub;
+            }
+        };
+
+        session = openSession(new FakeDawPlugin("fault.reload", () -> flaky));
+        EditorFrame frame = session.frame();
+        realize(frame);
+
+        // First attempt faulted: banner shown, placeholder body.
+        assertThat(frame.getFaultMessage()).isNotBlank();
+        Node banner = frame.lookup(".editor-fault-banner");
+        assertThat(banner).isNotNull();
+        assertThat(banner.isVisible()).isTrue();
+        assertThat(frame.lookup(".editor-fault-placeholder")).isNotNull();
+
+        // §6.6 [Reload] — re-runs the whole pipeline on the FX thread.
+        runOnFxThread(() -> {
+            frame.getOnReloadRequested().run();
+            return null;
+        });
+
+        assertThat(attempts).hasValue(2);
+        assertThat(frame.getFaultMessage()).isBlank();
+        assertThat(banner.isVisible()).isFalse();
+        assertThat(frame.getBody())
+                .as("the recovered body is the plugin's real region")
+                .isSameAs(stubRef.get());
+        assertThat(frame.lookup(".editor-fault-placeholder")).isNull();
+    }
+
+    // ── Shared scaffolding ────────────────────────────────────────────────
+
+    /** The §2.7 misbehaving plugin editor: {@code createPanel} always throws. */
+    private static final class ThrowingPanel implements PluginEditorFactory.Panel {
+        @Override
+        public Region createPanel(EditorContext context) {
+            throw new IllegalStateException("boom in panel");
+        }
+    }
+
+    private static PluginEditorSession openSession(DawPlugin plugin) {
+        return runOnFxThread(
+                () -> PluginEditorSession.open(plugin, "Drum Bus / Insert 2", DEPS));
+    }
+
+    /**
+     * Puts the frame in a {@link Scene} and forces CSS + layout so the skin
+     * exists and {@code lookup(...)} works (content is not reachable until
+     * the skin has run — known headless pitfall).
+     */
+    private static void realize(EditorFrame frame) {
+        runOnFxThread(() -> {
+            Scene scene = new Scene(new StackPane(frame), 900, 700);
+            frame.applyCss();
+            frame.layout();
+            return scene;
+        });
+    }
+
+    /**
+     * Minimal story-300 contract plugin: per-instance descriptor, two
+     * continuous parameters, lifecycle no-ops, the injected editor factory,
+     * and the default {@code asAudioProcessor()} ({@code Optional.empty()}).
+     */
+    private static final class FakeDawPlugin implements DawPlugin {
+
+        private final PluginDescriptor descriptor;
+        private final Supplier<PluginEditorFactory> factory;
+
+        FakeDawPlugin(String mode, Supplier<PluginEditorFactory> factory) {
+            this.descriptor = new PluginDescriptor(
+                    "com.test.story301.mode." + mode,
+                    "Mode Test", "1.0.0", "Test Vendor", PluginType.EFFECT);
+            this.factory = factory;
+        }
+
+        @Override
+        public PluginDescriptor getDescriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public void initialize(PluginContext context) {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void activate() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void deactivate() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void dispose() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public List<PluginParameter> getParameters() {
+            return List.of(GAIN, MIX);
+        }
+
+        @Override
+        public PluginEditorFactory editorFactory() {
+            return factory.get();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/EditorFrameRendersThreeModesTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/EditorFrameRendersThreeModesTest.java
@@ -1,0 +1,275 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.sdk.editor.CanvasSurface;
+import com.benesquivelmusic.daw.sdk.editor.EditorContext;
+import com.benesquivelmusic.daw.sdk.editor.EditorHints;
+import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
+import com.benesquivelmusic.daw.sdk.editor.RenderTick;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 301 acceptance — each of the three plugin-authored editor modes
+ * (Plugin View Design Book §2.1, §6.3) mounts inside the standard
+ * {@link EditorFrame} chrome when opened through
+ * {@link PluginEditorSession#open}:
+ *
+ * <ul>
+ *   <li>{@link PluginEditorFactory.Declarative} — a host-generated
+ *       {@link ParameterGridPanel} body (§6.2);</li>
+ *   <li>{@link PluginEditorFactory.Panel} — the plugin's own {@link Region}
+ *       embedded in the clipped body host (§6.3);</li>
+ *   <li>{@link PluginEditorFactory.Canvas} — a host-owned canvas surface,
+ *       attached and then given exactly one synchronous initial render
+ *       (§5.D, §6.3), detached again on {@link PluginEditorSession#dispose()}.</li>
+ * </ul>
+ *
+ * <p>All FX work runs through the capture-and-rethrow
+ * {@code FxSnapshotTest.runOnFxThread} helper; assertions target style
+ * classes, observable properties and instance identity only — never
+ * rasterized pixels (headless test convention).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+@DisplayName("EditorFrame renders all three editor modes (story 301, §2.1/§6.3)")
+class EditorFrameRendersThreeModesTest {
+
+    /** Two continuous parameters (non-integral defaults — knob cells, §6.2). */
+    private static final PluginParameter GAIN =
+            new PluginParameter(1, "Gain", 0.0, 1.0, 0.5);
+    private static final PluginParameter MIX =
+            new PluginParameter(2, "Mix", 0.0, 1.0, 0.25);
+
+    /** Headless deps — every nullable service degraded (session tolerates it). */
+    private static final PluginEditorSession.Deps DEPS =
+            new PluginEditorSession.Deps(() -> 48_000.0, () -> null, null, null);
+
+    private PluginEditorSession session;
+
+    @AfterEach
+    void disposeSession() {
+        if (session != null) {
+            PluginEditorSession doomed = session;
+            session = null;
+            runOnFxThread(() -> {
+                doomed.dispose();
+                return null;
+            });
+        }
+    }
+
+    // ── Declarative (§6.2) ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Declarative factory mounts a host-generated parameter grid inside breadcrumb + footer chrome")
+    void declarativeFactoryMountsParameterGridInsideChrome() {
+        FakeDawPlugin plugin = new FakeDawPlugin("declarative",
+                () -> new PluginEditorFactory.Declarative(
+                        List.of(GAIN, MIX), EditorHints.compact()));
+
+        session = openSession(plugin);
+        EditorFrame frame = session.frame();
+        realize(frame);
+
+        assertThat(frame.lookup(".editor-frame-header")).isNotNull();
+        assertThat(frame.lookup(".editor-frame-footer")).isNotNull();
+        assertThat(frame.lookup(".editor-frame-breadcrumb")).isNotNull();
+
+        assertThat(frame.getBody()).isInstanceOf(ParameterGridPanel.class);
+        ParameterGridPanel grid = (ParameterGridPanel) frame.getBody();
+        assertThat(grid.getChildrenUnmodifiable())
+                .as("one grid cell per declared parameter")
+                .hasSize(2);
+    }
+
+    // ── Panel (§6.3) ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Panel factory's region becomes the body and the body host is clipped")
+    void panelFactoryRegionIsMountedAsBodyAndClippedByHost() {
+        List<EditorContext> contexts = new ArrayList<>();
+        AtomicReference<Region> stubRef = new AtomicReference<>();
+        PluginEditorFactory.Panel factory = new PluginEditorFactory.Panel() {
+            @Override
+            public Region createPanel(EditorContext context) {
+                contexts.add(context);
+                Region stub = new Region();
+                stubRef.set(stub);
+                return stub;
+            }
+        };
+
+        session = openSession(new FakeDawPlugin("panel", () -> factory));
+        EditorFrame frame = session.frame();
+        realize(frame);
+
+        // createPanel ran exactly once, on the host's context (never null).
+        assertThat(contexts).hasSize(1);
+        assertThat(contexts.get(0)).isNotNull();
+
+        // The plugin's own region is the mounted body, framed by the chrome.
+        assertThat(frame.getBody()).isSameAs(stubRef.get());
+        assertThat(frame.lookup(".editor-frame-header")).isNotNull();
+        assertThat(frame.lookup(".editor-frame-footer")).isNotNull();
+
+        // §6.3 — the body HOST is clipped so a misbehaving plugin cannot
+        // paint over the breadcrumb or footer.
+        Node bodyHost = frame.lookup(".editor-frame-body");
+        assertThat(bodyHost).isNotNull();
+        assertThat(bodyHost.getClip()).isNotNull();
+        // Same node the skin exposes through its package-private seam.
+        EditorFrameSkin skin = (EditorFrameSkin) frame.getSkin();
+        assertThat(skin.bodyHost()).isSameAs(bodyHost);
+        assertThat(skin.bodyHost().getClip()).isNotNull();
+    }
+
+    // ── Canvas (§5.D, §6.3) ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Canvas factory receives attach then exactly one initial render, and detach on dispose")
+    void canvasFactoryAttachesThenRendersAndDetachesOnDispose() {
+        List<String> events = new ArrayList<>();
+        AtomicReference<CanvasSurface> surfaceRef = new AtomicReference<>();
+        PluginEditorFactory.Canvas factory = new PluginEditorFactory.Canvas() {
+            @Override
+            public void attach(CanvasSurface surface) {
+                events.add("attach");
+                surfaceRef.set(surface);
+            }
+
+            @Override
+            public void render(RenderTick tick) {
+                events.add("render");
+            }
+
+            @Override
+            public void detach() {
+                events.add("detach");
+            }
+        };
+
+        session = openSession(new FakeDawPlugin("canvas", () -> factory));
+
+        // open() synchronously attaches and performs one initial render
+        // (§8.2 pipeline contract). Later pulses may only APPEND further
+        // renders, so the prefix — not the whole list — is the invariant.
+        assertThat(events).startsWith("attach", "render");
+
+        // The captured host-owned surface is live and drawable.
+        assertThat(surfaceRef.get()).isNotNull();
+        GraphicsContext gc = runOnFxThread(() -> surfaceRef.get().graphicsContext());
+        assertThat(gc).isNotNull();
+
+        EditorFrame frame = session.frame();
+        realize(frame);
+        assertThat(frame.lookup(".editor-frame-header")).isNotNull();
+
+        // dispose() best-effort-detaches the attached canvas factory.
+        PluginEditorSession doomed = session;
+        session = null;
+        runOnFxThread(() -> {
+            doomed.dispose();
+            return null;
+        });
+        assertThat(events).contains("detach");
+        assertThat(events.getLast())
+                .as("detach is the final lifecycle event — no render after teardown")
+                .isEqualTo("detach");
+    }
+
+    // ── Shared scaffolding ────────────────────────────────────────────────
+
+    private static PluginEditorSession openSession(DawPlugin plugin) {
+        return runOnFxThread(
+                () -> PluginEditorSession.open(plugin, "Drum Bus / Insert 2", DEPS));
+    }
+
+    /**
+     * Puts the frame in a {@link Scene} and forces CSS + layout so the skin
+     * exists and {@code lookup(...)} works (content is not reachable until
+     * the skin has run — known headless pitfall).
+     */
+    private static void realize(EditorFrame frame) {
+        runOnFxThread(() -> {
+            Scene scene = new Scene(new StackPane(frame), 900, 700);
+            frame.applyCss();
+            frame.layout();
+            return scene;
+        });
+    }
+
+    /**
+     * Minimal story-300 contract plugin: per-instance descriptor, two
+     * continuous parameters, lifecycle no-ops, the injected editor factory,
+     * and the default {@code asAudioProcessor()} ({@code Optional.empty()}).
+     */
+    private static final class FakeDawPlugin implements DawPlugin {
+
+        private final PluginDescriptor descriptor;
+        private final Supplier<PluginEditorFactory> factory;
+
+        FakeDawPlugin(String mode, Supplier<PluginEditorFactory> factory) {
+            this.descriptor = new PluginDescriptor(
+                    "com.test.story301.mode." + mode,
+                    "Mode Test", "1.0.0", "Test Vendor", PluginType.EFFECT);
+            this.factory = factory;
+        }
+
+        @Override
+        public PluginDescriptor getDescriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public void initialize(PluginContext context) {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void activate() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void deactivate() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void dispose() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public List<PluginParameter> getParameters() {
+            return List.of(GAIN, MIX);
+        }
+
+        @Override
+        public PluginEditorFactory editorFactory() {
+            return factory.get();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/EditorHintsResizePolicyTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/EditorHintsResizePolicyTest.java
@@ -1,0 +1,311 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.sdk.editor.EditorContext;
+import com.benesquivelmusic.daw.sdk.editor.EditorHints;
+import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
+import com.benesquivelmusic.daw.sdk.editor.ResizePolicy;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 301 acceptance — {@link EditorHints#resize()} enforcement (Plugin
+ * View Design Book §6.3): a {@link ResizePolicy#FIXED} hint yields a
+ * non-resizable plugin body, {@link ResizePolicy#BOTH} a resizable one, and
+ * the HOST enforces the policy — the plugin cannot override it.
+ *
+ * <p>Two layers are pinned: the pure, statically-testable
+ * {@link EditorFrame#applyResizePolicy} min/pref/max mapping for all four
+ * policies, and the end-to-end path through
+ * {@link PluginEditorSession#open} where the hints a {@code Panel} factory
+ * declares are applied to the plugin's own region by the frame skin.
+ * Assertions target only the min/pref/max size-constraint properties —
+ * never rendered geometry. All FX work runs through the capture-and-rethrow
+ * {@code FxSnapshotTest.runOnFxThread} helper.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+@DisplayName("EditorHints resize policy is host-enforced (story 301, §6.3)")
+class EditorHintsResizePolicyTest {
+
+    private static final double PREF_W = 400.0;
+    private static final double PREF_H = 300.0;
+
+    /** Two continuous parameters (non-integral defaults — knob cells, §6.2). */
+    private static final PluginParameter GAIN =
+            new PluginParameter(1, "Gain", 0.0, 1.0, 0.5);
+    private static final PluginParameter MIX =
+            new PluginParameter(2, "Mix", 0.0, 1.0, 0.25);
+
+    /** Headless deps — every nullable service degraded (session tolerates it). */
+    private static final PluginEditorSession.Deps DEPS =
+            new PluginEditorSession.Deps(() -> 48_000.0, () -> null, null, null);
+
+    private PluginEditorSession session;
+
+    @AfterEach
+    void disposeSession() {
+        if (session != null) {
+            PluginEditorSession doomed = session;
+            session = null;
+            runOnFxThread(() -> {
+                doomed.dispose();
+                return null;
+            });
+        }
+    }
+
+    // ── applyResizePolicy — the pure min/pref/max mapping ─────────────────
+
+    @Test
+    @DisplayName("FIXED pins min == pref == max on both axes")
+    void fixedPinsMinPrefMaxOnBothAxes() {
+        Region body = applyToFreshRegion(ResizePolicy.FIXED);
+
+        assertThat(body.getMinWidth()).isEqualTo(PREF_W);
+        assertThat(body.getPrefWidth()).isEqualTo(PREF_W);
+        assertThat(body.getMaxWidth()).isEqualTo(PREF_W);
+        assertThat(body.getMinHeight()).isEqualTo(PREF_H);
+        assertThat(body.getPrefHeight()).isEqualTo(PREF_H);
+        assertThat(body.getMaxHeight()).isEqualTo(PREF_H);
+    }
+
+    @Test
+    @DisplayName("HORIZONTAL pins the height and frees the width")
+    void horizontalPinsHeightAndFreesWidth() {
+        Region body = applyToFreshRegion(ResizePolicy.HORIZONTAL);
+
+        assertThat(body.getMinHeight()).isEqualTo(PREF_H);
+        assertThat(body.getPrefHeight()).isEqualTo(PREF_H);
+        assertThat(body.getMaxHeight()).isEqualTo(PREF_H);
+        assertThat(body.getMinWidth()).isEqualTo(Region.USE_COMPUTED_SIZE);
+        assertThat(body.getPrefWidth()).isEqualTo(PREF_W);
+        assertThat(body.getMaxWidth()).isEqualTo(Double.MAX_VALUE);
+    }
+
+    @Test
+    @DisplayName("VERTICAL pins the width and frees the height (mirror of HORIZONTAL)")
+    void verticalPinsWidthAndFreesHeight() {
+        Region body = applyToFreshRegion(ResizePolicy.VERTICAL);
+
+        assertThat(body.getMinWidth()).isEqualTo(PREF_W);
+        assertThat(body.getPrefWidth()).isEqualTo(PREF_W);
+        assertThat(body.getMaxWidth()).isEqualTo(PREF_W);
+        assertThat(body.getMinHeight()).isEqualTo(Region.USE_COMPUTED_SIZE);
+        assertThat(body.getPrefHeight()).isEqualTo(PREF_H);
+        assertThat(body.getMaxHeight()).isEqualTo(Double.MAX_VALUE);
+    }
+
+    @Test
+    @DisplayName("BOTH sets the preferred size and frees max on both axes")
+    void bothSetsPreferredSizeAndFreesMaxOnBothAxes() {
+        Region body = applyToFreshRegion(ResizePolicy.BOTH);
+
+        assertThat(body.getPrefWidth()).isEqualTo(PREF_W);
+        assertThat(body.getPrefHeight()).isEqualTo(PREF_H);
+        assertThat(body.getMaxWidth()).isEqualTo(Double.MAX_VALUE);
+        assertThat(body.getMaxHeight()).isEqualTo(Double.MAX_VALUE);
+        assertThat(body.getMinWidth()).isEqualTo(Region.USE_COMPUTED_SIZE);
+        assertThat(body.getMinHeight()).isEqualTo(Region.USE_COMPUTED_SIZE);
+    }
+
+    // ── Through the session — the host applies the plugin's own hints ─────
+
+    @Test
+    @DisplayName("a FIXED hint through the session pins the plugin's own region non-resizable")
+    void fixedHintThroughSessionPinsThePluginRegion() {
+        AtomicReference<Region> stubRef = new AtomicReference<>();
+        session = openSession(hintedPanel(ResizePolicy.FIXED, stubRef));
+        EditorFrame frame = session.frame();
+        realize(frame);
+
+        // The hints landed on the frame…
+        assertThat(frame.getResizePolicy()).isEqualTo(ResizePolicy.FIXED);
+        assertThat(frame.getPreferredBodyWidth()).isEqualTo(PREF_W);
+        assertThat(frame.getPreferredBodyHeight()).isEqualTo(PREF_H);
+
+        // …and the host enforced them on the plugin's OWN region.
+        Region stub = stubRef.get();
+        assertThat(frame.getBody()).isSameAs(stub);
+        assertThat(stub.getMinWidth()).isEqualTo(PREF_W);
+        assertThat(stub.getPrefWidth()).isEqualTo(PREF_W);
+        assertThat(stub.getMaxWidth()).isEqualTo(PREF_W);
+        assertThat(stub.getMinHeight()).isEqualTo(PREF_H);
+        assertThat(stub.getPrefHeight()).isEqualTo(PREF_H);
+        assertThat(stub.getMaxHeight()).isEqualTo(PREF_H);
+    }
+
+    @Test
+    @DisplayName("a BOTH hint through the session leaves the plugin region freely resizable")
+    void bothHintThroughSessionLeavesThePluginRegionResizable() {
+        AtomicReference<Region> stubRef = new AtomicReference<>();
+        session = openSession(hintedPanel(ResizePolicy.BOTH, stubRef));
+        EditorFrame frame = session.frame();
+        realize(frame);
+
+        assertThat(frame.getResizePolicy()).isEqualTo(ResizePolicy.BOTH);
+        Region stub = stubRef.get();
+        assertThat(frame.getBody()).isSameAs(stub);
+        assertThat(stub.getPrefWidth()).isEqualTo(PREF_W);
+        assertThat(stub.getPrefHeight()).isEqualTo(PREF_H);
+        assertThat(stub.getMaxWidth()).isEqualTo(Double.MAX_VALUE);
+        assertThat(stub.getMaxHeight()).isEqualTo(Double.MAX_VALUE);
+    }
+
+    @Test
+    @DisplayName("the plugin cannot override enforcement: the skin re-pins the region on every policy change")
+    void pluginCannotOverrideHostEnforcement() {
+        AtomicReference<Region> stubRef = new AtomicReference<>();
+        session = openSession(hintedPanel(ResizePolicy.FIXED, stubRef));
+        EditorFrame frame = session.frame();
+        realize(frame);
+        Region stub = stubRef.get();
+
+        runOnFxThread(() -> {
+            // The plugin tries to fight the host…
+            stub.setMaxWidth(123.0);
+            // …and the skin's resize-policy listener re-applies the mapping
+            // synchronously on every policy change (it also re-applies on
+            // preferred-size and body changes).
+            frame.setResizePolicy(ResizePolicy.VERTICAL);
+            frame.setResizePolicy(ResizePolicy.FIXED);
+            return null;
+        });
+
+        assertThat(stub.getMaxWidth())
+                .as("host re-pinned the max width the plugin tried to override")
+                .isEqualTo(PREF_W);
+        assertThat(stub.getMinWidth()).isEqualTo(PREF_W);
+        assertThat(stub.getPrefWidth()).isEqualTo(PREF_W);
+        assertThat(stub.getMinHeight()).isEqualTo(PREF_H);
+        assertThat(stub.getPrefHeight()).isEqualTo(PREF_H);
+        assertThat(stub.getMaxHeight()).isEqualTo(PREF_H);
+    }
+
+    // ── Shared scaffolding ────────────────────────────────────────────────
+
+    /** Applies {@code policy} at 400 × 300 to a fresh plain region, on the FX thread. */
+    private static Region applyToFreshRegion(ResizePolicy policy) {
+        return runOnFxThread(() -> {
+            Region body = new Region();
+            EditorFrame.applyResizePolicy(body, policy, PREF_W, PREF_H);
+            return body;
+        });
+    }
+
+    /**
+     * A {@code Panel}-mode plugin whose factory declares
+     * {@code standard().withResize(policy).withSize(400, 300)} and returns a
+     * stub region, captured through {@code stubRef}.
+     */
+    private static DawPlugin hintedPanel(ResizePolicy policy,
+            AtomicReference<Region> stubRef) {
+        PluginEditorFactory.Panel factory = new PluginEditorFactory.Panel() {
+            @Override
+            public Region createPanel(EditorContext context) {
+                Region stub = new Region();
+                stubRef.set(stub);
+                return stub;
+            }
+
+            @Override
+            public EditorHints hints() {
+                return EditorHints.standard()
+                        .withResize(policy)
+                        .withSize((int) PREF_W, (int) PREF_H);
+            }
+        };
+        return new FakeDawPlugin("resize." + policy.name().toLowerCase(java.util.Locale.ROOT),
+                () -> factory);
+    }
+
+    private static PluginEditorSession openSession(DawPlugin plugin) {
+        return runOnFxThread(
+                () -> PluginEditorSession.open(plugin, "Drum Bus / Insert 2", DEPS));
+    }
+
+    /**
+     * Puts the frame in a {@link Scene} and forces CSS + layout so the skin
+     * exists and enforcement (which lives in the skin) has run — content is
+     * not reachable until the skin has run (known headless pitfall).
+     */
+    private static void realize(EditorFrame frame) {
+        runOnFxThread(() -> {
+            Scene scene = new Scene(new StackPane(frame), 900, 700);
+            frame.applyCss();
+            frame.layout();
+            return scene;
+        });
+    }
+
+    /**
+     * Minimal story-300 contract plugin: per-instance descriptor, two
+     * continuous parameters, lifecycle no-ops, the injected editor factory,
+     * and the default {@code asAudioProcessor()} ({@code Optional.empty()}).
+     */
+    private static final class FakeDawPlugin implements DawPlugin {
+
+        private final PluginDescriptor descriptor;
+        private final Supplier<PluginEditorFactory> factory;
+
+        FakeDawPlugin(String mode, Supplier<PluginEditorFactory> factory) {
+            this.descriptor = new PluginDescriptor(
+                    "com.test.story301.mode." + mode,
+                    "Mode Test", "1.0.0", "Test Vendor", PluginType.EFFECT);
+            this.factory = factory;
+        }
+
+        @Override
+        public PluginDescriptor getDescriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public void initialize(PluginContext context) {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void activate() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void deactivate() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public void dispose() {
+            // lifecycle no-op
+        }
+
+        @Override
+        public List<PluginParameter> getParameters() {
+            return List.of(GAIN, MIX);
+        }
+
+        @Override
+        public PluginEditorFactory editorFactory() {
+            return factory.get();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/ParameterGridPanelTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/ParameterGridPanelTest.java
@@ -1,0 +1,378 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.controls.Knob;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link ParameterGridPanel} — the §6.2 declarative parameter grid
+ * (story 301).
+ *
+ * <p>Column math is pure and asserted with no toolkit interaction; the
+ * behavioural tests build the panel on the FX thread and assert on style
+ * classes and observable properties only — never rasterized pixels or
+ * scene geometry (headless test convention). Note: a targeted
+ * {@code -Dtest} run of FX tests may trip a known environment-artifact
+ * {@code IllegalAccessError}; the full {@code mvn test} suite is
+ * authoritative.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ParameterGridPanelTest {
+
+    // ── Fixture descriptors ───────────────────────────────────────────────
+
+    /** Continuous — 0..1 with a non-integral default; must render a knob. */
+    private static final PluginParameter MIX =
+            new PluginParameter(7, "Mix", 0.0, 1.0, 0.5);
+
+    /** Boolean per the legacy heuristic — unit range, 0/1 default, "toggle" in the name. */
+    private static final PluginParameter BYPASS_TOGGLE =
+            new PluginParameter(11, "Bypass Toggle", 0.0, 1.0, 0.0);
+
+    /** Discrete — 0..3 all-integral, span 3 (4 states). */
+    private static final PluginParameter MODE =
+            new PluginParameter(13, "Mode", 0.0, 3.0, 0.0);
+
+    /** A user-gesture report captured from the panel's {@code ValueSink}. */
+    private record Change(int parameterId, double value) {
+    }
+
+    private static final class RecordingSink implements ParameterGridPanel.ValueSink {
+        final List<Change> changes = new ArrayList<>();
+
+        @Override
+        public void valueChanged(int parameterId, double newValue) {
+            changes.add(new Change(parameterId, newValue));
+        }
+    }
+
+    // ── computeColumns — pure math, no toolkit needed ─────────────────────
+
+    @ParameterizedTest(name = "computeColumns({0}) == {1}")
+    @CsvSource({
+            // Exact §6.2 block widths: n*96 + (n-1)*16.
+            "880,    8",   // 8*96 + 7*16
+            "656,    6",   // 6*96 + 5*16
+            "432,    4",   // 4*96 + 3*16
+            "208,    2",   // 2*96 + 1*16
+            "96,     1",   // 1*96
+            // One pixel less than each exact block drops to the next
+            // lower ALLOWED count — never an arbitrary count in between.
+            "879,    6",
+            "655,    4",
+            "431,    2",
+            "207,    1",
+            "95,     1",
+            // Mid-band widths stay on the allowed counts.
+            "700,    6",
+            "500,    4",
+            "300,    2",
+            // Huge widths cap at 8 columns.
+            "100000, 8",
+            // Zero / negative → a single column, never a crash.
+            "0,      1",
+            "-50,    1",
+    })
+    void computeColumnsHonoursTheAllowedColumnCounts(double availableWidth, int expectedColumns) {
+        assertThat(ParameterGridPanel.computeColumns(availableWidth))
+                .isEqualTo(expectedColumns);
+    }
+
+    @Test
+    void computeColumnsBoundariesDeriveFromThePinnedConstants() {
+        // Recompute the §6.2 boundaries from the public constants so the
+        // relationship (not just the literal pixel values) is pinned.
+        int[] allowed = {8, 6, 4, 2, 1};
+        for (int i = 0; i < allowed.length; i++) {
+            int n = allowed[i];
+            double exact = n * ParameterGridPanel.CELL_WIDTH
+                    + (n - 1) * ParameterGridPanel.GRID_GAP;
+            assertThat(ParameterGridPanel.computeColumns(exact)).isEqualTo(n);
+            int nextLower = (i + 1 < allowed.length) ? allowed[i + 1] : 1;
+            assertThat(ParameterGridPanel.computeColumns(exact - 1)).isEqualTo(nextLower);
+        }
+    }
+
+    // ── Cell generation ───────────────────────────────────────────────────
+
+    @Test
+    void threeParameterListBuildsThreeCellsWithExpectedControlTypes() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = newPanel(sink);
+
+        assertThat(panel.getStyleClass()).contains(ParameterGridPanel.STYLE_CLASS);
+        assertThat(panel.getChildrenUnmodifiable()).hasSize(3);
+        for (Node cell : panel.getChildrenUnmodifiable()) {
+            assertThat(cell.getStyleClass()).contains("parameter-grid-cell");
+        }
+
+        // Cell 0 — continuous "Mix": knob + name + numeric readout.
+        VBox mixCell = cellAt(panel, 0);
+        Knob knob = (Knob) mixCell.lookup(".knob");
+        assertThat(knob).isNotNull();
+        assertThat(knob.getMin()).isEqualTo(0.0);
+        assertThat(knob.getMax()).isEqualTo(1.0);
+        assertThat(knob.getDefaultValue()).isEqualTo(0.5);
+        assertThat(knob.getValue()).isEqualTo(0.5);
+        assertThat(knob.getTooltip().getText())
+                .isEqualTo("Double-click to reset to default");
+        Label mixName = (Label) mixCell.lookup(".parameter-name");
+        assertThat(mixName.getText()).isEqualTo("Mix");
+        Label mixReadout = (Label) mixCell.lookup(".parameter-value");
+        assertThat(mixReadout.getText()).isEqualTo("0.50");
+        assertThat(mixReadout.getStyleClass()).contains("numeric-caption");
+        assertThat(mixCell.lookup(".toggle-button")).isNull();
+
+        // Cell 1 — boolean "Bypass Toggle": labelled ON/OFF toggle, no knob.
+        VBox bypassCell = cellAt(panel, 1);
+        ToggleButton toggle = (ToggleButton) bypassCell.lookup(".toggle-button");
+        assertThat(toggle).isNotNull();
+        assertThat(toggle.isSelected()).isFalse();
+        assertThat(toggle.getText()).isEqualTo("OFF");
+        assertThat(bypassCell.lookup(".knob")).isNull();
+        assertThat(bypassCell.lookup(".segmented-selector")).isNull();
+
+        // Cell 2 — discrete "Mode": segmented selector, one segment per
+        // integer value, default selected.
+        VBox modeCell = cellAt(panel, 2);
+        assertThat(modeCell.lookup(".segmented-selector")).isNotNull();
+        assertThat(modeCell.lookup(".knob")).isNull();
+        List<ToggleButton> segments = segmentsOf(panel);
+        assertThat(segments).hasSize(4);
+        assertThat(segments.stream().map(ToggleButton::getText).toList())
+                .containsExactly("0", "1", "2", "3");
+        assertThat(selectedSegmentText(segments)).isEqualTo("0");
+
+        // Construction reports nothing through the sink.
+        assertThat(sink.changes).isEmpty();
+    }
+
+    @Test
+    void continuousUnitRangeParameterWithoutToggleNameDoesNotBecomeAToggle() {
+        // The conservative boolean heuristic needs the name guard: a 0..1
+        // parameter defaulting to an endpoint but NOT named "…toggle…"
+        // must not render as an ON/OFF toggle. (With all-integral range
+        // values it lands on the discrete branch — the §6.2 two-state
+        // segmented selector, like the mockup's SIDECHAIN off/EXT.)
+        RecordingSink sink = new RecordingSink();
+        PluginParameter dryKill = new PluginParameter(17, "Dry Kill", 0.0, 1.0, 0.0);
+        ParameterGridPanel panel = runOnFxThread(
+                () -> new ParameterGridPanel(List.of(dryKill), sink));
+
+        assertThat(panel.lookup(".segmented-selector")).isNotNull();
+        List<ToggleButton> segments = segmentsOf(panel);
+        assertThat(segments.stream().map(ToggleButton::getText).toList())
+                .containsExactly("0", "1");
+        // No ON/OFF labelled toggle anywhere in the cell.
+        assertThat(segments.stream().map(ToggleButton::getText))
+                .doesNotContain("ON", "OFF");
+    }
+
+    // ── User-gesture path (control → sink) ────────────────────────────────
+
+    @Test
+    void knobGestureFiresSinkExactlyOnceWithIdAndValue() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = newPanel(sink);
+        Knob knob = (Knob) panel.lookup(".knob");
+
+        runOnFxThread(() -> {
+            knob.setValue(0.7);
+            return null;
+        });
+
+        assertThat(sink.changes).containsExactly(new Change(7, 0.7));
+    }
+
+    @Test
+    void toggleGestureReportsThroughSink() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = newPanel(sink);
+        ToggleButton toggle = (ToggleButton) cellAt(panel, 1).lookup(".toggle-button");
+
+        runOnFxThread(() -> {
+            toggle.fire();
+            return null;
+        });
+
+        assertThat(toggle.isSelected()).isTrue();
+        assertThat(toggle.getText()).isEqualTo("ON");
+        assertThat(sink.changes).containsExactly(new Change(11, 1.0));
+    }
+
+    @Test
+    void segmentSelectionReportsOnceAndResistsDeselection() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = newPanel(sink);
+        List<ToggleButton> segments = segmentsOf(panel);
+
+        runOnFxThread(() -> {
+            segments.get(2).fire();
+            return null;
+        });
+        assertThat(selectedSegmentText(segments)).isEqualTo("2");
+        assertThat(sink.changes).containsExactly(new Change(13, 2.0));
+
+        // Clicking the already-selected segment attempts a ToggleGroup
+        // deselection — the guard must keep it selected and must NOT
+        // re-report through the sink.
+        runOnFxThread(() -> {
+            segments.get(2).fire();
+            return null;
+        });
+        assertThat(segments.get(2).isSelected()).isTrue();
+        assertThat(sink.changes).containsExactly(new Change(13, 2.0));
+    }
+
+    // ── Echo path (model → control, sink silent) ──────────────────────────
+
+    @Test
+    void updateValueMovesTheKnobAndReadoutWithoutFiringTheSink() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = newPanel(sink);
+        Knob knob = (Knob) panel.lookup(".knob");
+        Label readout = (Label) panel.lookup(".parameter-value");
+
+        runOnFxThread(() -> {
+            panel.updateValue(7, 0.25);
+            return null;
+        });
+
+        assertThat(knob.getValue()).isEqualTo(0.25);
+        assertThat(readout.getText()).isEqualTo("0.25");
+        assertThat(sink.changes).isEmpty();
+    }
+
+    @Test
+    void updateValueMovesToggleAndSegmentsWithoutFiringTheSink() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = newPanel(sink);
+        ToggleButton toggle = (ToggleButton) cellAt(panel, 1).lookup(".toggle-button");
+        List<ToggleButton> segments = segmentsOf(panel);
+
+        runOnFxThread(() -> {
+            panel.updateValue(11, 1.0);
+            panel.updateValue(13, 2.0);
+            return null;
+        });
+
+        assertThat(toggle.isSelected()).isTrue();
+        assertThat(toggle.getText()).isEqualTo("ON");
+        assertThat(selectedSegmentText(segments)).isEqualTo("2");
+        assertThat(sink.changes).isEmpty();
+    }
+
+    @Test
+    void updateValueForAnUnknownParameterIdIsIgnored() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = newPanel(sink);
+
+        runOnFxThread(() -> {
+            panel.updateValue(999, 0.5); // stale drain — must not throw
+            return null;
+        });
+
+        assertThat(sink.changes).isEmpty();
+    }
+
+    @Test
+    void setAllValuesEchoesEveryControlWithoutFiringTheSink() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = newPanel(sink);
+        Knob knob = (Knob) panel.lookup(".knob");
+        ToggleButton toggle = (ToggleButton) cellAt(panel, 1).lookup(".toggle-button");
+        List<ToggleButton> segments = segmentsOf(panel);
+
+        runOnFxThread(() -> {
+            panel.setAllValues(Map.of(7, 0.75, 11, 1.0, 13, 3.0));
+            return null;
+        });
+
+        assertThat(knob.getValue()).isEqualTo(0.75);
+        assertThat(toggle.isSelected()).isTrue();
+        assertThat(selectedSegmentText(segments)).isEqualTo("3");
+        assertThat(sink.changes).isEmpty();
+    }
+
+    @Test
+    void valueReadoutUsesTheLegacyFormattingRules() {
+        // Legacy PluginParameterEditorPanel.formatValue: |v| >= 1000 → one
+        // decimal, otherwise two.
+        RecordingSink sink = new RecordingSink();
+        PluginParameter cutoff = new PluginParameter(21, "Cutoff", 0.0, 20000.0, 1000.0);
+        ParameterGridPanel panel = runOnFxThread(
+                () -> new ParameterGridPanel(List.of(cutoff), sink));
+        Label readout = (Label) panel.lookup(".parameter-value");
+
+        assertThat(readout.getText()).isEqualTo("1000.0");
+
+        runOnFxThread(() -> {
+            panel.updateValue(21, 999.0);
+            return null;
+        });
+
+        assertThat(readout.getText()).isEqualTo("999.00");
+        assertThat(sink.changes).isEmpty();
+    }
+
+    // ── Empty grid ────────────────────────────────────────────────────────
+
+    @Test
+    void emptyParameterListConstructsAndRendersZeroCells() {
+        RecordingSink sink = new RecordingSink();
+        ParameterGridPanel panel = runOnFxThread(
+                () -> new ParameterGridPanel(List.of(), sink));
+
+        assertThat(panel.getStyleClass()).contains(ParameterGridPanel.STYLE_CLASS);
+        assertThat(panel.getChildrenUnmodifiable()).isEmpty();
+        assertThat(panel.lookupAll(".parameter-grid-cell")).isEmpty();
+        assertThat(sink.changes).isEmpty();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static ParameterGridPanel newPanel(RecordingSink sink) {
+        return runOnFxThread(() -> new ParameterGridPanel(
+                List.of(MIX, BYPASS_TOGGLE, MODE), sink));
+    }
+
+    private static VBox cellAt(ParameterGridPanel panel, int index) {
+        return (VBox) panel.getChildrenUnmodifiable().get(index);
+    }
+
+    private static List<ToggleButton> segmentsOf(ParameterGridPanel panel) {
+        HBox selector = (HBox) panel.lookup(".segmented-selector");
+        assertThat(selector).isNotNull();
+        List<ToggleButton> segments = new ArrayList<>();
+        for (Node node : selector.getChildrenUnmodifiable()) {
+            segments.add((ToggleButton) node);
+        }
+        return segments;
+    }
+
+    private static String selectedSegmentText(List<ToggleButton> segments) {
+        return segments.stream()
+                .filter(ToggleButton::isSelected)
+                .map(ToggleButton::getText)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/PluginInvocationSupervisor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/PluginInvocationSupervisor.java
@@ -57,7 +57,7 @@ public final class PluginInvocationSupervisor {
     public static final int QUARANTINE_THRESHOLD = 3;
 
     /** Sentinel pushed into the work queue to signal shutdown to the drain thread. */
-    private static final PendingFault SHUTDOWN = new PendingFault(null, null, null);
+    private static final PendingFault SHUTDOWN = new PendingFault(null, null, null, false);
 
     private final SubmissionPublisher<PluginFault> publisher = new SubmissionPublisher<>();
     private final Map<String, AtomicInteger> faultCounts = new ConcurrentHashMap<>();
@@ -111,6 +111,31 @@ public final class PluginInvocationSupervisor {
         Objects.requireNonNull(delegate, "delegate must not be null");
         SupervisedProcessor wrapper = new SupervisedProcessor(slot, delegate);
         return wrapper;
+    }
+
+    /**
+     * Reports a fault raised by a plugin's <em>editor</em> (FX-thread UI code)
+     * rather than its supervised audio processor — story 301's editor fault
+     * harness (Plugin View Design Book §2.7, §6.6). The fault is formatted,
+     * appended to the fault log and published to {@link #publisher()} exactly
+     * like an audio-side fault, but it does <strong>not</strong> increment the
+     * plugin's session fault count and can never quarantine the slot: only the
+     * editor is disabled, the audio processor keeps running (§6.6).
+     *
+     * <p>Safe to call from any thread; the heavy formatting and I/O run on the
+     * supervisor's drain thread. A no-op after {@link #close()}.</p>
+     *
+     * @param pluginId  stable identifier for the plugin whose editor faulted;
+     *                  must not be {@code null}
+     * @param throwable the throwable the editor raised; must not be {@code null}
+     */
+    public void reportUiFault(String pluginId, Throwable throwable) {
+        Objects.requireNonNull(pluginId, "pluginId must not be null");
+        Objects.requireNonNull(throwable, "throwable must not be null");
+        if (!running) {
+            return; // closed — the drain thread is gone, nothing would consume it
+        }
+        faultQueue.offer(new PendingFault(pluginId, throwable, Instant.now(), true));
     }
 
     /** Returns the fault count recorded for {@code pluginId} in this session. */
@@ -222,10 +247,21 @@ public final class PluginInvocationSupervisor {
         String stack = sw.toString();
 
         AtomicInteger counter = faultCounts.computeIfAbsent(pending.pluginId, _ -> new AtomicInteger());
-        int count = counter.incrementAndGet();
-        boolean isQuarantined = count > QUARANTINE_THRESHOLD;
-        if (isQuarantined) {
-            quarantined.put(pending.pluginId, Boolean.TRUE);
+        int count;
+        boolean isQuarantined;
+        if (pending.uiSourced()) {
+            // Editor-side fault (§6.6): report the current audio-slot state
+            // read-only — never increment the session count, never insert
+            // into the quarantined map. Only the editor is disabled; the
+            // audio processor keeps running.
+            count = counter.get();
+            isQuarantined = isQuarantined(pending.pluginId);
+        } else {
+            count = counter.incrementAndGet();
+            isQuarantined = count > QUARANTINE_THRESHOLD;
+            if (isQuarantined) {
+                quarantined.put(pending.pluginId, Boolean.TRUE);
+            }
         }
 
         return new PluginFault(
@@ -312,8 +348,11 @@ public final class PluginInvocationSupervisor {
     }
 
     // Pre-allocated, minimal-allocation record of the raw fault. Captured on
-    // the audio thread; materialized off-thread into the public PluginFault.
-    private record PendingFault(String pluginId, Throwable throwable, Instant clock) {
+    // the audio thread (uiSourced = false) or handed over from the editor's
+    // fault harness via reportUiFault (uiSourced = true); materialized
+    // off-thread into the public PluginFault. UI-sourced faults never count
+    // toward quarantine (§6.6).
+    private record PendingFault(String pluginId, Throwable throwable, Instant clock, boolean uiSourced) {
     }
 
     // ── Supervised wrapper ──────────────────────────────────────────────────
@@ -414,7 +453,7 @@ public final class PluginInvocationSupervisor {
             // LinkedBlockingQueue.offer allocates one Node wrapper; the
             // Instant.now() and PendingFault allocations are unavoidable but
             // tiny and only occur on the exception path, not the hot path.
-            faultQueue.offer(new PendingFault(pluginId, t, Instant.now()));
+            faultQueue.offer(new PendingFault(pluginId, t, Instant.now(), false));
         }
 
         private void logJvmError(Error err) {

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/plugin/PluginInvocationSupervisorUiFaultTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/plugin/PluginInvocationSupervisorUiFaultTest.java
@@ -1,0 +1,185 @@
+package com.benesquivelmusic.daw.core.plugin;
+
+import com.benesquivelmusic.daw.core.mixer.InsertSlot;
+import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers {@link PluginInvocationSupervisor#reportUiFault(String, Throwable)} —
+ * story 301's editor fault harness (Plugin View Design Book §2.7, §6.6).
+ * Editor-side faults flow to the fault log and the publisher like audio-side
+ * faults, but never increment the session fault count and can never
+ * quarantine the audio slot: only the editor is disabled, the audio processor
+ * keeps running.
+ */
+class PluginInvocationSupervisorUiFaultTest {
+
+    @TempDir
+    Path tempDir;
+
+    private PluginInvocationSupervisor supervisor;
+    private Path faultLog;
+
+    @BeforeEach
+    void setUp() {
+        faultLog = tempDir.resolve("plugin-faults.log");
+        supervisor = new PluginInvocationSupervisor(faultLog);
+    }
+
+    @AfterEach
+    void tearDown() {
+        supervisor.close();
+    }
+
+    @Test
+    void reportUiFaultShouldPublishAndLogFaultWithoutQuarantine() throws Exception {
+        CollectingSubscriber subscriber = new CollectingSubscriber(1);
+        supervisor.publisher().subscribe(subscriber);
+
+        supervisor.reportUiFault("WavyVisualizer", new IllegalStateException("editor kaboom"));
+
+        assertThat(subscriber.latch.await(2, TimeUnit.SECONDS)).isTrue();
+        PluginFault fault = subscriber.faults.getFirst();
+        assertThat(fault.pluginId()).isEqualTo("WavyVisualizer");
+        assertThat(fault.exceptionClass()).isEqualTo(IllegalStateException.class.getName());
+        assertThat(fault.message()).isEqualTo("editor kaboom");
+        assertThat(fault.stackTrace()).contains("IllegalStateException");
+        assertThat(fault.quarantined()).isFalse();
+        assertThat(fault.faultCountThisSession()).isZero();
+
+        // Drain thread writes the log file BEFORE publishing to subscribers,
+        // so the latch firing is a sufficient happens-before for the file.
+        assertThat(faultLog).exists();
+        String contents = Files.readString(faultLog);
+        assertThat(contents).contains("\"pluginId\":\"WavyVisualizer\"");
+    }
+
+    @Test
+    void uiFaultShouldNotIncrementSessionFaultCount() throws Exception {
+        CollectingSubscriber subscriber = new CollectingSubscriber(1);
+        supervisor.publisher().subscribe(subscriber);
+
+        supervisor.reportUiFault("CountFree", new RuntimeException("boom"));
+
+        assertThat(subscriber.latch.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(supervisor.getFaultCount("CountFree")).isZero();
+    }
+
+    @Test
+    void repeatedUiFaultsShouldNeverQuarantine() throws Exception {
+        int reports = PluginInvocationSupervisor.QUARANTINE_THRESHOLD + 2;
+        CollectingSubscriber subscriber = new CollectingSubscriber(reports);
+        supervisor.publisher().subscribe(subscriber);
+
+        for (int i = 0; i < reports; i++) {
+            supervisor.reportUiFault("StubbornEditor", new RuntimeException("editor fault #" + i));
+        }
+
+        assertThat(subscriber.latch.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(supervisor.isQuarantined("StubbornEditor")).isFalse();
+        assertThat(supervisor.getFaultCount("StubbornEditor")).isZero();
+        assertThat(subscriber.faults)
+                .hasSize(reports)
+                .allSatisfy(fault -> assertThat(fault.quarantined()).isFalse());
+    }
+
+    @Test
+    void uiFaultShouldReportCurrentAudioFaultCountWithoutIncrementing() throws Exception {
+        CollectingSubscriber subscriber = new CollectingSubscriber(2);
+        supervisor.publisher().subscribe(subscriber);
+
+        InsertSlot slot = new InsertSlot("MixedSource",
+                new ThrowingProcessor(new IllegalStateException("audio boom")));
+        AudioProcessor supervised = supervisor.supervise(slot, slot.getProcessor());
+
+        // Audio-sourced fault first: increments the session count to 1.
+        supervised.process(new float[][]{{0f}}, new float[][]{{0f}}, 1);
+        // Editor-sourced fault second: reads the count, never increments it.
+        supervisor.reportUiFault("MixedSource", new RuntimeException("editor boom"));
+
+        assertThat(subscriber.latch.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(supervisor.getFaultCount("MixedSource")).isEqualTo(1);
+
+        PluginFault audioFault = subscriber.faults.get(0);
+        assertThat(audioFault.faultCountThisSession()).isEqualTo(1);
+
+        PluginFault uiFault = subscriber.faults.get(1);
+        assertThat(uiFault.exceptionClass()).isEqualTo(RuntimeException.class.getName());
+        assertThat(uiFault.faultCountThisSession()).isEqualTo(1);
+        assertThat(uiFault.quarantined()).isFalse();
+    }
+
+    // --- helpers ---
+
+    private static final class ThrowingProcessor implements AudioProcessor {
+        private final RuntimeException error;
+
+        ThrowingProcessor(RuntimeException error) {
+            this.error = error;
+        }
+
+        @Override
+        public void process(float[][] inputBuffer, float[][] outputBuffer, int numFrames) {
+            throw error;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public int getInputChannelCount() {
+            return 2;
+        }
+
+        @Override
+        public int getOutputChannelCount() {
+            return 2;
+        }
+    }
+
+    private static final class CollectingSubscriber implements Flow.Subscriber<PluginFault> {
+        final List<PluginFault> faults = new CopyOnWriteArrayList<>();
+        final CountDownLatch latch;
+        private Flow.Subscription subscription;
+
+        CollectingSubscriber(int expected) {
+            this.latch = new CountDownLatch(expected);
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(PluginFault item) {
+            faults.add(item);
+            latch.countDown();
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            throwable.printStackTrace();
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/EditorContext.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/EditorContext.java
@@ -74,6 +74,22 @@ public interface EditorContext {
     void requestRender();
 
     /**
+     * Asks the host to drive a continuous animation loop for this editor at
+     * (approximately) the given frame rate. Only meaningful for a
+     * {@link PluginEditorFactory.Canvas} editor: the host then calls
+     * {@link PluginEditorFactory.Canvas#render(RenderTick) render(RenderTick)}
+     * on an animation tick in addition to the event-driven repaints (parameter
+     * change, resize, theme change) it already performs (§6.3). The host clamps
+     * the requested rate to a sensible range; a value {@code <= 0} cancels a
+     * previously requested timer, returning the editor to purely event-driven
+     * rendering.
+     *
+     * @param framesPerSecond the requested animation rate in frames per
+     *                        second; {@code <= 0} cancels the animation timer
+     */
+    void requestAnimationTimer(double framesPerSecond);
+
+    /**
      * Reports a recoverable fault from the plugin. The host routes it to the
      * in-surface fault banner (§6.6) and the plugin fault log, without tearing
      * the editor down. Use this for problems the plugin catches itself; faults

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginParameterStore.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginParameterStore.java
@@ -6,8 +6,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
+import com.benesquivelmusic.daw.sdk.plugin.PluginMeterSnapshot;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 
 /**
@@ -16,7 +18,11 @@ import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
  * Design Book §4.6). It is the enforcement seam behind Principle §2.6: a
  * plugin's editor cannot reach its {@code AudioProcessor} directly — both the
  * FX side (a knob turn) and the audio side (an internal envelope follower)
- * talk only to this store.
+ * talk only to this store. Alongside parameter values the store also carries
+ * the plugin's audio-side meter snapshot (§6.4): the processor
+ * {@linkplain #publishMeters(PluginMeterSnapshot) publishes} its instantaneous
+ * reading and the host taps it via {@link #meters()} to drive the always-on
+ * I/O meters in the editor chrome.
  *
  * <h2>Coherence and threading (§4.7)</h2>
  * <ul>
@@ -31,6 +37,12 @@ import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
  *       {@link RealTimeSafe}: it clamps and publishes, then posts onto a
  *       <em>separate</em> ring the FX thread drains via
  *       {@link #drainToUi(IndexConsumer)} for display update.</li>
+ *   <li>The audio-side meter snapshot (§6.4) is a single
+ *       {@link AtomicReference} the audio thread {@linkplain
+ *       #publishMeters(PluginMeterSnapshot) publishes} into and the FX thread
+ *       reads via {@link #meters()}. Latest-wins with no ring: meters are a
+ *       continuously refreshed level, so a missed intermediate frame carries
+ *       no information.</li>
  * </ul>
  *
  * <p>The rings carry only the changed parameter <em>index</em>; the value is
@@ -64,6 +76,8 @@ public final class PluginParameterStore {
     private final AtomicLongArray values;
     private final IntRing uiToAudio;
     private final IntRing audioToUi;
+    private final AtomicReference<PluginMeterSnapshot> meterSnapshot =
+            new AtomicReference<>(PluginMeterSnapshot.SILENT);
 
     /**
      * Creates a store for the given ordered parameter list. Each parameter's
@@ -233,6 +247,35 @@ public final class PluginParameterStore {
      */
     public int drainToUi(IndexConsumer sink) {
         return audioToUi.drain(sink);
+    }
+
+    /**
+     * Audio-thread publish of the plugin's instantaneous meter reading (§6.4).
+     * The plugin's processor allocates the immutable
+     * {@link PluginMeterSnapshot}; the store only publishes the reference — no
+     * locking, no blocking, no allocation inside the store. Latest-wins and
+     * there is no ring: meters are a continuously refreshed level, so a missed
+     * intermediate frame is meaningless — the FX side always reads the newest
+     * snapshot via {@link #meters()}.
+     *
+     * @param snapshot the instantaneous meter reading; must not be {@code null}
+     */
+    @RealTimeSafe
+    public void publishMeters(PluginMeterSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot must not be null");
+        meterSnapshot.set(snapshot);
+    }
+
+    /**
+     * FX-side read of the latest audio-side meter snapshot (§6.4). The host
+     * taps this to drive the always-on I/O meters in the editor chrome.
+     *
+     * @return the latest published snapshot; never {@code null} —
+     *         {@link PluginMeterSnapshot#SILENT} until the first
+     *         {@link #publishMeters(PluginMeterSnapshot)}
+     */
+    public PluginMeterSnapshot meters() {
+        return meterSnapshot.get();
     }
 
     @RealTimeSafe

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginParameterStoreMetersTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginParameterStoreMetersTest.java
@@ -1,0 +1,57 @@
+package com.benesquivelmusic.daw.sdk.editor;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.benesquivelmusic.daw.sdk.plugin.PluginMeterSnapshot;
+import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers the {@link PluginParameterStore} meter-snapshot channel (Plugin View
+ * Design Book §6.4, story 301): the audio side publishes an immutable
+ * {@link PluginMeterSnapshot} reference, the FX side reads the latest one.
+ */
+class PluginParameterStoreMetersTest {
+
+    private static PluginParameterStore newStore() {
+        return new PluginParameterStore(List.of(
+                new PluginParameter(1, "Gain", -60.0, 12.0, 0.0)));
+    }
+
+    @Test
+    void metersShouldBeSilentBeforeFirstPublish() {
+        assertThat(newStore().meters()).isSameAs(PluginMeterSnapshot.SILENT);
+    }
+
+    @Test
+    void publishMetersShouldRoundTripTheSameInstance() {
+        var store = newStore();
+        var snapshot = new PluginMeterSnapshot(-2.5, -10.0, -12.5);
+
+        store.publishMeters(snapshot);
+
+        assertThat(store.meters()).isSameAs(snapshot);
+    }
+
+    @Test
+    void publishMetersShouldRejectNull() {
+        assertThatThrownBy(() -> newStore().publishMeters(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void publishMetersShouldBeLatestWinsAcrossTwoPublishes() {
+        var store = newStore();
+        var first = PluginMeterSnapshot.ofGainReduction(-1.0);
+        var second = PluginMeterSnapshot.ofGainReduction(-6.0);
+
+        store.publishMeters(first);
+        store.publishMeters(second);
+
+        assertThat(store.meters()).isSameAs(second);
+    }
+}


### PR DESCRIPTION
# Host Honours the Editor Contract: Standard Chrome Around Declarative / Panel / Canvas Editors

## Motivation

Story 300 (Phase 1) defined `PluginEditorFactory` in `com.benesquivelmusic.daw.sdk.editor` and gave `DawPlugin` a default `editorFactory()` — but **nothing in the host calls it yet**. Until it does, the Design Book §1 problems remain live for every third-party plugin:

- **§1.2 — no path for a custom UI.** `PluginViewController.openBuiltInPluginView()` (`daw-app/.../ui/PluginViewController.java:161-183`) is a `switch` over built-in ids and only accepts `BuiltInDawPlugin`. A third-party `DawPlugin` that now overrides `editorFactory()` (after story 300) still gets nothing — the host never asks it for an editor.
- **§1.3 — the host cannot ask "how big? do you resize? do you want chrome?"** because no code path consumes `EditorHints`.
- **§1.6 — floating, embedded, and modal are not separated.** Built-ins open in floating `UTILITY` `Stage`s (`PluginViewController.java:194,274,302,…`); the Workshop right-pane host `PluginViewContainer` (`daw-app/.../ui/views/PluginViewContainer.java`) is built for *embedded* editors but receives plugins from no contract-driven source. There is no shared mental model for *where* a plugin lives.
- **§1.7 — no fault story.** `PluginFaultLogDialog` exists, but a plugin that throws on construction or sizing currently disappears or freezes with no in-surface recovery.

This is **Phase 2 of the §8 migration path** — *host honours the new contract* (§8.2). After this story, **third-party plugins have real editors for the first time**, rendered inside the host's standard chrome (breadcrumb header, A/B + preset bar, I/O meters, fault banner). Built-ins are deliberately **unchanged** — the legacy `switch` stays exactly as it is and still wins for any id it knows. The user sees: my downloaded plugin now opens an editor; the built-ins look identical to before.

## Goals

- **Build the host-side editor frame** that wraps any `PluginEditorFactory` in the §2.1 / §6 chrome the plugin cannot fight (§2.2 "the plugin is a guest, not a tenant"). One reusable component (e.g. `daw-app/.../ui/plugin/EditorFrame.java`) renders, for every mode:
  - the **breadcrumb header** (§6.1): vendor mark, plugin name, insert location, and the four host actions `[Bypass] [A|B] [↗ detach] [× close]` — single line, never wraps, host-owned (the plugin cannot add or remove buttons);
  - the **footer** (§6.4): preset selector + Save/Save As, and always-present IN/OUT meters tapped from the parameter store's audio-side snapshot (`PluginMeterSnapshot` already in the SDK);
  - the **A/B compare bar** (§6.5), backed by the existing `ABComparison` (`daw-core/.../plugin/parameter/ABComparison.java`);
  - the **fault banner** (§6.6), inline above the body, never modal.
- **Render the three modes** through the frame (§2.1):
  - **Declarative** → the host-generated parameter grid (§6.2). This is today's `PluginParameterEditorPanel` (`daw-app/.../ui/PluginParameterEditorPanel.java`) restyled into the responsive 96×96 knob grid (1/2/4/6/8 columns driven by container width); boolean params render as labelled toggles, discrete enums as segmented selectors. Re-using the panel (or a successor) keeps the auto-generated editor visually matching a hand-built one, removing the cue that today gives away "this is the fallback UI".
  - **Panel** → the plugin's `javafx.scene.layout.Region` from `createPanel(EditorContext)`, embedded inside the host frame, clipped to its bounds so it cannot paint over the breadcrumb or footer (§6.3).
  - **Canvas** → a host-owned canvas region; the host drives the render loop and calls `render(RenderTick)` on parameter change, resize, theme change, or an opted-in animation tick (`EditorContext#requestAnimationTimer(fps)`), honouring `ChromePolicy.IMMERSIVE` (chrome fades after 2 s of pointer inactivity, §5.D).
- **Teach the host to dispatch through the contract for non-built-in ids** (§8.2.1). Extend the activation path so that any plugin whose id is **not** matched by the legacy `switch` is routed to `editorFactory()` and rendered in the new frame. The `switch` (`PluginViewController.java:161-183`) keeps its arms unchanged and still wins for built-ins this phase — this is the documented escape hatch (§2.3), not yet removed.
- **Host the contract-driven editor in the Workshop right pane.** The new frame is set into the stable-identity `PluginViewContainer` (`PluginViewContainer.java:75`, `setPluginView(Node)`) so switching the focused plugin does not rebuild the container (the story-281 invariant). The §5.A "Workbench" is the embedded default; the `[↗]` detach button is wired in this phase only as far as firing the existing plugin-detach intent (full detach to a floating `Window` that re-hosts the same `Surface` is acknowledged in §3/§5.B but the panel-docking gesture machinery is story 288's domain — see Non-Goals).
- **Honour `EditorHints` and `ResizePolicy`** (§6.3): the host enforces the size policy; the plugin cannot resize itself. `ChromePolicy.MINIMAL` collapses the frame toward a title bar; `STANDARD` is the full chrome; `IMMERSIVE` is the auto-hiding canvas chrome.
- **Wrap every plugin-facing callback in a fault harness** (§2.7, §4.7, §6.6). Construction, sizing, drawing, and disposal each run inside a `Throwable`-catching harness; on a fault the host swaps in `PluginEditorFactory.Faulted`, shows the fault banner ("… threw NullPointerException in createPanel(). The editor was substituted with a safe placeholder."), routes the trace to `PluginFaultLogDialog` via the `[ⓘ]` button, and keeps the audio processor running if it was not the fault source. `[Reload]` re-invokes `editorFactory()` and re-attempts attach.
- Tests:
  - `ThirdPartyPluginGetsEditorTest` (new): a fake third-party `DawPlugin` (id not in the `switch`) overriding `editorFactory()` to return `Declarative` is activated; assert the host builds an `EditorFrame` whose body is the parameter grid and sets it on the `PluginViewContainer` — proves §8.2.1 "third-party plugins now have editors".
  - `BuiltInUnchangedInPhase2Test` (new): activating a `BuiltInDawPlugin` whose id is in the `switch` (e.g. `BusCompressorPlugin.PLUGIN_ID`) still routes to the legacy `openBusCompressorWindow(...)` path, not the new frame — proves built-ins are untouched this phase.
  - `EditorFrameRendersThreeModesTest` (new): a `Declarative`, a `Panel` (returns a stub `Region`), and a `Canvas` (records `attach`/`render` calls) each mount inside the frame with breadcrumb + footer present; the Panel region is clipped; the Canvas receives `attach` then `render`.
  - `EditorFaultHarnessShowsBannerTest` (new): a `Panel#createPanel` that throws does **not** propagate; the frame shows the fault banner, swaps in `Faulted`, and the editor node is still present (never a void). Assert via the banner's style class / accessible text, not by catching the exception in the test.
  - `EditorHintsResizePolicyTest` (new): a `FIXED` hint yields a non-resizable body; `BOTH` yields a resizable body — the host enforces, the plugin cannot override.
  - `FocusedEditorDoesNotRebuildContainerTest` (new): swapping the focused plugin twice keeps the same `PluginViewContainer` instance (`currentContentProperty` changes, container identity does not) — the story-281 invariant under the new frame.

## Non-Goals

- **No built-in migration.** The `switch` and all thirteen `*PluginView.java` classes are untouched; built-ins keep their floating `UTILITY` windows. Migrating them arm-by-arm is story 302 (Phase 3).
- **No `switch` removal.** Per §2.3 the `switch` is the documented internal escape hatch this phase; story 302 deletes it.
- **No install-UX change.** `PluginManagerDialog` is unchanged; how a third-party plugin gets *installed* (manifest, drag-a-JAR) is story 303 (Phase 4). This story is about how an *already-registered* plugin gets an editor.
- **No panel docking / detach-gesture machinery.** The `[↗]` button fires the detach intent; the floating-`Stage` placement, grip-handle drag, and dock drop-zones are story 288's domain (panel docking). This story does not re-implement them, and does not conflate *plugin* detach with *panel* detach (`feedback_javafx_animation_shared_slot_race.md` / story 288 Non-Goals keep the two drag vocabularies distinct).
- **No `PluginUI` consumption.** The deprecated `PluginUI.createUI()` is still never called — the host dispatches through `editorFactory()` only. `PluginUI` removal is story 304.

## Technical Notes

- **Single-writer binding retires the feedback loop.** The Declarative grid must wire knob ↔ value through the Control-Sync single-writer binding rather than the legacy `PluginParameterEditorPanel.refreshControls()` re-push (`PluginParameterEditorPanel.java:160-176`) and the per-view `suppressNotification` flags. Use the `PluginVM` view-model adapter from **story 294** (its single-writer binding builds on **story 291**) so a host-side value change and a user gesture cannot ping-pong; route display updates through the **story 289** `FxDispatcher` so all editor mutation lands on the FX thread (§4.7). This is the canonical wiring layer for plugin surfaces — do not hand-roll a second one.
- **`PluginParameterStore` is the only bridge to the audio side** (§2.6): the `EditorFrame` reads/writes parameter values via `EditorContext#parameterStore()`, never through `DawPlugin#asAudioProcessor()`. The I/O meters in the footer tap the store's audio-side `PluginMeterSnapshot`.
- **`Theme` tokens drive Canvas drawing** (§2.5): the host passes resolved `ThemeManager` (story 277) role-token values into `RenderTick.tokens()` so custom drawing tracks the palette; per `feedback_iconnode_tint_from_resolved_css.md` and `feedback_control_css_role_token_forwarding.md`, derive colours from resolved CSS, pair any listener with `applyCss()`, never mirror a hex literal.
- **Chrome is host-rendered in every mode** (§2.2/§6.1): the four header actions and the footer are added by the frame, not the plugin. Bypass and A/B are state toggles; detach and close are momentary. Keyboard map per §6.1 (`B` bypass, `Cmd+\` A/B, `Cmd+D` detach, `Cmd+W` close-focus).
- **Fault harness** wraps `editorFactory()`, `createPanel`, `attach`/`render`/`detach`, and dispose (§4.7 table). On `Throwable` it swaps `Faulted` in and routes to the existing `PluginFaultLogDialog` (`daw-app/.../ui/PluginFaultLogDialog.java`) / `PluginFaultUiController`. The audio processor is independent — only the editor is disabled (§6.6).
- **Headless test pitfalls** (`feedback_javafx_headless_test_pitfalls.md`): assert on style classes / accessible text and observable properties, not rasterisation; extract the pure layout/column-count math so it can be tested with no toolkit; `PluginViewContainer` content is the swapped child, so assert `getCurrentContent()`/`currentContentProperty()`, not scene-graph geometry. For typed editor events, assert on the payload via a parent `addEventFilter`, never `Event.getSource()` identity (`feedback_javafx_bubbling_event_test_pitfall.md`).
- Files: new `daw-app/.../ui/plugin/EditorFrame.java` (the chrome + mode renderer) and supporting host adapters for `EditorContext`/`CanvasSurface`; edits to `daw-app/.../ui/PluginViewController.java` (route non-`switch` ids to `editorFactory()`), `daw-app/.../ui/views/PluginViewContainer.java` (host the frame — likely no change beyond `setPluginView`), `daw-app/.../ui/PluginParameterEditorPanel.java` (restyle into the §6.2 grid or supersede it), `styles.css` (the `.editor-frame` / breadcrumb / fault-banner / parameter-grid chrome consuming forwarded role tokens), and the host-side `EditorContext` implementation that exposes the `PluginParameterStore`.
- Reference: Plugin View Design Book §1.2/§1.3/§1.6/§1.7 (problems), §2.1/§2.2/§2.5/§2.6/§2.7 (principles), §3 (Editor/Surface/Container model), §4.7 (threading), §5.A/§5.D (Workbench, Immersive), §6.1–§6.6 (chrome HD detail), §8.2 (this phase); user story 300 (the contract this consumes), user story 281 (Workshop / `PluginViewContainer` stable-identity host), user story 030 (parameter UI being restyled), user story 089 (audio-processing contract / the store boundary), user story 277 (`ThemeManager` tokens), user story 279 (Reduce Motion — the IMMERSIVE chrome fade must respect it), user story 288 (panel docking — the distinct detach vocabulary). SKILLs: `javafx-application-design` (§3 Control/Skin for the frame, §6 Canvas for Canvas mode, §11 threading, §12 typed events, §15 anti-patterns), `research-daw`.
