### PR TITLE
305-setting-descriptor-model-backing-the-existing-settings-dialog

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -6,6 +6,7 @@ import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
 import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.event.EventBusPublisher;
 import com.benesquivelmusic.daw.sdk.event.UiEvent;
@@ -76,6 +77,11 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
     private final SettingsModel model;
 
+    // Story 305 — the dialog resolves label / default / validator metadata
+    // through the settings catalogue (Settings View Design Book §7 Stage 1)
+    // instead of inline literals; SettingsModel stays the write path.
+    private final SettingsCatalogue catalogue;
+
     // ── Callback ─────────────────────────────────────────────────────────────
     private SettingsChangeListener settingsChangeListener;
     private AudioEngineController audioEngineController;
@@ -133,6 +139,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
      */
     public SettingsDialog(SettingsModel model) {
         this.model = model;
+        catalogue = SettingsCatalogue.create();
 
         setTitle("Settings");
         setHeaderText("Application Preferences");
@@ -164,7 +171,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
         // Story 298 — journaled persistence toggle, seeded from the model.
         journaledPersistenceCheck = new CheckBox(
-                "Use journaled persistence (write-ahead journal & crash recovery)");
+                settingLabel("project.useJournaledPersistence"));
         journaledPersistenceCheck.setSelected(model.isUseJournaledPersistence());
 
         Tab projectTab = new Tab("Project", buildProjectPane());
@@ -232,7 +239,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
         // applied in applySettings(). A tooltip restates the WCAG 2.3.3
         // intent (cut transitions, keep real-time meters).
         motionManager = MotionManager.getDefault();
-        reduceMotionCheck = new CheckBox(msg("appearance.reduceMotion.label"));
+        reduceMotionCheck = new CheckBox(settingLabel(MotionManager.PREF_KEY));
         reduceMotionCheck.setSelected(motionManager.isReduceMotion());
         reduceMotionCheck.setTooltip(
                 new Tooltip(msg("appearance.reduceMotion.tooltip")));
@@ -313,11 +320,11 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
         grid.add(header, 0, 0, 2, 1);
         grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label("Sample Rate (Hz):"), 0, 2);
+        grid.add(new Label(settingLabel("audio.sampleRate") + ":"), 0, 2);
         grid.add(sampleRateCombo, 1, 2);
-        grid.add(new Label("Bit Depth:"), 0, 3);
+        grid.add(new Label(settingLabel("audio.bitDepth") + ":"), 0, 3);
         grid.add(bitDepthCombo, 1, 3);
-        grid.add(new Label("Buffer Size (frames):"), 0, 4);
+        grid.add(new Label(settingLabel("audio.bufferSize") + ":"), 0, 4);
         grid.add(bufferSizeCombo, 1, 4);
 
         openAudioDeviceDialogButton = new Button("Audio Device Settings\u2026");
@@ -357,9 +364,9 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
         grid.add(header, 0, 0, 2, 1);
         grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label("Auto-Save Interval (seconds):"), 0, 2);
+        grid.add(new Label(settingLabel("project.autoSaveIntervalSeconds") + ":"), 0, 2);
         grid.add(autoSaveCombo, 1, 2);
-        grid.add(new Label("Default Tempo (BPM):"), 0, 3);
+        grid.add(new Label(settingLabel("project.defaultTempo") + ":"), 0, 3);
         grid.add(tempoField, 1, 3);
 
         // Story 298 — journaled persistence toggle + a one-line §7-Stage-4
@@ -386,14 +393,14 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
         grid.add(header, 0, 0, 2, 1);
         grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label(msg("appearance.theme.label") + ":"), 0, 2);
+        grid.add(new Label(settingLabel(ThemeManager.PREF_KEY) + ":"), 0, 2);
         grid.add(themeCombo, 1, 2);
         // Visual separator between the theme chooser (the prominent new
         // affordance) and the UI-scale row keeps the grouping clear —
         // mirrors the header/separator/fields pattern used elsewhere in
         // this dialog.
         grid.add(new Separator(), 0, 3, 2, 1);
-        grid.add(new Label("UI Scale:"), 0, 4);
+        grid.add(new Label(settingLabel("appearance.uiScale") + ":"), 0, 4);
         grid.add(uiScaleSlider, 1, 4);
         grid.add(uiScaleValueLabel, 2, 4);
 
@@ -401,7 +408,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
         // label + the three radios laid out horizontally, following the
         // header/separator/field grid idiom used above.
         grid.add(new Separator(), 0, 5, 2, 1);
-        grid.add(new Label(msg("appearance.density.label") + ":"), 0, 6);
+        grid.add(new Label(settingLabel(DensityManager.PREF_KEY) + ":"), 0, 6);
         HBox densityBox = new HBox(12,
                 densityButtons.get(DensityMode.COMPACT),
                 densityButtons.get(DensityMode.COMFORTABLE),
@@ -468,7 +475,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
                 row = 0;
             }
 
-            Label nameLabel = new Label(action.displayName() + ":");
+            Label nameLabel = new Label(settingLabel("keybinding." + action.name()) + ":");
             TextField field = new TextField();
             field.setEditable(false);
             field.setPrefWidth(180);
@@ -586,7 +593,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
         grid.add(header, 0, 0, 2, 1);
         grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label("Plugin Scan Paths:"), 0, 2);
+        grid.add(new Label(settingLabel("plugins.scanPaths") + ":"), 0, 2);
         grid.add(pluginScanPathsField, 1, 2);
 
         Label hint = new Label("Separate multiple paths with semicolons (;).");
