### PR TITLE
303-plugin-browser-and-drag-a-jar

### DIFF
--- a/daw-app/pom.xml
+++ b/daw-app/pom.xml
@@ -173,7 +173,8 @@
                         -Dprism.order=sw
                         -Dprism.lcdtext=false
                         -Dprism.text=t2k
-                        -Djava.awt.headless=true</argLine>
+                        -Djava.awt.headless=true
+                        --add-opens=daw.app/com.benesquivelmusic.daw.app.ui.plugin.fixtures=daw.core</argLine>
                     <systemPropertyVariables>
                         <!-- Built-in headless Glass platform (JavaFX 26,
                              JDK-8364687). Retained in addition to the -D

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/InsertEffectRack.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/InsertEffectRack.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.drag.DragSourceKind;
 import com.benesquivelmusic.daw.app.ui.drag.DragVisualAdvisor;
 import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginBrowser;
 import com.benesquivelmusic.daw.core.mixer.*;
 import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
 import com.benesquivelmusic.daw.core.plugin.ExternalPluginLoader;
@@ -425,62 +426,30 @@ public final class InsertEffectRack extends VBox {
     // ── Effect picker ───────────────────────────────────────────────────────
 
     /**
-     * A choice in the effect picker dialog — either a built-in effect type or
-     * an external plugin entry. Using a sealed interface avoids reliance on
-     * string-based {@code indexOf} matching, which breaks on duplicate names.
+     * Opens the §6.7 categorical {@link PluginBrowser} for the empty slot at
+     * {@code slotIndex} and applies the user's choice: a built-in effect goes
+     * through the existing {@link InsertEffectFactory#createSlot} path, an
+     * external plugin through {@link #loadAndInsertExternalPlugin}. The browser
+     * itself applies the Stereo-Imager stereo rule and the EFFECT-type filter,
+     * and offers the drag-a-JAR install flow (story 303).
      */
-    private sealed interface EffectChoice {
-        String displayName();
-    }
-
-    private record BuiltInChoice(InsertEffectType type) implements EffectChoice {
-        @Override public String displayName() { return type.getDisplayName(); }
-        @Override public String toString() { return displayName(); }
-    }
-
-    private record ExternalChoice(ExternalPluginEntry entry, String name) implements EffectChoice {
-        @Override public String displayName() { return "[ext] " + name; }
-        @Override public String toString() { return displayName(); }
-    }
-
     private void showEffectPicker(int slotIndex) {
-        List<EffectChoice> choices = new ArrayList<>();
+        String channelName = channel.getName();
+        String targetLabel = (channelName == null || channelName.isBlank())
+                ? "Insert " + (slotIndex + 1)
+                : channelName + " / Insert " + (slotIndex + 1);
 
-        // Built-in effects
-        InsertEffectFactory.availableTypes().stream()
-                .filter(t -> t != InsertEffectType.STEREO_IMAGER || audioChannels == 2)
-                .forEach(t -> choices.add(new BuiltInChoice(t)));
-
-        // Registered external plugins that process audio (EFFECT type)
-        if (pluginRegistry != null) {
-            for (var mapEntry : pluginRegistry.getLoadedPlugins().entrySet()) {
-                DawPlugin plugin = mapEntry.getValue();
-                if (plugin.getDescriptor().type() == PluginType.EFFECT) {
-                    choices.add(new ExternalChoice(
-                            mapEntry.getKey(), plugin.getDescriptor().name()));
-                }
-            }
-        }
-
-        if (choices.isEmpty()) {
-            return;
-        }
-
-        ChoiceDialog<EffectChoice> dialog = new ChoiceDialog<>(choices.getFirst(), choices);
-        dialog.setTitle("Add Insert Effect");
-        dialog.setHeaderText("Select an effect for slot " + (slotIndex + 1));
-        dialog.setContentText("Effect:");
-
-        Optional<EffectChoice> result = dialog.showAndWait();
-        result.ifPresent(selected -> {
-            switch (selected) {
-                case BuiltInChoice b -> {
+        PluginBrowser browser = new PluginBrowser(pluginRegistry, audioChannels == 2, targetLabel);
+        browser.setFxDispatcher(fxDispatcher);
+        browser.showAndWait().ifPresent(selection -> {
+            switch (selection) {
+                case PluginBrowser.BuiltInSelection builtIn -> {
                     InsertSlot slot = InsertEffectFactory.createSlot(
-                            b.type(), audioChannels, sampleRate);
+                            builtIn.type(), audioChannels, sampleRate);
                     addEffect(slotIndex, slot);
                 }
-                case ExternalChoice ext ->
-                        loadAndInsertExternalPlugin(slotIndex, ext.entry());
+                case PluginBrowser.ExternalSelection external ->
+                        loadAndInsertExternalPlugin(slotIndex, external.entry());
             }
         });
     }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginManagerDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/PluginManagerDialog.java
@@ -3,30 +3,41 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginIcons;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginInstallPanel;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner;
 import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
-import com.benesquivelmusic.daw.core.plugin.PluginLoadException;
 import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
 import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
-import com.benesquivelmusic.daw.sdk.plugin.PluginType;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.scene.control.*;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.TransferMode;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
 
 /**
- * Dialog for managing external DAW plugins.
+ * Dialog for managing external DAW plugins (Plugin View Design Book §6.8, §8.4;
+ * story 303).
  *
- * <p>Allows users to add plugins by specifying the path to a pre-compiled JAR file
- * and the fully qualified class name of their plugin implementation. This eliminates
- * the need for users to manually create {@code META-INF/services} files.</p>
+ * <p>Lists the registry's plugins with descriptor-driven icons (via
+ * {@link PluginIcons}), lets the user install a plugin by dropping / picking a
+ * JAR — the DAW reads the JAR's {@code META-INF/daw-plugin.json} manifest and
+ * installs every plugin it declares, so the user never types a class name (a
+ * manifest-less JAR falls back to the class-name form inside the install flow) —
+ * and removes a selected plugin. The class-name / JAR-path text fields the legacy
+ * dialog showed at all times are gone; icons come from the descriptor category /
+ * {@code iconHint} rather than the retired keyword-sniffing heuristic.</p>
  *
  * <p>Uses the {@link DawIcon} icon pack for all button graphics.</p>
  */
@@ -34,12 +45,19 @@ public final class PluginManagerDialog extends DawgDialog<Void> {
 
     private static final double BUTTON_ICON_SIZE = 16;
     private static final double HEADER_ICON_SIZE = 18;
+    private static final double BUSY_SPINNER_SIZE = 18;
 
     private final PluginRegistry registry;
     private final ObservableList<ExternalPluginEntry> entryList;
     private final ListView<ExternalPluginEntry> listView;
-    private final TextField jarPathField;
-    private final TextField classNameField;
+    private final HBox busyRow;
+    private final Label busyLabel;
+
+    /**
+     * The FX-thread marshalling seam (story 289) used for off-thread JAR scans.
+     * Nullable — {@link PluginJarScanner} defaults through the app-scoped seam.
+     */
+    private FxDispatcher fxDispatcher;
 
     /**
      * Creates a new plugin manager dialog.
@@ -69,8 +87,8 @@ public final class PluginManagerDialog extends DawgDialog<Void> {
                     if (plugin != null) {
                         PluginDescriptor desc = plugin.getDescriptor();
                         setText(desc.name() + " (" + desc.id() + ") — " + entry.jarPath().getFileName());
-                        // Use detail icon for known plugin types, falls back to type icon
-                        setGraphic(IconNode.of(pluginDetailIcon(desc), 14));
+                        // Descriptor-driven icon (category / iconHint), story 303
+                        setGraphic(PluginIcons.of(desc.category(), desc.iconHint(), 14));
                     } else {
                         setText(entry.className() + " — " + entry.jarPath().getFileName());
                         setGraphic(IconNode.of(DawIcon.KNOB, 14));
@@ -79,114 +97,124 @@ public final class PluginManagerDialog extends DawgDialog<Void> {
             }
         });
 
-        // --- JAR path input ---
-        jarPathField = new TextField();
-        jarPathField.setPromptText("Path to plugin JAR file");
-        HBox.setHgrow(jarPathField, Priority.ALWAYS);
-
-        Button browseButton = new Button("Browse…");
-        browseButton.setGraphic(IconNode.of(DawIcon.SEARCH, BUTTON_ICON_SIZE));
-        browseButton.setOnAction(_ -> browseForJar());
-
-        Label jarLabel = new Label("JAR Path:");
-        jarLabel.setGraphic(IconNode.of(DawIcon.FOLDER, 14));
-
-        HBox jarPathRow = new HBox(8, jarLabel, jarPathField, browseButton);
-        jarPathRow.setPadding(new Insets(4, 0, 4, 0));
-
-        // --- Class name input ---
-        classNameField = new TextField();
-        classNameField.setPromptText("e.g. com.example.MyReverbPlugin");
-        HBox.setHgrow(classNameField, Priority.ALWAYS);
-
-        Label classLabel = new Label("Plugin Class:");
-        classLabel.setGraphic(IconNode.of(DawIcon.TAG, 14));
-
-        HBox classNameRow = new HBox(8, classLabel, classNameField);
-        classNameRow.setPadding(new Insets(4, 0, 4, 0));
-
-        // --- Action buttons ---
-        Button addButton = new Button("Add Plugin");
-        addButton.setGraphic(IconNode.of(DawIcon.DOWNLOAD, BUTTON_ICON_SIZE));
-        addButton.setOnAction(_ -> addPlugin());
-
-        Button removeButton = new Button("Remove Selected");
-        removeButton.setGraphic(IconNode.of(DawIcon.CLOSE, BUTTON_ICON_SIZE));
-        removeButton.setOnAction(_ -> removeSelectedPlugin());
-
-        HBox buttonRow = new HBox(8, addButton, removeButton);
-        buttonRow.setPadding(new Insets(8, 0, 0, 0));
-
-        // --- Layout ---
+        // --- Header + info ---
         Label headerLabel = new Label("Loaded Plugins:");
         headerLabel.setGraphic(IconNode.of(DawIcon.LIBRARY, HEADER_ICON_SIZE));
 
-        Label infoLabel = new Label("Drop a JAR or browse to add a plugin");
+        Label infoLabel = new Label("Drag a JAR here, or use Install from JAR, to add a plugin.");
         infoLabel.setGraphic(IconNode.of(DawIcon.INFO, 14));
-        infoLabel.setStyle("-fx-text-fill: #808080; -fx-font-size: 11px;");
+        infoLabel.getStyleClass().add("plugin-manager-info");
 
-        Label notificationLabel = new Label("Plugin changes apply after restart");
+        // --- Action buttons ---
+        Button installButton = new Button("Install from JAR…");
+        installButton.setGraphic(IconNode.of(DawIcon.DOWNLOAD, BUTTON_ICON_SIZE));
+        installButton.getStyleClass().addAll("dawg-button", "size-default", "primary");
+        installButton.setOnAction(_ -> chooseAndInstallJar());
+
+        Button removeButton = new Button("Remove Selected");
+        removeButton.setGraphic(IconNode.of(DawIcon.CLOSE, BUTTON_ICON_SIZE));
+        removeButton.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        removeButton.setOnAction(_ -> removeSelectedPlugin());
+
+        HBox buttonRow = new HBox(8, installButton, removeButton);
+        buttonRow.setPadding(new Insets(8, 0, 0, 0));
+
+        // --- Busy row (JAR scan in flight) ---
+        ProgressIndicator spinner = new ProgressIndicator();
+        spinner.setPrefSize(BUSY_SPINNER_SIZE, BUSY_SPINNER_SIZE);
+        busyLabel = new Label();
+        busyRow = new HBox(8, spinner, busyLabel);
+        busyRow.getStyleClass().add("plugin-row-busy");
+        busyRow.setVisible(false);
+        busyRow.setManaged(false);
+
+        // --- Truthful session notice (§8.4) ---
+        Label notificationLabel = new Label(
+                "Installed plugins are ready to use immediately. "
+                        + "The plugin list is not yet saved between sessions.");
         notificationLabel.setGraphic(IconNode.of(DawIcon.NOTIFICATION, 14));
-        notificationLabel.setStyle("-fx-text-fill: #ff9100; -fx-font-size: 10px;");
+        notificationLabel.setWrapText(true);
+        notificationLabel.getStyleClass().add("plugin-manager-notice");
 
         VBox content = new VBox(8,
                 headerLabel,
                 listView,
                 infoLabel,
-                jarPathRow,
-                classNameRow,
                 buttonRow,
+                busyRow,
                 notificationLabel
         );
         content.setPadding(new Insets(16));
         content.setPrefWidth(600);
+        installDragDrop(content);
 
         getDialogPane().setContent(content);
         getDialogPane().getButtonTypes().add(ButtonType.CLOSE);
-        // story 276 — §5.9 width band. The footer CLOSE button is the
-        // dismiss path, so the redundant header close glyph is retracted
-        // by DawgDialog (§5.9 — "Cancel and Esc are the primary dismiss
-        // paths"); the header keeps this dialog's own SETTINGS graphic
-        // (set above). Flat header / accent primary / tokenized
-        // section-header chrome applied by the DawgDialog super-ctor.
+        // story 276 — the footer CLOSE button is the dismiss path, so the
+        // redundant header close glyph is retracted by DawgDialog (§5.9); the
+        // header keeps this dialog's own SETTINGS graphic (set above).
         sized(DawgDialog.Size.LARGE);
     }
 
-    private void browseForJar() {
+    /**
+     * Injects the FX-thread marshalling seam used for off-thread JAR scans
+     * (story 289); defaults through the app-scoped seam when {@code null}.
+     *
+     * @param dispatcher the dispatcher, or {@code null} for the default
+     */
+    public void setFxDispatcher(FxDispatcher dispatcher) {
+        this.fxDispatcher = dispatcher;
+    }
+
+    private void chooseAndInstallJar() {
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Select Plugin JAR");
         fileChooser.getExtensionFilters().add(
                 new FileChooser.ExtensionFilter("JAR Files", "*.jar"));
         File file = fileChooser.showOpenDialog(getOwner());
         if (file != null) {
-            jarPathField.setText(file.getAbsolutePath());
+            beginJarInstall(file.toPath());
         }
     }
 
-    private void addPlugin() {
-        String jarPathText = jarPathField.getText();
-        String className = classNameField.getText();
+    private void beginJarInstall(Path jar) {
+        busyLabel.setText("Scanning " + jar.getFileName() + "…");
+        busyRow.setVisible(true);
+        busyRow.setManaged(true);
+        new PluginJarScanner(fxDispatcher).scan(jar, inspection -> {
+            busyRow.setVisible(false);
+            busyRow.setManaged(false);
+            PluginInstallPanel.showDialog(inspection, registry,
+                    () -> entryList.setAll(registry.getEntries()));
+        });
+    }
 
-        if (jarPathText == null || jarPathText.isBlank()) {
-            showError("Please specify the path to the plugin JAR file.");
-            return;
-        }
-        if (className == null || className.isBlank()) {
-            showError("Please specify the fully qualified plugin class name.");
-            return;
-        }
-
-        Path jarPath = Path.of(jarPathText.strip());
-        ExternalPluginEntry entry = new ExternalPluginEntry(jarPath, className.strip());
-
-        try {
-            registry.register(entry);
-            entryList.setAll(registry.getEntries());
-            jarPathField.clear();
-            classNameField.clear();
-        } catch (PluginLoadException e) {
-            showError("Failed to load plugin:\n" + e.getMessage());
-        }
+    private void installDragDrop(VBox content) {
+        content.setOnDragOver(event -> {
+            Dragboard db = event.getDragboard();
+            if (db.hasFiles() && db.getFiles().stream()
+                    .anyMatch(f -> f.getName().toLowerCase(Locale.ROOT).endsWith(".jar"))) {
+                event.acceptTransferModes(TransferMode.COPY);
+            }
+            event.consume();
+        });
+        content.setOnDragDropped(event -> {
+            Dragboard db = event.getDragboard();
+            boolean ok = false;
+            if (db.hasFiles()) {
+                List<Path> jars = db.getFiles().stream()
+                        .filter(f -> f.getName().toLowerCase(Locale.ROOT).endsWith(".jar"))
+                        .map(File::toPath)
+                        .toList();
+                if (!jars.isEmpty()) {
+                    // Mirror AudioImportController: handle the first dropped JAR.
+                    beginJarInstall(jars.getFirst());
+                    ok = true;
+                }
+            }
+            event.setDropCompleted(ok);
+            event.consume();
+        });
     }
 
     private void removeSelectedPlugin() {
@@ -200,100 +228,8 @@ public final class PluginManagerDialog extends DawgDialog<Void> {
     }
 
     private void showError(String message) {
-        // story 276 — route through DawgDialog.error(...) so the error
-        // dialog gets the §5.9 flat chrome instead of JavaFX's Alert
-        // (whose header gradient bypasses the author stylesheet).
+        // story 276 — route through DawgDialog.error(...) so the error dialog
+        // gets the §5.9 flat chrome instead of JavaFX's Alert.
         DawgDialog.error("Plugin Error", message).showAndWait();
-    }
-
-    /**
-     * Returns the appropriate icon for a given plugin type.
-     *
-     * <p>Maps plugin types to icons from the <em>DAW</em>, <em>Instruments</em>,
-     * <em>Metering</em>, and <em>Media</em> categories.</p>
-     */
-    private static DawIcon pluginTypeIcon(PluginType type) {
-        return switch (type) {
-            case EFFECT      -> DawIcon.REVERB;
-            case INSTRUMENT  -> DawIcon.KEYBOARD;
-            case ANALYZER    -> DawIcon.OSCILLOSCOPE;
-            case MIDI_EFFECT -> DawIcon.MIDI;
-        };
-    }
-
-    /**
-     * Returns a secondary detail icon for a plugin based on its descriptor.
-     *
-     * <p>Uses keywords in the plugin name to pick a category-specific icon
-     * from the <em>DAW</em>, <em>Media</em>, <em>General</em>, <em>Connectivity</em>,
-     * and other categories for the richest possible visual mapping.</p>
-     */
-    private static DawIcon pluginDetailIcon(PluginDescriptor desc) {
-        String lower = desc.name().toLowerCase();
-        // DAW category
-        if (lower.contains("compressor") || lower.contains("comp"))   return DawIcon.COMPRESSOR;
-        if (lower.contains("delay") || lower.contains("echo"))       return DawIcon.DELAY;
-        if (lower.contains("distort"))                                return DawIcon.DISTORTION;
-        if (lower.contains("flang"))                                  return DawIcon.FLANGER;
-        if (lower.contains("chorus"))                                 return DawIcon.CHORUS;
-        if (lower.contains("phas"))                                   return DawIcon.PHASER;
-        if (lower.contains("pitch"))                                  return DawIcon.PITCH_SHIFT;
-        if (lower.contains("gate") || lower.contains("noise"))       return DawIcon.NOISE_GATE;
-        if (lower.contains("limit"))                                  return DawIcon.LIMITER;
-        if (lower.contains("eq") || lower.contains("equaliz"))       return DawIcon.EQ;
-        if (lower.contains("filter") || lower.contains("low pass"))  return DawIcon.LOW_PASS;
-        if (lower.contains("high pass"))                              return DawIcon.HIGH_PASS;
-        if (lower.contains("gain"))                                   return DawIcon.GAIN;
-        if (lower.contains("automat"))                                return DawIcon.AUTOMATION;
-        if (lower.contains("marker"))                                 return DawIcon.MARKER;
-        if (lower.contains("waveform"))                               return DawIcon.WAVEFORM;
-        if (lower.contains("shuffle"))                                return DawIcon.SHUFFLE;
-        // Media category
-        if (lower.contains("amp"))                                    return DawIcon.AMPLIFIER;
-        if (lower.contains("meter") || lower.contains("analyz"))     return DawIcon.VU_METER;
-        if (lower.contains("rms"))                                    return DawIcon.RMS;
-        if (lower.contains("correlat"))                               return DawIcon.CORRELATION;
-        if (lower.contains("turntable") || lower.contains("vinyl"))  return DawIcon.TURNTABLE;
-        if (lower.contains("radio"))                                  return DawIcon.RADIO;
-        if (lower.contains("record"))                                 return DawIcon.RECORD_PLAYER;
-        if (lower.contains("cd") || lower.contains("disc"))          return DawIcon.CD;
-        if (lower.contains("boombox"))                                return DawIcon.BOOMBOX;
-        if (lower.contains("monitor") || lower.contains("screen"))   return DawIcon.MONITOR;
-        if (lower.contains("camera") || lower.contains("video"))     return DawIcon.CAMERA;
-        if (lower.contains("film"))                                   return DawIcon.FILM_STRIP;
-        if (lower.contains("mp3"))                                    return DawIcon.MP3_PLAYER;
-        if (lower.contains("wireless") || lower.contains("bluetooth")) return DawIcon.SPEAKER_WIRELESS;
-        if (lower.contains("drum machine"))                           return DawIcon.DRUM;
-        // Connectivity category
-        if (lower.contains("bluetooth"))                              return DawIcon.BLUETOOTH;
-        if (lower.contains("wifi") || lower.contains("wireless"))    return DawIcon.WIFI;
-        if (lower.contains("cloud"))                                  return DawIcon.CLOUD;
-        if (lower.contains("airplay"))                                return DawIcon.AIRPLAY;
-        if (lower.contains("ethernet"))                               return DawIcon.ETHERNET;
-        if (lower.contains("nfc"))                                    return DawIcon.NFC;
-        if (lower.contains("optical"))                                return DawIcon.OPTICAL;
-        if (lower.contains("antenna"))                                return DawIcon.ANTENNA;
-        if (lower.contains("aux"))                                    return DawIcon.AUX_CABLE;
-        if (lower.contains("cast"))                                   return DawIcon.CAST;
-        // General category
-        if (lower.contains("album"))                                  return DawIcon.ALBUM;
-        if (lower.contains("cassette") || lower.contains("tape"))    return DawIcon.CASSETTE;
-        if (lower.contains("vinyl"))                                  return DawIcon.VINYL;
-        if (lower.contains("podcast"))                                return DawIcon.PODCAST;
-        if (lower.contains("queue"))                                  return DawIcon.QUEUE_MUSIC;
-        // Playback category
-        if (lower.contains("repeat"))                                 return DawIcon.REPEAT;
-        if (lower.contains("fast forward") || lower.contains("ff"))  return DawIcon.FAST_FORWARD;
-        if (lower.contains("rewind"))                                 return DawIcon.REWIND;
-        if (lower.contains("slow"))                                   return DawIcon.SLOW_MOTION;
-        if (lower.contains("speed"))                                  return DawIcon.SPEED_UP;
-        if (lower.contains("eject"))                                  return DawIcon.EJECT;
-        if (lower.contains("next") || lower.contains("queue"))       return DawIcon.QUEUE_NEXT;
-        // Volume category
-        if (lower.contains("bass boost"))                             return DawIcon.BASS_BOOST;
-        if (lower.contains("treble"))                                 return DawIcon.TREBLE_BOOST;
-        if (lower.contains("loudness"))                               return DawIcon.LOUDNESS;
-        if (lower.contains("volume off") || lower.contains("silent")) return DawIcon.VOLUME_OFF;
-        return pluginTypeIcon(desc.type());
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginBrowser.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginBrowser.java
@@ -1,0 +1,584 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.PluginManagerDialog;
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.core.mixer.InsertEffectFactory;
+import com.benesquivelmusic.daw.core.mixer.InsertEffectType;
+import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TreeCell;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+/**
+ * The §6.7 categorical plugin browser (Plugin View Design Book §6.7, §6.8,
+ * §8.4). It replaces the flat {@code ChoiceDialog} the mixer's empty insert slot
+ * used to show: one shared, searchable tree with two top groups — <em>Built-in</em>
+ * (grouped by {@link PluginCategory}) and <em>Installed (third-party)</em>
+ * (grouped by vendor) — plus install affordances ([+ Install from JAR…],
+ * [+ Install from folder…]) and a [Manage…] shortcut. Selecting a row (double
+ * click, {@code Enter}, or the Add button) yields a {@link Selection}; Cancel /
+ * the header close glyph yields {@code null}.
+ *
+ * <p>The model / filter logic is pure package-private {@code static} so it is
+ * unit-testable without a JavaFX scene; the tree, cell rendering and install flow
+ * layer on top.</p>
+ */
+public final class PluginBrowser extends DawgDialog<PluginBrowser.Selection> {
+
+    /** The user's choice: a built-in effect type or a registered external plugin. */
+    public sealed interface Selection permits BuiltInSelection, ExternalSelection {}
+
+    /** A built-in DSP effect chosen from the browser. */
+    public record BuiltInSelection(InsertEffectType type) implements Selection {}
+
+    /** A registered external plugin chosen from the browser. */
+    public record ExternalSelection(ExternalPluginEntry entry) implements Selection {}
+
+    static final String BUILT_IN_GROUP = "Built-in";
+    static final String INSTALLED_GROUP = "Installed (third-party)";
+
+    private static final double ICON_SIZE = 14;
+    private static final double BUSY_SPINNER_SIZE = 18;
+    private static final ButtonType ADD_BUTTON = new ButtonType("Add", ButtonBar.ButtonData.OK_DONE);
+
+    private final PluginRegistry registry;
+    private final boolean stereo;
+    private final List<InsertEffectType> builtInTypes;
+
+    private final TreeView<BrowserRow> tree = new TreeView<>();
+    private final TextField searchField = new TextField();
+    private final Label busyLabel = new Label();
+    private final HBox busyRow;
+
+    private List<BrowserRow> model;
+    private FxDispatcher fxDispatcher;
+
+    /**
+     * Creates a browser targeting an insert slot.
+     *
+     * @param registryOrNull the plugin registry (may be {@code null}: no
+     *                       third-party group, install / Manage disabled)
+     * @param stereo         whether the target has &ge; 2 channels (gates the
+     *                       Stereo Imager built-in)
+     * @param targetLabel    a human label for the target slot (e.g.
+     *                       {@code "Drum Bus / Insert 2"}), shown in the header
+     */
+    public PluginBrowser(PluginRegistry registryOrNull, boolean stereo, String targetLabel) {
+        this.registry = registryOrNull;
+        this.stereo = stereo;
+        this.builtInTypes = InsertEffectFactory.availableTypes();
+        this.model = buildModel(builtInTypes, stereo, loadedPlugins());
+
+        setTitle("Add plugin");
+        setHeaderText(targetLabel == null || targetLabel.isBlank()
+                ? "Add plugin" : "Add plugin to " + targetLabel);
+
+        // ── Search bar + Manage… ─────────────────────────────────────────────
+        searchField.setPromptText("Search plugins…");
+        searchField.getStyleClass().add("search-field");
+        HBox.setHgrow(searchField, Priority.ALWAYS);
+        searchField.textProperty().addListener((_, _, query) -> rebuildTree(query));
+
+        Button manageButton = new Button("Manage…");
+        manageButton.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        manageButton.setDisable(registry == null);
+        manageButton.setOnAction(_ -> {
+            if (registry != null) {
+                PluginManagerDialog manager = new PluginManagerDialog(registry);
+                manager.setFxDispatcher(fxDispatcher);
+                manager.showAndWait();
+                refreshThirdParty();
+            }
+        });
+
+        HBox searchBar = new HBox(8, searchField, manageButton);
+        searchBar.setAlignment(Pos.CENTER_LEFT);
+
+        // ── Tree ─────────────────────────────────────────────────────────────
+        tree.getStyleClass().add("plugin-browser-tree");
+        tree.setShowRoot(false);
+        tree.setCellFactory(_ -> new BrowserCell());
+        VBox.setVgrow(tree, Priority.ALWAYS);
+        rebuildTree("");
+
+        tree.setOnMouseClicked(event -> {
+            if (event.getClickCount() == 2) {
+                fireAddIfLeafSelected();
+            }
+        });
+        tree.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                fireAddIfLeafSelected();
+            }
+        });
+
+        // ── Busy row (scan in flight) ────────────────────────────────────────
+        ProgressIndicator spinner = new ProgressIndicator();
+        spinner.setPrefSize(BUSY_SPINNER_SIZE, BUSY_SPINNER_SIZE);
+        busyRow = new HBox(8, spinner, busyLabel);
+        busyRow.setAlignment(Pos.CENTER_LEFT);
+        busyRow.getStyleClass().add("plugin-row-busy");
+        busyRow.setVisible(false);
+        busyRow.setManaged(false);
+
+        // ── Install actions ──────────────────────────────────────────────────
+        Button installJar = new Button("+ Install from JAR…");
+        installJar.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        installJar.setDisable(registry == null);
+        installJar.setOnAction(_ -> chooseAndInstallJar());
+
+        Button installFolder = new Button("+ Install from folder…");
+        installFolder.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        installFolder.setDisable(registry == null);
+        installFolder.setOnAction(_ -> chooseAndInstallFolder());
+
+        HBox installBar = new HBox(8, installJar, installFolder);
+        installBar.setAlignment(Pos.CENTER_LEFT);
+        installBar.getStyleClass().add("plugin-install-row");
+
+        VBox content = new VBox(12, searchBar, tree, busyRow, installBar);
+        content.setPadding(new Insets(16));
+        content.getStyleClass().add("plugin-browser");
+        installDragDrop(content);
+
+        getDialogPane().setContent(content);
+        sized(DawgDialog.Size.LARGE);
+
+        // ── Footer buttons (Cancel + Add) ────────────────────────────────────
+        getDialogPane().getButtonTypes().addAll(ButtonType.CANCEL, ADD_BUTTON);
+        setResultConverter(buttonType -> buttonType == ADD_BUTTON ? selectionFromTree() : null);
+
+        if (getDialogPane().lookupButton(ADD_BUTTON) instanceof Button add) {
+            add.getStyleClass().addAll("dawg-button", "size-default", "primary");
+            add.setDisable(true);
+            tree.getSelectionModel().selectedItemProperty().addListener((_, _, selected) ->
+                    add.setDisable(selected == null || selected.getValue() instanceof GroupRow));
+        }
+    }
+
+    /**
+     * Injects the FX-thread marshalling seam used for off-thread JAR scans
+     * (story 289); defaults through the app-scoped seam when {@code null}.
+     *
+     * @param dispatcher the dispatcher, or {@code null} for the default
+     */
+    public void setFxDispatcher(FxDispatcher dispatcher) {
+        this.fxDispatcher = dispatcher;
+    }
+
+    // ── Selection commit ──────────────────────────────────────────────────────
+
+    private Selection selectionFromTree() {
+        TreeItem<BrowserRow> selected = tree.getSelectionModel().getSelectedItem();
+        if (selected == null) {
+            return null;
+        }
+        return switch (selected.getValue()) {
+            case BuiltInRow builtIn -> new BuiltInSelection(builtIn.type());
+            case ExternalRow external -> new ExternalSelection(external.entry());
+            case GroupRow ignored -> null;
+        };
+    }
+
+    private void fireAddIfLeafSelected() {
+        TreeItem<BrowserRow> selected = tree.getSelectionModel().getSelectedItem();
+        if (selected != null && !(selected.getValue() instanceof GroupRow)
+                && getDialogPane().lookupButton(ADD_BUTTON) instanceof Button add) {
+            add.fire();
+        }
+    }
+
+    // ── Tree building ─────────────────────────────────────────────────────────
+
+    private void rebuildTree(String query) {
+        boolean searching = query != null && !query.isBlank();
+        List<BrowserRow> visible = searching
+                ? filter(model, query.toLowerCase(Locale.ROOT))
+                : model;
+        TreeItem<BrowserRow> root = new TreeItem<>(new GroupRow("", List.of()));
+        root.setExpanded(true);
+        for (BrowserRow row : visible) {
+            root.getChildren().add(toTreeItem(row));
+        }
+        tree.setRoot(root);
+    }
+
+    private TreeItem<BrowserRow> toTreeItem(BrowserRow row) {
+        TreeItem<BrowserRow> item = new TreeItem<>(row);
+        if (row instanceof GroupRow group) {
+            item.setExpanded(true);
+            for (BrowserRow child : group.children()) {
+                item.getChildren().add(toTreeItem(child));
+            }
+        }
+        return item;
+    }
+
+    private Map<ExternalPluginEntry, DawPlugin> loadedPlugins() {
+        return registry == null ? Map.of() : registry.getLoadedPlugins();
+    }
+
+    private void refreshThirdParty() {
+        this.model = buildModel(builtInTypes, stereo, loadedPlugins());
+        rebuildTree(searchField.getText());
+    }
+
+    // ── Install flow ──────────────────────────────────────────────────────────
+
+    private void chooseAndInstallJar() {
+        if (registry == null) {
+            return;
+        }
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Install plugin from JAR");
+        chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("JAR Files", "*.jar"));
+        File file = chooser.showOpenDialog(getOwner());
+        if (file != null) {
+            beginJarInstall(file.toPath());
+        }
+    }
+
+    private void beginJarInstall(Path jar) {
+        if (registry == null) {
+            return;
+        }
+        runScan(jar, new PluginJarScanner(fxDispatcher), this::openInstallDialog);
+    }
+
+    private Thread runScan(Path jar, PluginJarScanner scanner, Consumer<JarInspection> onReady) {
+        showBusyRow(jarName(jar));
+        return scanner.scan(jar, inspection -> {
+            hideBusyRow();
+            onReady.accept(inspection);
+        });
+    }
+
+    private void openInstallDialog(JarInspection inspection) {
+        PluginInstallPanel.showDialog(inspection, registry, this::refreshThirdParty);
+    }
+
+    private void chooseAndInstallFolder() {
+        if (registry == null) {
+            return;
+        }
+        DirectoryChooser chooser = new DirectoryChooser();
+        chooser.setTitle("Install plugins from folder");
+        File dir = chooser.showDialog(getOwner());
+        if (dir != null) {
+            installFromFolder(dir.toPath());
+        }
+    }
+
+    private void installFromFolder(Path folder) {
+        showBusyRow(jarName(folder));
+        PluginJarScanner scanner = new PluginJarScanner(fxDispatcher);
+        Thread.ofVirtual().name("daw-plugin-folder-scan").start(() -> {
+            List<JarInspection> manifestBearing = new ArrayList<>();
+            List<String> skipped = new ArrayList<>();
+            try (DirectoryStream<Path> jars = Files.newDirectoryStream(folder, "*.jar")) {
+                for (Path jar : jars) {
+                    JarInspection inspection = scanner.scanBlocking(jar);
+                    if (inspection.manifests().isValid()) {
+                        manifestBearing.add(inspection);
+                    } else {
+                        skipped.add(jarName(jar));
+                    }
+                }
+            } catch (IOException | RuntimeException e) {
+                // Best-effort — an unreadable folder yields no installs.
+            }
+            FxDispatcher.runOnFx(fxDispatcher, () -> {
+                hideBusyRow();
+                for (JarInspection inspection : manifestBearing) {
+                    openInstallDialog(inspection);
+                }
+                if (!skipped.isEmpty()) {
+                    DawgDialog.info("Install plugins",
+                            "Skipped " + skipped.size() + " JAR(s) with no manifest:\n"
+                                    + String.join("\n", skipped)).showAndWait();
+                }
+            });
+        });
+    }
+
+    private void installDragDrop(Region content) {
+        content.setOnDragOver(event -> {
+            Dragboard db = event.getDragboard();
+            if (registry != null && db.hasFiles() && containsJar(db)) {
+                event.acceptTransferModes(TransferMode.COPY);
+            }
+            event.consume();
+        });
+        content.setOnDragDropped(event -> {
+            Dragboard db = event.getDragboard();
+            boolean ok = false;
+            if (registry != null && db.hasFiles()) {
+                List<Path> jars = jarPaths(db);
+                if (!jars.isEmpty()) {
+                    // Mirror AudioImportController: handle the first dropped JAR.
+                    beginJarInstall(jars.getFirst());
+                    ok = true;
+                }
+            }
+            event.setDropCompleted(ok);
+            event.consume();
+        });
+    }
+
+    private void showBusyRow(String label) {
+        busyLabel.setText("Scanning " + label + "…");
+        busyRow.setVisible(true);
+        busyRow.setManaged(true);
+    }
+
+    private void hideBusyRow() {
+        busyRow.setVisible(false);
+        busyRow.setManaged(false);
+    }
+
+    // ── Pure model + filter (package-private, static, toolkit-free) ────────────
+
+    /** A row in the browser tree — a group header or a selectable plugin leaf. */
+    sealed interface BrowserRow permits GroupRow, BuiltInRow, ExternalRow {
+        String displayText();
+    }
+
+    /** A group header (top group, a category, or a vendor) with child rows. */
+    record GroupRow(String name, List<BrowserRow> children) implements BrowserRow {
+        @Override
+        public String displayText() {
+            return name;
+        }
+    }
+
+    /** A built-in DSP effect leaf. */
+    record BuiltInRow(InsertEffectType type) implements BrowserRow {
+        @Override
+        public String displayText() {
+            return type.getDisplayName();
+        }
+    }
+
+    /** A registered third-party plugin leaf. */
+    record ExternalRow(ExternalPluginEntry entry, String name, String version,
+                       PluginCategory category, String iconHint) implements BrowserRow {
+        @Override
+        public String displayText() {
+            return name;
+        }
+    }
+
+    /**
+     * Builds the shared browser model: a "Built-in" group whose subgroups are the
+     * non-empty {@link PluginCategory}s (in enum order), and an
+     * "Installed (third-party)" group whose subgroups are the vendors (sorted) of
+     * the registered {@link PluginType#EFFECT} plugins. Empty top groups are
+     * omitted. Pure and {@code static} for unit testing.
+     */
+    static List<BrowserRow> buildModel(List<InsertEffectType> builtInTypes, boolean stereo,
+                                       Map<ExternalPluginEntry, DawPlugin> loadedPlugins) {
+        List<BrowserRow> roots = new ArrayList<>();
+
+        Map<PluginCategory, List<BrowserRow>> byCategory = new EnumMap<>(PluginCategory.class);
+        for (InsertEffectType type : builtInTypes) {
+            if (type == InsertEffectType.STEREO_IMAGER && !stereo) {
+                continue;
+            }
+            byCategory.computeIfAbsent(categoryOf(type), _ -> new ArrayList<>())
+                    .add(new BuiltInRow(type));
+        }
+        List<BrowserRow> builtInGroups = new ArrayList<>();
+        for (PluginCategory category : PluginCategory.values()) {
+            List<BrowserRow> rows = byCategory.get(category);
+            if (rows != null && !rows.isEmpty()) {
+                builtInGroups.add(new GroupRow(category.displayName(), rows));
+            }
+        }
+        if (!builtInGroups.isEmpty()) {
+            roots.add(new GroupRow(BUILT_IN_GROUP, builtInGroups));
+        }
+
+        Map<String, List<BrowserRow>> byVendor = new TreeMap<>();
+        for (Map.Entry<ExternalPluginEntry, DawPlugin> entry : loadedPlugins.entrySet()) {
+            PluginDescriptor descriptor = entry.getValue().getDescriptor();
+            if (descriptor.type() != PluginType.EFFECT) {
+                continue;
+            }
+            byVendor.computeIfAbsent(descriptor.vendor(), _ -> new ArrayList<>())
+                    .add(new ExternalRow(entry.getKey(), descriptor.name(),
+                            descriptor.version(), descriptor.category(), descriptor.iconHint()));
+        }
+        List<BrowserRow> vendorGroups = new ArrayList<>();
+        for (Map.Entry<String, List<BrowserRow>> entry : byVendor.entrySet()) {
+            vendorGroups.add(new GroupRow(entry.getKey(), entry.getValue()));
+        }
+        if (!vendorGroups.isEmpty()) {
+            roots.add(new GroupRow(INSTALLED_GROUP, vendorGroups));
+        }
+
+        return roots;
+    }
+
+    /**
+     * Pure recursive filter: keeps a group when its own name matches
+     * {@code lowerQuery} (whole group retained) or any descendant survives, keeps
+     * a leaf when its display text matches, and prunes empty groups.
+     * {@code lowerQuery} must already be lower-cased ({@link Locale#ROOT}); an
+     * empty query keeps everything. Package-private + {@code static} for tests.
+     */
+    static List<BrowserRow> filter(List<BrowserRow> rows, String lowerQuery) {
+        List<BrowserRow> out = new ArrayList<>();
+        for (BrowserRow row : rows) {
+            BrowserRow kept = filterRow(row, lowerQuery);
+            if (kept != null) {
+                out.add(kept);
+            }
+        }
+        return out;
+    }
+
+    private static BrowserRow filterRow(BrowserRow row, String lowerQuery) {
+        if (lowerQuery.isEmpty()) {
+            return row;
+        }
+        boolean nameMatches = row.displayText().toLowerCase(Locale.ROOT).contains(lowerQuery);
+        if (row instanceof GroupRow group) {
+            if (nameMatches) {
+                return group;
+            }
+            List<BrowserRow> kept = filter(group.children(), lowerQuery);
+            return kept.isEmpty() ? null : new GroupRow(group.name(), kept);
+        }
+        return nameMatches ? row : null;
+    }
+
+    private static PluginCategory categoryOf(InsertEffectType type) {
+        try {
+            return InsertEffectFactory.getCategory(type);
+        } catch (IllegalArgumentException e) {
+            // An unregistered/CLAP type (availableTypes() excludes CLAP) — group
+            // under Utility rather than dropping the row.
+            return PluginCategory.UTILITY;
+        }
+    }
+
+    private static boolean containsJar(Dragboard db) {
+        return db.getFiles().stream().anyMatch(PluginBrowser::isJar);
+    }
+
+    private static List<Path> jarPaths(Dragboard db) {
+        List<Path> jars = new ArrayList<>();
+        for (File file : db.getFiles()) {
+            if (isJar(file)) {
+                jars.add(file.toPath());
+            }
+        }
+        return jars;
+    }
+
+    private static boolean isJar(File file) {
+        return file.getName().toLowerCase(Locale.ROOT).endsWith(".jar");
+    }
+
+    private static String jarName(Path path) {
+        Path name = path.getFileName();
+        return name != null ? name.toString() : path.toString();
+    }
+
+    // ── Cell rendering ────────────────────────────────────────────────────────
+
+    private static final class BrowserCell extends TreeCell<BrowserRow> {
+        @Override
+        protected void updateItem(BrowserRow row, boolean empty) {
+            super.updateItem(row, empty);
+            getStyleClass().removeAll("plugin-browser-group", "plugin-browser-row");
+            if (empty || row == null) {
+                setText(null);
+                setGraphic(null);
+                return;
+            }
+            switch (row) {
+                case GroupRow group -> {
+                    setText(group.name());
+                    setGraphic(null);
+                    getStyleClass().add("plugin-browser-group");
+                }
+                case BuiltInRow builtIn -> {
+                    setText(builtIn.type().getDisplayName());
+                    setGraphic(PluginIcons.of(categoryOf(builtIn.type()), "", ICON_SIZE));
+                    getStyleClass().add("plugin-browser-row");
+                }
+                case ExternalRow external -> {
+                    setText(external.name() + "  v" + external.version()
+                            + "   [EFFECT · " + external.category().displayName() + "]");
+                    setGraphic(PluginIcons.of(external.category(), external.iconHint(), ICON_SIZE));
+                    getStyleClass().add("plugin-browser-row");
+                }
+            }
+        }
+    }
+
+    // ── Test hooks ────────────────────────────────────────────────────────────
+
+    /** The backing tree, for structural assertions. */
+    TreeView<BrowserRow> treeForTest() {
+        return tree;
+    }
+
+    /** The busy row node (style class {@code plugin-row-busy}), for scan tests. */
+    Region busyRowForTest() {
+        return busyRow;
+    }
+
+    /** Applies the search filter as if the user typed {@code query}. */
+    void applyFilterForTest(String query) {
+        searchField.setText(query);
+    }
+
+    /**
+     * Drives the same busy-row + off-thread scan flow production uses, with an
+     * injected scanner and completion consumer — the deterministic seam for
+     * {@code NonBlockingScanShowsRowSpinnerTest}.
+     */
+    Thread runScanForTest(Path jar, PluginJarScanner scanner, Consumer<JarInspection> onReady) {
+        return runScan(jar, scanner, onReady);
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginBrowser.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginBrowser.java
@@ -312,31 +312,66 @@ public final class PluginBrowser extends DawgDialog<PluginBrowser.Selection> {
         PluginJarScanner scanner = new PluginJarScanner(fxDispatcher);
         Thread.ofVirtual().name("daw-plugin-folder-scan").start(() -> {
             List<JarInspection> manifestBearing = new ArrayList<>();
-            List<String> skipped = new ArrayList<>();
+            List<JarInspection> rejected = new ArrayList<>();
             try (DirectoryStream<Path> jars = Files.newDirectoryStream(folder, "*.jar")) {
                 for (Path jar : jars) {
                     JarInspection inspection = scanner.scanBlocking(jar);
                     if (inspection.manifests().isValid()) {
                         manifestBearing.add(inspection);
                     } else {
-                        skipped.add(jarName(jar));
+                        rejected.add(inspection);
                     }
                 }
             } catch (IOException | RuntimeException e) {
                 // Best-effort — an unreadable folder yields no installs.
             }
+            String skippedSummary = skippedSummary(rejected);
             FxDispatcher.runOnFx(fxDispatcher, () -> {
                 hideBusyRow();
                 for (JarInspection inspection : manifestBearing) {
                     openInstallDialog(inspection);
                 }
-                if (!skipped.isEmpty()) {
-                    DawgDialog.info("Install plugins",
-                            "Skipped " + skipped.size() + " JAR(s) with no manifest:\n"
-                                    + String.join("\n", skipped)).showAndWait();
+                if (skippedSummary != null) {
+                    DawgDialog.info("Install plugins", skippedSummary).showAndWait();
                 }
             });
         });
+    }
+
+    /**
+     * The skipped-JARs dialog body for a folder install, one section per skip
+     * reason so an unreadable JAR (or one whose manifest failed to parse) is
+     * never misreported as manifest-less; {@code null} when nothing was skipped.
+     * Package-private for tests.
+     */
+    static String skippedSummary(List<JarInspection> rejected) {
+        List<String> unreadable = new ArrayList<>();
+        List<String> invalidManifest = new ArrayList<>();
+        List<String> noManifest = new ArrayList<>();
+        for (JarInspection inspection : rejected) {
+            String name = jarName(inspection.jar());
+            if (!inspection.jarReadable()) {
+                unreadable.add(name);
+            } else if (inspection.manifestPresent()) {
+                invalidManifest.add(name);
+            } else {
+                noManifest.add(name);
+            }
+        }
+        List<String> sections = new ArrayList<>();
+        if (!unreadable.isEmpty()) {
+            sections.add("Skipped " + unreadable.size() + " JAR(s) that could not be read:\n"
+                    + String.join("\n", unreadable));
+        }
+        if (!invalidManifest.isEmpty()) {
+            sections.add("Skipped " + invalidManifest.size() + " JAR(s) with an invalid manifest:\n"
+                    + String.join("\n", invalidManifest));
+        }
+        if (!noManifest.isEmpty()) {
+            sections.add("Skipped " + noManifest.size() + " JAR(s) with no manifest:\n"
+                    + String.join("\n", noManifest));
+        }
+        return sections.isEmpty() ? null : String.join("\n\n", sections);
     }
 
     private void installDragDrop(Region content) {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginIcons.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginIcons.java
@@ -1,0 +1,95 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
+import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+
+import javafx.scene.Node;
+
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Maps a plugin's {@link PluginCategory} + optional {@code iconHint} onto a
+ * concrete {@link DawIcon} (Plugin View Design Book §4.4, §6.7). This replaces
+ * the legacy ~60-branch keyword-sniffing {@code pluginDetailIcon} that guessed a
+ * plugin's kind from its name: a plugin now declares its category (and, when it
+ * wants a specific glyph, a stable {@code iconHint}) in its manifest, and the
+ * host resolves it structurally here.
+ *
+ * <p>Resolution (never {@code null}):</p>
+ * <ol>
+ *   <li>a non-blank {@code iconHint} is normalised (trimmed, upper-cased in
+ *       {@link Locale#ROOT}, {@code '-'} &rarr; {@code '_'}) and matched against
+ *       {@link DawIcon#valueOf(String)} — so {@code "compressor"} &rarr;
+ *       {@link DawIcon#COMPRESSOR}, {@code "low-pass"} &rarr;
+ *       {@link DawIcon#LOW_PASS};</li>
+ *   <li>on a miss (or a blank hint) it falls back to the category's default glyph
+ *       from a fixed {@link EnumMap}.</li>
+ * </ol>
+ *
+ * <p>There is deliberately no {@code switch} on a plugin id anywhere: the map is
+ * keyed on the closed {@link PluginCategory} enum (pinned by
+ * {@code NoSwitchOnPluginIdTest}).</p>
+ */
+public final class PluginIcons {
+
+    /** The category &rarr; default {@link DawIcon} fallback map (§6.7). */
+    private static final Map<PluginCategory, DawIcon> CATEGORY_ICONS = buildCategoryIcons();
+
+    private PluginIcons() {
+        // utility class
+    }
+
+    /**
+     * Returns a ready-to-use icon {@link Node} for the given category / hint,
+     * scaled to {@code size} pixels.
+     *
+     * @param category the plugin's browser category; must not be {@code null}
+     * @param iconHint the plugin's icon hint, or {@code ""} / {@code null} for none
+     * @param size     the icon size in pixels (both width and height)
+     * @return a scaled icon node (never {@code null})
+     */
+    public static Node of(PluginCategory category, String iconHint, double size) {
+        return IconNode.of(resolve(category, iconHint), size);
+    }
+
+    /**
+     * Resolves the {@link DawIcon} for a category / hint without building a node.
+     * Package-private so a unit test can assert the mapping (e.g. that
+     * {@code REVERB_AND_DELAY} and {@code DYNAMICS} resolve to different glyphs)
+     * without a JavaFX scene.
+     *
+     * @param category the plugin's browser category; must not be {@code null}
+     * @param iconHint the plugin's icon hint, or {@code ""} / {@code null} for none
+     * @return the resolved icon (never {@code null})
+     */
+    static DawIcon resolve(PluginCategory category, String iconHint) {
+        Objects.requireNonNull(category, "category must not be null");
+        if (iconHint != null && !iconHint.isBlank()) {
+            String normalized = iconHint.strip().toUpperCase(Locale.ROOT).replace('-', '_');
+            try {
+                return DawIcon.valueOf(normalized);
+            } catch (IllegalArgumentException ignored) {
+                // Unknown hint — fall back to the category default below.
+            }
+        }
+        return CATEGORY_ICONS.getOrDefault(category, DawIcon.KNOB);
+    }
+
+    private static Map<PluginCategory, DawIcon> buildCategoryIcons() {
+        Map<PluginCategory, DawIcon> map = new EnumMap<>(PluginCategory.class);
+        map.put(PluginCategory.DYNAMICS, DawIcon.COMPRESSOR);
+        map.put(PluginCategory.EQ_AND_FILTER, DawIcon.EQ);
+        map.put(PluginCategory.MODULATION, DawIcon.CHORUS);
+        map.put(PluginCategory.REVERB_AND_DELAY, DawIcon.REVERB);
+        map.put(PluginCategory.SPATIAL, DawIcon.CORRELATION);
+        map.put(PluginCategory.UTILITY, DawIcon.KNOB);
+        map.put(PluginCategory.ANALYZER, DawIcon.SPECTRUM);
+        map.put(PluginCategory.INSTRUMENT, DawIcon.KEYBOARD);
+        map.put(PluginCategory.MIDI_EFFECT, DawIcon.MIDI);
+        return map;
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginInstallPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginInstallPanel.java
@@ -1,0 +1,283 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
+import com.benesquivelmusic.daw.core.plugin.PluginLoadException;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifest;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifestReader;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * The §6.8 inspect-and-install content for a single dropped / picked JAR (Plugin
+ * View Design Book §6.8, §8.4). Built from a {@link JarInspection}, it presents
+ * one of three faces and installs every plugin without the user ever typing or
+ * seeing a class name on the manifest path:
+ *
+ * <ul>
+ *   <li><strong>Valid manifest</strong> — a header, the common vendor (or
+ *       "Multiple vendors"), one row per declared plugin
+ *       ({@code name  vVERSION  TYPE · Category}), a footprint line, and a primary
+ *       install button whose label reflects the count ("Install" / "Install both"
+ *       / "Install N plugins"). Installing registers <em>every</em> declared
+ *       plugin. There is no class-name field anywhere on this path.</li>
+ *   <li><strong>No manifest</strong> — the de-emphasised legacy fallback: a
+ *       class-name {@link TextField} and an "Add" button (story 304 removes this
+ *       fallback later).</li>
+ *   <li><strong>Manifest present but invalid</strong> — the reader's error lines
+ *       above the same de-emphasised class-name fallback.</li>
+ * </ul>
+ */
+public final class PluginInstallPanel extends VBox {
+
+    private static final double CONTENT_SPACING = 12;
+    private static final double CONTENT_PADDING = 16;
+    private static final double ROW_SPACING = 8;
+    private static final double ICON_SIZE = 16;
+
+    private final Button primaryButton;
+    private final TextField classNameField;
+    private Runnable onCloseRequest;
+
+    /**
+     * Builds the install content for {@code inspection}.
+     *
+     * @param inspection  the JAR inspection; must not be {@code null}
+     * @param registry    the registry to install into; must not be {@code null}
+     * @param onInstalled run after a successful install (e.g. refresh a list);
+     *                    must not be {@code null}
+     */
+    public PluginInstallPanel(JarInspection inspection, PluginRegistry registry, Runnable onInstalled) {
+        Objects.requireNonNull(inspection, "inspection must not be null");
+        Objects.requireNonNull(registry, "registry must not be null");
+        Objects.requireNonNull(onInstalled, "onInstalled must not be null");
+
+        setSpacing(CONTENT_SPACING);
+        setPadding(new Insets(CONTENT_PADDING));
+        getStyleClass().add("plugin-install-panel");
+
+        String jarName = jarName(inspection.jar());
+
+        if (inspection.manifests().isValid()) {
+            this.classNameField = null;
+            this.primaryButton = buildManifestPath(inspection, registry, onInstalled, jarName);
+        } else {
+            // No manifest, or a manifest that failed to parse/validate: both land
+            // on the de-emphasised class-name fallback (story 304 removes it).
+            this.classNameField = new TextField();
+            this.primaryButton = buildFallbackPath(inspection, registry, onInstalled, jarName);
+        }
+    }
+
+    /**
+     * Wraps a {@code PluginInstallPanel} in a MEDIUM {@link DawgDialog} titled
+     * "Install plugin"; the panel's own Cancel / install buttons drive the close.
+     *
+     * @param inspection  the JAR inspection; must not be {@code null}
+     * @param registry    the registry to install into; must not be {@code null}
+     * @param onInstalled run after a successful install; must not be {@code null}
+     */
+    public static void showDialog(JarInspection inspection, PluginRegistry registry, Runnable onInstalled) {
+        DawgDialog<Void> dialog = new DawgDialog<>();
+        dialog.setTitle("Install plugin");
+        dialog.setHeaderText("Install plugin");
+        dialog.sized(DawgDialog.Size.MEDIUM);
+        PluginInstallPanel panel = new PluginInstallPanel(inspection, registry, onInstalled);
+        panel.setOnCloseRequest(dialog::close);
+        dialog.getDialogPane().setContent(panel);
+        dialog.showAndWait();
+    }
+
+    /** Sets the callback the panel invokes to request its containing dialog close. */
+    void setOnCloseRequest(Runnable onCloseRequest) {
+        this.onCloseRequest = onCloseRequest;
+    }
+
+    /** The primary action button (install on the manifest path, Add on the fallback). */
+    Button primaryButtonForTest() {
+        return primaryButton;
+    }
+
+    /** The class-name field, or {@code null} on the manifest (no-typing) path. */
+    TextField classNameFieldForTest() {
+        return classNameField;
+    }
+
+    // ── Manifest path ─────────────────────────────────────────────────────────
+
+    private Button buildManifestPath(JarInspection inspection, PluginRegistry registry,
+                                     Runnable onInstalled, String jarName) {
+        List<PluginManifest> manifests = inspection.manifests().manifests();
+
+        Label title = new Label("Inspecting " + jarName);
+        title.getStyleClass().add("plugin-install-title");
+
+        Label vendor = new Label(vendorLine(manifests));
+
+        VBox rows = new VBox(ROW_SPACING);
+        for (PluginManifest manifest : manifests) {
+            rows.getChildren().add(manifestRow(manifest));
+        }
+
+        Label footprint = new Label(footprintLine(inspection));
+        footprint.getStyleClass().add("plugin-manager-info");
+
+        Button install = new Button(installLabel(manifests.size()));
+        install.getStyleClass().addAll("dawg-button", "size-default", "primary");
+        install.setOnAction(_ -> installAll(inspection.jar(), manifests, registry, onInstalled));
+
+        getChildren().addAll(title, vendor, rows, footprint, footer(install));
+        return install;
+    }
+
+    private Node manifestRow(PluginManifest manifest) {
+        PluginDescriptor d = manifest.descriptor();
+        Node icon = PluginIcons.of(d.category(), d.iconHint(), ICON_SIZE);
+        Label label = new Label(d.name() + "  v" + d.version()
+                + "  " + d.type().name() + " · " + d.category().displayName());
+        HBox row = new HBox(ROW_SPACING, icon, label);
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.getStyleClass().add("plugin-install-row");
+        return row;
+    }
+
+    private void installAll(Path jar, List<PluginManifest> manifests,
+                            PluginRegistry registry, Runnable onInstalled) {
+        List<String> failures = new ArrayList<>();
+        for (PluginManifest manifest : manifests) {
+            try {
+                registry.register(new ExternalPluginEntry(jar, manifest.pluginClass()));
+            } catch (PluginLoadException e) {
+                failures.add(manifest.pluginClass() + " — " + e.getMessage());
+            }
+        }
+        if (!failures.isEmpty()) {
+            DawgDialog.error("Install plugin",
+                    "Some plugins could not be installed:\n" + String.join("\n", failures))
+                    .showAndWait();
+        }
+        onInstalled.run();
+        requestClose();
+    }
+
+    // ── Fallback (no / invalid manifest) path ─────────────────────────────────
+
+    private Button buildFallbackPath(JarInspection inspection, PluginRegistry registry,
+                                     Runnable onInstalled, String jarName) {
+        Label title = new Label(jarName);
+        title.getStyleClass().add("plugin-install-title");
+
+        getChildren().add(title);
+
+        if (inspection.manifestPresent()
+                && inspection.manifests() instanceof PluginManifestReader.BundleResult.Invalid invalid) {
+            for (String error : invalid.errors()) {
+                Label errorLabel = new Label(error);
+                errorLabel.setWrapText(true);
+                errorLabel.getStyleClass().add("plugin-manager-notice");
+                getChildren().add(errorLabel);
+            }
+            getChildren().add(info("This JAR's manifest could not be read. "
+                    + "Install by class name instead:"));
+        } else {
+            getChildren().add(info("This JAR has no daw-plugin.json manifest. "
+                    + "Enter the plugin's fully-qualified class name to install it:"));
+        }
+
+        classNameField.setPromptText("e.g. com.example.MyReverbPlugin");
+
+        Button add = new Button("Add");
+        add.getStyleClass().addAll("dawg-button", "size-default", "primary");
+        add.setOnAction(_ -> addByClassName(inspection.jar(), registry, onInstalled));
+
+        getChildren().addAll(classNameField, footer(add));
+        return add;
+    }
+
+    private void addByClassName(Path jar, PluginRegistry registry, Runnable onInstalled) {
+        String className = classNameField.getText();
+        if (className == null || className.isBlank()) {
+            DawgDialog.error("Install plugin",
+                    "Please enter the plugin's fully-qualified class name.").showAndWait();
+            return;
+        }
+        try {
+            registry.register(new ExternalPluginEntry(jar, className.strip()));
+        } catch (PluginLoadException e) {
+            DawgDialog.error("Install plugin",
+                    "Failed to load plugin:\n" + e.getMessage()).showAndWait();
+            return;
+        }
+        onInstalled.run();
+        requestClose();
+    }
+
+    // ── Shared helpers ────────────────────────────────────────────────────────
+
+    private HBox footer(Button primary) {
+        Button cancel = new Button("Cancel");
+        cancel.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        cancel.setOnAction(_ -> requestClose());
+        HBox footer = new HBox(ROW_SPACING, cancel, primary);
+        footer.setAlignment(Pos.CENTER_RIGHT);
+        footer.getStyleClass().add("plugin-install-row");
+        return footer;
+    }
+
+    private static Label info(String text) {
+        Label label = new Label(text);
+        label.setWrapText(true);
+        label.getStyleClass().add("plugin-manager-info");
+        return label;
+    }
+
+    private void requestClose() {
+        if (onCloseRequest != null) {
+            onCloseRequest.run();
+        }
+    }
+
+    private static String jarName(Path jar) {
+        Path name = jar.getFileName();
+        return name != null ? name.toString() : jar.toString();
+    }
+
+    private static String vendorLine(List<PluginManifest> manifests) {
+        Set<String> vendors = new LinkedHashSet<>();
+        for (PluginManifest manifest : manifests) {
+            vendors.add(manifest.descriptor().vendor());
+        }
+        return vendors.size() == 1 ? "Vendor: " + vendors.iterator().next() : "Multiple vendors";
+    }
+
+    private static String footprintLine(JarInspection inspection) {
+        return "classes " + inspection.classFiles()
+                + " · resources " + inspection.resourceFiles()
+                + " · native " + inspection.nativeLibs();
+    }
+
+    private static String installLabel(int count) {
+        return switch (count) {
+            case 1 -> "Install";
+            case 2 -> "Install both";
+            default -> "Install " + count + " plugins";
+        };
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginInstallPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginInstallPanel.java
@@ -41,8 +41,9 @@ import java.util.Set;
  *   <li><strong>No manifest</strong> — the de-emphasised legacy fallback: a
  *       class-name {@link TextField} and an "Add" button (story 304 removes this
  *       fallback later).</li>
- *   <li><strong>Manifest present but invalid</strong> — the reader's error lines
- *       above the same de-emphasised class-name fallback.</li>
+ *   <li><strong>Manifest present but invalid, or JAR unreadable</strong> — the
+ *       reader's error lines above the same de-emphasised class-name fallback,
+ *       so an I/O failure is never misreported as a missing manifest.</li>
  * </ul>
  */
 public final class PluginInstallPanel extends VBox {
@@ -79,8 +80,9 @@ public final class PluginInstallPanel extends VBox {
             this.classNameField = null;
             this.primaryButton = buildManifestPath(inspection, registry, onInstalled, jarName);
         } else {
-            // No manifest, or a manifest that failed to parse/validate: both land
-            // on the de-emphasised class-name fallback (story 304 removes it).
+            // No manifest, a manifest that failed to parse/validate, or an
+            // unreadable JAR: all land on the de-emphasised class-name fallback
+            // (story 304 removes it).
             this.classNameField = new TextField();
             this.primaryButton = buildFallbackPath(inspection, registry, onInstalled, jarName);
         }
@@ -186,15 +188,20 @@ public final class PluginInstallPanel extends VBox {
 
         getChildren().add(title);
 
-        if (inspection.manifestPresent()
-                && inspection.manifests() instanceof PluginManifestReader.BundleResult.Invalid invalid) {
+        // Surface the reader's errors both for a manifest that failed to
+        // parse/validate AND for a JAR that could not be read at all — only a
+        // readable JAR genuinely lacking a manifest gets the "no manifest" copy.
+        if (inspection.manifests() instanceof PluginManifestReader.BundleResult.Invalid invalid
+                && (inspection.manifestPresent() || !inspection.jarReadable())) {
             for (String error : invalid.errors()) {
                 Label errorLabel = new Label(error);
                 errorLabel.setWrapText(true);
                 errorLabel.getStyleClass().add("plugin-manager-notice");
                 getChildren().add(errorLabel);
             }
-            getChildren().add(info("This JAR's manifest could not be read. "
+            getChildren().add(info((inspection.jarReadable()
+                    ? "This JAR's manifest could not be read. "
+                    : "This JAR could not be read. ")
                     + "Install by class name instead:"));
         } else {
             getChildren().add(info("This JAR has no daw-plugin.json manifest. "

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginJarScanner.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginJarScanner.java
@@ -36,6 +36,11 @@ public final class PluginJarScanner {
      * The result of inspecting a plugin JAR.
      *
      * @param jar             the inspected JAR
+     * @param jarReadable     whether the JAR could be opened and enumerated at
+     *                        all; {@code false} for a missing, corrupt or
+     *                        otherwise unreadable file — in which case
+     *                        {@code manifestPresent} says nothing about the JAR's
+     *                        actual content
      * @param manifestPresent whether the JAR carries a {@code META-INF/daw-plugin.json} entry
      * @param manifests       every plugin the manifest declares (or the reader's
      *                        validation errors); {@link PluginManifestReader.BundleResult.Invalid}
@@ -47,6 +52,7 @@ public final class PluginJarScanner {
      */
     public record JarInspection(
             Path jar,
+            boolean jarReadable,
             boolean manifestPresent,
             PluginManifestReader.BundleResult manifests,
             int classFiles,
@@ -83,7 +89,8 @@ public final class PluginJarScanner {
 
     /**
      * Inspects {@code jar} on the <strong>calling</strong> thread (all I/O; never
-     * touches JavaFX). Robust: an unreadable JAR yields a zero footprint plus an
+     * touches JavaFX). Robust: an unreadable JAR yields a zero footprint with
+     * {@code jarReadable=false} plus an
      * {@link PluginManifestReader.BundleResult.Invalid} rather than throwing.
      *
      * @param jar the JAR to inspect; must not be {@code null}
@@ -91,6 +98,7 @@ public final class PluginJarScanner {
      */
     public JarInspection scanBlocking(Path jar) {
         Objects.requireNonNull(jar, "jar must not be null");
+        boolean jarReadable = true;
         boolean manifestPresent = false;
         int classFiles = 0;
         int resourceFiles = 0;
@@ -117,11 +125,12 @@ public final class PluginJarScanner {
         } catch (IOException | RuntimeException e) {
             // Unreadable JAR — report an empty footprint; readAllFromJar below
             // reports the same problem as a BundleResult.Invalid (never throws).
+            jarReadable = false;
         }
         PluginManifestReader.BundleResult manifests =
                 new PluginManifestReader().readAllFromJar(jar);
         return new JarInspection(
-                jar, manifestPresent, manifests, classFiles, resourceFiles, nativeLibs);
+                jar, jarReadable, manifestPresent, manifests, classFiles, resourceFiles, nativeLibs);
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginJarScanner.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginJarScanner.java
@@ -1,0 +1,152 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifestReader;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Off-FX-thread inspection of a plugin JAR (Plugin View Design Book §6.8). Opens
+ * the JAR once, records whether it carries a {@code META-INF/daw-plugin.json}
+ * manifest, counts a rough footprint (class files / resources / native
+ * libraries), and reads every plugin the manifest declares through the SDK
+ * {@link PluginManifestReader}.
+ *
+ * <h2>Off the FX thread ({@code javafx-application-design} §11)</h2>
+ *
+ * <p>{@link #scanBlocking(Path)} performs all the I/O on the calling thread and
+ * never touches JavaFX. {@link #scan(Path, Consumer)} spawns a background
+ * <strong>virtual thread</strong> ({@code Thread.ofVirtual()}), runs the
+ * (injectable) inspector there, then marshals the result to the FX-thread
+ * consumer through the story-289 {@link FxDispatcher} — exactly the shape of
+ * {@code ProjectHealthScanner.scan}. A busy row in the browser / manager shows
+ * while the scan is in flight, never a modal "loading" dialog.</p>
+ */
+public final class PluginJarScanner {
+
+    /**
+     * The result of inspecting a plugin JAR.
+     *
+     * @param jar             the inspected JAR
+     * @param manifestPresent whether the JAR carries a {@code META-INF/daw-plugin.json} entry
+     * @param manifests       every plugin the manifest declares (or the reader's
+     *                        validation errors); {@link PluginManifestReader.BundleResult.Invalid}
+     *                        when the manifest is absent, unreadable or malformed
+     * @param classFiles      number of {@code .class} entries
+     * @param resourceFiles   number of non-class, non-native, non-directory entries
+     *                        (the manifest itself is counted here)
+     * @param nativeLibs      number of {@code .dll} / {@code .so} / {@code .dylib} entries
+     */
+    public record JarInspection(
+            Path jar,
+            boolean manifestPresent,
+            PluginManifestReader.BundleResult manifests,
+            int classFiles,
+            int resourceFiles,
+            int nativeLibs) {}
+
+    private final FxDispatcher dispatcher;
+    private final Function<Path, JarInspection> inspector;
+
+    /**
+     * Creates a scanner that marshals scan results through {@code dispatcher}.
+     *
+     * @param dispatcher the FX marshalling seam, or {@code null} to fall back to
+     *                   the {@link FxDispatcher#getDefault() app-scoped default}
+     */
+    public PluginJarScanner(FxDispatcher dispatcher) {
+        this(dispatcher, null);
+    }
+
+    /**
+     * Creates a scanner with an explicit inspector — the deterministic-test seam
+     * (inject a latch-blocking or canned inspector to drive the busy-row UI
+     * without real I/O). A {@code null} inspector defaults to
+     * {@link #scanBlocking(Path)}.
+     *
+     * @param dispatcher the FX marshalling seam, or {@code null} for the default
+     * @param inspector  the blocking inspection function, or {@code null} to use
+     *                   {@link #scanBlocking(Path)}
+     */
+    public PluginJarScanner(FxDispatcher dispatcher, Function<Path, JarInspection> inspector) {
+        this.dispatcher = dispatcher;
+        this.inspector = inspector != null ? inspector : this::scanBlocking;
+    }
+
+    /**
+     * Inspects {@code jar} on the <strong>calling</strong> thread (all I/O; never
+     * touches JavaFX). Robust: an unreadable JAR yields a zero footprint plus an
+     * {@link PluginManifestReader.BundleResult.Invalid} rather than throwing.
+     *
+     * @param jar the JAR to inspect; must not be {@code null}
+     * @return the inspection result (never {@code null})
+     */
+    public JarInspection scanBlocking(Path jar) {
+        Objects.requireNonNull(jar, "jar must not be null");
+        boolean manifestPresent = false;
+        int classFiles = 0;
+        int resourceFiles = 0;
+        int nativeLibs = 0;
+        try (JarFile jarFile = new JarFile(jar.toFile())) {
+            Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                String name = entry.getName();
+                if (name.equals(PluginManifestReader.MANIFEST_ENTRY)) {
+                    manifestPresent = true;
+                    resourceFiles++;
+                } else if (name.endsWith(".class")) {
+                    classFiles++;
+                } else if (isNativeLib(name)) {
+                    nativeLibs++;
+                } else {
+                    resourceFiles++;
+                }
+            }
+        } catch (IOException | RuntimeException e) {
+            // Unreadable JAR — report an empty footprint; readAllFromJar below
+            // reports the same problem as a BundleResult.Invalid (never throws).
+        }
+        PluginManifestReader.BundleResult manifests =
+                new PluginManifestReader().readAllFromJar(jar);
+        return new JarInspection(
+                jar, manifestPresent, manifests, classFiles, resourceFiles, nativeLibs);
+    }
+
+    /**
+     * Spawns one inspection on a fresh background <strong>virtual</strong> thread
+     * and returns it (so callers — and tests — can join on completion). The
+     * inspection runs off the FX thread and marshals the result to
+     * {@code fxConsumer} through {@link FxDispatcher#runOnFx(FxDispatcher, Runnable)}.
+     *
+     * @param jar        the JAR to inspect; must not be {@code null}
+     * @param fxConsumer the FX-thread consumer of the result; must not be {@code null}
+     * @return the started virtual scan thread
+     */
+    public Thread scan(Path jar, Consumer<JarInspection> fxConsumer) {
+        Objects.requireNonNull(jar, "jar must not be null");
+        Objects.requireNonNull(fxConsumer, "fxConsumer must not be null");
+        Thread t = Thread.ofVirtual().name("daw-plugin-jar-scan").unstarted(() -> {
+            JarInspection inspection = inspector.apply(jar);
+            FxDispatcher.runOnFx(dispatcher, () -> fxConsumer.accept(inspection));
+        });
+        t.start();
+        return t;
+    }
+
+    private static boolean isNativeLib(String name) {
+        String lower = name.toLowerCase(Locale.ROOT);
+        return lower.endsWith(".dll") || lower.endsWith(".so") || lower.endsWith(".dylib");
+    }
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -2498,3 +2498,72 @@
     -fx-text-fill: -text-hi;
     -fx-font-size: 11px;
 }
+
+/* ════════════════════════════════════════════════════════════════════
+ * Plugin browser + drag-a-JAR install flow (story 303)
+ * Plugin View Design Book §6.7 (categorical browser), §6.8 (inspect-and-
+ * install), §8.4. Tokens only (Palette A on .root-pane) — no literal hex,
+ * no literal dropshadow. Structural spacing/padding is set in Java; these
+ * rules carry only tokenized colour / border / font.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* §6.7 browser dialog body. */
+.plugin-browser {
+    -fx-background-color: -surface-1;
+}
+
+/* The one shared, searchable tree (Built-in + Installed groups). */
+.plugin-browser-tree {
+    -fx-background-color: -surface-bg;
+    -fx-border-color: -line-soft;
+    -fx-border-radius: 4;
+    -fx-background-radius: 4;
+}
+
+/* Group header rows (Built-in / category / vendor) — muted small label. */
+.plugin-browser-group {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+    -fx-font-weight: bold;
+}
+
+/* Selectable plugin leaf rows. */
+.plugin-browser-row {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 12px;
+}
+
+/* §6.8 busy row shown while a dropped/picked JAR is scanned off-thread. */
+.plugin-row-busy {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+}
+
+/* §6.8 inspect-and-install panel body. */
+.plugin-install-panel {
+    -fx-background-color: -surface-1;
+}
+
+/* Bold-ish title line in the install panel. */
+.plugin-install-title {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 13px;
+    -fx-font-weight: bold;
+}
+
+/* Shared row (plugin row in the install panel, install-action bar). */
+.plugin-install-row {
+    -fx-text-fill: -text;
+}
+
+/* De-emphasised helper text (drop hint, missing-manifest hint). */
+.plugin-manager-info {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+}
+
+/* Truthful session notice — warn hue, not an error (§8.4). */
+.plugin-manager-notice {
+    -fx-text-fill: -warn;
+    -fx-font-size: 11px;
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineControllerTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DefaultAudioEngineControllerTest.java
@@ -192,6 +192,14 @@ class DefaultAudioEngineControllerTest {
         waitFor(() -> controller.engineState() == EngineState.STOPPED);
 
         assertThat(controller.engineState()).isEqualTo(EngineState.STOPPED);
+        // The SubmissionPublisher delivers events asynchronously, so the
+        // subscriber may observe the STOPPED transition slightly after the
+        // controller's state field flips — wait for delivery before asserting.
+        waitFor(() -> {
+            synchronized (seen) {
+                return seen.contains(EngineState.STOPPED);
+            }
+        });
         synchronized (seen) {
             assertThat(seen).contains(EngineState.DEVICE_LOST, EngineState.STOPPED);
         }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/BrowserCategoriesFromPluginCategoryTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/BrowserCategoriesFromPluginCategoryTest.java
@@ -1,0 +1,124 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginBrowser.BrowserRow;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginBrowser.GroupRow;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginA;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginC;
+import com.benesquivelmusic.daw.core.mixer.InsertEffectFactory;
+import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 — the §6.7 browser groups built-in effects by their SDK
+ * {@link com.benesquivelmusic.daw.sdk.editor.PluginCategory} (via
+ * {@link InsertEffectFactory#getCategory}) and installed third-party plugins by
+ * vendor, over one shared, searchable model. Most assertions drive the pure
+ * static model / filter; one end-to-end assertion checks the constructed
+ * {@link PluginBrowser}'s tree.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class BrowserCategoriesFromPluginCategoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void builtInsGroupByCategoryAndThirdPartyByVendorWithSearch() throws Exception {
+        PluginManifest a = PluginTestJars.manifest(InstallFixturePluginA.class); // Acme Audio
+        PluginManifest c = PluginTestJars.manifest(InstallFixturePluginC.class); // QuietSky DSP
+        Path jar = PluginTestJars.buildJar(tempDir, "ac.jar",
+                List.of(a, c),
+                List.of(InstallFixturePluginA.class, InstallFixturePluginC.class));
+
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            registry.register(new ExternalPluginEntry(jar, InstallFixturePluginA.class.getName()));
+            registry.register(new ExternalPluginEntry(jar, InstallFixturePluginC.class.getName()));
+
+            List<BrowserRow> model = PluginBrowser.buildModel(
+                    InsertEffectFactory.availableTypes(), true, registry.getLoadedPlugins());
+
+            // ── Built-in grouped by PluginCategory display name ──────────────
+            GroupRow builtIn = group(model, PluginBrowser.BUILT_IN_GROUP);
+            assertThat(subgroupNames(builtIn)).contains("Dynamics", "Reverb & Delay");
+            assertThat(leafLabels(group(builtIn.children(), "Dynamics")))
+                    .as("the Compressor sits under Dynamics").contains("Compressor");
+            assertThat(leafLabels(group(builtIn.children(), "Reverb & Delay")))
+                    .as("the Reverb sits under Reverb & Delay").contains("Reverb");
+
+            // ── Third-party grouped by vendor ────────────────────────────────
+            GroupRow installed = group(model, PluginBrowser.INSTALLED_GROUP);
+            assertThat(subgroupNames(installed))
+                    .containsExactlyInAnyOrder("Acme Audio", "QuietSky DSP");
+
+            // ── Search "compress" keeps Built-in/Dynamics, drops the rest ────
+            List<BrowserRow> filtered = PluginBrowser.filter(model, "compress");
+            GroupRow filteredBuiltIn = group(filtered, PluginBrowser.BUILT_IN_GROUP);
+            assertThat(subgroupNames(filteredBuiltIn))
+                    .as("only the Dynamics subgroup (holding the match) survives")
+                    .containsExactly("Dynamics");
+            assertThat(leafLabels(group(filteredBuiltIn.children(), "Dynamics")))
+                    .containsExactly("Compressor");
+            assertThat(groupOrNull(filtered, PluginBrowser.INSTALLED_GROUP))
+                    .as("no third-party name matches 'compress'").isNull();
+
+            // ── Search matching nothing yields no rows ───────────────────────
+            assertThat(PluginBrowser.filter(model, "zzzznotathing")).isEmpty();
+
+            // ── End-to-end: the constructed browser's tree top groups ────────
+            PluginBrowser browser = runOnFxThread(() ->
+                    new PluginBrowser(registry, true, "Test / Insert 1"));
+            List<String> topGroups = runOnFxThread(() ->
+                    browser.treeForTest().getRoot().getChildren().stream()
+                            .map(item -> item.getValue().displayText())
+                            .toList());
+            assertThat(topGroups)
+                    .containsExactly(PluginBrowser.BUILT_IN_GROUP, PluginBrowser.INSTALLED_GROUP);
+        } finally {
+            registry.disposeAll();
+        }
+    }
+
+    // ── Model navigation helpers ──────────────────────────────────────────────
+
+    private static GroupRow group(List<BrowserRow> rows, String name) {
+        GroupRow found = groupOrNull(rows, name);
+        assertThat(found).as("group '%s' present", name).isNotNull();
+        return found;
+    }
+
+    private static GroupRow groupOrNull(List<BrowserRow> rows, String name) {
+        for (BrowserRow row : rows) {
+            if (row instanceof GroupRow group && group.name().equals(name)) {
+                return group;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> subgroupNames(GroupRow group) {
+        return group.children().stream()
+                .filter(GroupRow.class::isInstance)
+                .map(child -> ((GroupRow) child).name())
+                .toList();
+    }
+
+    private static List<String> leafLabels(GroupRow group) {
+        return group.children().stream()
+                .filter(child -> !(child instanceof GroupRow))
+                .map(BrowserRow::displayText)
+                .toList();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/FolderInstallSkippedSummaryTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/FolderInstallSkippedSummaryTest.java
@@ -1,0 +1,59 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifestReader;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 review follow-up — the folder-install skipped-JARs dialog must
+ * partition by skip reason: a JAR the scanner could not read (or whose manifest
+ * failed to parse) must never be lumped into the "no manifest" section.
+ */
+class FolderInstallSkippedSummaryTest {
+
+    private static final PluginManifestReader.BundleResult.Invalid INVALID =
+            new PluginManifestReader.BundleResult.Invalid(List.of("some problem"));
+
+    private static JarInspection inspection(String name, boolean jarReadable,
+                                            boolean manifestPresent) {
+        return new JarInspection(Path.of(name), jarReadable, manifestPresent, INVALID, 0, 0, 0);
+    }
+
+    @Test
+    void summarySeparatesUnreadableInvalidAndManifestLessJars() {
+        String summary = PluginBrowser.skippedSummary(List.of(
+                inspection("corrupt.jar", false, false),
+                inspection("bad-manifest.jar", true, true),
+                inspection("plain.jar", true, false)));
+
+        assertThat(summary).isNotNull();
+        String[] sections = summary.split("\n\n");
+        assertThat(sections).hasSize(3);
+        assertThat(sections[0])
+                .as("an unreadable JAR is reported as unreadable, not manifest-less")
+                .contains("could not be read").contains("corrupt.jar");
+        assertThat(sections[1])
+                .as("a present-but-invalid manifest is reported as invalid")
+                .contains("invalid manifest").contains("bad-manifest.jar");
+        assertThat(sections[2])
+                .as("only a readable, manifest-less JAR lands in the no-manifest section")
+                .contains("no manifest").contains("plain.jar")
+                .doesNotContain("corrupt.jar").doesNotContain("bad-manifest.jar");
+    }
+
+    @Test
+    void summaryOmitsEmptySectionsAndIsNullWhenNothingSkipped() {
+        assertThat(PluginBrowser.skippedSummary(List.of()))
+                .as("no dialog when nothing was skipped").isNull();
+        assertThat(PluginBrowser.skippedSummary(List.of(inspection("plain.jar", true, false))))
+                .as("only the applicable section is emitted")
+                .contains("no manifest")
+                .doesNotContain("could not be read").doesNotContain("invalid manifest");
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/InstallRegistersEveryDeclaredPluginTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/InstallRegistersEveryDeclaredPluginTest.java
@@ -1,0 +1,69 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginA;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginB;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginC;
+import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 — a three-plugin manifest installs exactly three registry entries
+ * from ONE install action, each {@code className} matching the manifest's
+ * declared classes in declared order.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class InstallRegistersEveryDeclaredPluginTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void oneInstallActionRegistersEveryDeclaredPluginInOrder() throws Exception {
+        PluginManifest a = PluginTestJars.manifest(InstallFixturePluginA.class);
+        PluginManifest b = PluginTestJars.manifest(InstallFixturePluginB.class);
+        PluginManifest c = PluginTestJars.manifest(InstallFixturePluginC.class);
+        Path jar = PluginTestJars.buildJar(tempDir, "three-plugins.jar",
+                List.of(a, b, c),
+                List.of(InstallFixturePluginA.class,
+                        InstallFixturePluginB.class,
+                        InstallFixturePluginC.class));
+
+        JarInspection inspection = new PluginJarScanner(null).scanBlocking(jar);
+        assertThat(inspection.manifests().manifests())
+                .as("the bundle declares three plugins").hasSize(3);
+
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            PluginInstallPanel panel = runOnFxThread(() ->
+                    new PluginInstallPanel(inspection, registry, () -> { }));
+
+            runOnFxThread(() -> {
+                panel.primaryButtonForTest().fire();
+                return null;
+            });
+
+            assertThat(registry.getEntries()).hasSize(3);
+            assertThat(registry.getEntries().stream().map(ExternalPluginEntry::className).toList())
+                    .as("every declared plugin was registered, in declared order")
+                    .containsExactly(
+                            InstallFixturePluginA.class.getName(),
+                            InstallFixturePluginB.class.getName(),
+                            InstallFixturePluginC.class.getName());
+        } finally {
+            registry.disposeAll();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/InvalidManifestShowsReaderErrorsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/InvalidManifestShowsReaderErrorsTest.java
@@ -1,0 +1,64 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 review follow-up — a readable JAR whose {@code daw-plugin.json} is
+ * present but malformed must surface the reader's validation errors above the
+ * §6.8 class-name fallback (the {@code manifestPresent} arm of the fallback
+ * predicate), not the "no manifest" copy.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class InvalidManifestShowsReaderErrorsTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void malformedManifestSurfacesValidationErrorsInsteadOfNoManifestCopy() throws Exception {
+        // A real JAR whose manifest entry is missing every required field but one.
+        Path jar = PluginTestJars.buildJarWithManifestJson(tempDir, "bad-manifest.jar",
+                "{\"pluginClass\": \"com.example.MissingEverythingElse\"}", List.of());
+
+        JarInspection inspection = new PluginJarScanner(null).scanBlocking(jar);
+        assertThat(inspection.jarReadable())
+                .as("the JAR itself is readable").isTrue();
+        assertThat(inspection.manifestPresent())
+                .as("the manifest entry is present").isTrue();
+        assertThat(inspection.manifests().isValid())
+                .as("the manifest fails validation").isFalse();
+
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            PluginInstallPanel panel = runOnFxThread(() ->
+                    new PluginInstallPanel(inspection, registry, () -> { }));
+
+            List<String> labels = PluginNodes.labelTexts(panel);
+            assertThat(labels)
+                    .as("the reader's validation errors are surfaced")
+                    .anySatisfy(text -> assertThat(text).contains("missing required field"));
+            assertThat(labels)
+                    .as("the invalid-manifest copy is shown")
+                    .anySatisfy(text ->
+                            assertThat(text).contains("This JAR's manifest could not be read"));
+            assertThat(labels)
+                    .as("a present-but-invalid manifest is not misreported as absent")
+                    .noneSatisfy(text ->
+                            assertThat(text).contains("has no daw-plugin.json manifest"));
+        } finally {
+            registry.disposeAll();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/LegacySingleManifestInstallTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/LegacySingleManifestInstallTest.java
@@ -1,0 +1,111 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginA;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginB;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginC;
+import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifest;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifestWriter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 — §6.8 backward compatibility: a JAR carrying the story-300
+ * <em>legacy single-object</em> manifest (not the story-303 bundle array) still
+ * flows through the manifest install path — one listed row, no class-name
+ * field, an "Install" confirm — and registers its one declared plugin. Also
+ * pins the §6.8 confirm-button label contract: "Install" / "Install both" /
+ * "Install N plugins".
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class LegacySingleManifestInstallTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void legacySingleObjectManifestInstallsItsOnePlugin() throws Exception {
+        PluginManifest manifest = PluginTestJars.manifest(InstallFixturePluginC.class);
+        // The single-manifest writer overload emits the story-300 flat object,
+        // NOT the story-303 top-level array.
+        String legacyJson = new PluginManifestWriter().toJson(manifest);
+        assertThat(legacyJson.stripLeading()).startsWith("{");
+        Path jar = PluginTestJars.buildJarWithManifestJson(tempDir, "legacy-single.jar",
+                legacyJson, List.of(InstallFixturePluginC.class));
+
+        JarInspection inspection = new PluginJarScanner(null).scanBlocking(jar);
+        assertThat(inspection.manifestPresent())
+                .as("the JAR carries a daw-plugin.json manifest").isTrue();
+        assertThat(inspection.manifests().isValid())
+                .as("a legacy single-object manifest is a valid one-plugin bundle").isTrue();
+        assertThat(inspection.manifests().manifests()).hasSize(1);
+
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            PluginInstallPanel panel = runOnFxThread(() ->
+                    new PluginInstallPanel(inspection, registry, () -> { }));
+
+            assertThat(PluginNodes.findTextFields(panel))
+                    .as("the legacy-manifest path is still the no-typing path")
+                    .isEmpty();
+            assertThat(panel.primaryButtonForTest().getText())
+                    .as("§6.8 — a one-plugin manifest confirms with plain \"Install\"")
+                    .isEqualTo("Install");
+
+            runOnFxThread(() -> {
+                panel.primaryButtonForTest().fire();
+                return null;
+            });
+
+            assertThat(registry.getEntries())
+                    .as("the single declared plugin registered without class-name input")
+                    .containsExactly(
+                            new ExternalPluginEntry(jar, InstallFixturePluginC.class.getName()));
+        } finally {
+            registry.disposeAll();
+        }
+    }
+
+    @Test
+    void installButtonLabelReflectsDeclaredPluginCount() throws Exception {
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            assertThat(installLabelFor(registry, "two.jar",
+                    List.of(InstallFixturePluginA.class, InstallFixturePluginB.class)))
+                    .as("§6.8 — two declared plugins confirm with \"Install both\"")
+                    .isEqualTo("Install both");
+            assertThat(installLabelFor(registry, "three.jar",
+                    List.of(InstallFixturePluginA.class, InstallFixturePluginB.class,
+                            InstallFixturePluginC.class)))
+                    .as("§6.8 — N > 2 declared plugins confirm with \"Install N plugins\"")
+                    .isEqualTo("Install 3 plugins");
+        } finally {
+            registry.disposeAll();
+        }
+    }
+
+    private String installLabelFor(PluginRegistry registry, String jarName,
+                                   List<Class<?>> fixtures) throws Exception {
+        List<PluginManifest> manifests = fixtures.stream()
+                .map(cls -> PluginTestJars.manifest(cls.asSubclass(
+                        com.benesquivelmusic.daw.sdk.plugin.DawPlugin.class)))
+                .toList();
+        Path jar = PluginTestJars.buildJar(tempDir, jarName, manifests, fixtures);
+        JarInspection inspection = new PluginJarScanner(null).scanBlocking(jar);
+        assertThat(inspection.manifests().isValid()).isTrue();
+        PluginInstallPanel panel = runOnFxThread(() ->
+                new PluginInstallPanel(inspection, registry, () -> { }));
+        return panel.primaryButtonForTest().getText();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/ManifestDrivenInstallTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/ManifestDrivenInstallTest.java
@@ -1,0 +1,77 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginA;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginB;
+import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 — a JAR whose manifest declares TWO plugins installs BOTH from a
+ * single action, driven entirely off the manifest with zero class-name input:
+ * the §6.8 install panel lists a row per declared plugin, shows no
+ * {@code TextField} anywhere, and firing its install action registers both
+ * {@link ExternalPluginEntry}s.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ManifestDrivenInstallTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void twoPluginManifestInstallsBothWithNoClassNameInput() throws Exception {
+        PluginManifest a = PluginTestJars.manifest(InstallFixturePluginA.class);
+        PluginManifest b = PluginTestJars.manifest(InstallFixturePluginB.class);
+        Path jar = PluginTestJars.buildJar(tempDir, "two-plugins.jar",
+                List.of(a, b),
+                List.of(InstallFixturePluginA.class, InstallFixturePluginB.class));
+
+        JarInspection inspection = new PluginJarScanner(null).scanBlocking(jar);
+        assertThat(inspection.manifestPresent())
+                .as("the JAR carries a daw-plugin.json manifest").isTrue();
+        assertThat(inspection.manifests().isValid())
+                .as("the manifest bundle parses").isTrue();
+        assertThat(inspection.manifests().manifests())
+                .as("the bundle declares two plugins").hasSize(2);
+
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            PluginInstallPanel panel = runOnFxThread(() ->
+                    new PluginInstallPanel(inspection, registry, () -> { }));
+
+            assertThat(PluginNodes.findTextFields(panel))
+                    .as("the manifest install path never asks for a class name")
+                    .isEmpty();
+            assertThat(PluginNodes.labelTexts(panel))
+                    .as("both declared plugins are listed with their manifest names")
+                    .anyMatch(text -> text.contains("Acme Punch"))
+                    .anyMatch(text -> text.contains("Acme Echo"));
+
+            runOnFxThread(() -> {
+                panel.primaryButtonForTest().fire();
+                return null;
+            });
+
+            assertThat(registry.getEntries())
+                    .as("firing install registered BOTH declared plugins, class-name-free")
+                    .contains(
+                            new ExternalPluginEntry(jar, InstallFixturePluginA.class.getName()),
+                            new ExternalPluginEntry(jar, InstallFixturePluginB.class.getName()));
+        } finally {
+            registry.disposeAll();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/MissingManifestFallsBackToClassNameTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/MissingManifestFallsBackToClassNameTest.java
@@ -1,0 +1,69 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginC;
+import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+
+import javafx.scene.control.TextField;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 — a JAR with classes but NO {@code daw-plugin.json} falls back to the
+ * de-emphasised legacy class-name form (kept reachable; story 304 removes it):
+ * the §6.8 panel exposes the class-name {@link TextField}, and typing the
+ * fixture's FQCN + firing Add registers it.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class MissingManifestFallsBackToClassNameTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void manifestLessJarShowsClassNameFallbackThatInstalls() throws Exception {
+        // A JAR with the fixture's class bytes but no manifest entry.
+        Path jar = PluginTestJars.buildJar(tempDir, "no-manifest.jar",
+                null, List.of(InstallFixturePluginC.class));
+
+        JarInspection inspection = new PluginJarScanner(null).scanBlocking(jar);
+        assertThat(inspection.manifestPresent())
+                .as("the JAR carries no daw-plugin.json manifest").isFalse();
+
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            PluginInstallPanel panel = runOnFxThread(() ->
+                    new PluginInstallPanel(inspection, registry, () -> { }));
+
+            TextField field = panel.classNameFieldForTest();
+            assertThat(field)
+                    .as("the fallback path exposes the class-name field")
+                    .isNotNull();
+            assertThat(PluginNodes.findTextFields(panel))
+                    .as("the class-name field is present in the panel's node tree")
+                    .contains(field);
+
+            runOnFxThread(() -> {
+                field.setText(InstallFixturePluginC.class.getName());
+                panel.primaryButtonForTest().fire();
+                return null;
+            });
+
+            assertThat(registry.getEntries())
+                    .as("typing the FQCN + Add registers the plugin")
+                    .contains(new ExternalPluginEntry(jar, InstallFixturePluginC.class.getName()));
+        } finally {
+            registry.disposeAll();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/NoClassNameFieldInDefaultPathTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/NoClassNameFieldInDefaultPathTest.java
@@ -1,0 +1,58 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.PluginManagerDialog;
+import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 — the re-skinned {@link PluginManagerDialog} shows the registry as a
+ * list with descriptor-driven icons and <em>no</em> always-visible class-name /
+ * JAR-path text fields, and the ~60-branch keyword-sniffing {@code pluginDetailIcon}
+ * (and its {@code pluginTypeIcon} helper) are gone: the icon is now resolved by
+ * {@link PluginIcons} from the descriptor category / hint.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class NoClassNameFieldInDefaultPathTest {
+
+    @Test
+    void managerDialogHasNoTextFieldAndKeywordSniffingIsGone() {
+        PluginRegistry registry = new PluginRegistry();
+        PluginManagerDialog dialog = runOnFxThread(() -> new PluginManagerDialog(registry));
+
+        assertThat(PluginNodes.findTextFields(dialog.getDialogPane().getContent()))
+                .as("the re-skinned manager exposes no class-name / JAR-path text field")
+                .isEmpty();
+
+        assertThat(Arrays.stream(PluginManagerDialog.class.getDeclaredMethods())
+                .map(Method::getName).toList())
+                .as("the keyword-sniffing pluginDetailIcon / pluginTypeIcon helpers are deleted")
+                .doesNotContain("pluginDetailIcon", "pluginTypeIcon");
+    }
+
+    @Test
+    void pluginIconsResolvesFromCategoryNotName() {
+        DawIcon reverb = PluginIcons.resolve(PluginCategory.REVERB_AND_DELAY, "");
+        DawIcon dynamics = PluginIcons.resolve(PluginCategory.DYNAMICS, "");
+
+        assertThat(reverb)
+                .as("a Reverb & Delay plugin resolves to the REVERB glyph via its category")
+                .isEqualTo(DawIcon.REVERB);
+        assertThat(dynamics)
+                .as("a Dynamics plugin resolves to the COMPRESSOR glyph via its category")
+                .isEqualTo(DawIcon.COMPRESSOR);
+        assertThat(reverb)
+                .as("different categories produce different glyphs — no name-keyword sniffing")
+                .isNotEqualTo(dynamics);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/NonBlockingScanShowsRowSpinnerTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/NonBlockingScanShowsRowSpinnerTest.java
@@ -1,0 +1,131 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifestReader;
+
+import javafx.application.Platform;
+import javafx.scene.layout.Region;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 — JAR inspection runs on a virtual thread and marshals back via the
+ * {@link FxDispatcher}; while a scan is in flight a busy row with a spinner shows
+ * (never a modal "loading" dialog), the FX thread stays responsive, and on
+ * completion the row is gone and the consumer ran on the FX thread.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class NonBlockingScanShowsRowSpinnerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private FxDispatcher dispatcher;
+
+    @BeforeEach
+    void installDispatcher() {
+        dispatcher = new FxDispatcher();
+        FxDispatcher.installDefault(dispatcher);
+        runOnFxThread(() -> {
+            dispatcher.start();
+            return null;
+        });
+    }
+
+    @AfterEach
+    void disposeDispatcher() {
+        runOnFxThread(() -> {
+            dispatcher.dispose();
+            return null;
+        });
+        FxDispatcher.installDefault(null);
+    }
+
+    @Test
+    void busySpinnerShowsDuringScanWhileFxStaysResponsive() throws Exception {
+        PluginRegistry registry = new PluginRegistry();
+        PluginBrowser browser = runOnFxThread(() -> {
+            PluginBrowser b = new PluginBrowser(registry, true, "Test / Insert 1");
+            b.setFxDispatcher(dispatcher);
+            return b;
+        });
+
+        Path jar = tempDir.resolve("blocking.jar"); // path unused — inspector is injected
+        CountDownLatch inspectorLatch = new CountDownLatch(1);
+        JarInspection canned = new JarInspection(jar, false,
+                new PluginManifestReader.BundleResult.Invalid(List.of("no manifest")), 0, 0, 0);
+        Function<Path, JarInspection> blockingInspector = path -> {
+            try {
+                inspectorLatch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return canned;
+        };
+        PluginJarScanner scanner = new PluginJarScanner(dispatcher, blockingInspector);
+
+        AtomicBoolean consumerRanOnFx = new AtomicBoolean(false);
+        CountDownLatch consumerDone = new CountDownLatch(1);
+
+        Thread scanThread = runOnFxThread(() ->
+                browser.runScanForTest(jar, scanner, inspection -> {
+                    consumerRanOnFx.set(Platform.isFxApplicationThread());
+                    consumerDone.countDown();
+                }));
+
+        assertThat(scanThread.isVirtual())
+                .as("JAR inspection runs OFF the FX thread on a virtual thread").isTrue();
+
+        // ── During the scan (latch held): busy row visible with a spinner ────
+        runOnFxThread(() -> {
+            Region busy = browser.busyRowForTest();
+            assertThat(busy.isVisible())
+                    .as("a busy row is shown while the scan is in flight").isTrue();
+            assertThat(busy.getStyleClass()).contains("plugin-row-busy");
+            assertThat(PluginNodes.hasProgressIndicator(busy))
+                    .as("the busy row carries a spinner").isTrue();
+            return null;
+        });
+
+        // ── The FX thread stays responsive (a probe completes) ───────────────
+        AtomicBoolean probeRan = new AtomicBoolean(false);
+        runOnFxThread(() -> {
+            probeRan.set(true);
+            return null;
+        });
+        assertThat(probeRan)
+                .as("the FX thread is not blocked by the in-flight scan").isTrue();
+
+        // ── Release the scan; the consumer marshals back to the FX thread ────
+        inspectorLatch.countDown();
+        assertThat(consumerDone.await(5, TimeUnit.SECONDS))
+                .as("the completion consumer ran").isTrue();
+        scanThread.join(2_000);
+        runOnFxThread(() -> null); // FX barrier
+
+        assertThat(consumerRanOnFx)
+                .as("the completion consumer ran on the FX thread").isTrue();
+        runOnFxThread(() -> {
+            assertThat(browser.busyRowForTest().isVisible())
+                    .as("the busy row is gone after the scan completes").isFalse();
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/NonBlockingScanShowsRowSpinnerTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/NonBlockingScanShowsRowSpinnerTest.java
@@ -69,7 +69,7 @@ class NonBlockingScanShowsRowSpinnerTest {
 
         Path jar = tempDir.resolve("blocking.jar"); // path unused — inspector is injected
         CountDownLatch inspectorLatch = new CountDownLatch(1);
-        JarInspection canned = new JarInspection(jar, false,
+        JarInspection canned = new JarInspection(jar, true, false,
                 new PluginManifestReader.BundleResult.Invalid(List.of("no manifest")), 0, 0, 0);
         Function<Path, JarInspection> blockingInspector = path -> {
             try {

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/PluginIconsResolveTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/PluginIconsResolveTest.java
@@ -1,0 +1,44 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 — pins the §4.4 icon-resolution contract of {@link PluginIcons}: a
+ * declared {@code iconHint} maps into the host icon pack and WINS over the
+ * category default; an unknown hint (or none) falls back to the category glyph.
+ * Pure mapping test, no JavaFX scene needed.
+ */
+class PluginIconsResolveTest {
+
+    @Test
+    void nonBlankIconHintWinsOverCategoryDefault() {
+        assertThat(PluginIcons.resolve(PluginCategory.REVERB_AND_DELAY, "delay"))
+                .as("a known hint overrides the category default (REVERB)")
+                .isEqualTo(DawIcon.DELAY);
+    }
+
+    @Test
+    void iconHintIsNormalisedLikeManifestHints() {
+        assertThat(PluginIcons.resolve(PluginCategory.DYNAMICS, "low-pass"))
+                .as("hints normalise trim/case/dashes into DawIcon constant names")
+                .isEqualTo(DawIcon.LOW_PASS);
+        assertThat(PluginIcons.resolve(PluginCategory.DYNAMICS, "  Compressor "))
+                .isEqualTo(DawIcon.COMPRESSOR);
+    }
+
+    @Test
+    void unknownOrMissingHintFallsBackToCategoryGlyph() {
+        assertThat(PluginIcons.resolve(PluginCategory.REVERB_AND_DELAY, "no-such-glyph"))
+                .as("an unresolvable hint falls back to the category default")
+                .isEqualTo(DawIcon.REVERB);
+        assertThat(PluginIcons.resolve(PluginCategory.UTILITY, null))
+                .isEqualTo(DawIcon.KNOB);
+        assertThat(PluginIcons.resolve(PluginCategory.SPATIAL, ""))
+                .isEqualTo(DawIcon.CORRELATION);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/PluginNodes.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/PluginNodes.java
@@ -1,0 +1,53 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.control.TextField;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Small toolkit-free scene-graph walkers shared by the story-303 FX tests. */
+final class PluginNodes {
+
+    private PluginNodes() {
+        // test utility
+    }
+
+    /** All {@link TextField}s in the subtree rooted at {@code root} (inclusive). */
+    static List<TextField> findTextFields(Node root) {
+        List<TextField> found = new ArrayList<>();
+        collect(root, TextField.class, found);
+        return found;
+    }
+
+    /** All {@link Label} text values in the subtree rooted at {@code root}. */
+    static List<String> labelTexts(Node root) {
+        List<Label> labels = new ArrayList<>();
+        collect(root, Label.class, labels);
+        return labels.stream().map(Label::getText).toList();
+    }
+
+    /** Whether the subtree rooted at {@code root} contains a {@link ProgressIndicator}. */
+    static boolean hasProgressIndicator(Node root) {
+        List<ProgressIndicator> found = new ArrayList<>();
+        collect(root, ProgressIndicator.class, found);
+        return !found.isEmpty();
+    }
+
+    private static <T> void collect(Node node, Class<T> type, List<? super T> out) {
+        if (node == null) {
+            return;
+        }
+        if (type.isInstance(node)) {
+            out.add(type.cast(node));
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collect(child, type, out);
+            }
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/PluginTestJars.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/PluginTestJars.java
@@ -1,0 +1,104 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.sdk.editor.PluginManifest;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifestReader;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifestWriter;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+/**
+ * Test helper that builds honest plugin JARs for the story-303 install-flow
+ * tests: it writes a real {@code META-INF/daw-plugin.json} (via
+ * {@link PluginManifestWriter}) and copies each fixture's <em>actual</em> class
+ * bytes into the JAR.
+ *
+ * <p>The class bytes make the JAR self-describing, but registration would resolve
+ * the fixture through the parent test classpath anyway — the loader's
+ * {@code URLClassLoader} delegates to its parent — so the on-disk JAR need only
+ * exist. Copying the bytes keeps the JAR honest rather than empty.</p>
+ */
+final class PluginTestJars {
+
+    private PluginTestJars() {
+        // test utility
+    }
+
+    /**
+     * Builds a JAR at {@code dir/jarName} containing an optional manifest (a
+     * top-level array when {@code manifests} is non-empty) and the class bytes of
+     * each fixture in {@code classes}.
+     *
+     * @param dir       the directory to write the JAR into
+     * @param jarName   the JAR file name
+     * @param manifests the manifests to declare, or {@code null} / empty for a
+     *                  manifest-less JAR
+     * @param classes   the fixture classes whose bytes to embed
+     * @return the JAR path
+     */
+    static Path buildJar(Path dir, String jarName,
+                         List<PluginManifest> manifests, List<Class<?>> classes) throws IOException {
+        String json = manifests == null || manifests.isEmpty()
+                ? null
+                : new PluginManifestWriter().toJson(manifests);
+        return buildJarWithManifestJson(dir, jarName, json, classes);
+    }
+
+    /**
+     * Builds a JAR whose {@code META-INF/daw-plugin.json} carries the given raw
+     * JSON verbatim — for the story-300 legacy single-object form, which
+     * {@link #buildJar} (always a top-level array) cannot emit.
+     *
+     * @param dir          the directory to write the JAR into
+     * @param jarName      the JAR file name
+     * @param manifestJson the manifest JSON, or {@code null} for a manifest-less JAR
+     * @param classes      the fixture classes whose bytes to embed
+     * @return the JAR path
+     */
+    static Path buildJarWithManifestJson(Path dir, String jarName,
+                                         String manifestJson, List<Class<?>> classes) throws IOException {
+        Path jar = dir.resolve(jarName);
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+            if (manifestJson != null) {
+                out.putNextEntry(new JarEntry(PluginManifestReader.MANIFEST_ENTRY));
+                out.write(manifestJson.getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+            for (Class<?> cls : classes) {
+                String entryName = cls.getName().replace('.', '/') + ".class";
+                try (InputStream in = cls.getResourceAsStream("/" + entryName)) {
+                    if (in == null) {
+                        throw new IOException("class bytes not found on classpath: " + entryName);
+                    }
+                    out.putNextEntry(new JarEntry(entryName));
+                    in.transferTo(out);
+                    out.closeEntry();
+                }
+            }
+        }
+        return jar;
+    }
+
+    /**
+     * Builds a {@link PluginManifest} whose {@code pluginClass} is the fixture's
+     * fully-qualified name and whose descriptor is the fixture's own descriptor.
+     *
+     * @param cls the fixture class
+     * @return the manifest
+     */
+    static PluginManifest manifest(Class<? extends DawPlugin> cls) {
+        try {
+            DawPlugin instance = cls.getDeclaredConstructor().newInstance();
+            return new PluginManifest(cls.getName(), instance.getDescriptor());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("cannot instantiate fixture " + cls, e);
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/UnreadableJarShowsReadErrorTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/UnreadableJarShowsReadErrorTest.java
@@ -1,0 +1,64 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 303 review follow-up — a JAR the scanner cannot read at all (corrupt /
+ * not a zip) must surface the reader's "could not read" error in the §6.8
+ * fallback panel instead of being misreported as a JAR that merely has no
+ * {@code daw-plugin.json} manifest.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class UnreadableJarShowsReadErrorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void unreadableJarSurfacesReadErrorInsteadOfNoManifestCopy() throws Exception {
+        // Not a zip at all — JarFile fails to open it.
+        Path jar = tempDir.resolve("corrupt.jar");
+        Files.writeString(jar, "this is not a jar");
+
+        JarInspection inspection = new PluginJarScanner(null).scanBlocking(jar);
+        assertThat(inspection.jarReadable())
+                .as("the scanner records that the JAR could not be read").isFalse();
+        assertThat(inspection.manifests().isValid())
+                .as("the reader reports the same problem as Invalid").isFalse();
+
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            PluginInstallPanel panel = runOnFxThread(() ->
+                    new PluginInstallPanel(inspection, registry, () -> { }));
+
+            List<String> labels = PluginNodes.labelTexts(panel);
+            assertThat(labels)
+                    .as("the reader's read error is surfaced")
+                    .anySatisfy(text -> assertThat(text).contains("could not read"));
+            assertThat(labels)
+                    .as("the unreadable-JAR copy is shown, not the invalid-manifest copy")
+                    .anySatisfy(text -> assertThat(text).contains("This JAR could not be read."))
+                    .noneSatisfy(text ->
+                            assertThat(text).contains("This JAR's manifest could not be read"));
+            assertThat(labels)
+                    .as("an unreadable JAR is not misreported as manifest-less")
+                    .noneSatisfy(text ->
+                            assertThat(text).contains("has no daw-plugin.json manifest"));
+        } finally {
+            registry.disposeAll();
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/fixtures/InstallFixturePluginA.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/fixtures/InstallFixturePluginA.java
@@ -1,0 +1,44 @@
+package com.benesquivelmusic.daw.app.ui.plugin.fixtures;
+
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+/**
+ * Story-303 install-flow fixture: a DYNAMICS effect from vendor "Acme Audio".
+ * Public top-level type with a public no-arg constructor so
+ * {@code ExternalPluginLoader} can instantiate it via reflection when it is
+ * registered from a test JAR (its class bytes are copied into the JAR by
+ * {@code PluginTestJars}, and the class resolves via the parent test classpath).
+ */
+public final class InstallFixturePluginA implements DawPlugin {
+
+    @Override
+    public PluginDescriptor getDescriptor() {
+        return new PluginDescriptor(
+                "com.acme.punch", "Acme Punch", "1.0.0", "Acme Audio",
+                PluginType.EFFECT, PluginCategory.DYNAMICS, "compressor");
+    }
+
+    @Override
+    public void initialize(PluginContext context) {
+        // no-op
+    }
+
+    @Override
+    public void activate() {
+        // no-op
+    }
+
+    @Override
+    public void deactivate() {
+        // no-op
+    }
+
+    @Override
+    public void dispose() {
+        // no-op
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/fixtures/InstallFixturePluginB.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/fixtures/InstallFixturePluginB.java
@@ -1,0 +1,43 @@
+package com.benesquivelmusic.daw.app.ui.plugin.fixtures;
+
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+/**
+ * Story-303 install-flow fixture: a REVERB_AND_DELAY effect from vendor
+ * "Acme Audio" (same vendor as {@link InstallFixturePluginA}, so a two-plugin
+ * bundle reports a single common vendor). Public top-level type with a public
+ * no-arg constructor.
+ */
+public final class InstallFixturePluginB implements DawPlugin {
+
+    @Override
+    public PluginDescriptor getDescriptor() {
+        return new PluginDescriptor(
+                "com.acme.echo", "Acme Echo", "2.1.0", "Acme Audio",
+                PluginType.EFFECT, PluginCategory.REVERB_AND_DELAY, "reverb");
+    }
+
+    @Override
+    public void initialize(PluginContext context) {
+        // no-op
+    }
+
+    @Override
+    public void activate() {
+        // no-op
+    }
+
+    @Override
+    public void deactivate() {
+        // no-op
+    }
+
+    @Override
+    public void dispose() {
+        // no-op
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/fixtures/InstallFixturePluginC.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/fixtures/InstallFixturePluginC.java
@@ -1,0 +1,43 @@
+package com.benesquivelmusic.daw.app.ui.plugin.fixtures;
+
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
+import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import com.benesquivelmusic.daw.sdk.plugin.PluginType;
+
+/**
+ * Story-303 install-flow fixture: a UTILITY effect from a different vendor
+ * ("QuietSky DSP"), so a bundle mixing it with the Acme fixtures reports
+ * "Multiple vendors" and the browser groups it under its own vendor. Public
+ * top-level type with a public no-arg constructor.
+ */
+public final class InstallFixturePluginC implements DawPlugin {
+
+    @Override
+    public PluginDescriptor getDescriptor() {
+        return new PluginDescriptor(
+                "com.quietsky.hall", "QuietSky Hall", "0.9.0", "QuietSky DSP",
+                PluginType.EFFECT, PluginCategory.UTILITY, "knob");
+    }
+
+    @Override
+    public void initialize(PluginContext context) {
+        // no-op
+    }
+
+    @Override
+    public void activate() {
+        // no-op
+    }
+
+    @Override
+    public void deactivate() {
+        // no-op
+    }
+
+    @Override
+    public void dispose() {
+        // no-op
+    }
+}

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/AnalogDistortionProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/AnalogDistortionProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 
 /**
@@ -39,7 +40,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "ANALOG_DISTORTION", displayName = "Analog Distortion")
+@InsertEffect(type = "ANALOG_DISTORTION", displayName = "Analog Distortion", category = PluginCategory.UTILITY)
 public final class AnalogDistortionProcessor implements AudioProcessor {
 
     private static final double TWO_PI = 2.0 * Math.PI;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/BassExtensionProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/BassExtensionProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 
 /**
@@ -46,7 +47,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "BASS_EXTENSION", displayName = "Bass Extension")
+@InsertEffect(type = "BASS_EXTENSION", displayName = "Bass Extension", category = PluginCategory.EQ_AND_FILTER)
 public final class BassExtensionProcessor implements AudioProcessor {
 
     /** Minimum allowed crossover frequency in Hz. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/ChirpPeakReducer.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/ChirpPeakReducer.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
@@ -50,7 +51,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "CHIRP_PEAK_REDUCER", displayName = "Chirp Peak Reducer")
+@InsertEffect(type = "CHIRP_PEAK_REDUCER", displayName = "Chirp Peak Reducer", category = PluginCategory.DYNAMICS)
 public final class ChirpPeakReducer implements AudioProcessor {
 
     /** Minimum allowed threshold in dB. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/ChorusProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/ChorusProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
@@ -26,7 +27,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "CHORUS", displayName = "Chorus")
+@InsertEffect(type = "CHORUS", displayName = "Chorus", category = PluginCategory.MODULATION)
 public final class ChorusProcessor implements AudioProcessor {
 
     private static final double MAX_DELAY_MS = 50.0;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/CompressorProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/CompressorProcessor.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.dsp;
 import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.SidechainAwareProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 
 /**
@@ -26,7 +27,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  * This enables classic sidechain compression techniques such as kick-driven
  * bass ducking and dialogue ducking.</p>
  */
-@InsertEffect(type = "COMPRESSOR", displayName = "Compressor")
+@InsertEffect(type = "COMPRESSOR", displayName = "Compressor", category = PluginCategory.DYNAMICS)
 public final class CompressorProcessor implements SidechainAwareProcessor, GainReductionProvider {
 
     /** Detection mode for the compressor. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/DelayProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/DelayProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
@@ -25,7 +26,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "DELAY", displayName = "Delay")
+@InsertEffect(type = "DELAY", displayName = "Delay", category = PluginCategory.REVERB_AND_DELAY)
 public final class DelayProcessor implements AudioProcessor {
 
     private static final double MAX_FEEDBACK = 0.99;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/GainStagingProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/GainStagingProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 
 /**
@@ -15,7 +16,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "GAIN_STAGING", displayName = "Gain Staging")
+@InsertEffect(type = "GAIN_STAGING", displayName = "Gain Staging", category = PluginCategory.UTILITY)
 public final class GainStagingProcessor implements AudioProcessor {
 
     private final int channels;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/GraphicEqProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/GraphicEqProcessor.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -49,7 +50,7 @@ import java.util.Objects;
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
 @RealTimeSafe
-@InsertEffect(type = "GRAPHIC_EQ", displayName = "Graphic EQ")
+@InsertEffect(type = "GRAPHIC_EQ", displayName = "Graphic EQ", category = PluginCategory.EQ_AND_FILTER)
 public final class GraphicEqProcessor implements AudioProcessor {
 
     /** Maximum gain magnitude allowed per band (±12 dB). */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/HearingLossSimulator.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/HearingLossSimulator.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -64,7 +65,7 @@ import java.util.Objects;
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
 @RealTimeSafe
-@InsertEffect(type = "HEARING_LOSS_SIMULATOR", displayName = "Hearing Loss Simulator")
+@InsertEffect(type = "HEARING_LOSS_SIMULATOR", displayName = "Hearing Loss Simulator", category = PluginCategory.UTILITY)
 public final class HearingLossSimulator implements AudioProcessor {
 
     /** ISO octave-band audiogram center frequencies (Hz), 250 Hz – 8 kHz. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/LeslieProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/LeslieProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
@@ -32,7 +33,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "LESLIE", displayName = "Leslie")
+@InsertEffect(type = "LESLIE", displayName = "Leslie", category = PluginCategory.MODULATION)
 public final class LeslieProcessor implements AudioProcessor {
 
     // Leslie speaker physical constants

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/LimiterProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/LimiterProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.mastering.TruePeakCeilingPreset;
 
 import java.util.Arrays;
@@ -27,7 +28,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "LIMITER", displayName = "Limiter")
+@InsertEffect(type = "LIMITER", displayName = "Limiter", category = PluginCategory.DYNAMICS)
 public final class LimiterProcessor implements AudioProcessor, GainReductionProvider {
 
     private static final double MIN_LOOK_AHEAD_MS = 1.0;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/NoiseGateProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/NoiseGateProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.SidechainAwareProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 
 /**
@@ -29,7 +30,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "NOISE_GATE", displayName = "Noise Gate")
+@InsertEffect(type = "NOISE_GATE", displayName = "Noise Gate", category = PluginCategory.DYNAMICS)
 public final class NoiseGateProcessor implements SidechainAwareProcessor {
 
     /** Gate state. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/ParametricEqProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/ParametricEqProcessor.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.dsp;
 import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -63,7 +64,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "PARAMETRIC_EQ", displayName = "Parametric EQ")
+@InsertEffect(type = "PARAMETRIC_EQ", displayName = "Parametric EQ", category = PluginCategory.EQ_AND_FILTER)
 public final class ParametricEqProcessor implements AudioProcessor {
 
     /** Filter implementation mode. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/PitchShiftProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/PitchShiftProcessor.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 import com.benesquivelmusic.daw.core.audio.StretchQuality;
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -28,7 +29,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "PITCH_SHIFT", displayName = "Pitch Shift")
+@InsertEffect(type = "PITCH_SHIFT", displayName = "Pitch Shift", category = PluginCategory.MODULATION)
 public final class PitchShiftProcessor implements AudioProcessor {
 
     private final int channels;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/ReverbProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/ReverbProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
@@ -28,7 +29,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "REVERB", displayName = "Reverb")
+@InsertEffect(type = "REVERB", displayName = "Reverb", category = PluginCategory.REVERB_AND_DELAY)
 public final class ReverbProcessor implements AudioProcessor {
 
     private static final int NUM_COMBS = 4;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/SpringReverbProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/SpringReverbProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
@@ -31,7 +32,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "SPRING_REVERB", displayName = "Spring Reverb")
+@InsertEffect(type = "SPRING_REVERB", displayName = "Spring Reverb", category = PluginCategory.REVERB_AND_DELAY)
 public final class SpringReverbProcessor implements AudioProcessor {
 
     private static final int NUM_ALLPASS_STAGES = 8;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/StereoImagerProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/StereoImagerProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 
 /**
@@ -23,7 +24,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "STEREO_IMAGER", displayName = "Stereo Imager", stereoOnly = true)
+@InsertEffect(type = "STEREO_IMAGER", displayName = "Stereo Imager", stereoOnly = true, category = PluginCategory.SPATIAL)
 public final class StereoImagerProcessor implements AudioProcessor {
 
     private double width;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/TimeStretchProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/TimeStretchProcessor.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 import com.benesquivelmusic.daw.core.audio.StretchQuality;
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -30,7 +31,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "TIME_STRETCH", displayName = "Time Stretch")
+@InsertEffect(type = "TIME_STRETCH", displayName = "Time Stretch", category = PluginCategory.UTILITY)
 public final class TimeStretchProcessor implements AudioProcessor {
 
     private final int channels;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/VelvetNoiseReverbProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/VelvetNoiseReverbProcessor.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import java.util.Random;
@@ -39,7 +40,7 @@ import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
  *
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
-@InsertEffect(type = "VELVET_NOISE_REVERB", displayName = "Velvet Noise Reverb")
+@InsertEffect(type = "VELVET_NOISE_REVERB", displayName = "Velvet Noise Reverb", category = PluginCategory.REVERB_AND_DELAY)
 public final class VelvetNoiseReverbProcessor implements AudioProcessor {
 
     private static final double MIN_DECAY_SECONDS = 0.1;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/WaveshaperProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/WaveshaperProcessor.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,7 +37,7 @@ import java.util.Objects;
  * <p>This is a pure-Java implementation — no JNI required.</p>
  */
 @RealTimeSafe
-@InsertEffect(type = "WAVESHAPER", displayName = "Waveshaper")
+@InsertEffect(type = "WAVESHAPER", displayName = "Waveshaper", category = PluginCategory.UTILITY)
 public final class WaveshaperProcessor implements AudioProcessor {
 
     /** Minimum drive in dB accepted by {@link #setDriveDb(double)}. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/reverb/ConvolutionReverbProcessor.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/dsp/reverb/ConvolutionReverbProcessor.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.core.mixer.InsertEffect;
 import com.benesquivelmusic.daw.sdk.annotation.ProcessorParam;
 import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -52,7 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * non-realtime and is dispatched onto a virtual thread by
  * {@link #setImpulseResponseAsync}.</p>
  */
-@InsertEffect(type = "CONVOLUTION_REVERB", displayName = "Convolution Reverb")
+@InsertEffect(type = "CONVOLUTION_REVERB", displayName = "Convolution Reverb", category = PluginCategory.REVERB_AND_DELAY)
 public final class ConvolutionReverbProcessor implements AudioProcessor {
 
     /** Partition / block size — power of two; FFT length is twice this. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/mixer/InsertEffect.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/mixer/InsertEffect.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.core.mixer;
 
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -24,6 +26,10 @@ import java.lang.annotation.Target;
  * with {@code @InsertEffect}, and register the class in the
  * {@link ProcessorRegistry} known-classes list. No changes are required to
  * {@link InsertEffectFactory}.</p>
+ *
+ * <p>The {@link #category()} attribute declares the {@link PluginCategory}
+ * under which the effect is grouped by the §6.7 plugin browser; it defaults
+ * to {@link PluginCategory#UTILITY}.</p>
  *
  * <p>Example:</p>
  * <pre>{@code
@@ -52,4 +58,11 @@ public @interface InsertEffect {
      * constructor.
      */
     boolean stereoOnly() default false;
+
+    /**
+     * The {@link PluginCategory} used to group this built-in insert effect in
+     * the §6.7 plugin browser. Effects that do not declare a category default
+     * to {@link PluginCategory#UTILITY}.
+     */
+    PluginCategory category() default PluginCategory.UTILITY;
 }

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/mixer/InsertEffectFactory.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/mixer/InsertEffectFactory.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.mixer;
 import com.benesquivelmusic.daw.core.dsp.*;
 import com.benesquivelmusic.daw.core.event.EventBusPublisher;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.event.PluginEvent;
 import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
@@ -294,6 +295,20 @@ public final class InsertEffectFactory {
      */
     public static List<InsertEffectType> availableTypes() {
         return ProcessorRegistry.getInstance().availableTypes();
+    }
+
+    /**
+     * Returns the {@link PluginCategory} declared for the given built-in effect
+     * type, used to group effects in the §6.7 plugin browser.
+     *
+     * @param type the built-in effect type
+     * @return the declared category
+     * @throws IllegalArgumentException if {@code type} is not a registered
+     *                                  built-in effect (e.g. {@link InsertEffectType#CLAP_PLUGIN})
+     */
+    public static PluginCategory getCategory(InsertEffectType type) {
+        Objects.requireNonNull(type, "type must not be null");
+        return ProcessorRegistry.getInstance().categoryOf(type);
     }
 
     /**

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/mixer/ProcessorRegistry.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/mixer/ProcessorRegistry.java
@@ -22,6 +22,7 @@ import com.benesquivelmusic.daw.core.dsp.VelvetNoiseReverbProcessor;
 import com.benesquivelmusic.daw.core.dsp.WaveshaperProcessor;
 import com.benesquivelmusic.daw.core.dsp.reverb.ConvolutionReverbProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -252,6 +253,27 @@ public final class ProcessorRegistry {
         return byType.containsKey(type);
     }
 
+    /**
+     * Returns the {@link PluginCategory} declared by the {@link InsertEffect}
+     * annotation on the processor registered for the given type. The §6.7
+     * plugin browser uses this to group built-in insert effects.
+     *
+     * @param type the built-in effect type
+     * @return the declared category
+     * @throws IllegalArgumentException if the type is not registered
+     *                                  (e.g. {@link InsertEffectType#CLAP_PLUGIN})
+     */
+    public PluginCategory categoryOf(InsertEffectType type) {
+        Objects.requireNonNull(type, "type must not be null");
+        Entry entry = byType.get(type);
+        if (entry == null) {
+            throw new IllegalArgumentException(
+                    "No registered processor for " + type
+                            + " (CLAP plugins must be loaded via ClapPluginManager)");
+        }
+        return entry.category;
+    }
+
     // ── Constructor resolution ──────────────────────────────────────────────
 
     private static MethodHandle resolveConstructor(MethodHandles.Lookup lookup,
@@ -305,6 +327,7 @@ public final class ProcessorRegistry {
         final InsertEffect annotation;
         final MethodHandle handle;
         final InvocationKind invocationKind;
+        final PluginCategory category;
 
         Entry(Class<? extends AudioProcessor> processorClass,
               InsertEffect annotation,
@@ -312,6 +335,7 @@ public final class ProcessorRegistry {
             this.processorClass = processorClass;
             this.annotation = annotation;
             this.handle = handle;
+            this.category = annotation.category();
             // Detect kind from handle's parameter list: constructors are
             // adapted to return the class; static factories return AudioProcessor.
             MethodType type = handle.type();

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/AcousticReverbPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/AcousticReverbPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.acoustics.AcousticReverbProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -30,7 +31,9 @@ public final class AcousticReverbPlugin implements BuiltInDawPlugin {
             "Acoustic Reverb",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.REVERB_AND_DELAY,
+            "acoustic-reverb"
     );
 
     private AcousticReverbProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/BinauralMonitorPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/BinauralMonitorPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.plugin.editor.BinauralMonitorEditor;
 import com.benesquivelmusic.daw.core.spatial.binaural.BinauralMonitoringProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -34,7 +35,9 @@ public final class BinauralMonitorPlugin implements BuiltInDawPlugin {
             "Binaural Monitor",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.SPATIAL,
+            "binaural-monitor"
     );
 
     private BinauralMonitoringProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/BusCompressorPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/BusCompressorPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.dynamics.BusCompressorProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -30,7 +31,9 @@ public final class BusCompressorPlugin implements BuiltInDawPlugin {
             "Bus Compressor",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.DYNAMICS,
+            "compressor"
     );
 
     private BusCompressorProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/CompressorPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/CompressorPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.CompressorProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -28,7 +29,9 @@ public final class CompressorPlugin implements BuiltInDawPlugin {
             "Compressor",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.DYNAMICS,
+            "compressor"
     );
 
     private CompressorProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/ConvolutionReverbPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/ConvolutionReverbPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.reverb.ConvolutionReverbProcessor;
 import com.benesquivelmusic.daw.core.plugin.editor.ConvolutionReverbEditor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -35,7 +36,9 @@ public final class ConvolutionReverbPlugin implements BuiltInDawPlugin {
             "Convolution Reverb",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.REVERB_AND_DELAY,
+            "reverb"
     );
 
     private ConvolutionReverbProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/DeEsserPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/DeEsserPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.dynamics.DeEsserProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -28,7 +29,9 @@ public final class DeEsserPlugin implements BuiltInDawPlugin {
             "De-Esser",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.DYNAMICS,
+            "compressor"
     );
 
     private DeEsserProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/DitherPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/DitherPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.mastering.DitherProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -48,7 +49,9 @@ public final class DitherPlugin implements BuiltInDawPlugin {
             "Dither",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.UTILITY,
+            "dither"
     );
 
     /** Cached enum arrays — avoids the allocation of {@code Enum.values()} on every call. */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/ExciterPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/ExciterPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.saturation.ExciterProcessor;
 import com.benesquivelmusic.daw.core.plugin.editor.ExciterEditor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -33,7 +34,9 @@ public final class ExciterPlugin implements BuiltInDawPlugin {
             "Harmonic Exciter",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.UTILITY,
+            "exciter"
     );
 
     private ExciterProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/GraphicEqPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/GraphicEqPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.GraphicEqProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -36,7 +37,9 @@ public final class GraphicEqPlugin implements BuiltInDawPlugin {
             "Graphic EQ",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.EQ_AND_FILTER,
+            "eq"
     );
 
     private GraphicEqProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/MatchEqPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/MatchEqPlugin.java
@@ -7,6 +7,7 @@ import com.benesquivelmusic.daw.core.export.SampleRateConverter;
 import com.benesquivelmusic.daw.core.plugin.editor.MatchEqEditor;
 import com.benesquivelmusic.daw.core.reference.ReferenceTrack;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -44,7 +45,9 @@ public final class MatchEqPlugin implements BuiltInDawPlugin {
             "Match EQ",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.EQ_AND_FILTER,
+            "eq"
     );
 
     private MatchEqProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/MetronomePlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/MetronomePlugin.java
@@ -5,6 +5,7 @@ import com.benesquivelmusic.daw.core.recording.CountInMode;
 import com.benesquivelmusic.daw.core.recording.Metronome;
 import com.benesquivelmusic.daw.core.recording.Subdivision;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
 
@@ -58,7 +59,9 @@ public final class MetronomePlugin implements BuiltInDawPlugin {
             "Metronome",
             "1.0.0",
             "DAW Built-in",
-            PluginType.MIDI_EFFECT
+            PluginType.MIDI_EFFECT,
+            PluginCategory.UTILITY,
+            "metronome"
     );
 
     private PluginContext context;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/MidSideWrapperPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/MidSideWrapperPlugin.java
@@ -7,6 +7,7 @@ import com.benesquivelmusic.daw.core.dsp.MidSideWrapperProcessor;
 import com.benesquivelmusic.daw.core.dsp.ParametricEqProcessor;
 import com.benesquivelmusic.daw.core.plugin.editor.MidSideWrapperEditor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.DawPlugin;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
@@ -69,7 +70,9 @@ public final class MidSideWrapperPlugin implements BuiltInDawPlugin {
             "Mid/Side Wrapper",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.SPATIAL,
+            "stereo"
     );
 
     private final List<DawPlugin> midChain  = new ArrayList<>();

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/MultibandCompressorPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/MultibandCompressorPlugin.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.dsp.CompressorProcessor;
 import com.benesquivelmusic.daw.core.dsp.MultibandCompressorProcessor;
 import com.benesquivelmusic.daw.core.plugin.editor.MultibandCompressorEditor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.AutomatableParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
@@ -61,7 +62,9 @@ public final class MultibandCompressorPlugin implements BuiltInDawPlugin {
             "Multiband Compressor",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.DYNAMICS,
+            "compressor"
     );
 
     private MultibandCompressorProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/NoiseGatePlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/NoiseGatePlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.dynamics.NoiseGateProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -38,7 +39,9 @@ public final class NoiseGatePlugin implements BuiltInDawPlugin {
             "Noise Gate",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.DYNAMICS,
+            "compressor"
     );
 
     private NoiseGateProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/ParametricEqPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/ParametricEqPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.ParametricEqProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -28,7 +29,9 @@ public final class ParametricEqPlugin implements BuiltInDawPlugin {
             "Parametric EQ",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.EQ_AND_FILTER,
+            "eq"
     );
 
     private ParametricEqProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/ReverbPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/ReverbPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.ReverbProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -28,7 +29,9 @@ public final class ReverbPlugin implements BuiltInDawPlugin {
             "Reverb",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.REVERB_AND_DELAY,
+            "reverb"
     );
 
     private ReverbProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/SignalGeneratorPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/SignalGeneratorPlugin.java
@@ -1,6 +1,7 @@
 package com.benesquivelmusic.daw.core.plugin;
 
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
 
@@ -74,7 +75,9 @@ public final class SignalGeneratorPlugin implements BuiltInDawPlugin {
             "Signal Generator",
             "1.0.0",
             "DAW Built-in",
-            PluginType.INSTRUMENT
+            PluginType.INSTRUMENT,
+            PluginCategory.UTILITY,
+            "waveform"
     );
 
     /**

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/SoundWaveTelemetryPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/SoundWaveTelemetryPlugin.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.core.plugin;
 
 import com.benesquivelmusic.daw.core.plugin.editor.SoundWaveTelemetryEditor;
 import com.benesquivelmusic.daw.core.telemetry.ArmedTrackSourceProvider;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -40,7 +41,9 @@ public final class SoundWaveTelemetryPlugin implements BuiltInDawPlugin {
             "Sound Wave Telemetry",
             "1.0.0",
             "DAW Built-in",
-            PluginType.ANALYZER
+            PluginType.ANALYZER,
+            PluginCategory.ANALYZER,
+            "surround"
     );
 
     private PluginContext context;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/SpectrumAnalyzerPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/SpectrumAnalyzerPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.analysis.SpectrumAnalyzer;
 import com.benesquivelmusic.daw.core.plugin.editor.SpectrumAnalyzerEditor;
 import com.benesquivelmusic.daw.sdk.analysis.WindowType;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -43,7 +44,9 @@ public final class SpectrumAnalyzerPlugin implements BuiltInDawPlugin {
             "Spectrum Analyzer",
             "1.0.0",
             "DAW Built-in",
-            PluginType.ANALYZER
+            PluginType.ANALYZER,
+            PluginCategory.ANALYZER,
+            "spectrum"
     );
 
     private PluginContext context;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/TransientShaperPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/TransientShaperPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.dynamics.TransientShaperProcessor;
 import com.benesquivelmusic.daw.core.plugin.editor.TransientShaperEditor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -33,7 +34,9 @@ public final class TransientShaperPlugin implements BuiltInDawPlugin {
             "Transient Shaper",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.DYNAMICS,
+            "compressor"
     );
 
     private TransientShaperProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/TruePeakLimiterPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/TruePeakLimiterPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.dynamics.TruePeakLimiterProcessor;
 import com.benesquivelmusic.daw.core.plugin.editor.TruePeakLimiterEditor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -41,7 +42,9 @@ public final class TruePeakLimiterPlugin implements BuiltInDawPlugin {
             "True-Peak Limiter",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.DYNAMICS,
+            "limiter"
     );
 
     private TruePeakLimiterProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/TunerPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/TunerPlugin.java
@@ -2,6 +2,7 @@ package com.benesquivelmusic.daw.core.plugin;
 
 import com.benesquivelmusic.daw.core.analysis.PitchDetector;
 import com.benesquivelmusic.daw.core.plugin.editor.TunerEditor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -63,7 +64,9 @@ public final class TunerPlugin implements BuiltInDawPlugin {
             "Chromatic Tuner",
             "1.0.0",
             "DAW Built-in",
-            PluginType.ANALYZER
+            PluginType.ANALYZER,
+            PluginCategory.ANALYZER,
+            "spectrum"
     );
 
     /** Stored for potential future reconfiguration (e.g., changing buffer size). */

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/VirtualKeyboardPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/VirtualKeyboardPlugin.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.midi.KeyboardPreset;
 import com.benesquivelmusic.daw.core.midi.KeyboardProcessor;
 import com.benesquivelmusic.daw.core.midi.javasound.JavaSoundRenderer;
 import com.benesquivelmusic.daw.core.plugin.editor.VirtualKeyboardEditor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.midi.SoundFontRenderer;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
@@ -39,7 +40,9 @@ public final class VirtualKeyboardPlugin implements BuiltInDawPlugin {
             "Virtual Keyboard",
             "1.0.0",
             "DAW Built-in",
-            PluginType.INSTRUMENT
+            PluginType.INSTRUMENT,
+            PluginCategory.INSTRUMENT,
+            "keyboard"
     );
 
     private SoundFontRenderer renderer;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/WaveshaperPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/WaveshaperPlugin.java
@@ -3,6 +3,7 @@ package com.benesquivelmusic.daw.core.plugin;
 import com.benesquivelmusic.daw.core.dsp.WaveshaperProcessor;
 import com.benesquivelmusic.daw.sdk.audio.AudioProcessor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import com.benesquivelmusic.daw.sdk.plugin.PluginParameter;
 import com.benesquivelmusic.daw.sdk.plugin.PluginType;
@@ -30,7 +31,9 @@ public final class WaveshaperPlugin implements BuiltInDawPlugin {
             "Waveshaper / Saturation",
             "1.0.0",
             "DAW Built-in",
-            PluginType.EFFECT
+            PluginType.EFFECT,
+            PluginCategory.UTILITY,
+            "waveshaper"
     );
 
     private WaveshaperProcessor processor;

--- a/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/builtin/midi/ArpeggiatorPlugin.java
+++ b/daw-core/src/main/java/com/benesquivelmusic/daw/core/plugin/builtin/midi/ArpeggiatorPlugin.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.core.plugin.BuiltInPlugin;
 import com.benesquivelmusic.daw.core.plugin.BuiltInPluginCategory;
 import com.benesquivelmusic.daw.core.plugin.MidiEffectPlugin;
 import com.benesquivelmusic.daw.core.plugin.editor.ArpeggiatorEditor;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.editor.PluginEditorFactory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginContext;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -51,7 +52,9 @@ public final class ArpeggiatorPlugin implements MidiEffectPlugin {
             "Arpeggiator",
             "1.0.0",
             "DAW Built-in",
-            PluginType.MIDI_EFFECT
+            PluginType.MIDI_EFFECT,
+            PluginCategory.MIDI_EFFECT,
+            "arpeggiator"
     );
 
     /** Step note value, expressed as a fraction of a whole note. */

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/mixer/InsertEffectCategoryTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/mixer/InsertEffectCategoryTest.java
@@ -1,0 +1,73 @@
+package com.benesquivelmusic.daw.core.mixer;
+
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the {@link PluginCategory} declared by every registered
+ * {@link InsertEffect @InsertEffect} processor. The §6.7 plugin browser groups
+ * built-in insert effects by these categories, so a newly registered effect
+ * must fail here until it is added to {@link #EXPECTED}.
+ */
+class InsertEffectCategoryTest {
+
+    /** Hand-maintained expected category per registered built-in effect type. */
+    private static final Map<InsertEffectType, PluginCategory> EXPECTED = expected();
+
+    private static Map<InsertEffectType, PluginCategory> expected() {
+        Map<InsertEffectType, PluginCategory> map = new EnumMap<>(InsertEffectType.class);
+        map.put(InsertEffectType.COMPRESSOR, PluginCategory.DYNAMICS);
+        map.put(InsertEffectType.LIMITER, PluginCategory.DYNAMICS);
+        map.put(InsertEffectType.NOISE_GATE, PluginCategory.DYNAMICS);
+        map.put(InsertEffectType.CHIRP_PEAK_REDUCER, PluginCategory.DYNAMICS);
+        map.put(InsertEffectType.PARAMETRIC_EQ, PluginCategory.EQ_AND_FILTER);
+        map.put(InsertEffectType.GRAPHIC_EQ, PluginCategory.EQ_AND_FILTER);
+        map.put(InsertEffectType.BASS_EXTENSION, PluginCategory.EQ_AND_FILTER);
+        map.put(InsertEffectType.CHORUS, PluginCategory.MODULATION);
+        map.put(InsertEffectType.LESLIE, PluginCategory.MODULATION);
+        map.put(InsertEffectType.PITCH_SHIFT, PluginCategory.MODULATION);
+        map.put(InsertEffectType.REVERB, PluginCategory.REVERB_AND_DELAY);
+        map.put(InsertEffectType.DELAY, PluginCategory.REVERB_AND_DELAY);
+        map.put(InsertEffectType.SPRING_REVERB, PluginCategory.REVERB_AND_DELAY);
+        map.put(InsertEffectType.VELVET_NOISE_REVERB, PluginCategory.REVERB_AND_DELAY);
+        map.put(InsertEffectType.CONVOLUTION_REVERB, PluginCategory.REVERB_AND_DELAY);
+        map.put(InsertEffectType.STEREO_IMAGER, PluginCategory.SPATIAL);
+        map.put(InsertEffectType.ANALOG_DISTORTION, PluginCategory.UTILITY);
+        map.put(InsertEffectType.GAIN_STAGING, PluginCategory.UTILITY);
+        map.put(InsertEffectType.HEARING_LOSS_SIMULATOR, PluginCategory.UTILITY);
+        map.put(InsertEffectType.TIME_STRETCH, PluginCategory.UTILITY);
+        map.put(InsertEffectType.WAVESHAPER, PluginCategory.UTILITY);
+        return map;
+    }
+
+    @Test
+    void expectedMappingShouldExactlyCoverEveryRegisteredType() {
+        List<InsertEffectType> available = InsertEffectFactory.availableTypes();
+        // Both directions: every registered effect must be mapped, and no stale
+        // mapping may survive for a type that is no longer registered. A newly
+        // registered effect therefore fails until it is added to EXPECTED.
+        assertThat(EXPECTED.keySet()).containsExactlyInAnyOrderElementsOf(available);
+    }
+
+    @Test
+    void getCategoryShouldMatchExpectedForEveryRegisteredType() {
+        for (Map.Entry<InsertEffectType, PluginCategory> entry : EXPECTED.entrySet()) {
+            assertThat(InsertEffectFactory.getCategory(entry.getKey()))
+                    .as("category of %s", entry.getKey())
+                    .isEqualTo(entry.getValue());
+        }
+    }
+
+    @Test
+    void getCategoryShouldRejectClapPlugin() {
+        assertThatThrownBy(() -> InsertEffectFactory.getCategory(InsertEffectType.CLAP_PLUGIN))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/plugin/BuiltInPluginDescriptorCategoryTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/plugin/BuiltInPluginDescriptorCategoryTest.java
@@ -5,8 +5,7 @@ import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.reflect.Field;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * a future built-in plugin cannot skip declaring one, and each descriptor's
  * {@code iconHint} is cross-checked reflectively against the plugin's
  * {@link BuiltInPlugin} annotation {@code icon()}.
+ *
+ * <p>Descriptors are read from each plugin's static {@code DESCRIPTOR} constant
+ * — the instance its {@code getDescriptor()} returns — rather than by
+ * instantiating the plugin, because a no-arg construction that probes an audio
+ * backend can fail headlessly and the mapping must be verified everywhere.</p>
  */
 class BuiltInPluginDescriptorCategoryTest {
 
@@ -67,7 +71,6 @@ class BuiltInPluginDescriptorCategoryTest {
 
     @Test
     void everyDescriptorCategoryAndIconHintMustMatchTheAnnotation() {
-        List<String> skipped = new ArrayList<>();
         for (Map.Entry<Class<?>, PluginCategory> expected : EXPECTED.entrySet()) {
             Class<?> clazz = expected.getKey();
             BuiltInPlugin annotation = clazz.getAnnotation(BuiltInPlugin.class);
@@ -75,17 +78,7 @@ class BuiltInPluginDescriptorCategoryTest {
                     .as("%s must be annotated with @BuiltInPlugin", clazz.getSimpleName())
                     .isNotNull();
 
-            PluginDescriptor descriptor;
-            try {
-                BuiltInDawPlugin plugin = (BuiltInDawPlugin) clazz.getConstructor().newInstance();
-                descriptor = plugin.getDescriptor();
-            } catch (Throwable t) {
-                // Descriptors are plain records needing no JavaFX toolkit, but a
-                // plugin whose no-arg construction probes an audio backend can
-                // fail headlessly; skip only that plugin's descriptor assertions.
-                skipped.add(clazz.getSimpleName() + " (" + t + ")");
-                continue;
-            }
+            PluginDescriptor descriptor = staticDescriptor(clazz);
 
             assertThat(descriptor.category())
                     .as("%s descriptor category", clazz.getSimpleName())
@@ -95,9 +88,22 @@ class BuiltInPluginDescriptorCategoryTest {
                     .isNotBlank()
                     .isEqualTo(annotation.icon());
         }
-        if (!skipped.isEmpty()) {
-            System.out.println("BuiltInPluginDescriptorCategoryTest skipped "
-                    + "headless-unconstructable plugins: " + skipped);
+    }
+
+    /**
+     * Reads {@code clazz}'s static {@code DESCRIPTOR} constant — the instance
+     * its {@code getDescriptor()} returns — without instantiating the plugin,
+     * so the mapping assertions can never be skipped by a construction failure.
+     */
+    private static PluginDescriptor staticDescriptor(Class<?> clazz) {
+        try {
+            Field field = clazz.getDeclaredField("DESCRIPTOR");
+            field.setAccessible(true);
+            return (PluginDescriptor) field.get(null);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(clazz.getSimpleName()
+                    + " must expose its descriptor as a static DESCRIPTOR constant"
+                    + " so this test can verify it without instantiating the plugin", e);
         }
     }
 }

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/plugin/BuiltInPluginDescriptorCategoryTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/plugin/BuiltInPluginDescriptorCategoryTest.java
@@ -1,0 +1,103 @@
+package com.benesquivelmusic.daw.core.plugin;
+
+import com.benesquivelmusic.daw.core.plugin.builtin.midi.ArpeggiatorPlugin;
+import com.benesquivelmusic.daw.sdk.editor.PluginCategory;
+import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies every built-in {@link BuiltInDawPlugin} declares the
+ * {@link PluginCategory} and {@code iconHint} the §6.7 plugin browser groups
+ * and renders by. The expected category per plugin is hand-maintained here so
+ * a future built-in plugin cannot skip declaring one, and each descriptor's
+ * {@code iconHint} is cross-checked reflectively against the plugin's
+ * {@link BuiltInPlugin} annotation {@code icon()}.
+ */
+class BuiltInPluginDescriptorCategoryTest {
+
+    /**
+     * Hand-maintained expected browser category per built-in plugin class.
+     * {@link ArpeggiatorPlugin} is a {@code MidiEffectPlugin} that is
+     * intentionally not registered as a {@code ServiceLoader} provider (see the
+     * {@code daw.core} {@code module-info}); it is listed here so its descriptor
+     * is still verified.
+     */
+    private static final Map<Class<?>, PluginCategory> EXPECTED = Map.ofEntries(
+            Map.entry(CompressorPlugin.class,          PluginCategory.DYNAMICS),
+            Map.entry(BusCompressorPlugin.class,       PluginCategory.DYNAMICS),
+            Map.entry(MultibandCompressorPlugin.class, PluginCategory.DYNAMICS),
+            Map.entry(NoiseGatePlugin.class,           PluginCategory.DYNAMICS),
+            Map.entry(DeEsserPlugin.class,             PluginCategory.DYNAMICS),
+            Map.entry(TransientShaperPlugin.class,     PluginCategory.DYNAMICS),
+            Map.entry(TruePeakLimiterPlugin.class,     PluginCategory.DYNAMICS),
+            Map.entry(ParametricEqPlugin.class,        PluginCategory.EQ_AND_FILTER),
+            Map.entry(GraphicEqPlugin.class,           PluginCategory.EQ_AND_FILTER),
+            Map.entry(MatchEqPlugin.class,             PluginCategory.EQ_AND_FILTER),
+            Map.entry(ReverbPlugin.class,              PluginCategory.REVERB_AND_DELAY),
+            Map.entry(AcousticReverbPlugin.class,      PluginCategory.REVERB_AND_DELAY),
+            Map.entry(ConvolutionReverbPlugin.class,   PluginCategory.REVERB_AND_DELAY),
+            Map.entry(MidSideWrapperPlugin.class,      PluginCategory.SPATIAL),
+            Map.entry(BinauralMonitorPlugin.class,     PluginCategory.SPATIAL),
+            Map.entry(SpectrumAnalyzerPlugin.class,    PluginCategory.ANALYZER),
+            Map.entry(SoundWaveTelemetryPlugin.class,  PluginCategory.ANALYZER),
+            Map.entry(TunerPlugin.class,               PluginCategory.ANALYZER),
+            Map.entry(DitherPlugin.class,              PluginCategory.UTILITY),
+            Map.entry(MetronomePlugin.class,           PluginCategory.UTILITY),
+            Map.entry(SignalGeneratorPlugin.class,     PluginCategory.UTILITY),
+            Map.entry(ExciterPlugin.class,             PluginCategory.UTILITY),
+            Map.entry(WaveshaperPlugin.class,          PluginCategory.UTILITY),
+            Map.entry(VirtualKeyboardPlugin.class,     PluginCategory.INSTRUMENT),
+            Map.entry(ArpeggiatorPlugin.class,         PluginCategory.MIDI_EFFECT));
+
+    @Test
+    void everyDiscoveredBuiltInPluginMustDeclareAnExpectedCategory() {
+        // A future registered plugin fails here until it is added to EXPECTED.
+        for (Class<? extends BuiltInDawPlugin> clazz : BuiltInPluginProviders.providerClasses()) {
+            assertThat(EXPECTED)
+                    .as("%s must declare an expected browser category", clazz.getSimpleName())
+                    .containsKey(clazz);
+        }
+    }
+
+    @Test
+    void everyDescriptorCategoryAndIconHintMustMatchTheAnnotation() {
+        List<String> skipped = new ArrayList<>();
+        for (Map.Entry<Class<?>, PluginCategory> expected : EXPECTED.entrySet()) {
+            Class<?> clazz = expected.getKey();
+            BuiltInPlugin annotation = clazz.getAnnotation(BuiltInPlugin.class);
+            assertThat(annotation)
+                    .as("%s must be annotated with @BuiltInPlugin", clazz.getSimpleName())
+                    .isNotNull();
+
+            PluginDescriptor descriptor;
+            try {
+                BuiltInDawPlugin plugin = (BuiltInDawPlugin) clazz.getConstructor().newInstance();
+                descriptor = plugin.getDescriptor();
+            } catch (Throwable t) {
+                // Descriptors are plain records needing no JavaFX toolkit, but a
+                // plugin whose no-arg construction probes an audio backend can
+                // fail headlessly; skip only that plugin's descriptor assertions.
+                skipped.add(clazz.getSimpleName() + " (" + t + ")");
+                continue;
+            }
+
+            assertThat(descriptor.category())
+                    .as("%s descriptor category", clazz.getSimpleName())
+                    .isEqualTo(expected.getValue());
+            assertThat(descriptor.iconHint())
+                    .as("%s descriptor iconHint", clazz.getSimpleName())
+                    .isNotBlank()
+                    .isEqualTo(annotation.icon());
+        }
+        if (!skipped.isEmpty()) {
+            System.out.println("BuiltInPluginDescriptorCategoryTest skipped "
+                    + "headless-unconstructable plugins: " + skipped);
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifest.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifest.java
@@ -13,8 +13,10 @@ import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
  * class name (§1.4, §6.8).
  *
  * <p>Read with {@link PluginManifestReader}, written with
- * {@link PluginManifestWriter}. This Phase-1 story defines and round-trips the
- * manifest; the install UX that consumes it is Phase 4 (story 303).</p>
+ * {@link PluginManifestWriter}. A JAR may carry a single manifest object or a
+ * top-level array of them — a <em>bundle</em> declaring several plugins that the
+ * §6.8 install flow registers together (story 303). Either form round-trips
+ * through the reader/writer to equal manifests.</p>
  *
  * @param pluginClass the fully-qualified class name of the {@code DawPlugin}
  *                    implementation (never {@code null} or blank)

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReader.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReader.java
@@ -5,11 +5,13 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
@@ -19,13 +21,29 @@ import com.benesquivelmusic.daw.sdk.plugin.PluginType;
 /**
  * Finds, parses and validates a plugin's {@code META-INF/daw-plugin.json}
  * manifest (Plugin View Design Book §4.5). Never throws for a malformed or
- * missing manifest — every problem is reported as a {@link Result.Invalid} with
- * human-readable reasons, so a bad JAR drop degrades gracefully rather than
- * escaping an exception into the install flow (§1.4, §6.8).
+ * missing manifest — every problem is reported as a {@link Result.Invalid} (or
+ * {@link BundleResult.Invalid}) with human-readable reasons, so a bad JAR drop
+ * degrades gracefully rather than escaping an exception into the install flow
+ * (§1.4, §6.8).
+ *
+ * <p>A manifest comes in two forms:</p>
+ * <ul>
+ *   <li>a single flat object — one plugin per JAR (the story-300 form), read
+ *       with {@link #readFromJar(Path)} / {@link #parse(String)};</li>
+ *   <li>a top-level array of those same flat objects — a <em>bundle</em>
+ *       declaring several plugins in one JAR, so the §6.8 install flow can offer
+ *       "Install all" and register N entries from a single drop (story 303).
+ *       Read with {@link #readAllFromJar(Path)} / {@link #parseAll(String)}.</li>
+ * </ul>
+ *
+ * <p>The bundle methods accept either form (a single object is treated as a
+ * one-plugin bundle), so a story-300 manifest keeps working unchanged. The
+ * legacy single-object methods reject an array gracefully, pointing the caller
+ * at the bundle API.</p>
  *
  * <p>The reader deliberately embeds a tiny JSON parser for a <em>flat object of
- * string values</em> rather than depend on a JSON library: {@code daw-sdk} is the
- * project's dependency-free API floor.</p>
+ * string values</em> (and a top-level array of such objects) rather than depend
+ * on a JSON library: {@code daw-sdk} is the project's dependency-free API floor.</p>
  */
 public final class PluginManifestReader {
 
@@ -42,8 +60,8 @@ public final class PluginManifestReader {
     static final String KEY_ICON_HINT = "iconHint";
 
     /**
-     * The outcome of a read/parse attempt: either a valid {@link PluginManifest}
-     * or a non-empty list of validation errors.
+     * The outcome of a single-manifest read/parse attempt: either a valid
+     * {@link PluginManifest} or a non-empty list of validation errors.
      */
     public sealed interface Result permits Result.Valid, Result.Invalid {
 
@@ -77,7 +95,50 @@ public final class PluginManifestReader {
     }
 
     /**
-     * Reads and validates the manifest inside the given JAR file.
+     * The outcome of a bundle read/parse attempt: either a non-empty list of
+     * valid {@link PluginManifest}s in declared order, or a non-empty list of
+     * validation errors (§6.8, story 303). A single-object manifest yields a
+     * one-element {@link Valid}.
+     */
+    public sealed interface BundleResult permits BundleResult.Valid, BundleResult.Invalid {
+
+        /** A successful parse of one or more manifests, in declared order. */
+        record Valid(List<PluginManifest> values) implements BundleResult {
+            public Valid {
+                Objects.requireNonNull(values, "values must not be null");
+                values = List.copyOf(values);
+                if (values.isEmpty()) {
+                    throw new IllegalArgumentException("values must not be empty");
+                }
+            }
+        }
+
+        /** A failed parse: one or more human-readable reasons. */
+        record Invalid(List<String> errors) implements BundleResult {
+            public Invalid {
+                Objects.requireNonNull(errors, "errors must not be null");
+                errors = List.copyOf(errors);
+                if (errors.isEmpty()) {
+                    throw new IllegalArgumentException("errors must not be empty");
+                }
+            }
+        }
+
+        /** @return {@code true} if this is a {@link Valid} result. */
+        default boolean isValid() {
+            return this instanceof Valid;
+        }
+
+        /** @return the manifests if valid, otherwise an empty list. */
+        default List<PluginManifest> manifests() {
+            return this instanceof Valid v ? v.values() : List.of();
+        }
+    }
+
+    /**
+     * Reads and validates the single manifest inside the given JAR file. A JAR
+     * whose manifest is a bundle (top-level array) is reported as
+     * {@link Result.Invalid}; use {@link #readAllFromJar(Path)} for those.
      *
      * @param jarFile the plugin JAR (never {@code null})
      * @return a {@link Result.Valid} or {@link Result.Invalid}; never throws for a
@@ -99,8 +160,8 @@ public final class PluginManifestReader {
     }
 
     /**
-     * Parses and validates manifest JSON read from the given stream (UTF-8). Does
-     * not close the stream.
+     * Parses and validates a single-manifest document read from the given stream
+     * (UTF-8). Does not close the stream.
      *
      * @param jsonStream the manifest content (never {@code null})
      * @return a validation result; never throws for malformed content
@@ -115,21 +176,150 @@ public final class PluginManifestReader {
     }
 
     /**
-     * Parses and validates the given manifest JSON text.
+     * Parses and validates a single-manifest document. A top-level array (a
+     * bundle) is reported as {@link Result.Invalid} pointing at the bundle API;
+     * use {@link #parseAll(String)} for those.
      *
      * @param json the manifest document (never {@code null})
      * @return a validation result; never throws for malformed content
      */
     public Result parse(String json) {
         Objects.requireNonNull(json, "json must not be null");
-        Map<String, String> fields;
+        ParsedDocument document;
         try {
-            fields = JsonObject.parse(json);
+            document = JsonReader.parse(json);
         } catch (RuntimeException e) {
             return new Result.Invalid(List.of("malformed JSON: " + e.getMessage()));
         }
 
+        if (document.bundle()) {
+            return new Result.Invalid(List.of(
+                    "manifest is a bundle (top-level array); use readAllFromJar/parseAll"));
+        }
+
         List<String> errors = new ArrayList<>();
+        PluginManifest manifest = validate(document.elements().get(0), errors);
+        if (!errors.isEmpty()) {
+            return new Result.Invalid(errors);
+        }
+        return new Result.Valid(manifest);
+    }
+
+    /**
+     * Reads and validates every manifest declared in the given JAR file, whether
+     * the manifest is a single object (a one-plugin bundle) or a top-level array
+     * (§6.8, story 303).
+     *
+     * @param jarFile the plugin JAR (never {@code null})
+     * @return a {@link BundleResult.Valid} or {@link BundleResult.Invalid}; never
+     *         throws for a missing/malformed manifest or an unreadable JAR
+     */
+    public BundleResult readAllFromJar(Path jarFile) {
+        Objects.requireNonNull(jarFile, "jarFile must not be null");
+        try (JarFile jar = new JarFile(jarFile.toFile())) {
+            ZipEntry entry = jar.getEntry(MANIFEST_ENTRY);
+            if (entry == null) {
+                return new BundleResult.Invalid(
+                        List.of("no " + MANIFEST_ENTRY + " entry in " + jarFile));
+            }
+            try (InputStream in = jar.getInputStream(entry)) {
+                return parseAll(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        } catch (IOException | RuntimeException e) {
+            return new BundleResult.Invalid(
+                    List.of("could not read " + jarFile + ": " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Parses and validates a bundle document read from the given stream (UTF-8).
+     * Does not close the stream.
+     *
+     * @param jsonStream the manifest content (never {@code null})
+     * @return a bundle result; never throws for malformed content
+     */
+    public BundleResult parseAll(InputStream jsonStream) {
+        Objects.requireNonNull(jsonStream, "jsonStream must not be null");
+        try {
+            return parseAll(new String(jsonStream.readAllBytes(), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            return new BundleResult.Invalid(
+                    List.of("could not read manifest stream: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Parses and validates a bundle document. A single flat object is accepted as
+     * a one-plugin bundle (full backward compatibility with story 300); a
+     * top-level array declares several plugins in declared order. Every element is
+     * validated with the same field rules as {@link #parse(String)}; an element's
+     * errors are prefixed with its index (for example
+     * {@code "plugins[1]: missing required field: vendor"}). Any element error, an
+     * empty array, or a duplicate {@code pluginClass} across elements yields
+     * {@link BundleResult.Invalid} carrying all accumulated errors — no partial
+     * results leak.
+     *
+     * @param json the manifest document (never {@code null})
+     * @return a bundle result; never throws for malformed content
+     */
+    public BundleResult parseAll(String json) {
+        Objects.requireNonNull(json, "json must not be null");
+        ParsedDocument document;
+        try {
+            document = JsonReader.parse(json);
+        } catch (RuntimeException e) {
+            return new BundleResult.Invalid(List.of("malformed JSON: " + e.getMessage()));
+        }
+
+        List<Map<String, String>> elements = document.elements();
+
+        if (!document.bundle()) {
+            // A single flat object is a one-plugin bundle; keep its errors
+            // unprefixed so they read exactly like the single-object API.
+            List<String> errors = new ArrayList<>();
+            PluginManifest manifest = validate(elements.get(0), errors);
+            if (!errors.isEmpty()) {
+                return new BundleResult.Invalid(errors);
+            }
+            return new BundleResult.Valid(List.of(manifest));
+        }
+
+        if (elements.isEmpty()) {
+            return new BundleResult.Invalid(List.of("manifest declares no plugins"));
+        }
+
+        List<String> errors = new ArrayList<>();
+        List<PluginManifest> manifests = new ArrayList<>();
+        for (int index = 0; index < elements.size(); index++) {
+            List<String> elementErrors = new ArrayList<>();
+            PluginManifest manifest = validate(elements.get(index), elementErrors);
+            if (elementErrors.isEmpty()) {
+                manifests.add(manifest);
+            } else {
+                for (String error : elementErrors) {
+                    errors.add("plugins[" + index + "]: " + error);
+                }
+            }
+        }
+
+        // A repeated pluginClass would register two plugins under one class name
+        // (§6.8): reject the whole bundle rather than install a conflict.
+        collectDuplicatePluginClasses(elements, errors);
+
+        if (!errors.isEmpty()) {
+            return new BundleResult.Invalid(errors);
+        }
+        return new BundleResult.Valid(manifests);
+    }
+
+    /**
+     * Validates one flat field map against the manifest field rules, adding any
+     * problems to {@code errors}.
+     *
+     * @return the manifest when the fields are valid, otherwise {@code null} (with
+     *         reasons appended to {@code errors})
+     */
+    private static PluginManifest validate(Map<String, String> fields, List<String> errors) {
         String pluginClass = required(fields, KEY_PLUGIN_CLASS, errors);
         String id = required(fields, KEY_ID, errors);
         String name = required(fields, KEY_NAME, errors);
@@ -159,15 +349,31 @@ public final class PluginManifestReader {
         String iconHint = fields.getOrDefault(KEY_ICON_HINT, "");
 
         if (!errors.isEmpty()) {
-            return new Result.Invalid(errors);
+            return null;
         }
 
         try {
             PluginDescriptor descriptor =
                     new PluginDescriptor(id, name, version, vendor, type, category, iconHint);
-            return new Result.Valid(new PluginManifest(pluginClass, descriptor));
+            return new PluginManifest(pluginClass, descriptor);
         } catch (RuntimeException e) {
-            return new Result.Invalid(List.of("invalid manifest fields: " + e.getMessage()));
+            errors.add("invalid manifest fields: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static void collectDuplicatePluginClasses(
+            List<Map<String, String>> elements, List<String> errors) {
+        Set<String> seen = new HashSet<>();
+        Set<String> reported = new HashSet<>();
+        for (Map<String, String> element : elements) {
+            String pluginClass = element.get(KEY_PLUGIN_CLASS);
+            if (pluginClass == null || pluginClass.isBlank()) {
+                continue;
+            }
+            if (!seen.add(pluginClass) && reported.add(pluginClass)) {
+                errors.add("duplicate pluginClass across plugins: " + pluginClass);
+            }
         }
     }
 
@@ -181,28 +387,61 @@ public final class PluginManifestReader {
     }
 
     /**
-     * A deliberately tiny JSON reader for a <em>flat object of string values</em>
-     * — all a {@code daw-plugin.json} manifest needs. Rejects anything that is not
-     * a flat {@code {"key":"value", ...}} object (nested objects/arrays, or
-     * number/boolean/null values) by throwing, which the caller converts into a
-     * {@link Result.Invalid}.
+     * A parsed manifest document: one or more flat field maps. {@code bundle} is
+     * {@code true} when the source was a top-level array, {@code false} when it
+     * was a single object (in which case {@code elements} always has one entry).
      */
-    private static final class JsonObject {
+    private record ParsedDocument(boolean bundle, List<Map<String, String>> elements) {}
+
+    /**
+     * A deliberately tiny JSON reader for a <em>flat object of string values</em>,
+     * or a <em>top-level array</em> of such objects — all a {@code daw-plugin.json}
+     * manifest needs. Rejects anything else (nested objects/arrays inside an
+     * element, or number/boolean/null values) by throwing, which the caller
+     * converts into an {@code Invalid} result.
+     */
+    private static final class JsonReader {
         private final String s;
         private int i;
 
-        private JsonObject(String s) {
+        private JsonReader(String s) {
             this.s = s;
         }
 
-        static Map<String, String> parse(String json) {
-            JsonObject p = new JsonObject(json);
-            Map<String, String> out = p.parseObject();
+        static ParsedDocument parse(String json) {
+            JsonReader p = new JsonReader(json);
+            p.skipWs();
+            ParsedDocument document = p.peek() == '['
+                    ? new ParsedDocument(true, p.parseObjectArray())
+                    : new ParsedDocument(false, List.of(p.parseObject()));
             p.skipWs();
             if (p.i != p.s.length()) {
                 throw new IllegalArgumentException("trailing content at index " + p.i);
             }
-            return out;
+            return document;
+        }
+
+        private List<Map<String, String>> parseObjectArray() {
+            List<Map<String, String>> out = new ArrayList<>();
+            skipWs();
+            expect('[');
+            skipWs();
+            if (peek() == ']') {
+                i++;
+                return out;
+            }
+            while (true) {
+                skipWs();
+                out.add(parseObject());
+                skipWs();
+                char c = next();
+                if (c == ']') {
+                    return out;
+                }
+                if (c != ',') {
+                    throw new IllegalArgumentException("expected ',' or ']' at index " + (i - 1));
+                }
+            }
         }
 
         private Map<String, String> parseObject() {

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriter.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriter.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -16,6 +17,12 @@ import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
  * {@code META-INF/daw-plugin.json} (Plugin View Design Book §4.5). The output
  * round-trips through {@link PluginManifestReader} to an equal manifest.
  *
+ * <p>Two forms are emitted, matching the two the reader accepts: a single flat
+ * object for a one-plugin JAR, or a top-level array of those objects for a
+ * <em>bundle</em> that declares several plugins in one JAR for the §6.8 install
+ * flow (story 303). The list overloads always emit an array — a one-element list
+ * is the explicit bundle call.</p>
+ *
  * <p>This is the library type only; the Maven goal that emits the manifest at
  * build time is out of scope for this story (§7.1/§7.3 — the book scopes the
  * plugin code out).</p>
@@ -23,7 +30,7 @@ import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
 public final class PluginManifestWriter {
 
     /**
-     * Renders the manifest as a pretty-printed JSON object string. The
+     * Renders a single manifest as a pretty-printed JSON object string. The
      * {@code iconHint} key is omitted when the descriptor's icon hint is empty;
      * every other field is always written.
      *
@@ -32,39 +39,44 @@ public final class PluginManifestWriter {
      */
     public String toJson(PluginManifest manifest) {
         Objects.requireNonNull(manifest, "manifest must not be null");
-        PluginDescriptor d = manifest.descriptor();
-
-        Map<String, String> fields = new LinkedHashMap<>();
-        fields.put(PluginManifestReader.KEY_PLUGIN_CLASS, manifest.pluginClass());
-        fields.put(PluginManifestReader.KEY_ID, d.id());
-        fields.put(PluginManifestReader.KEY_NAME, d.name());
-        fields.put(PluginManifestReader.KEY_VERSION, d.version());
-        fields.put(PluginManifestReader.KEY_VENDOR, d.vendor());
-        fields.put(PluginManifestReader.KEY_TYPE, d.type().name());
-        fields.put(PluginManifestReader.KEY_CATEGORY, d.category().name());
-        if (!d.iconHint().isEmpty()) {
-            fields.put(PluginManifestReader.KEY_ICON_HINT, d.iconHint());
-        }
-
         StringBuilder sb = new StringBuilder();
-        sb.append("{\n");
-        int i = 0;
-        for (Map.Entry<String, String> e : fields.entrySet()) {
-            sb.append("  ");
-            appendQuoted(sb, e.getKey());
-            sb.append(": ");
-            appendQuoted(sb, e.getValue());
-            if (++i < fields.size()) {
-                sb.append(',');
-            }
-            sb.append('\n');
-        }
-        sb.append("}\n");
+        appendObject(sb, fieldsOf(manifest), "");
+        sb.append('\n');
         return sb.toString();
     }
 
     /**
-     * Writes the manifest as a standalone {@code daw-plugin.json} file (UTF-8).
+     * Renders a bundle of manifests as a pretty-printed top-level JSON array of
+     * the per-manifest object form. A one-element list still emits an array.
+     *
+     * @param manifests the manifests to serialise (never {@code null} or empty,
+     *                  and never containing {@code null})
+     * @return the JSON document, never {@code null}
+     */
+    public String toJson(List<PluginManifest> manifests) {
+        Objects.requireNonNull(manifests, "manifests must not be null");
+        if (manifests.isEmpty()) {
+            throw new IllegalArgumentException("manifests must not be empty");
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("[\n");
+        for (int i = 0; i < manifests.size(); i++) {
+            PluginManifest manifest = manifests.get(i);
+            Objects.requireNonNull(manifest, "manifests must not contain null");
+            sb.append("  ");
+            appendObject(sb, fieldsOf(manifest), "  ");
+            if (i < manifests.size() - 1) {
+                sb.append(',');
+            }
+            sb.append('\n');
+        }
+        sb.append("]\n");
+        return sb.toString();
+    }
+
+    /**
+     * Writes a single manifest as a standalone {@code daw-plugin.json} file
+     * (UTF-8).
      *
      * @param manifest the manifest to write (never {@code null})
      * @param jsonFile the destination file path (never {@code null})
@@ -76,8 +88,21 @@ public final class PluginManifestWriter {
     }
 
     /**
-     * Writes the manifest JSON to the given stream (UTF-8). Does not close the
-     * stream.
+     * Writes a bundle of manifests as a standalone {@code daw-plugin.json} file
+     * (UTF-8, top-level array).
+     *
+     * @param manifests the manifests to write (never {@code null} or empty)
+     * @param jsonFile  the destination file path (never {@code null})
+     * @throws IOException if writing fails
+     */
+    public void writeToFile(List<PluginManifest> manifests, Path jsonFile) throws IOException {
+        Objects.requireNonNull(jsonFile, "jsonFile must not be null");
+        Files.writeString(jsonFile, toJson(manifests), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Writes a single manifest JSON to the given stream (UTF-8). Does not close
+     * the stream.
      *
      * @param manifest the manifest to write (never {@code null})
      * @param out      the destination stream (never {@code null})
@@ -86,6 +111,56 @@ public final class PluginManifestWriter {
     public void writeTo(PluginManifest manifest, OutputStream out) throws IOException {
         Objects.requireNonNull(out, "out must not be null");
         out.write(toJson(manifest).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Writes a bundle of manifests to the given stream (UTF-8, top-level array).
+     * Does not close the stream.
+     *
+     * @param manifests the manifests to write (never {@code null} or empty)
+     * @param out       the destination stream (never {@code null})
+     * @throws IOException if writing fails
+     */
+    public void writeTo(List<PluginManifest> manifests, OutputStream out) throws IOException {
+        Objects.requireNonNull(out, "out must not be null");
+        out.write(toJson(manifests).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Map<String, String> fieldsOf(PluginManifest manifest) {
+        PluginDescriptor d = manifest.descriptor();
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put(PluginManifestReader.KEY_PLUGIN_CLASS, manifest.pluginClass());
+        fields.put(PluginManifestReader.KEY_ID, d.id());
+        fields.put(PluginManifestReader.KEY_NAME, d.name());
+        fields.put(PluginManifestReader.KEY_VERSION, d.version());
+        fields.put(PluginManifestReader.KEY_VENDOR, d.vendor());
+        fields.put(PluginManifestReader.KEY_TYPE, d.type().name());
+        fields.put(PluginManifestReader.KEY_CATEGORY, d.category().name());
+        if (!d.iconHint().isEmpty()) {
+            fields.put(PluginManifestReader.KEY_ICON_HINT, d.iconHint());
+        }
+        return fields;
+    }
+
+    /**
+     * Appends a flat object, its braces at {@code indent} and its keys at
+     * {@code indent + "  "}. The opening brace is written where the cursor
+     * already sits (the caller positions it); no trailing newline is added.
+     */
+    private static void appendObject(StringBuilder sb, Map<String, String> fields, String indent) {
+        sb.append("{\n");
+        int i = 0;
+        for (Map.Entry<String, String> e : fields.entrySet()) {
+            sb.append(indent).append("  ");
+            appendQuoted(sb, e.getKey());
+            sb.append(": ");
+            appendQuoted(sb, e.getValue());
+            if (++i < fields.size()) {
+                sb.append(',');
+            }
+            sb.append('\n');
+        }
+        sb.append(indent).append('}');
     }
 
     private static void appendQuoted(StringBuilder sb, String value) {

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReaderTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestReaderTest.java
@@ -35,6 +35,59 @@ class PluginManifestReaderTest {
             }
             """;
 
+    /** A bundle declaring two self-contained plugins (§6.8, story 303). */
+    private static final String BUNDLE_OF_TWO_JSON = """
+            [
+              {
+                "pluginClass": "com.acme.ReverbPlugin",
+                "id": "com.acme.reverb",
+                "name": "Acme Reverb",
+                "version": "1.0.0",
+                "vendor": "Acme Audio",
+                "type": "EFFECT",
+                "category": "REVERB_AND_DELAY"
+              },
+              {
+                "pluginClass": "com.acme.DelayPlugin",
+                "id": "com.acme.delay",
+                "name": "Acme Delay",
+                "version": "2.0.0",
+                "vendor": "Acme Audio",
+                "type": "EFFECT"
+              }
+            ]
+            """;
+
+    /** A bundle declaring three self-contained plugins. */
+    private static final String BUNDLE_OF_THREE_JSON = """
+            [
+              {
+                "pluginClass": "com.acme.PluginA",
+                "id": "com.acme.a",
+                "name": "Acme A",
+                "version": "1.0.0",
+                "vendor": "Acme Audio",
+                "type": "EFFECT"
+              },
+              {
+                "pluginClass": "com.acme.PluginB",
+                "id": "com.acme.b",
+                "name": "Acme B",
+                "version": "1.0.0",
+                "vendor": "Acme Audio",
+                "type": "INSTRUMENT"
+              },
+              {
+                "pluginClass": "com.acme.PluginC",
+                "id": "com.acme.c",
+                "name": "Acme C",
+                "version": "1.0.0",
+                "vendor": "Acme Audio",
+                "type": "ANALYZER"
+              }
+            ]
+            """;
+
     private final PluginManifestReader reader = new PluginManifestReader();
 
     @Test
@@ -135,6 +188,177 @@ class PluginManifestReaderTest {
         PluginManifestReader.Result result = reader.readFromJar(jar);
 
         assertThat(result).isInstanceOf(PluginManifestReader.Result.Invalid.class);
+        assertThat(result.isValid()).isFalse();
+    }
+
+    @Test
+    void parsesBundleOfTwoInDeclaredOrder() {
+        PluginManifestReader.BundleResult result = reader.parseAll(BUNDLE_OF_TWO_JSON);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.manifests()).hasSize(2);
+        assertThat(result.manifests().get(0).pluginClass()).isEqualTo("com.acme.ReverbPlugin");
+        assertThat(result.manifests().get(0).descriptor().category())
+                .isEqualTo(PluginCategory.REVERB_AND_DELAY);
+        assertThat(result.manifests().get(1).pluginClass()).isEqualTo("com.acme.DelayPlugin");
+    }
+
+    @Test
+    void parsesBundleOfThreeInDeclaredOrder() {
+        PluginManifestReader.BundleResult result = reader.parseAll(BUNDLE_OF_THREE_JSON);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.manifests()).hasSize(3);
+        assertThat(result.manifests())
+                .extracting(PluginManifest::pluginClass)
+                .containsExactly("com.acme.PluginA", "com.acme.PluginB", "com.acme.PluginC");
+    }
+
+    @Test
+    void readsBundleFromJarInDeclaredOrder(@TempDir Path tempDir) throws IOException {
+        Path jar = writeJar(tempDir, "bundle.jar",
+                PluginManifestReader.MANIFEST_ENTRY, BUNDLE_OF_THREE_JSON.getBytes(StandardCharsets.UTF_8));
+
+        PluginManifestReader.BundleResult result = reader.readAllFromJar(jar);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.manifests())
+                .extracting(PluginManifest::pluginClass)
+                .containsExactly("com.acme.PluginA", "com.acme.PluginB", "com.acme.PluginC");
+    }
+
+    @Test
+    void parseAllAcceptsSingleObjectAsOnePluginBundle() {
+        PluginManifestReader.BundleResult result = reader.parseAll(MINIMAL_JSON);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.manifests()).hasSize(1);
+        assertThat(result.manifests().get(0).pluginClass()).isEqualTo("com.acme.MinimalPlugin");
+    }
+
+    @Test
+    void legacyParseRejectsBundleArrayPointingAtBundleApi() {
+        PluginManifestReader.Result result = reader.parse(BUNDLE_OF_TWO_JSON);
+
+        assertThat(result).isInstanceOf(PluginManifestReader.Result.Invalid.class);
+        assertThat(result.isValid()).isFalse();
+        PluginManifestReader.Result.Invalid invalid = (PluginManifestReader.Result.Invalid) result;
+        assertThat(invalid.errors()).anyMatch(e -> e.contains("parseAll"));
+    }
+
+    @Test
+    void bundleAccumulatesPerElementErrorsWithIndexPrefixAndLeaksNoManifests() {
+        String json = """
+                [
+                  {
+                    "pluginClass": "com.acme.GoodPlugin",
+                    "id": "com.acme.good",
+                    "name": "Acme Good",
+                    "version": "1.0.0",
+                    "vendor": "Acme Audio",
+                    "type": "EFFECT"
+                  },
+                  {
+                    "pluginClass": "com.acme.BadPlugin",
+                    "id": "com.acme.bad",
+                    "name": "Acme Bad",
+                    "version": "1.0.0",
+                    "type": "EFFECT"
+                  }
+                ]
+                """;
+
+        PluginManifestReader.BundleResult result = reader.parseAll(json);
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result).isInstanceOf(PluginManifestReader.BundleResult.Invalid.class);
+        assertThat(result.manifests()).isEmpty();
+        PluginManifestReader.BundleResult.Invalid invalid =
+                (PluginManifestReader.BundleResult.Invalid) result;
+        assertThat(invalid.errors())
+                .anyMatch(e -> e.startsWith("plugins[1]:") && e.contains("vendor"))
+                .noneMatch(e -> e.startsWith("plugins[0]:"));
+    }
+
+    @Test
+    void bundleSurfacesUnknownTypeAndCategoryWithIndexPrefix() {
+        String json = """
+                [
+                  {
+                    "pluginClass": "com.acme.PluginA",
+                    "id": "com.acme.a",
+                    "name": "Acme A",
+                    "version": "1.0.0",
+                    "vendor": "Acme Audio",
+                    "type": "BOGUS"
+                  },
+                  {
+                    "pluginClass": "com.acme.PluginB",
+                    "id": "com.acme.b",
+                    "name": "Acme B",
+                    "version": "1.0.0",
+                    "vendor": "Acme Audio",
+                    "type": "EFFECT",
+                    "category": "NONSENSE"
+                  }
+                ]
+                """;
+
+        PluginManifestReader.BundleResult result = reader.parseAll(json);
+
+        assertThat(result.isValid()).isFalse();
+        PluginManifestReader.BundleResult.Invalid invalid =
+                (PluginManifestReader.BundleResult.Invalid) result;
+        assertThat(invalid.errors()).contains("plugins[0]: unknown type: BOGUS");
+        assertThat(invalid.errors()).contains("plugins[1]: unknown category: NONSENSE");
+    }
+
+    @Test
+    void emptyBundleReportedAsInvalid() {
+        PluginManifestReader.BundleResult result = reader.parseAll("[]");
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.manifests()).isEmpty();
+        assertThat(((PluginManifestReader.BundleResult.Invalid) result).errors())
+                .anyMatch(e -> e.contains("no plugins"));
+    }
+
+    @Test
+    void bundleWithDuplicatePluginClassReportedAsInvalid() {
+        String json = """
+                [
+                  {
+                    "pluginClass": "com.acme.DupPlugin",
+                    "id": "com.acme.one",
+                    "name": "Acme One",
+                    "version": "1.0.0",
+                    "vendor": "Acme Audio",
+                    "type": "EFFECT"
+                  },
+                  {
+                    "pluginClass": "com.acme.DupPlugin",
+                    "id": "com.acme.two",
+                    "name": "Acme Two",
+                    "version": "1.0.0",
+                    "vendor": "Acme Audio",
+                    "type": "EFFECT"
+                  }
+                ]
+                """;
+
+        PluginManifestReader.BundleResult result = reader.parseAll(json);
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.manifests()).isEmpty();
+        assertThat(((PluginManifestReader.BundleResult.Invalid) result).errors())
+                .anyMatch(e -> e.contains("com.acme.DupPlugin"));
+    }
+
+    @Test
+    void malformedBundleArrayReportedAsInvalid() {
+        PluginManifestReader.BundleResult result = reader.parseAll("[ { not json ");
+
+        assertThat(result).isInstanceOf(PluginManifestReader.BundleResult.Invalid.class);
         assertThat(result.isValid()).isFalse();
     }
 

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriterRoundTripTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/editor/PluginManifestWriterRoundTripTest.java
@@ -1,5 +1,7 @@
 package com.benesquivelmusic.daw.sdk.editor;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.benesquivelmusic.daw.sdk.plugin.PluginDescriptor;
@@ -10,8 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Verifies that {@link PluginManifestWriter} output round-trips through
  * {@link PluginManifestReader} to an equal {@link PluginManifest} (Plugin View
- * Design Book §4.5), including non-default {@code category}/{@code iconHint} and
- * strings that require JSON escaping.
+ * Design Book §4.5), including non-default {@code category}/{@code iconHint},
+ * strings that require JSON escaping, and the top-level-array bundle form
+ * (§6.8, story 303).
  */
 class PluginManifestWriterRoundTripTest {
 
@@ -57,6 +60,40 @@ class PluginManifestWriterRoundTripTest {
 
         assertThat(json).doesNotContain("iconHint");
         assertThat(reader.parse(json).manifest().orElseThrow().descriptor().iconHint()).isEmpty();
+    }
+
+    @Test
+    void roundTripsBundleOfTwo() {
+        PluginManifest first = new PluginManifest(
+                "com.acme.TubeWarmth",
+                new PluginDescriptor(
+                        "com.acme.tubewarmth", "TubeWarmth", "1.2.0", "Acme Audio",
+                        PluginType.EFFECT, PluginCategory.DYNAMICS, "compressor"));
+        PluginManifest second = new PluginManifest(
+                "com.acme.SynthPlugin",
+                new PluginDescriptor(
+                        "com.acme.synth", "Acme Synth", "1.0.0", "Acme Audio", PluginType.INSTRUMENT));
+
+        PluginManifestReader.BundleResult result =
+                reader.parseAll(writer.toJson(List.of(first, second)));
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.manifests()).containsExactly(first, second);
+    }
+
+    @Test
+    void oneElementListEmitsArrayReadBackByParseAll() {
+        PluginManifest manifest = new PluginManifest(
+                "com.acme.SoloPlugin",
+                new PluginDescriptor(
+                        "com.acme.solo", "Acme Solo", "1.0.0", "Acme Audio", PluginType.EFFECT));
+
+        String json = writer.toJson(List.of(manifest));
+
+        assertThat(json.stripLeading()).startsWith("[");
+        PluginManifestReader.BundleResult result = reader.parseAll(json);
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.manifests()).containsExactly(manifest);
     }
 
     @Test


### PR DESCRIPTION
# Plugin Browser and Drag-a-JAR Install Flow (Retire the Type-a-Class-Name Field)

## Motivation

With the editor contract live (story 300) and honoured by both third parties (story 301) and built-ins (story 302), the last §1 problem is *getting a developer's plugin into the DAW in the first place*:

- **§1.4 — no discoverability for the developer.** The install path asks the user to **type a fully-qualified class name into a text field**. Verified: `PluginManagerDialog` builds a `classNameField` with prompt `"e.g. com.example.MyReverbPlugin"` (`daw-app/.../ui/PluginManagerDialog.java:98-99`) and refuses to add a plugin until both a JAR path *and* a class name are supplied (`PluginManagerDialog.java:170-180`). This is exactly the friction the `DawPlugin` Javadoc claims to remove ("no `META-INF/services` configuration required", `DawPlugin.java:13-15`). A user has no way to know the class name unless the developer tells them out of band.
- **§1.4 / §6.7 — keyword-sniffing instead of categories.** The dialog picks a list icon by string-matching the plugin's display name through ~60 `if (lower.contains(...))` branches in `pluginDetailIcon(PluginDescriptor)` (verified, `PluginManagerDialog.java:231-298`). The Design Book replaces this with the real `PluginCategory` field added in story 300 (§4.4).

This is **Phase 4 of the §8 migration path** — *install UX rewrite* (§8.4). It (1) replaces `PluginManagerDialog`'s text fields with the manifest-driven install flow (§6.8) and (2) adds the categorical plugin browser (§6.7) to the mixer's "add plugin" affordance. The user drags a JAR; the DAW reads `META-INF/daw-plugin.json` (the `PluginManifest` from story 300) and installs every plugin it declares. The class name is no longer something the user sees.

## Goals

- **Drag-a-JAR / pick-a-JAR install flow** (§6.8) replacing the class-name field. On a JAR drop (or `[+ Install from JAR…]`), the DAW runs `PluginManifestReader` (story 300) against `META-INF/daw-plugin.json` and shows the §6.8 "Install plugin" inspection panel: vendor, the list of declared plugins (name · version · type · category), targets, footprint, and an **[Install both]/[Install N]** confirm. Installing registers **every plugin declared in the manifest** — the user never types or sees a class name.
- **Categorical plugin browser** (§6.7) on the mixer "add plugin" affordance. A searchable browser keyed off the new `PluginCategory` (story 300, §4.4) with two top-level groups — **Built-in** (grouped by category: Dynamics, Reverb & Delay, Spatial, Utility, …) and **Installed (third-party)** (grouped by vendor) — sharing one list so built-in and third-party plugins are not second-class (§6.7). Selecting a plugin adds it to the targeted insert slot; `[+ Install from JAR…]` / `[+ Install from folder…]` open the install flow; `[Manage…]` opens the re-skinned manager.
- **Re-skin `PluginManagerDialog` to the list view** (§6.8): same registry data, **no text field for class names**. The keyword-sniffing `pluginDetailIcon(...)` (`PluginManagerDialog.java:231-298`) is replaced by the plugin's declared `category` (→ category icon) and `iconHint` (→ icon pack), decoupling the icon from name string-matching and from `DawIcon` guesswork (§4.4).
- **Non-blocking scan with a per-row spinner** (§9 rejection #9): the JAR is scanned off the FX thread; the browser shows a spinner on the row while scanning, never a modal "plugin loading" dialog. Results post back via `FxDispatcher` to the FX thread.
- **Legacy class-name fallback retained for now** (§6.8): a JAR with **no manifest** falls back to the existing "type a class name" form, for compatibility with plugins built against the pre-manifest SDK. This is the path story 304 (Phase 5) removes once telemetry shows it is unused — keep it reachable but de-emphasised.
- Tests:
  - `ManifestDrivenInstallTest` (new): dropping/selecting a JAR whose `META-INF/daw-plugin.json` declares two plugins registers both via `PluginRegistry` without any class-name input; the install panel lists both with name/version/type/category from the manifest.
  - `NoClassNameFieldInDefaultPathTest` (new): the re-skinned manager / install flow exposes **no** class-name `TextField` on the manifest path (assert the field is absent or hidden), and `pluginDetailIcon`-style name-keyword icon selection is gone — the list icon comes from `category`/`iconHint`.
  - `BrowserCategoriesFromPluginCategoryTest` (new): built-ins group under their declared `PluginCategory`; third-party plugins group under vendor; search filters the shared list (model the filter on the story-275 `FileNode`/`buildFilteredItem` pattern for a tree filter that preserves group headers).
  - `MissingManifestFallsBackToClassNameTest` (new): a JAR with no `daw-plugin.json` routes to the legacy class-name form and still registers via `ExternalPluginEntry(jarPath, className)` (`PluginManagerDialog.java:179-184`) — proves the §6.8 fallback survives this phase.
  - `NonBlockingScanShowsRowSpinnerTest` (new): a JAR scan does not block the FX thread; the row shows a spinner during scan and resolves on completion (assert via the row's busy state / style class, headless-safe).
  - `InstallRegistersEveryDeclaredPluginTest` (new): a manifest with three plugins results in three registry entries after one install action — proves "install every declared plugin in that JAR" (§6.8).

## Non-Goals

- **No SDK changes.** `PluginManifest`/reader/writer and `PluginCategory`/`iconHint` all shipped in story 300; this story consumes them.
- **No editor or chrome changes.** The editor frame, three modes, and fault banner are stories 301–302; this story is purely the *install + browse* surface.
- **No removal of the class-name fallback.** It stays as the no-manifest compatibility path; removing it is story 304 (Phase 5), gated on telemetry.
- **No Maven archetype / `daw-plugin-maven-plugin`.** §7.1/§7.3's scaffold archetype and manifest-emitting build goal are out of scope (book scopes the build-plugin code out); the DAW only *reads* the manifest here.
- **No developer-mode tooling.** §7.5's hot-reload, the hints-vs-actual overlay, and the fault sandbox are a later enhancement, not this story.
- **No JAR signature enforcement.** §6.8 shows a "Signature ✓ signed by…" line; surfacing/validating developer-key signatures is a security follow-up, not a blocker for the install flow. If a signature affordance is shown, it is informational this phase.
- **No marketplace.** §7.6 "publish" is explicitly out of scope; "install" means "drag the JAR".

## Technical Notes

- **`PluginManifestReader` is the only thing that reads the JAR's intent** (story 300, §4.5): the install flow never reflects on class names to guess a plugin (§9 rejection #8) — it reads the declared list. `PluginRegistry.register(ExternalPluginEntry)` (verified, `daw-app`/`daw-core` plugin package; the existing entry is `ExternalPluginEntry(Path jarPath, String className)`) is driven from the manifest's class names, not user input. The manifest may declare multiple plugins per JAR, so the install loop registers one `ExternalPluginEntry` per declared class.
- **`PluginCategory` replaces keyword-sniffing** (§4.4): delete the `pluginDetailIcon(...)` name-matching cascade (`PluginManagerDialog.java:231-298`) in favour of `descriptor.category()` → a category icon and `descriptor.iconHint()` → the host icon pack. Per `feedback_ui_design_philosophy.md` the icons replace labels, never decorate them; per the icon-tinting note (`feedback_iconnode_tint_from_resolved_css.md`) tint from resolved CSS.
- **Off-thread scan, FX-thread results.** Scan JARs on a background/virtual thread; marshal results back through `FxDispatcher` (the Control-Sync dispatcher) so the browser list and per-row spinner mutate only on the FX thread (`feedback_javafx_headless_test_pitfalls.md` — assertions inside an FX runnable are swallowed; capture+rethrow in tests). Never a modal load dialog (§9 rejection #9).
- **The manager dialog keeps its story-276 chrome.** `PluginManagerDialog` already extends `DawgDialog` with the §5.9 flat-header / accent-primary chrome and routes errors through `DawgDialog.error(...)` (verified, `PluginManagerDialog.java:33,202-207`). The re-skin swaps the *content* (list view, no class-name field) and keeps the dialog shell; the hardcoded inline `-fx-text-fill: #808080` / `#ff9100` styles on the info/notification labels (`PluginManagerDialog.java:126,130`) should move to tokens (`feedback_ui_design_philosophy.md` — tokens not hex).
- **"Plugin changes apply after restart"** is the dialog's current notification (`PluginManagerDialog.java:128`). If the registry now supports live registration, re-verify whether the restart caveat still holds; if it does, keep the notice — do not silently imply hot-install that the engine does not yet do.
- **Browser tree filter** reuses the story-275 BrowserPanel filter shape (`FileNode` / `buildFilteredItem`) so searching does not drop the category/vendor group headers; do not fork a parallel filter (`feedback_prefer_existing_conventions.md`).
- Files: new `daw-app/.../ui/plugin/PluginBrowser.java` (the §6.7 categorical browser) and `daw-app/.../ui/plugin/PluginInstallPanel.java` (the §6.8 inspect-and-install flow); edits to `daw-app/.../ui/PluginManagerDialog.java` (drop `classNameField` on the manifest path, drop `pluginDetailIcon`, list-view re-skin, retain fallback), the mixer "add plugin" affordance wiring (route to `PluginBrowser`), and `styles.css` (browser/install chrome consuming role tokens). Consumes `daw-sdk/.../editor/PluginManifest.java` + `PluginManifestReader.java` and the `PluginDescriptor.category`/`iconHint` from story 300.
- Reference: Plugin View Design Book §1.4 (the friction), §2.4 (discoverable from a fresh checkout), §4.4 (`category`/`iconHint`), §4.5 (`PluginManifest`), §6.7 (browser), §6.8 (install flow + fallback), §8.4 (this phase), §9 rejections #8/#9 (no reflective discovery, no modal load); user story 300 (manifest + category contract), user story 301/302 (the editors the installed plugin now has), user story 275 (BrowserPanel accent-bar/search/audition — the filter pattern and the de-TabPaned section model), user story 276 (`DawgDialog` chrome the manager keeps), user story 034 (CLAP hosting — a future second install source the browser should accommodate), user story 079 (built-in discovery feeding the Built-in group). SKILLs: `javafx-application-design` (§4 Properties for the observable list, §11 threading for the off-thread scan, §15 anti-patterns), `dawg-annotations-reflection` (ServiceLoader discovery — note the SKILL is stale on sealed-permits), `research-daw`.