@@ -628,7 +635,12 @@ public final class SettingsDialog extends DawgDialog<Void> {
         String tempoText = tempoField.getText();
         if (tempoText != null && !tempoText.isBlank()) {
             double tempo = Double.parseDouble(tempoText);
-            if (tempo >= 20.0 && tempo <= 999.0) {
+            // Story 305 — the descriptor validator delegates to the setter
+            // guard, whose range comparisons cannot express NaN rejection
+            // (both are false for NaN), so the call site keeps the pre-305
+            // inline check's silent drop for NaN explicitly.
+            if (!Double.isNaN(tempo)
+                    && catalogue.byId("project.defaultTempo").orElseThrow().accepts(tempo)) {
                 model.setDefaultTempo(tempo);
             }
         }
@@ -724,6 +736,20 @@ public final class SettingsDialog extends DawgDialog<Void> {
         } catch (MissingResourceException e) {
             return key;
         }
+    }
+
+    /**
+     * Resolves a control's label text through its {@link SettingsCatalogue}
+     * descriptor, so the descriptor — not the call site — owns the string.
+     *
+     * @param id the descriptor id (the {@code Preferences} key)
+     * @return the descriptor's resolved label
+     * @throws IllegalStateException if no descriptor exists for the id
+     */
+    private String settingLabel(String id) {
+        return catalogue.byId(id)
+                .orElseThrow(() -> new IllegalStateException("No descriptor for setting: " + id))
+                .label();
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/ApplyClass.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/ApplyClass.java
@@ -1,0 +1,30 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+/**
+ * When a changed setting takes effect (Settings View Design Book §6.4,
+ * story 305).
+ *
+ * <p>Exactly three apply classes, in the book's §6.4 order. This
+ * replaces the audio tab's blanket "may require a restart" hint with
+ * per-setting truth: most audio changes are an engine reconfigure, not
+ * an application restart, and only the backend choice genuinely needs a
+ * restart. The enum shape is pinned by
+ * {@code DescriptorEnumsAreCanonicalTest}.</p>
+ */
+public enum ApplyClass {
+
+    /** Takes effect immediately — no engine re-arm, no restart. */
+    LIVE,
+
+    /**
+     * Takes effect on the next audio-engine stream re-arm (an engine
+     * stop/start cycle), <em>not</em> an application restart.
+     */
+    ENGINE_RECONFIGURE,
+
+    /**
+     * Takes effect only after the application restarts. Exactly one
+     * descriptor ({@code audio.backend}) carries this class today.
+     */
+    RESTART_REQUIRED
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/ControlKind.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/ControlKind.java
@@ -1,0 +1,37 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+/**
+ * The kind of control a setting renders as (Settings View Design Book
+ * §3.4, story 305).
+ *
+ * <p>Constants in the book's §3.4 order. The descriptor records the
+ * kind as metadata only — no descriptor holds a scene-graph node; the
+ * generic setting row that renders these arrives with story 306. The
+ * enum shape is pinned by {@code DescriptorEnumsAreCanonicalTest}.</p>
+ */
+public enum ControlKind {
+
+    /** An on/off switch or check box. */
+    TOGGLE,
+
+    /** A fixed-option picker (combo box). */
+    CHOICE,
+
+    /** A continuous numeric slider. */
+    SLIDER,
+
+    /**
+     * A discrete numeric stepper. No descriptor uses it today — the
+     * constant exists per §3.4 canon for later stages.
+     */
+    STEPPER,
+
+    /** A free-form text field. */
+    TEXT,
+
+    /** A file / folder path picker. */
+    PATH,
+
+    /** A key-combination capture field (Key Bindings rows). */
+    KEY_CAPTURE
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/Scope.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/Scope.java
@@ -1,0 +1,36 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+/**
+ * The reach of a setting — how far a changed value travels (Settings
+ * View Design Book §3.2, story 305).
+ *
+ * <p>Exactly four scopes, in the book's §3.2 order. This is the
+ * canonical vocabulary for the whole settings surface (one name per
+ * thing); later stages surface the scope on screen but never invent a
+ * synonym. The enum shape is pinned by
+ * {@code DescriptorEnumsAreCanonicalTest}.</p>
+ */
+public enum Scope {
+
+    /** Applies to the whole application, across every project. */
+    APPLICATION,
+
+    /**
+     * Stored as a default for future projects. Some project-default
+     * settings (default tempo, auto-save interval) are additionally
+     * live-applied to the open project by {@code LiveSettingsApplier} —
+     * the §3.2 dual-reach note. The tag records where the value is
+     * stored; the secondary live application is behaviour, not scope.
+     */
+    PROJECT_DEFAULTS,
+
+    /**
+     * Applies to the currently open project only. No descriptor carries
+     * this scope today — the constant exists per §3.2 canon so later
+     * stages need no vocabulary change.
+     */
+    THIS_PROJECT,
+
+    /** Tied to the configured audio device / driver stack. */
+    AUDIO_DEVICE
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingDescriptor.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingDescriptor.java
@@ -1,0 +1,84 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * The §3.4 setting descriptor — an immutable, transparent data carrier
+ * for exactly the nine per-setting metadata fields (Settings View Design
+ * Book §3.4, story 305).
+ *
+ * <p>A descriptor <em>describes</em> a setting; it never stores one.
+ * {@code SettingsModel} over {@link java.util.prefs.Preferences} stays
+ * the single source of truth, and the descriptor's {@link #validator()}
+ * delegates to the existing setter guard rather than replacing it (see
+ * {@link SettingsCatalogue}). The descriptor holds no scene-graph node —
+ * the generic setting row that renders it arrives with story 306.</p>
+ *
+ * @param id           the setting's identity — the {@code Preferences}
+ *                     key (or manager {@code PREF_KEY}, or
+ *                     {@code "keybinding." + action.name()})
+ * @param label        the resolved, localized display label (no
+ *                     trailing colon; call sites add punctuation)
+ * @param description  the resolved, localized one-sentence description
+ * @param synonyms     lowercase extra search terms for the §6.1 search
+ *                     index (search data, not display strings);
+ *                     defensively copied to an immutable list
+ * @param scope        the setting's reach (§3.2)
+ * @param applyClass   when a change takes effect (§6.4)
+ * @param controlKind  the kind of control the setting renders as (§3.4)
+ * @param defaultValue the canonical default, derived from the owning
+ *                     authority; nullable — a key-binding action may
+ *                     have no factory binding
+ * @param validator    per-value acceptance check delegating to the
+ *                     canonical setter guard; never {@code null}
+ * @param <T>          the setting's value type
+ */
+public record SettingDescriptor<T>(
+        String id, String label, String description, List<String> synonyms,
+        Scope scope, ApplyClass applyClass, ControlKind controlKind,
+        T defaultValue, Predicate<T> validator) {
+
+    /**
+     * Validates every component except {@code defaultValue} (nullable by
+     * design) and defensively copies {@code synonyms}.
+     */
+    public SettingDescriptor {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(label, "label must not be null");
+        Objects.requireNonNull(description, "description must not be null");
+        Objects.requireNonNull(synonyms, "synonyms must not be null");
+        Objects.requireNonNull(scope, "scope must not be null");
+        Objects.requireNonNull(applyClass, "applyClass must not be null");
+        Objects.requireNonNull(controlKind, "controlKind must not be null");
+        Objects.requireNonNull(validator, "validator must not be null");
+        synonyms = List.copyOf(synonyms);
+    }
+
+    /**
+     * Tests an untyped candidate against this descriptor's validator.
+     *
+     * <p>Type rejection is best-effort: a wrong-typed candidate fails
+     * only when the validator body itself casts the value — as every
+     * setter-delegating validator does — and that
+     * {@link ClassCastException} is caught and reported as a plain
+     * rejection. Validators that never cast (e.g. {@code Objects::nonNull}
+     * or the always-true key-binding validators) accept any candidate
+     * their predicate accepts, regardless of runtime type. Callers
+     * holding an {@code Object} (e.g. a dialog field's parsed value)
+     * still need no per-type dispatch.</p>
+     *
+     * @param value the candidate value (may be {@code null})
+     * @return {@code true} if the validator accepts the value
+     */
+    public boolean accepts(Object value) {
+        @SuppressWarnings("unchecked")
+        Predicate<Object> untyped = (Predicate<Object>) validator;
+        try {
+            return untyped.test(value);
+        } catch (ClassCastException wrongType) {
+            return false;
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsCatalogue.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsCatalogue.java
@@ -1,0 +1,504 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.DawAction;
+import com.benesquivelmusic.daw.app.ui.SettingsModel;
+import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
+import javafx.scene.input.KeyCombination;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * The complete index of every user-configurable setting — the §3.4
+ * descriptor catalogue behind the existing {@code SettingsDialog}
+ * (Settings View Design Book §3.4 / §7 Stage 1, story 305).
+ *
+ * <p>{@link #create()} registers one {@link SettingDescriptor} per
+ * setting the application exposes today, grouped under the §3.3
+ * category/group taxonomy (Audio, Appearance, Project, Recording,
+ * Backups, Key Bindings, Plugins, General — Recording / Backups /
+ * General carry empty placeholder groups that story 308 populates).
+ * The catalogue is metadata only — it renders nothing and changes no
+ * behaviour — and is the data source for the §6.1 search index
+ * (story 306) and the §6.3 import/export profile (story 309).</p>
+ *
+ * <h2>Descriptor population ({@code 20 + DawAction.values().length})</h2>
+ * <ul>
+ *   <li>17 {@code SettingsModel}-backed descriptors — id = the
+ *       {@code Preferences} key. Defaults are read from a scratch
+ *       {@code SettingsModel} over an in-memory
+ *       {@link TransientPreferences} node (an empty node makes every
+ *       getter return the authority's canonical default), and each
+ *       validator delegates to the real setter on that scratch model —
+ *       the existing guard, not a parallel one.</li>
+ *   <li>3 manager-backed descriptors — ids
+ *       {@link ThemeManager#PREF_KEY}, {@link DensityManager#PREF_KEY}
+ *       and {@link MotionManager#PREF_KEY} (referenced, never
+ *       duplicated), the three {@code LIVE} appearance managers of
+ *       stories 277/278/279.</li>
+ *   <li>One {@code KEY_CAPTURE} descriptor per {@link DawAction} — id
+ *       {@code "keybinding." + action.name()} (the
+ *       {@code KeyBindingManager} persistence key format), grouped by
+ *       {@link DawAction.Category} in enum order. Every combination —
+ *       or {@code null}, which clears a binding — is per-value valid;
+ *       conflict rejection ("already assigned to …") is a
+ *       cross-setting concern that stays in
+ *       {@code KeyBindingManager.setBinding}.</li>
+ * </ul>
+ *
+ * <h2>Deliberate exclusions</h2>
+ * <ul>
+ *   <li>{@code appearance.themeId} — a dead legacy key (story 194's
+ *       WCAG JSON registry): no production writer except
+ *       {@code SettingsModel.resetToDefaults()}. The live theme
+ *       authority is {@link ThemeManager#PREF_KEY}
+ *       ({@code "appearance.tokenTheme"}), which <em>is</em>
+ *       catalogued.</li>
+ *   <li>Clock source — live-only engine state via
+ *       {@code AudioEngineController}, never persisted; §3.4 defines
+ *       the id as "the Preferences key or project field", and it has
+ *       none.</li>
+ *   <li>WASAPI exclusive mode — rides the {@code audio.backend} value
+ *       rather than owning a key of its own.</li>
+ * </ul>
+ *
+ * <h2>Localization</h2>
+ *
+ * <p>Labels, descriptions and category/group titles are resolved at
+ * {@link #create()} time through the shared {@code Messages} bundle
+ * (key-fallback {@code msg} idiom); the catalogue passes message keys
+ * internally and hard-codes no display string. Two exceptions by
+ * design: key-binding labels delegate to
+ * {@link DawAction#displayName()} and Key Bindings group titles to
+ * {@link DawAction.Category#displayName()} (the enum authority), and
+ * {@link SettingDescriptor#synonyms() synonyms} are lowercase search
+ * literals (search data, not display strings).</p>
+ *
+ * <h2>Thread-safety</h2>
+ *
+ * <p>Validators are <strong>not</strong> thread-safe: they share the
+ * one scratch model created by {@link #create()} (each test writes it).
+ * Defaults are captured into the descriptor records at build time
+ * <em>before</em> any validator runs, so later validator mutations of
+ * the scratch model are harmless — but concurrent validation is not
+ * supported. FX-thread / test use only.</p>
+ */
+public final class SettingsCatalogue {
+
+    private static final String BUNDLE_NAME =
+            "com.benesquivelmusic.daw.app.i18n.Messages";
+
+    private final List<Category> categories;
+    private final List<SettingDescriptor<?>> descriptors;
+    private final Map<String, SettingDescriptor<?>> descriptorsById;
+
+    private SettingsCatalogue(List<Category> categories) {
+        this.categories = List.copyOf(categories);
+        List<SettingDescriptor<?>> flattened = new ArrayList<>();
+        Map<String, SettingDescriptor<?>> index = new LinkedHashMap<>();
+        for (Category category : this.categories) {
+            for (Group group : category.groups()) {
+                for (SettingDescriptor<?> setting : group.settings()) {
+                    if (index.putIfAbsent(setting.id(), setting) != null) {
+                        throw new IllegalStateException(
+                                "Duplicate setting id: " + setting.id());
+                    }
+                    flattened.add(setting);
+                }
+            }
+        }
+        this.descriptors = List.copyOf(flattened);
+        this.descriptorsById = Collections.unmodifiableMap(index);
+    }
+
+    /**
+     * A §3.3 settings category — an ordered list of groups.
+     *
+     * @param id     the stable category id (e.g. {@code "audio"})
+     * @param title  the resolved, localized category title
+     * @param groups the category's groups in display order
+     */
+    public record Category(String id, String title, List<Group> groups) {}
+
+    /**
+     * A §3.3 settings group — an ordered list of descriptors. Empty
+     * placeholder groups mark taxonomy slots that later stages populate.
+     *
+     * @param id       the stable group id (e.g. {@code "format"})
+     * @param title    the resolved, localized group title
+     * @param settings the group's descriptors in display order
+     */
+    public record Group(String id, String title,
+                        List<SettingDescriptor<?>> settings) {}
+
+    /**
+     * Builds the full catalogue: taxonomy, defaults, validators, and
+     * resolved labels/descriptions. Cheap and I/O-free — the scratch
+     * model writes only to an in-memory {@link TransientPreferences}
+     * node, and device enumeration / disk usage stay off this path.
+     *
+     * @return a fully populated, immutable catalogue
+     */
+    public static SettingsCatalogue create() {
+        ResourceBundle messages =
+                ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
+        TransientPreferences scratchPrefs = new TransientPreferences(null, "");
+        SettingsModel scratch = new SettingsModel(scratchPrefs);
+
+        // Capture every canonical default from the scratch model FIRST —
+        // over an empty node each getter returns the authority's default
+        // (SettingsModel's DEFAULT_* constants are package-private and not
+        // visible here) — so later validator invocations, which mutate the
+        // scratch model, cannot disturb the captured values.
+        double defaultSampleRate = scratch.getSampleRate();
+        int defaultBitDepth = scratch.getBitDepth();
+        int defaultBufferSize = scratch.getBufferSize();
+        var defaultMixPrecision = scratch.getMixPrecision();
+        String defaultBackend = scratch.getAudioBackend();
+        String defaultInputDevice = scratch.getAudioInputDevice();
+        String defaultOutputDevice = scratch.getAudioOutputDevice();
+        boolean defaultLatencyCompensation = scratch.isApplyLatencyCompensation();
+        var defaultSrcQuality = scratch.getSrcQuality();
+        int defaultWorkerPoolSize = scratch.getWorkerPoolSize();
+        double defaultMasterCpuFraction = scratch.getMasterCpuBudgetFraction();
+        int defaultAutoSaveInterval = scratch.getAutoSaveIntervalSeconds();
+        double defaultTempo = scratch.getDefaultTempo();
+        boolean defaultJournaledPersistence = scratch.isUseJournaledPersistence();
+        double defaultUiScale = scratch.getUiScale();
+        String defaultScanPaths = scratch.getPluginScanPaths();
+
+        // The policy persists as a String short-name, but the mapping
+        // (SettingsModel.policyName / parsePolicy) is package-private in
+        // ..app.ui and unreachable here. Derive the canonical name without
+        // duplicating it: round-trip the default policy through the real
+        // setter — which persists policyName(...) into the scratch node —
+        // and read the persisted representation back.
+        scratch.setMasterCpuBudgetPolicy(scratch.getMasterCpuBudgetPolicy());
+        String defaultMasterCpuPolicy = Objects.requireNonNull(
+                scratchPrefs.get("audio.masterCpuBudgetPolicy", null),
+                "scratch setter did not persist the default policy name");
+
+        // ── 1. Audio ─────────────────────────────────────────────────────
+        Group audioFormat = new Group("format",
+                msg(messages, "settings.group.audio.format"), List.of(
+                modelDescriptor(messages, "audio.sampleRate",
+                        List.of("hz", "frequency"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                        defaultSampleRate, scratch::setSampleRate),
+                modelDescriptor(messages, "audio.bitDepth",
+                        List.of("bits", "resolution"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                        defaultBitDepth, scratch::setBitDepth),
+                modelDescriptor(messages, "audio.mixPrecision",
+                        List.of("double", "float", "64-bit"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                        defaultMixPrecision, scratch::setMixPrecision),
+                modelDescriptor(messages, "audio.srcQuality",
+                        List.of("resampling", "conversion"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                        defaultSrcQuality, scratch::setSrcQuality)));
+
+        Group audioDevice = new Group("device",
+                msg(messages, "settings.group.audio.device"), List.of(
+                // The only RESTART_REQUIRED descriptor in the catalogue
+                // (§6.4): switching the driver stack needs an app restart;
+                // every other audio change is an engine re-arm at most.
+                modelDescriptor(messages, "audio.backend",
+                        List.of("asio", "wasapi", "driver"),
+                        ApplyClass.RESTART_REQUIRED, ControlKind.CHOICE,
+                        defaultBackend, scratch::setAudioBackend),
+                modelDescriptor(messages, "audio.inputDevice",
+                        List.of("latency", "device", "interface"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                        defaultInputDevice, scratch::setAudioInputDevice),
+                modelDescriptor(messages, "audio.outputDevice",
+                        List.of("latency", "device", "interface"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                        defaultOutputDevice, scratch::setAudioOutputDevice),
+                modelDescriptor(messages, "audio.bufferSize",
+                        List.of("latency", "frames", "block size"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                        defaultBufferSize, scratch::setBufferSize),
+                // LIVE: the flag is read per-take by the recording
+                // pipeline — no engine re-arm involved.
+                modelDescriptor(messages, "audio.applyLatencyCompensation",
+                        List.of("latency", "compensation"),
+                        ApplyClass.LIVE, ControlKind.TOGGLE,
+                        defaultLatencyCompensation,
+                        scratch::setApplyLatencyCompensation)));
+
+        Group audioPerformance = new Group("performance",
+                msg(messages, "settings.group.audio.performance"), List.of(
+                modelDescriptor(messages, "audio.workerPoolSize",
+                        List.of("threads", "cores", "multicore"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                        defaultWorkerPoolSize, scratch::setWorkerPoolSize),
+                modelDescriptor(messages, "audio.masterCpuBudgetFraction",
+                        List.of("cpu", "performance"),
+                        ApplyClass.ENGINE_RECONFIGURE, ControlKind.SLIDER,
+                        defaultMasterCpuFraction,
+                        scratch::setMasterCpuBudgetFraction),
+                new SettingDescriptor<>("audio.masterCpuBudgetPolicy",
+                        msg(messages, "audio.masterCpuBudgetPolicy.label"),
+                        msg(messages, "audio.masterCpuBudgetPolicy.description"),
+                        List.of("cpu", "performance"),
+                        Scope.AUDIO_DEVICE, ApplyClass.ENGINE_RECONFIGURE,
+                        ControlKind.CHOICE, defaultMasterCpuPolicy,
+                        // The value is the persisted short-name String.
+                        // SettingsModel.parsePolicy is forward-compatible —
+                        // every non-null name resolves to a policy object the
+                        // setter accepts — and setMasterCpuBudgetPolicy's only
+                        // guard is requireNonNull, so the delegated guard chain
+                        // reduces exactly to a non-null check (parsePolicy
+                        // itself is package-private and unreachable here).
+                        Objects::nonNull)));
+
+        // ── 2. Appearance ────────────────────────────────────────────────
+        Group appearanceTheme = new Group("theme",
+                msg(messages, "settings.group.appearance.theme"), List.of(
+                new SettingDescriptor<>(ThemeManager.PREF_KEY,
+                        msg(messages, "appearance.theme.label"),
+                        msg(messages, "appearance.theme.description"),
+                        List.of("dark", "color", "colour"),
+                        Scope.APPLICATION, ApplyClass.LIVE, ControlKind.CHOICE,
+                        ThemeManager.DEFAULT_THEME,
+                        // Mirrors ThemeManager.setActiveTheme's requireNonNull.
+                        Objects::nonNull)));
+
+        Group appearanceDensity = new Group("density",
+                msg(messages, "settings.group.appearance.density"), List.of(
+                new SettingDescriptor<>(DensityManager.PREF_KEY,
+                        msg(messages, "appearance.density.label"),
+                        msg(messages, "appearance.density.description"),
+                        List.of("spacing", "compact", "touch"),
+                        Scope.APPLICATION, ApplyClass.LIVE, ControlKind.CHOICE,
+                        DensityManager.DEFAULT_DENSITY,
+                        // Mirrors DensityManager.setActiveDensity's requireNonNull.
+                        Objects::nonNull)));
+
+        Group appearanceScale = new Group("scale",
+                msg(messages, "settings.group.appearance.scale"), List.of(
+                modelDescriptor(messages, "appearance.uiScale",
+                        List.of("zoom", "scaling", "dpi"),
+                        Scope.APPLICATION, ApplyClass.LIVE, ControlKind.SLIDER,
+                        defaultUiScale, scratch::setUiScale)));
+
+        Group appearanceMotion = new Group("motion",
+                msg(messages, "settings.group.appearance.motion"), List.of(
+                new SettingDescriptor<>(MotionManager.PREF_KEY,
+                        msg(messages, "appearance.reduceMotion.label"),
+                        msg(messages, "appearance.reduceMotion.description"),
+                        List.of("animation", "accessibility"),
+                        Scope.APPLICATION, ApplyClass.LIVE, ControlKind.TOGGLE,
+                        MotionManager.DEFAULT_REDUCE_MOTION,
+                        // MotionManager.setReduceMotion takes a primitive
+                        // boolean — null has no representation there; both
+                        // true and false are always applied.
+                        Objects::nonNull)));
+
+        // ── 3. Project ───────────────────────────────────────────────────
+        Group projectDefaults = new Group("defaults",
+                msg(messages, "settings.group.project.defaults"), List.of(
+                // PROJECT_DEFAULTS dual reach (§3.2): stored as a default
+                // for future projects AND live-applied to the open project
+                // by LiveSettingsApplier — recorded in the description.
+                modelDescriptor(messages, "project.defaultTempo",
+                        List.of("bpm"),
+                        Scope.PROJECT_DEFAULTS, ApplyClass.LIVE, ControlKind.TEXT,
+                        defaultTempo, scratch::setDefaultTempo)));
+
+        Group projectAutosave = new Group("autosave",
+                msg(messages, "settings.group.project.autosave"), List.of(
+                modelDescriptor(messages, "project.autoSaveIntervalSeconds",
+                        List.of("checkpoint"),
+                        Scope.PROJECT_DEFAULTS, ApplyClass.LIVE, ControlKind.CHOICE,
+                        defaultAutoSaveInterval,
+                        scratch::setAutoSaveIntervalSeconds),
+                // LIVE with a documented delay: the persistence coordinator
+                // reads the flag when a project opens, so the change takes
+                // effect on the next project open (no restart involved).
+                modelDescriptor(messages, "project.useJournaledPersistence",
+                        List.of("crash", "recovery", "journal"),
+                        Scope.APPLICATION, ApplyClass.LIVE, ControlKind.TOGGLE,
+                        defaultJournaledPersistence,
+                        scratch::setUseJournaledPersistence)));
+
+        // ── 4./5. Recording & Backups (placeholders — story 308) ─────────
+        Category recording = new Category("recording",
+                msg(messages, "settings.category.recording"), List.of(
+                placeholderGroup(messages, "recording", "metronome"),
+                placeholderGroup(messages, "recording", "clickRouting"),
+                placeholderGroup(messages, "recording", "cueMix")));
+
+        Category backups = new Category("backups",
+                msg(messages, "settings.category.backups"), List.of(
+                placeholderGroup(messages, "backups", "retention"),
+                placeholderGroup(messages, "backups", "diskUsage")));
+
+        // ── 6. Key Bindings — one group per DawAction.Category ───────────
+        String keyBindingDescription =
+                msg(messages, "keyBindings.action.description");
+        // Every combination — or null, which clears the binding — is
+        // per-value valid (KeyBindingManager.setBinding accepts both);
+        // conflict rejection is cross-setting, not per-value.
+        Predicate<KeyCombination> anyBinding = _ -> true;
+        List<Group> keyBindingGroups = new ArrayList<>();
+        for (DawAction.Category actionCategory : DawAction.Category.values()) {
+            List<SettingDescriptor<?>> bindings = new ArrayList<>();
+            for (DawAction action : DawAction.values()) {
+                if (action.category() == actionCategory) {
+                    bindings.add(new SettingDescriptor<>(
+                            "keybinding." + action.name(),
+                            action.displayName(),
+                            keyBindingDescription,
+                            List.of("shortcut", "hotkey"),
+                            Scope.APPLICATION, ApplyClass.LIVE,
+                            ControlKind.KEY_CAPTURE,
+                            action.defaultBinding(), anyBinding));
+                }
+            }
+            keyBindingGroups.add(new Group(actionCategory.name(),
+                    actionCategory.displayName(), List.copyOf(bindings)));
+        }
+
+        // ── 7. Plugins ───────────────────────────────────────────────────
+        Group pluginsScanPaths = new Group("scanPaths",
+                msg(messages, "settings.group.plugins.scanPaths"), List.of(
+                modelDescriptor(messages, "plugins.scanPaths",
+                        List.of("clap", "folder"),
+                        Scope.APPLICATION, ApplyClass.LIVE, ControlKind.PATH,
+                        defaultScanPaths, scratch::setPluginScanPaths)));
+
+        // ── §3.3 category order ──────────────────────────────────────────
+        return new SettingsCatalogue(List.of(
+                new Category("audio",
+                        msg(messages, "settings.category.audio"),
+                        List.of(audioFormat, audioDevice, audioPerformance)),
+                new Category("appearance",
+                        msg(messages, "settings.category.appearance"),
+                        List.of(appearanceTheme, appearanceDensity,
+                                appearanceScale, appearanceMotion)),
+                new Category("project",
+                        msg(messages, "settings.category.project"),
+                        List.of(projectDefaults, projectAutosave)),
+                recording,
+                backups,
+                new Category("keyBindings",
+                        msg(messages, "settings.category.keyBindings"),
+                        List.copyOf(keyBindingGroups)),
+                new Category("plugins",
+                        msg(messages, "settings.category.plugins"),
+                        List.of(pluginsScanPaths,
+                                placeholderGroup(messages, "plugins", "manager"))),
+                new Category("general",
+                        msg(messages, "settings.category.general"),
+                        List.of(placeholderGroup(messages, "general", "startup"),
+                                placeholderGroup(messages, "general", "language"),
+                                placeholderGroup(messages, "general",
+                                        "resetProfiles")))));
+    }
+
+    /** @return the §3.3 categories in display order (unmodifiable) */
+    public List<Category> categories() {
+        return categories;
+    }
+
+    /** @return every descriptor, flattened in category order (unmodifiable) */
+    public List<SettingDescriptor<?>> descriptors() {
+        return descriptors;
+    }
+
+    /**
+     * Looks a descriptor up by its id.
+     *
+     * @param id the setting id (must not be {@code null})
+     * @return the descriptor, or empty for an unknown id
+     */
+    public Optional<SettingDescriptor<?>> byId(String id) {
+        Objects.requireNonNull(id, "id must not be null");
+        return Optional.ofNullable(descriptorsById.get(id));
+    }
+
+    // ── Build helpers ────────────────────────────────────────────────────
+
+    /**
+     * An audio-scoped {@code SettingsModel}-backed descriptor whose
+     * message keys equal its id and whose validator delegates to the
+     * scratch setter.
+     */
+    private static <T> SettingDescriptor<T> modelDescriptor(
+            ResourceBundle messages, String id, List<String> synonyms,
+            ApplyClass applyClass, ControlKind controlKind,
+            T defaultValue, Consumer<T> scratchSetter) {
+        return modelDescriptor(messages, id, synonyms, Scope.AUDIO_DEVICE,
+                applyClass, controlKind, defaultValue, scratchSetter);
+    }
+
+    /**
+     * A {@code SettingsModel}-backed descriptor: message keys equal the
+     * id ({@code <id>.label} / {@code <id>.description}) and the
+     * validator delegates to the real setter guard on the scratch model
+     * — accepted iff the setter does not throw.
+     */
+    private static <T> SettingDescriptor<T> modelDescriptor(
+            ResourceBundle messages, String id, List<String> synonyms,
+            Scope scope, ApplyClass applyClass, ControlKind controlKind,
+            T defaultValue, Consumer<T> scratchSetter) {
+        return new SettingDescriptor<>(id,
+                msg(messages, id + ".label"),
+                msg(messages, id + ".description"),
+                synonyms, scope, applyClass, controlKind, defaultValue,
+                delegating(scratchSetter));
+    }
+
+    /**
+     * Wraps a scratch-model setter as a per-value validator: the value
+     * is accepted iff the real setter guard does not reject it. Writes
+     * land in the in-memory scratch node only. Not thread-safe (shared
+     * scratch model — see the class Javadoc).
+     */
+    private static <T> Predicate<T> delegating(Consumer<T> scratchSetter) {
+        return value -> {
+            try {
+                scratchSetter.accept(value);
+                return true;
+            } catch (IllegalArgumentException | NullPointerException rejected) {
+                return false;
+            }
+        };
+    }
+
+    /** An empty §3.3 taxonomy slot that a later stage (story 308) populates. */
+    private static Group placeholderGroup(
+            ResourceBundle messages, String categoryId, String groupId) {
+        return new Group(groupId,
+                msg(messages, "settings.group." + categoryId + "." + groupId),
+                List.of());
+    }
+
+    /**
+     * Key-fallback bundle lookup (the {@code DawgDialog#msg} /
+     * {@code ThemeManager#displayName} idiom — returns the key itself
+     * for a missing resource).
+     */
+    private static String msg(ResourceBundle messages, String key) {
+        try {
+            return messages.getString(key);
+        } catch (MissingResourceException missing) {
+            return key;
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/TransientPreferences.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/TransientPreferences.java
@@ -1,0 +1,88 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.prefs.AbstractPreferences;
+
+/**
+ * A purely in-memory {@link AbstractPreferences} node — no backing
+ * store, no I/O, ever (story 305).
+ *
+ * <p>{@link SettingsCatalogue#create()} builds its scratch
+ * {@code SettingsModel} over a root {@code TransientPreferences}
+ * ({@code new TransientPreferences(null, "")}) so that reading canonical
+ * defaults and delegating validators through the real setters neither
+ * touches nor pollutes the user's real preferences store. {@code flush}
+ * and {@code sync} are no-ops; children are further in-memory nodes.</p>
+ *
+ * <p>Thread-safety follows {@link AbstractPreferences}' own locking —
+ * every SPI method below is invoked with the node lock held.</p>
+ */
+final class TransientPreferences extends AbstractPreferences {
+
+    private final TransientPreferences parentNode;
+    private final Map<String, String> values = new HashMap<>();
+    private final Map<String, TransientPreferences> children = new HashMap<>();
+
+    /**
+     * Creates a node under {@code parent} ({@code null} for the root,
+     * whose name must be {@code ""} per the {@link AbstractPreferences}
+     * contract).
+     *
+     * @param parent the parent node, or {@code null} for the root
+     * @param name   the node name ({@code ""} for the root)
+     */
+    TransientPreferences(TransientPreferences parent, String name) {
+        super(parent, name);
+        this.parentNode = parent;
+    }
+
+    @Override
+    protected void putSpi(String key, String value) {
+        values.put(key, value);
+    }
+
+    @Override
+    protected String getSpi(String key) {
+        return values.get(key);
+    }
+
+    @Override
+    protected void removeSpi(String key) {
+        values.remove(key);
+    }
+
+    @Override
+    protected void removeNodeSpi() {
+        values.clear();
+        if (parentNode != null) {
+            parentNode.children.remove(name());
+        }
+    }
+
+    @Override
+    protected String[] keysSpi() {
+        return values.keySet().toArray(String[]::new);
+    }
+
+    @Override
+    protected String[] childrenNamesSpi() {
+        return children.keySet().toArray(String[]::new);
+    }
+
+    @Override
+    protected AbstractPreferences childSpi(String name) {
+        return children.computeIfAbsent(
+                name, childName -> new TransientPreferences(this, childName));
+    }
+
+    @Override
+    protected void syncSpi() {
+        // In-memory only — there is no backing store to synchronize with.
+    }
+
+    @Override
+    protected void flushSpi() {
+        // In-memory only — there is no backing store to flush to.
+    }
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -188,3 +188,87 @@ editor.frame.preset.saveError=Failed to save preset: %s
 # editor frame. Section-scoped prefix per the file convention.
 menu.plugins.external=External
 menu.plugins.external.none=(none installed)
+
+# Settings descriptor catalogue (story 305) -- Settings View Design Book
+# §3.4 / §7 Stage 1. Labels and descriptions for every SettingDescriptor
+# in SettingsCatalogue. Label values are pinned to the exact strings
+# SettingsDialog renders today (minus the trailing colon) so backing the
+# controls with descriptors changes nothing visible. The three manager-
+# backed descriptors (appearance.tokenTheme / appearance.density /
+# appearance.reduceMotion) reuse the existing appearance.*.label keys
+# above; only their .description keys are new here. Key-binding
+# descriptors take their labels from DawAction.displayName() (the enum
+# authority) and share the single keyBindings.action.description key.
+# Section-scoped prefix per the file convention.
+audio.sampleRate.label=Sample Rate (Hz)
+audio.sampleRate.description=Audio engine sample rate in hertz.
+audio.bitDepth.label=Bit Depth
+audio.bitDepth.description=Bits per sample used for recording and playback.
+audio.bufferSize.label=Buffer Size (frames)
+audio.bufferSize.description=Audio buffer size in sample frames; smaller buffers lower latency but cost more CPU.
+audio.mixPrecision.label=Mix Bus Precision
+audio.mixPrecision.description=Internal mix bus precision; 64-bit double matches the summing precision of professional consoles.
+audio.backend.label=Backend
+audio.backend.description=Preferred audio backend driver; leave empty to auto-select the best available.
+audio.inputDevice.label=Input Device
+audio.inputDevice.description=Preferred audio input device; leave empty to use the backend default.
+audio.outputDevice.label=Output Device
+audio.outputDevice.description=Preferred audio output device; leave empty to use the backend default.
+audio.applyLatencyCompensation.label=Apply latency compensation to recorded takes
+audio.applyLatencyCompensation.description=Compensate recorded takes for the driver's reported round-trip latency.
+audio.srcQuality.label=SRC Quality
+audio.srcQuality.description=Sample-rate-conversion quality used when clip and engine rates differ.
+audio.workerPoolSize.label=Worker Pool Size
+audio.workerPoolSize.description=Worker threads for the multi-core audio graph scheduler; 1 disables parallelism.
+audio.masterCpuBudgetFraction.label=Max fraction per block
+audio.masterCpuBudgetFraction.description=Master CPU ceiling per audio block; 1.0 disables the cap.
+audio.masterCpuBudgetPolicy.label=Cascade policy
+audio.masterCpuBudgetPolicy.description=Degradation applied to the highest-CPU tracks when the master CPU ceiling is exceeded.
+project.autoSaveIntervalSeconds.label=Auto-Save Interval (seconds)
+project.autoSaveIntervalSeconds.description=Seconds between automatic saves; stored as a project default and also applied to the open project.
+project.defaultTempo.label=Default Tempo (BPM)
+project.defaultTempo.description=Tempo for new projects in BPM; stored as a project default and also applied to the open project.
+project.useJournaledPersistence.label=Use journaled persistence (write-ahead journal & crash recovery)
+project.useJournaledPersistence.description=Write-ahead journal & crash recovery; takes effect when a project opens.
+appearance.uiScale.label=UI Scale
+appearance.uiScale.description=Scale factor applied to the whole user interface.
+plugins.scanPaths.label=Plugin Scan Paths
+plugins.scanPaths.description=Semicolon-separated folders scanned for installable plugins.
+# Descriptions for the three manager-backed descriptors; their labels
+# are the existing appearance.*.label keys above (stories 277/278/279).
+appearance.theme.description=Colour palette applied live to the whole application.
+appearance.density.description=Global spacing profile controlling padding and row heights.
+appearance.reduceMotion.description=Cut UI transitions to zero while real-time meters, scopes and the playhead stay live.
+# Shared description for every key-binding descriptor; labels come from
+# DawAction.displayName().
+keyBindings.action.description=Keyboard shortcut. Click the field and press a new key combination to reassign.
+# §3.3 category / group titles for the SettingsCatalogue taxonomy. Key
+# Bindings group titles delegate to DawAction.Category.displayName()
+# (the enum authority) and have no keys here.
+settings.category.audio=Audio
+settings.category.appearance=Appearance
+settings.category.project=Project
+settings.category.recording=Recording
+settings.category.backups=Backups
+settings.category.keyBindings=Key Bindings
+settings.category.plugins=Plugins
+settings.category.general=General
+settings.group.audio.format=Format
+settings.group.audio.device=Device
+settings.group.audio.performance=Performance
+settings.group.appearance.theme=Theme
+settings.group.appearance.density=Density
+settings.group.appearance.scale=Scale
+settings.group.appearance.motion=Motion
+settings.group.project.defaults=Defaults
+settings.group.project.autosave=Autosave
+settings.group.recording.metronome=Metronome
+settings.group.recording.clickRouting=Click routing
+settings.group.recording.cueMix=Cue mix
+settings.group.backups.retention=Retention
+settings.group.backups.diskUsage=Disk usage
+settings.group.plugins.scanPaths=Scan paths
+settings.group.plugins.manager=Manager
+settings.group.general.startup=Startup
+settings.group.general.language=Language
+settings.group.general.resetProfiles=Reset & profiles

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SettingsDialogUnchangedTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SettingsDialogUnchangedTest.java
@@ -1,0 +1,310 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.density.DensityMode;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+import com.benesquivelmusic.daw.core.event.DefaultEventBus;
+import com.benesquivelmusic.daw.core.event.EventBusPublisher;
+import com.benesquivelmusic.daw.sdk.event.DispatchMode;
+import com.benesquivelmusic.daw.sdk.event.EventBus;
+import com.benesquivelmusic.daw.sdk.event.UiEvent;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TextField;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Story 305 — the no-UI-change guard. Backing {@code SettingsDialog}'s
+ * labels and the tempo validator with {@code SettingsCatalogue}
+ * descriptors must be invisible: the five tabs keep their exact titles,
+ * every pinned label string still renders byte-identical, Apply still
+ * writes the {@code SettingsModel} with the old silent-drop tempo
+ * semantics, and the well-formed {@link UiEvent.SettingsApplied} publish
+ * (story 294) still fires. If anything here changes, the story is wrong.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class SettingsDialogUnchangedTest {
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    private static SettingsModel newModel() {
+        Preferences prefs = Preferences.userRoot()
+                .node("settingsDialogUnchangedTest_" + System.nanoTime());
+        return new SettingsModel(prefs);
+    }
+
+    /**
+     * Walks a tab-content graph collecting every {@link Labeled} text
+     * (covers both {@code Label} and {@code CheckBox}). {@code ScrollPane}
+     * content is not a child until a skin attaches, so it is followed
+     * explicitly.
+     */
+    private static void collectLabeledTexts(Node node, List<String> into) {
+        if (node == null) {
+            return;
+        }
+        if (node instanceof Labeled labeled && labeled.getText() != null) {
+            into.add(labeled.getText());
+        }
+        if (node instanceof ScrollPane scrollPane) {
+            collectLabeledTexts(scrollPane.getContent(), into);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collectLabeledTexts(child, into);
+            }
+        }
+    }
+
+    private static <T extends Node> void collectInstances(Node node, Class<T> type, List<T> into) {
+        if (node == null) {
+            return;
+        }
+        if (type.isInstance(node)) {
+            into.add(type.cast(node));
+        }
+        if (node instanceof ScrollPane scrollPane) {
+            collectInstances(scrollPane.getContent(), type, into);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collectInstances(child, type, into);
+            }
+        }
+    }
+
+    /** The Project tab carries exactly one {@code TextField}: the tempo field. */
+    private static TextField tempoField(SettingsDialog dialog) {
+        TabPane tabPane = (TabPane) dialog.getDialogPane().getContent();
+        Tab projectTab = tabPane.getTabs().stream()
+                .filter(tab -> "Project".equals(tab.getText()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No Project tab"));
+        List<TextField> fields = new ArrayList<>();
+        collectInstances(projectTab.getContent(), TextField.class, fields);
+        assertThat(fields).as("the Project tab's only TextField is the tempo field").hasSize(1);
+        return fields.get(0);
+    }
+
+    @Test
+    void fiveTabsShouldKeepTheirExactTitlesInOrder() throws Exception {
+        List<String> titles = runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(newModel());
+            TabPane tabPane = (TabPane) dialog.getDialogPane().getContent();
+            return tabPane.getTabs().stream().map(Tab::getText).toList();
+        });
+
+        assertThat(titles).containsExactly(
+                "Audio", "Project", "Appearance", "Key Bindings", "Plugins");
+    }
+
+    @Test
+    void pinnedLabelStringsShouldStillRenderByteIdentical() throws Exception {
+        List<String> texts = runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(newModel());
+            TabPane tabPane = (TabPane) dialog.getDialogPane().getContent();
+            List<String> collected = new ArrayList<>();
+            for (Tab tab : tabPane.getTabs()) {
+                collectLabeledTexts(tab.getContent(), collected);
+            }
+            return collected;
+        });
+
+        assertThat(texts).contains(
+                "Sample Rate (Hz):",
+                "Bit Depth:",
+                "Buffer Size (frames):",
+                "Auto-Save Interval (seconds):",
+                "Default Tempo (BPM):",
+                "Use journaled persistence (write-ahead journal & crash recovery)",
+                "Theme:",
+                "UI Scale:",
+                "Density:",
+                "Reduce Motion",
+                "Plugin Scan Paths:",
+                // The untouched blanket hint — replacing it with per-setting
+                // apply-class truth on screen is story 306/307, not 305.
+                "Changes to audio settings may require a restart.");
+    }
+
+    @Test
+    void applyWithUntouchedControlsShouldKeepModelDefaults() throws Exception {
+        SettingsModel model = runOnFxThread(() -> {
+            SettingsModel m = newModel();
+            SettingsDialog dialog = new SettingsDialog(m);
+            dialog.applySettings();
+            return m;
+        });
+
+        // The controls seed from the live model, so applying without edits
+        // must round-trip the canonical defaults (compared against a fresh
+        // model over an empty node, never literals).
+        SettingsModel defaults = newModel();
+        assertThat(model.getSampleRate()).isEqualTo(defaults.getSampleRate());
+        assertThat(model.getBitDepth()).isEqualTo(defaults.getBitDepth());
+        assertThat(model.getBufferSize()).isEqualTo(defaults.getBufferSize());
+        assertThat(model.getAutoSaveIntervalSeconds())
+                .isEqualTo(defaults.getAutoSaveIntervalSeconds());
+        assertThat(model.getDefaultTempo())
+                .isCloseTo(defaults.getDefaultTempo(), within(0.01));
+        assertThat(model.isUseJournaledPersistence())
+                .isEqualTo(defaults.isUseJournaledPersistence());
+        assertThat(model.getUiScale()).isCloseTo(defaults.getUiScale(), within(0.01));
+        assertThat(model.getPluginScanPaths()).isEqualTo(defaults.getPluginScanPaths());
+    }
+
+    @Test
+    void applyShouldStillSilentlyDropOutOfRangeTempo() throws Exception {
+        SettingsModel model = runOnFxThread(() -> {
+            SettingsModel m = newModel();
+            SettingsDialog dialog = new SettingsDialog(m);
+            tempoField(dialog).setText("1000");
+            dialog.applySettings();
+            return m;
+        });
+
+        // The descriptor-validator swap must keep the old semantics: an
+        // out-of-range tempo is dropped silently, the model keeps 120.0.
+        assertThat(model.getDefaultTempo()).isCloseTo(120.0, within(0.01));
+    }
+
+    @Test
+    void applyShouldStillSilentlyDropNaNTempo() throws Exception {
+        SettingsModel model = runOnFxThread(() -> {
+            SettingsModel m = newModel();
+            SettingsDialog dialog = new SettingsDialog(m);
+            tempoField(dialog).setText("NaN");
+            dialog.applySettings();
+            return m;
+        });
+
+        // The setter guard's range comparisons are both false for NaN, so
+        // it cannot reject it — the call site must. Pre-305 the inline
+        // range check dropped NaN silently; the model keeps 120.0.
+        assertThat(model.getDefaultTempo()).isCloseTo(120.0, within(0.01));
+    }
+
+    @Test
+    void applyShouldStillWriteInRangeTempo() throws Exception {
+        SettingsModel model = runOnFxThread(() -> {
+            SettingsModel m = newModel();
+            SettingsDialog dialog = new SettingsDialog(m);
+            tempoField(dialog).setText("150");
+            dialog.applySettings();
+            return m;
+        });
+
+        assertThat(model.getDefaultTempo()).isCloseTo(150.0, within(0.01));
+    }
+
+    /**
+     * The story-294 producer contract must survive the label wiring: Apply
+     * still publishes one well-formed {@link UiEvent.SettingsApplied} with
+     * the manager-seeded values (the EventBus-swap capture idiom from
+     * {@code SettingsDialogTest#applySettingsPublishesWellFormedSettingsAppliedEvent}).
+     */
+    @Test
+    void applyShouldStillPublishWellFormedSettingsAppliedEvent() throws Exception {
+        EventBus previous = EventBusPublisher.getDefault();
+        // ON_UI_THREAD subscribers run inline on the publish thread — no
+        // toolkit needed for the capture.
+        DefaultEventBus bus = DefaultEventBus.builder().uiExecutor(Runnable::run).build();
+        AtomicReference<UiEvent.SettingsApplied> captured = new AtomicReference<>();
+        bus.on(UiEvent.SettingsApplied.class, DispatchMode.ON_UI_THREAD, captured::set);
+        EventBusPublisher.setDefault(bus);
+
+        AtomicReference<String> expectedTheme = new AtomicReference<>();
+        AtomicReference<String> expectedDensity = new AtomicReference<>();
+        AtomicBoolean expectedMotion = new AtomicBoolean();
+        try {
+            runOnFxThread(() -> {
+                // The dialog seeds its controls from the live managers;
+                // capture those exact values so the assertions can't drift.
+                expectedTheme.set(ThemeManager.getDefault().getActiveTheme().name());
+                expectedDensity.set(DensityManager.getDefault().getActiveDensity().name());
+                expectedMotion.set(MotionManager.getDefault().isReduceMotion());
+
+                SettingsDialog dialog = new SettingsDialog(newModel());
+                dialog.applySettings();
+                return null;
+            });
+
+            // Delivery is async on a bus worker thread — poll the capture.
+            waitUntil(() -> captured.get() != null);
+            UiEvent.SettingsApplied event = captured.get();
+            assertThat(event)
+                    .as("applySettings still publishes a SettingsApplied event")
+                    .isNotNull();
+            assertThat(event.timestamp()).isNotNull();
+            assertThat(event.themeId()).isEqualTo(expectedTheme.get());
+            assertThat(event.densityId()).isEqualTo(expectedDensity.get());
+            assertThat(event.reduceMotion()).isEqualTo(expectedMotion.get());
+            // Right record order: themeId parses as a Theme, densityId as a
+            // DensityMode — an arg swap fails here.
+            assertThat(ThemeManager.Theme.valueOf(event.themeId())).isNotNull();
+            assertThat(DensityMode.valueOf(event.densityId())).isNotNull();
+        } finally {
+            EventBusPublisher.setDefault(previous);
+            bus.close();
+        }
+    }
+
+    /** Polls {@code condition} up to five seconds; returns as soon as it holds. */
+    private static void waitUntil(BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/DescriptorEnumsAreCanonicalTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/DescriptorEnumsAreCanonicalTest.java
@@ -1,0 +1,60 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 305 — sentinel against vocabulary drift (the {@code DawViewTest}
+ * enum-shape idiom): {@link Scope} has exactly the four §3.2 values,
+ * {@link ApplyClass} exactly the three §6.4 values, and
+ * {@link ControlKind} exactly the seven §3.4 values, each in the book's
+ * documented order. Later stages never invent a synonym.
+ */
+class DescriptorEnumsAreCanonicalTest {
+
+    @Test
+    void scopeShouldHaveExactlyTheFourBookValuesInOrder() {
+        assertThat(Scope.values()).hasSize(4);
+        assertThat(Scope.values())
+                .containsExactly(Scope.APPLICATION, Scope.PROJECT_DEFAULTS,
+                        Scope.THIS_PROJECT, Scope.AUDIO_DEVICE);
+    }
+
+    @Test
+    void applyClassShouldHaveExactlyTheThreeBookValuesInOrder() {
+        assertThat(ApplyClass.values()).hasSize(3);
+        assertThat(ApplyClass.values())
+                .containsExactly(ApplyClass.LIVE, ApplyClass.ENGINE_RECONFIGURE,
+                        ApplyClass.RESTART_REQUIRED);
+    }
+
+    @Test
+    void controlKindShouldHaveExactlyTheSevenBookValuesInOrder() {
+        assertThat(ControlKind.values()).hasSize(7);
+        assertThat(ControlKind.values())
+                .containsExactly(ControlKind.TOGGLE, ControlKind.CHOICE,
+                        ControlKind.SLIDER, ControlKind.STEPPER, ControlKind.TEXT,
+                        ControlKind.PATH, ControlKind.KEY_CAPTURE);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Scope.class)
+    void scopeValueOfShouldRoundTrip(Scope scope) {
+        assertThat(Scope.valueOf(scope.name())).isEqualTo(scope);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplyClass.class)
+    void applyClassValueOfShouldRoundTrip(ApplyClass applyClass) {
+        assertThat(ApplyClass.valueOf(applyClass.name())).isEqualTo(applyClass);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ControlKind.class)
+    void controlKindValueOfShouldRoundTrip(ControlKind controlKind) {
+        assertThat(ControlKind.valueOf(controlKind.name())).isEqualTo(controlKind);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ScopeAndApplyClassAssignmentTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ScopeAndApplyClassAssignmentTest.java
@@ -1,0 +1,126 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 305 — locks the pinned §3.2 scope and §6.4 apply-class
+ * assignments so the metadata is correct, not placeholder: the
+ * project-defaults dual-reach pair, the single {@code RESTART_REQUIRED}
+ * backend descriptor (replacing the audio tab's blanket restart hint
+ * with per-setting truth), the engine-reconfigure audio set, the four
+ * {@code LIVE} appearance settings, and the uniform key-binding shape.
+ */
+class ScopeAndApplyClassAssignmentTest {
+
+    private final SettingsCatalogue catalogue = SettingsCatalogue.create();
+
+    private SettingDescriptor<?> descriptor(String id) {
+        return catalogue.byId(id).orElseThrow(
+                () -> new AssertionError("No descriptor for setting: " + id));
+    }
+
+    private Scope scopeOf(String id) {
+        return descriptor(id).scope();
+    }
+
+    private ApplyClass applyClassOf(String id) {
+        return descriptor(id).applyClass();
+    }
+
+    @Test
+    void projectDefaultsScopeShouldCoverTempoAndAutoSave() {
+        // §3.2 dual reach: stored as project defaults, also live-applied to
+        // the open project by LiveSettingsApplier — the tag records where
+        // the value is stored.
+        assertThat(scopeOf("project.defaultTempo")).isEqualTo(Scope.PROJECT_DEFAULTS);
+        assertThat(scopeOf("project.autoSaveIntervalSeconds"))
+                .isEqualTo(Scope.PROJECT_DEFAULTS);
+    }
+
+    @Test
+    void applicationScopeShouldCoverAppearancePluginsAndJournalSettings() {
+        assertThat(scopeOf(ThemeManager.PREF_KEY)).isEqualTo(Scope.APPLICATION);
+        assertThat(scopeOf(DensityManager.PREF_KEY)).isEqualTo(Scope.APPLICATION);
+        assertThat(scopeOf(MotionManager.PREF_KEY)).isEqualTo(Scope.APPLICATION);
+        assertThat(scopeOf("appearance.uiScale")).isEqualTo(Scope.APPLICATION);
+        assertThat(scopeOf("plugins.scanPaths")).isEqualTo(Scope.APPLICATION);
+        assertThat(scopeOf("project.useJournaledPersistence")).isEqualTo(Scope.APPLICATION);
+    }
+
+    @Test
+    void allTwelveAudioDescriptorsShouldBeAudioDeviceScope() {
+        List<SettingDescriptor<?>> audioDescriptors = catalogue.descriptors().stream()
+                .filter(descriptor -> descriptor.id().startsWith("audio."))
+                .toList();
+        assertThat(audioDescriptors).hasSize(12);
+        assertThat(audioDescriptors)
+                .allSatisfy(descriptor -> assertThat(descriptor.scope())
+                        .as("scope of %s", descriptor.id())
+                        .isEqualTo(Scope.AUDIO_DEVICE));
+    }
+
+    @Test
+    void noDescriptorShouldCarryThisProjectScopeYet() {
+        // THIS_PROJECT exists per §3.2 canon; no setting reaches only the
+        // open project today.
+        assertThat(catalogue.descriptors())
+                .noneMatch(descriptor -> descriptor.scope() == Scope.THIS_PROJECT);
+    }
+
+    @Test
+    void backendShouldBeTheOnlyRestartRequiredDescriptor() {
+        assertThat(applyClassOf("audio.backend")).isEqualTo(ApplyClass.RESTART_REQUIRED);
+        assertThat(catalogue.descriptors().stream()
+                .filter(descriptor -> descriptor.applyClass() == ApplyClass.RESTART_REQUIRED)
+                .map(SettingDescriptor::id))
+                .as("exactly one RESTART_REQUIRED descriptor in the whole catalogue")
+                .containsExactly("audio.backend");
+    }
+
+    @Test
+    void engineReconfigureShouldCoverThePinnedAudioSettings() {
+        // "Takes effect on the next engine restart" in the SettingsModel
+        // Javadocs = a stream re-arm, not an application restart.
+        assertThat(applyClassOf("audio.sampleRate")).isEqualTo(ApplyClass.ENGINE_RECONFIGURE);
+        assertThat(applyClassOf("audio.bufferSize")).isEqualTo(ApplyClass.ENGINE_RECONFIGURE);
+        assertThat(applyClassOf("audio.srcQuality")).isEqualTo(ApplyClass.ENGINE_RECONFIGURE);
+        assertThat(applyClassOf("audio.workerPoolSize"))
+                .isEqualTo(ApplyClass.ENGINE_RECONFIGURE);
+    }
+
+    @Test
+    void liveApplyClassShouldCoverTheFourAppearanceSettings() {
+        assertThat(applyClassOf(ThemeManager.PREF_KEY)).isEqualTo(ApplyClass.LIVE);
+        assertThat(applyClassOf(DensityManager.PREF_KEY)).isEqualTo(ApplyClass.LIVE);
+        assertThat(applyClassOf(MotionManager.PREF_KEY)).isEqualTo(ApplyClass.LIVE);
+        assertThat(applyClassOf("appearance.uiScale")).isEqualTo(ApplyClass.LIVE);
+    }
+
+    @Test
+    void everyKeyBindingDescriptorShouldBeApplicationLiveKeyCapture() {
+        List<SettingDescriptor<?>> bindings = catalogue.descriptors().stream()
+                .filter(descriptor -> descriptor.id().startsWith("keybinding."))
+                .toList();
+        // Non-empty guard: an id-format drift must not pass vacuously.
+        assertThat(bindings).isNotEmpty();
+        assertThat(bindings).allSatisfy(descriptor -> {
+            assertThat(descriptor.scope())
+                    .as("scope of %s", descriptor.id())
+                    .isEqualTo(Scope.APPLICATION);
+            assertThat(descriptor.applyClass())
+                    .as("apply class of %s", descriptor.id())
+                    .isEqualTo(ApplyClass.LIVE);
+            assertThat(descriptor.controlKind())
+                    .as("control kind of %s", descriptor.id())
+                    .isEqualTo(ControlKind.KEY_CAPTURE);
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/SettingDescriptorTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/SettingDescriptorTest.java
@@ -1,0 +1,218 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.SettingsModel;
+import com.benesquivelmusic.daw.sdk.audio.MixPrecision;
+import com.benesquivelmusic.daw.sdk.audio.SampleRateConverter.QualityTier;
+import com.benesquivelmusic.daw.sdk.audio.performance.DegradationPolicy;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story 305 — proves each {@link SettingDescriptor}'s validator delegates
+ * to the canonical {@code SettingsModel} setter guard rather than a
+ * parallel re-implementation: for every {@code SettingsModel}-backed
+ * descriptor and a table of accept/reject candidates,
+ * {@code descriptor.accepts(v)} must equal "the real setter does not
+ * throw for {@code v}". Also pins the record's nine-field §3.4 shape,
+ * the defensive synonyms copy, and that descriptor defaults equal the
+ * authority's defaults (a fresh model over an empty node).
+ */
+class SettingDescriptorTest {
+
+    private static Preferences isolatedNode() {
+        return Preferences.userRoot().node("settingDescriptorTest_" + System.nanoTime());
+    }
+
+    /**
+     * One invoker per SettingsModel-backed descriptor id, calling the
+     * REAL setter on the given model with an untyped candidate.
+     */
+    private static Map<String, Consumer<Object>> settersById(SettingsModel model) {
+        Map<String, Consumer<Object>> setters = new LinkedHashMap<>();
+        setters.put("audio.sampleRate", v -> model.setSampleRate((Double) v));
+        setters.put("audio.bitDepth", v -> model.setBitDepth((Integer) v));
+        setters.put("audio.bufferSize", v -> model.setBufferSize((Integer) v));
+        setters.put("audio.mixPrecision", v -> model.setMixPrecision((MixPrecision) v));
+        setters.put("audio.backend", v -> model.setAudioBackend((String) v));
+        setters.put("audio.inputDevice", v -> model.setAudioInputDevice((String) v));
+        setters.put("audio.outputDevice", v -> model.setAudioOutputDevice((String) v));
+        setters.put("audio.applyLatencyCompensation",
+                v -> model.setApplyLatencyCompensation((Boolean) v));
+        setters.put("audio.srcQuality", v -> model.setSrcQuality((QualityTier) v));
+        setters.put("audio.workerPoolSize", v -> model.setWorkerPoolSize((Integer) v));
+        setters.put("audio.masterCpuBudgetFraction",
+                v -> model.setMasterCpuBudgetFraction((Double) v));
+        // The descriptor's value is the persisted policy short-name String.
+        // SettingsModel.parsePolicy (package-private, unreachable here) maps
+        // every non-null name to a policy object the setter accepts, so the
+        // real guard chain sees null iff the name is null — mirror exactly
+        // that: null name -> null policy (requireNonNull rejects), non-null
+        // name -> a policy instance (accepted).
+        setters.put("audio.masterCpuBudgetPolicy", v -> model.setMasterCpuBudgetPolicy(
+                v == null ? null : new DegradationPolicy.DoNothing()));
+        setters.put("project.autoSaveIntervalSeconds",
+                v -> model.setAutoSaveIntervalSeconds((Integer) v));
+        setters.put("project.defaultTempo", v -> model.setDefaultTempo((Double) v));
+        setters.put("project.useJournaledPersistence",
+                v -> model.setUseJournaledPersistence((Boolean) v));
+        setters.put("appearance.uiScale", v -> model.setUiScale((Double) v));
+        setters.put("plugins.scanPaths", v -> model.setPluginScanPaths((String) v));
+        return setters;
+    }
+
+    /**
+     * The accept/reject candidate table per setting. Arrays.asList (not
+     * List.of) because null itself is a candidate for the reference-typed
+     * settings.
+     */
+    private static Map<String, List<Object>> candidatesById() {
+        Map<String, List<Object>> candidates = new LinkedHashMap<>();
+        candidates.put("audio.sampleRate", Arrays.asList(44_100.0, 96_000.0, 0.0, -1.0));
+        candidates.put("audio.bitDepth", Arrays.asList(16, 0));
+        candidates.put("audio.bufferSize", Arrays.asList(256, -256));
+        candidates.put("audio.mixPrecision", Arrays.asList(MixPrecision.FLOAT_32, null));
+        candidates.put("audio.backend", Arrays.asList("ASIO", null));
+        candidates.put("audio.inputDevice", Arrays.asList("USB Interface", null));
+        candidates.put("audio.outputDevice", Arrays.asList("Main Out", null));
+        candidates.put("audio.applyLatencyCompensation", Arrays.asList(true, false));
+        candidates.put("audio.srcQuality", Arrays.asList(QualityTier.HIGH, null));
+        candidates.put("audio.workerPoolSize", Arrays.asList(1, 0));
+        candidates.put("audio.masterCpuBudgetFraction",
+                Arrays.asList(0.5, 1.0, 0.0, 1.5, Double.NaN));
+        candidates.put("audio.masterCpuBudgetPolicy", Arrays.asList("DoNothing", null));
+        candidates.put("project.autoSaveIntervalSeconds", Arrays.asList(30, 0));
+        candidates.put("project.defaultTempo",
+                Arrays.asList(20.0, 999.0, 19.9, 999.1, 1000.0));
+        candidates.put("project.useJournaledPersistence", Arrays.asList(true, false));
+        candidates.put("appearance.uiScale", Arrays.asList(0.5, 3.0, 0.49, 3.01));
+        candidates.put("plugins.scanPaths", Arrays.asList("C:\\plugins;D:\\vst", null));
+        return candidates;
+    }
+
+    private static boolean setterAccepts(Consumer<Object> setter, Object candidate) {
+        try {
+            setter.accept(candidate);
+            return true;
+        } catch (IllegalArgumentException | NullPointerException rejected) {
+            return false;
+        }
+    }
+
+    @Test
+    void validatorShouldMatchTheCanonicalSetterGuardForEveryCandidate() {
+        SettingsCatalogue catalogue = SettingsCatalogue.create();
+        SettingsModel model = new SettingsModel(isolatedNode());
+        Map<String, Consumer<Object>> setters = settersById(model);
+        Map<String, List<Object>> candidates = candidatesById();
+        // Non-empty guard: the table must cover all 17 SettingsModel-backed
+        // descriptors, so a silently shrunken table cannot green-wash this.
+        assertThat(candidates).hasSize(17);
+        assertThat(candidates.keySet()).isEqualTo(setters.keySet());
+
+        for (Map.Entry<String, List<Object>> entry : candidates.entrySet()) {
+            String id = entry.getKey();
+            SettingDescriptor<?> descriptor = catalogue.byId(id).orElseThrow(
+                    () -> new AssertionError("No descriptor for setting: " + id));
+            Consumer<Object> setter = setters.get(id);
+            for (Object candidate : entry.getValue()) {
+                boolean expected = setterAccepts(setter, candidate);
+                assertThat(descriptor.accepts(candidate))
+                        .as("%s.accepts(%s) must equal the real setter guard (%s)",
+                                id, candidate, expected)
+                        .isEqualTo(expected);
+            }
+        }
+    }
+
+    @Test
+    void synonymsShouldBeDefensivelyCopiedAndImmutable() {
+        List<String> source = new ArrayList<>(List.of("latency", "frames"));
+        SettingDescriptor<Integer> descriptor = new SettingDescriptor<>(
+                "test.bufferSize", "Buffer Size", "A test descriptor.", source,
+                Scope.AUDIO_DEVICE, ApplyClass.ENGINE_RECONFIGURE, ControlKind.CHOICE,
+                256, value -> value > 0);
+
+        source.add("mutated-after-construction");
+
+        assertThat(descriptor.synonyms())
+                .as("mutating the source list must not reach the descriptor")
+                .containsExactly("latency", "frames");
+        assertThatThrownBy(() -> descriptor.synonyms().add("nope"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void recordShouldHaveExactlyTheNineBookComponentsInOrder() {
+        RecordComponent[] components = SettingDescriptor.class.getRecordComponents();
+        assertThat(components).hasSize(9);
+        assertThat(Arrays.stream(components).map(RecordComponent::getName))
+                .containsExactly("id", "label", "description", "synonyms",
+                        "scope", "applyClass", "controlKind", "defaultValue", "validator");
+    }
+
+    @Test
+    void descriptorDefaultsShouldEqualTheCanonicalModelDefaults() {
+        SettingsCatalogue catalogue = SettingsCatalogue.create();
+        Preferences emptyNode = isolatedNode();
+        SettingsModel fresh = new SettingsModel(emptyNode);
+
+        Map<String, Object> expectedById = new LinkedHashMap<>();
+        expectedById.put("audio.sampleRate", fresh.getSampleRate());
+        expectedById.put("audio.bitDepth", fresh.getBitDepth());
+        expectedById.put("audio.bufferSize", fresh.getBufferSize());
+        expectedById.put("audio.mixPrecision", fresh.getMixPrecision());
+        expectedById.put("audio.backend", fresh.getAudioBackend());
+        expectedById.put("audio.inputDevice", fresh.getAudioInputDevice());
+        expectedById.put("audio.outputDevice", fresh.getAudioOutputDevice());
+        expectedById.put("audio.applyLatencyCompensation",
+                fresh.isApplyLatencyCompensation());
+        expectedById.put("audio.srcQuality", fresh.getSrcQuality());
+        // Machine-dependent (derived from availableProcessors()) — compare
+        // against the getter, never a literal.
+        expectedById.put("audio.workerPoolSize", fresh.getWorkerPoolSize());
+        expectedById.put("audio.masterCpuBudgetFraction",
+                fresh.getMasterCpuBudgetFraction());
+        expectedById.put("audio.masterCpuBudgetPolicy",
+                canonicalPolicyName(fresh, emptyNode));
+        expectedById.put("project.autoSaveIntervalSeconds",
+                fresh.getAutoSaveIntervalSeconds());
+        expectedById.put("project.defaultTempo", fresh.getDefaultTempo());
+        expectedById.put("project.useJournaledPersistence",
+                fresh.isUseJournaledPersistence());
+        expectedById.put("appearance.uiScale", fresh.getUiScale());
+        expectedById.put("plugins.scanPaths", fresh.getPluginScanPaths());
+        assertThat(expectedById).hasSize(17);
+
+        for (Map.Entry<String, Object> expected : expectedById.entrySet()) {
+            assertThat(catalogue.byId(expected.getKey()).orElseThrow().defaultValue())
+                    .as("defaultValue of %s", expected.getKey())
+                    .isEqualTo(expected.getValue());
+        }
+    }
+
+    /**
+     * Derives the canonical persisted policy short-name the same way the
+     * catalogue does: round-trip the default policy through the real
+     * setter (which persists {@code SettingsModel.policyName(...)},
+     * package-private in {@code ..app.ui}) and read the persisted
+     * representation back — no duplicated literal.
+     */
+    private static String canonicalPolicyName(SettingsModel fresh, Preferences node) {
+        fresh.setMasterCpuBudgetPolicy(fresh.getMasterCpuBudgetPolicy());
+        String name = node.get("audio.masterCpuBudgetPolicy", null);
+        assertThat(name).as("setter persisted the default policy name").isNotNull();
+        return name;
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/SettingsCatalogueCompletenessTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/SettingsCatalogueCompletenessTest.java
@@ -1,0 +1,185 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.DawAction;
+import com.benesquivelmusic.daw.app.ui.SettingsModel;
+import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 305 — closes the §1.2 split-catalogue gap structurally: every
+ * user-facing {@code SettingsModel} preferences key (reflected from the
+ * class's {@code KEY_*} constants, so a newly added key without a
+ * descriptor fails the build), the three manager-backed appearance keys,
+ * and one key-binding descriptor per {@link DawAction} must all be
+ * present in {@link SettingsCatalogue}, under the pinned §3.3 taxonomy.
+ *
+ * <p>The single documented exclusion is {@code appearance.themeId} — a
+ * dead legacy key whose live replacement is
+ * {@link ThemeManager#PREF_KEY} (see the catalogue's Javadoc).</p>
+ */
+class SettingsCatalogueCompletenessTest {
+
+    private static final String EXCLUDED_DEAD_THEME_KEY = "appearance.themeId";
+
+    private final SettingsCatalogue catalogue = SettingsCatalogue.create();
+
+    /**
+     * Reflects every {@code static final String KEY_*} constant off
+     * {@code SettingsModel}. Same-module deep reflection — always
+     * permitted regardless of {@code opens} directives.
+     */
+    private static Set<String> reflectedSettingsModelKeys() throws IllegalAccessException {
+        Set<String> keys = new TreeSet<>();
+        for (Field field : SettingsModel.class.getDeclaredFields()) {
+            if (field.getName().startsWith("KEY_")
+                    && Modifier.isStatic(field.getModifiers())
+                    && Modifier.isFinal(field.getModifiers())
+                    && field.getType() == String.class) {
+                field.setAccessible(true);
+                keys.add((String) field.get(null));
+            }
+        }
+        return keys;
+    }
+
+    private static Set<String> managerKeys() {
+        return Set.of(ThemeManager.PREF_KEY, DensityManager.PREF_KEY, MotionManager.PREF_KEY);
+    }
+
+    private SettingsCatalogue.Category categoryById(String id) {
+        return catalogue.categories().stream()
+                .filter(category -> category.id().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No category with id: " + id));
+    }
+
+    @Test
+    void everySettingsModelKeyShouldHaveExactlyOneDescriptor() throws IllegalAccessException {
+        Set<String> reflectedKeys = reflectedSettingsModelKeys();
+        // Non-empty guard: an accidental rename of the KEY_ convention must
+        // not let this test pass vacuously.
+        assertThat(reflectedKeys).isNotEmpty();
+        reflectedKeys.remove(EXCLUDED_DEAD_THEME_KEY);
+
+        Set<String> modelBackedIds = catalogue.descriptors().stream()
+                .map(SettingDescriptor::id)
+                .filter(id -> !id.startsWith("keybinding."))
+                .filter(id -> !managerKeys().contains(id))
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        assertThat(modelBackedIds)
+                .as("SettingsModel-backed descriptor ids must be exactly the reflected "
+                        + "KEY_* set minus the documented %s exclusion — a new "
+                        + "SettingsModel key without a descriptor fails here",
+                        EXCLUDED_DEAD_THEME_KEY)
+                .containsExactlyInAnyOrderElementsOf(reflectedKeys);
+    }
+
+    @Test
+    void deadThemeIdKeyShouldBeExcludedInFavourOfTheLiveThemeKey() {
+        assertThat(catalogue.byId(EXCLUDED_DEAD_THEME_KEY))
+                .as("the dead legacy theme key must not be catalogued")
+                .isEmpty();
+        assertThat(catalogue.byId(ThemeManager.PREF_KEY))
+                .as("the live theme authority key must be catalogued")
+                .isPresent();
+    }
+
+    @Test
+    void managerBackedDescriptorsShouldBePresent() {
+        assertThat(catalogue.byId(ThemeManager.PREF_KEY)).isPresent();
+        assertThat(catalogue.byId(DensityManager.PREF_KEY)).isPresent();
+        assertThat(catalogue.byId(MotionManager.PREF_KEY)).isPresent();
+    }
+
+    @Test
+    void everyDawActionShouldHaveExactlyOneKeyCaptureDescriptor() {
+        for (DawAction action : DawAction.values()) {
+            String id = "keybinding." + action.name();
+            SettingDescriptor<?> descriptor = catalogue.byId(id).orElseThrow(
+                    () -> new AssertionError("No key-binding descriptor for " + action));
+            assertThat(descriptor.controlKind())
+                    .as("control kind of %s", id)
+                    .isEqualTo(ControlKind.KEY_CAPTURE);
+        }
+        long keyCaptureCount = catalogue.descriptors().stream()
+                .filter(descriptor -> descriptor.controlKind() == ControlKind.KEY_CAPTURE)
+                .count();
+        assertThat(keyCaptureCount)
+                .as("exactly one KEY_CAPTURE descriptor per DawAction")
+                .isEqualTo(DawAction.values().length);
+    }
+
+    @Test
+    void allIdsShouldBeUniqueAndTheTotalCountPinned() {
+        List<String> ids = catalogue.descriptors().stream()
+                .map(SettingDescriptor::id)
+                .toList();
+        assertThat(ids).doesNotHaveDuplicates();
+        // 17 SettingsModel-backed + 3 manager-backed + one per DawAction.
+        assertThat(catalogue.descriptors())
+                .hasSize(20 + DawAction.values().length);
+    }
+
+    @Test
+    void categoriesShouldFollowTheBookOrder() {
+        assertThat(catalogue.categories())
+                .extracting(SettingsCatalogue.Category::id)
+                .containsExactly("audio", "appearance", "project", "recording",
+                        "backups", "keyBindings", "plugins", "general");
+    }
+
+    @Test
+    void placeholderCategoriesShouldCarryTheirEmptyGroups() {
+        SettingsCatalogue.Category recording = categoryById("recording");
+        assertThat(recording.groups())
+                .extracting(SettingsCatalogue.Group::id)
+                .containsExactly("metronome", "clickRouting", "cueMix");
+        SettingsCatalogue.Category backups = categoryById("backups");
+        assertThat(backups.groups())
+                .extracting(SettingsCatalogue.Group::id)
+                .containsExactly("retention", "diskUsage");
+        SettingsCatalogue.Category general = categoryById("general");
+        assertThat(general.groups())
+                .extracting(SettingsCatalogue.Group::id)
+                .containsExactly("startup", "language", "resetProfiles");
+
+        for (SettingsCatalogue.Category category : List.of(recording, backups, general)) {
+            for (SettingsCatalogue.Group group : category.groups()) {
+                assertThat(group.settings())
+                        .as("placeholder group %s.%s stays empty until story 308",
+                                category.id(), group.id())
+                        .isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void keyBindingGroupsShouldMatchDawActionCategoryEnumOrder() {
+        SettingsCatalogue.Category keyBindings = categoryById("keyBindings");
+        assertThat(keyBindings.groups())
+                .extracting(SettingsCatalogue.Group::id)
+                .containsExactlyElementsOf(Arrays.stream(DawAction.Category.values())
+                        .map(Enum::name)
+                        .toList());
+        // Group titles delegate to the enum authority, not the bundle.
+        assertThat(keyBindings.groups())
+                .extracting(SettingsCatalogue.Group::title)
+                .containsExactlyElementsOf(Arrays.stream(DawAction.Category.values())
+                        .map(DawAction.Category::displayName)
+                        .toList());
+    }
+}


### PR DESCRIPTION
# Setting Descriptor Model Backing the Existing SettingsDialog (No UI Change)

## Motivation

The Settings View Design Book (`docs/design/SETTINGS_VIEW_DESIGN_BOOK.md`) opens its migration path (§7) with one deliberately invisible stage: introduce the §3.4 *setting descriptor* and back the controls already in `SettingsDialog` with it, changing nothing the user sees. This is the load-bearing seam — search (§6.1), four-level reset (§5.7), import/export (§6.3), and the scope/apply-class labels (§3.2, §6.4) are all generic *over* the descriptor. Without it, every later stage special-cases each pane by hand — precisely the trap §1.5 documents (each pane re-invents its own row idiom and inline styles).

This story exists because three book §1 problems are unfixable until a uniform per-setting metadata record exists, even though none of them is *visibly* fixed here:

- **§1.2 — the model is wider than the view.** `SettingsModel` persists `mixPrecision`, `audioBackend`, `audioInputDevice`, `audioOutputDevice`, `applyLatencyCompensation`, `srcQuality`, `workerPoolSize`, `masterCpuBudgetFraction`, `masterCpuBudgetPolicy` (book §1.2) that the main dialog never shows. There is no single index of "everything you can configure". A descriptor catalogue is that index.
- **§1.6 — apply semantics are mixed and unexplained.** Theme/density/motion are live; the audio tab carries a blanket "Changes to audio settings may require a restart." hint (`SettingsDialog.java:312-315`). Nothing records, per setting, which of the three apply classes (§6.4) it belongs to. The descriptor's `apply class` field is where that truth lives.
- **§1.8 — scope is invisible.** App vs. project-defaults vs. this-project vs. audio-device is mixed on one tab with no cue. The descriptor's `scope` field (§3.2) records the reach so later stages can surface it.

Per §7 Stage 1 and Appendix A, this is a pure additive seam: `SettingsModel` over `Preferences` stays the single source of truth, the `TabPane` stays, the validating setters stay, the localization `MESSAGES`/`msg(...)` seam stays. We add a metadata layer *beside* the existing controls, not a view rework.

## Goals

- **A `SettingDescriptor` record (§3.4).** Introduce an immutable descriptor carrying the nine §3.4 fields: `id`/key (the `Preferences` key or project field), `label` (localized), `description`, `synonyms` (extra search terms), `scope` (§3.2), `applyClass` (§6.4), `controlKind` (toggle / choice / slider / stepper / text / path / key-capture), `default`, and a `validator` that delegates to the existing `SettingsModel` setter guard. Model it as a Java `record` (with `List<String> synonyms` defensively copied) so it is a transparent data carrier, not a bean.
- **A `Scope` enum and an `ApplyClass` enum, one name per thing.** Exactly four scopes — `APPLICATION`, `PROJECT_DEFAULTS`, `THIS_PROJECT`, `AUDIO_DEVICE` (§3.2) — and exactly three apply classes — `LIVE`, `ENGINE_RECONFIGURE`, `RESTART_REQUIRED` (§6.4). These are the canonical vocabulary the whole surface uses (per `research-daw` §4, one name per thing); no later stage invents a synonym.
- **A `SettingsCatalogue` that registers every current setting as a descriptor.** Build the catalogue covering every control the existing `SettingsDialog` *and* `AudioSettingsDialog` expose today (so §1.2's hidden audio settings are catalogued even though their dialog is untouched here). Group descriptors under the §3.3 category/group taxonomy (Audio ▸ Format/Device/Performance, Appearance ▸ Theme/Density/Scale/Motion, Project ▸ Defaults/Autosave, Key Bindings grouped by `DawAction.Category`, Plugins, plus placeholders for Recording/Backups/General that later stages populate). The catalogue is the §6.1 search index's data source even though search ships in story 306.
- **Back the existing controls with descriptors, with no behavioural change.** Each control the dialog builds today resolves its label/default/validator *through* its descriptor instead of from inline literals, so the descriptor — not the call site — owns that metadata. The dialog still reads/writes `SettingsModel` exactly as before; Apply still calls the same `applySettings()` path; the live managers still fire unchanged. A screenshot before and after this story is pixel-identical.
- **Scope and apply-class metadata are correct, not placeholder.** `defaultTempo` and `autoSaveIntervalSeconds` are tagged `PROJECT_DEFAULTS` (the §3.2 note: stored as project-defaults, also live-applied to the open project by `LiveSettingsApplier` — the tag records the dual reach without changing the stored value). `audioBackend` is `RESTART_REQUIRED`; sample rate / buffer size / SRC quality / worker pool are `ENGINE_RECONFIGURE` (most audio changes are reconfigure, not restart — §6.4); theme/density/motion/UI-scale are `LIVE`.
- Tests:
  - `SettingDescriptorTest` (new): a descriptor's `validator` accepts the values the matching `SettingsModel` setter accepts and rejects what it rejects (proves the descriptor reuses the existing guard, not a parallel one — per `feedback_test_only_callers_are_not_live_usage.md`, validate against the canonical setter).
  - `SettingsCatalogueCompletenessTest` (new): every user-facing `SettingsModel` key (the keys named in §1.2 plus the dialog's existing keys) has exactly one descriptor; assert the count and key set so a newly added `SettingsModel` key without a descriptor fails the build (closes §1.2's split-catalogue gap structurally).
  - `ScopeAndApplyClassAssignmentTest` (new): `defaultTempo`/`autoSaveIntervalSeconds` are `PROJECT_DEFAULTS`; `audioBackend` is `RESTART_REQUIRED`; sample rate/buffer/SRC/worker-pool are `ENGINE_RECONFIGURE`; theme/density/motion/scale are `LIVE`.
  - `SettingsDialogUnchangedTest` (new): the existing `SettingsDialogTest` assertions still pass — the dialog still builds its five tabs, still writes `SettingsModel` on Apply, still triggers the live managers. (No new visible node; this is the no-UI-change guard.)
  - `DescriptorEnumsAreCanonicalTest` (new): `Scope` has exactly the four §3.2 values and `ApplyClass` exactly the three §6.4 values, in the documented order (sentinel against vocabulary drift, mirroring the `DawViewTest`/`DawActionTest` enum-shape guards per `feedback_dawview_enum_propagation.md`).

## Non-Goals

- **No visible UI change whatsoever.** No rail, no search box, no per-setting reset, no scope label on screen — those are stories 306+. This stage is the invisible seam (§7 Stage 1). If anything renders differently, the story is wrong.
- **No new persisted values and no `Preferences` schema change.** The descriptor *describes* existing keys; it does not add, rename, or migrate any (Appendix A: "Annotate each key with a scope; no stored-value change").
- **No change to `SettingsModel`'s setters or `LiveSettingsApplier`.** Both are explicitly "keep" (§1.10); the descriptor's `validator` delegates *to* the setter, it does not replace it.
- **No absorbing of the four dialogs.** `AudioSettingsDialog`, `MetronomeSettingsDialog`, and `BackupSettingsDialog` still open from their old entry points; their settings are *catalogued* (audio especially, per §1.2) but their views are untouched until stories 307/308.
- **No search index UI, no import/export, no first-run wizard.** Those consume the catalogue in stories 306 and 309; here the catalogue merely exists and is correct.
- **No `Control`/`Skin` work.** The generic setting row (§5.4, a `Control` + `Skin` per `javafx-application-design` §3) arrives with the shell in story 306; Stage 1 keeps today's ad-hoc `GridPane` rows.

## Technical Notes

- Files: new `daw-app/.../ui/settings/SettingDescriptor.java` (the §3.4 record), `daw-app/.../ui/settings/Scope.java` and `ApplyClass.java` (the §3.2/§6.4 enums), `daw-app/.../ui/settings/SettingsCatalogue.java` (registers every descriptor under the §3.3 taxonomy); edits to `daw-app/.../ui/SettingsDialog.java` to resolve each control's label/default/validator through its descriptor. `daw-app/.../ui/SettingsModel.java` (`public final class SettingsModel`, line 17) and `daw-app/.../ui/LiveSettingsApplier.java` (package-private `final class LiveSettingsApplier`, line 23) are read-only here. All in package `com.benesquivelmusic.daw.app.ui`.
- The four dialogs the book unifies (line numbers are locators — grep before editing): `daw-app/.../ui/SettingsDialog.java` (`public final class SettingsDialog extends DawgDialog<Void>`, line 42; the 5-tab `TabPane`), `daw-app/.../ui/AudioSettingsDialog.java` (`extends DawgDialog<Void>`, line 64), `daw-app/.../ui/MetronomeSettingsDialog.java` (`extends Dialog<MetronomeSettingsDialog.Result>`, line 60), `daw-app/.../ui/BackupSettingsDialog.java` (`extends DawgDialog<BackupRetentionPolicy>`, line 49). This story touches only the first two; the latter two are catalogued in later stages.
- The catalogue is the data source for the §6.1 search index (story 306) and the §6.3 import/export profile (story 309), so build it open-time-cheap (a `List<SettingDescriptor>` keyed by id) with no I/O — device enumeration and disk usage stay off this path and off the FX thread (§2.7/§6.6) in their own stages.
- Keep the catalogue JavaFX-light: the descriptor record itself holds no `Node`. Per `daw-core` staying JavaFX-free, the descriptor + catalogue live in `daw-app`; they reference `Preferences` keys (strings) and validator lambdas, not scene graph. State the descriptor's `validator` as a `Predicate`/throwing-`Consumer` over the typed value, mirroring the existing setter signature.
- Apply-class assignment must reflect §6.4's honest contract, not today's blanket hint: the always-on "may require a restart" string (`SettingsDialog.java:312`, with its inline `-fx-text-fill: #ff9100; -fx-font-size: 10px;` at line 314 — book rejection #2/#4) is *not* introduced into the descriptor as a universal flag — only `audioBackend` carries `RESTART_REQUIRED`. The visible banner that consumes this (§5.6) lands in stories 306/307; here it is metadata only.
- Control-Sync cross-reference: the apply → event → live-manager flow is specified in `docs/design/CONTROL_SYNCHRONIZATION_DESIGN_BOOK.md`, which names `SettingsVM` (per-key value + scope, line 301/594), `SettingsApplied`/`ThemeChanged` (the event the live managers subscribe to, lines 595/623/639), and explicitly maps the Settings book's restart-class contract to "an event payload field" (line 639). **Important:** those `SettingsVM`/`SettingsApplied` types are **not yet in the source tree** — they are owned by **story 294** (migrate the settings surface onto the shared wiring), itself a spec like this story (no `.java` file references them yet). This story therefore does **not** depend on them — it leaves the live-manager Apply path exactly as `SettingsDialog` has it today, and story 294 can later re-home the catalogue's Apply onto a `SettingsApplied` event without re-touching the descriptor.
- The localization seam (`MESSAGES = ResourceBundle.getBundle(... Messages, Locale.ROOT)`, `SettingsDialog.java:71-72`, book §1.10) is reused to resolve each descriptor's `label`/`description`; do not hard-code display strings in the catalogue — pass message keys.
- SKILL refs: `javafx-application-design` §4 (express scope/apply-class/modified as `Property`-friendly metadata so the story-306 row can bind to them), §15 (anti-patterns — do not let the descriptor become a god-object that also renders). `research-daw` §4 (one name per thing — the `Scope`/`ApplyClass` vocabulary). `java-26.agent.md` Project Amber (model the descriptor as a `record`).
- Reference: Settings View Design Book §3.4 (descriptor), §3.2 (scope), §6.4 (apply classes), §7 Stage 1, Appendix A (code mapping), §1.2/§1.6/§1.8 (the catalogued problems). Sibling stories: 306 (the Rail & Pane shell that first renders these descriptors), 307/308 (the dialogs whose settings this catalogue already indexes), 277/278/279 (`ThemeManager`/`DensityManager`/`MotionManager` — the `LIVE` apply-class managers, unchanged), 098 (audio engine configuration UI — the engine-reconfigure path these descriptors tag), 244 (backup settings dialog — catalogued in story 308), 010 (keyboard shortcuts — the Key Bindings category descriptors), 260 (semantic tokens — consumed when the rows render in 306).
