### PR TITLE
306-rail-and-pane-settings-shell-with-search-and-per-setting-reset

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -2,46 +2,71 @@ package com.benesquivelmusic.daw.app.ui;
 
 import com.benesquivelmusic.daw.app.ui.density.DensityManager;
 import com.benesquivelmusic.daw.app.ui.density.DensityMode;
-import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
-import com.benesquivelmusic.daw.app.ui.icons.DawIcon;
-import com.benesquivelmusic.daw.app.ui.icons.IconNode;
+import com.benesquivelmusic.daw.app.ui.icons.DawgIcon;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.settings.SettingDescriptor;
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
 import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.event.EventBusPublisher;
+import com.benesquivelmusic.daw.sdk.audio.MixPrecision;
+import com.benesquivelmusic.daw.sdk.audio.SampleRateConverter.QualityTier;
 import com.benesquivelmusic.daw.sdk.event.UiEvent;
-import javafx.geometry.Insets;
+
+import javafx.event.ActionEvent;
 import javafx.scene.Node;
-import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
 import javafx.scene.input.KeyCombination;
-import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
 
 import java.time.Instant;
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.ResourceBundle;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
- * Modal dialog for configuring application settings.
+ * Modal dialog for configuring application settings — the story-306
+ * Rail &amp; Pane shell over the story-305 descriptor catalogue
+ * (Settings View Design Book §4.A, §7 Stage 2).
  *
- * <p>Provides tabbed sections for Audio, Project, Appearance,
- * Key Bindings, and Plugins configuration. Settings are persisted
- * through the supplied {@link SettingsModel} using the Java
- * {@link java.util.prefs.Preferences} API.</p>
+ * <p>The old {@code TabPane} body is gone: the dialog's content is one
+ * {@link SettingsShell} rendering <em>every</em> catalogue descriptor
+ * through generic {@link SettingRow}s, with always-on search (§6.1),
+ * per-setting reset (§5.7 tier 1) and a generalised dirty/apply model
+ * (§6.2). This class owns exactly what the shell cannot: the persisted
+ * read path ({@link SettingsShell.ValueAccess} over {@link SettingsModel}
+ * and the three live managers), the per-descriptor render hints, and the
+ * write path {@link #applySettings()} — which writes through the SAME
+ * authorities as before (model setters, {@code KeyBindingManager}
+ * clear-all-then-set, the unconditional {@link UiEvent.SettingsApplied}
+ * publish of story 294).</p>
  *
- * <p>An optional {@link SettingsChangeListener} can be registered to receive
- * a callback after settings are applied, allowing the caller to propagate
- * changes to the running audio engine, transport, UI, or other subsystems.</p>
+ * <p>An optional {@link SettingsChangeListener} can be registered to
+ * receive a callback after settings are applied, allowing the caller to
+ * propagate changes to the running audio engine, transport, UI, or other
+ * subsystems.</p>
  *
- * <p>Uses the {@link DawIcon} icon pack for all tab and header graphics.</p>
+ * <h2>Close paths (§6.2)</h2>
+ *
+ * <p>The shell owns the visible Cancel / Apply / OK footer; the dialog
+ * keeps one hidden {@code ButtonType.CANCEL} so Esc/[X] still close.
+ * Every close path — footer Cancel, the hidden cancel button, and the
+ * window close request — routes through the same dirty guard: with
+ * pending edits, an Apply / Discard / Cancel prompt runs first (the
+ * {@link #setDirtyClosePrompt(Supplier)} seam replaces the modal in
+ * headless tests).</p>
  */
 public final class SettingsDialog extends DawgDialog<Void> {
 
@@ -62,8 +87,10 @@ public final class SettingsDialog extends DawgDialog<Void> {
         void onSettingsChanged(SettingsModel model);
     }
 
-    private static final double HEADER_ICON_SIZE = 18;
-    private static final double TAB_ICON_SIZE = 14;
+    /** The §6.2 dirty-close prompt outcomes (Apply / Discard / Cancel). */
+    enum DirtyChoice { APPLY, DISCARD, CANCEL }
+
+    private static final String KEYBINDING_PREFIX = "keybinding.";
 
     /**
      * Resource bundle for localized strings (Skill §14) — uses
@@ -77,60 +104,46 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
     private final SettingsModel model;
 
-    // Story 305 — the dialog resolves label / default / validator metadata
-    // through the settings catalogue (Settings View Design Book §7 Stage 1)
-    // instead of inline literals; SettingsModel stays the write path.
+    // Story 305 — descriptor metadata (labels / defaults / validators)
+    // comes from the settings catalogue; SettingsModel stays the write path.
     private final SettingsCatalogue catalogue;
+
+    // Captured-once manager singletons (stories 277/278/279) — the
+    // project rule: capture a swappable singleton reference at
+    // construction, never re-resolve getDefault() per use.
+    private final ThemeManager themeManager;
+    private final DensityManager densityManager;
+    private final MotionManager motionManager;
+
+    private final SettingsShell shell;
 
     // ── Callback ─────────────────────────────────────────────────────────────
     private SettingsChangeListener settingsChangeListener;
     private AudioEngineController audioEngineController;
-    private Button openAudioDeviceDialogButton;
+    private final Button openAudioDeviceDialogButton;
 
-    // ── Audio tab controls ───────────────────────────────────────────────────
-    private final ComboBox<String> sampleRateCombo;
-    private final ComboBox<String> bitDepthCombo;
-    private final ComboBox<String> bufferSizeCombo;
-
-    // ── Project tab controls ─────────────────────────────────────────────────
-    private final ComboBox<String> autoSaveCombo;
-    private final TextField tempoField;
-
-    // ── Appearance tab controls ──────────────────────────────────────────────
-    private final Slider uiScaleSlider;
-    private final Label uiScaleValueLabel;
-    private final ThemeManager themeManager;
-    private final ComboBox<ThemeManager.Theme> themeCombo;
-    // Story 278 — global density chooser (UI Design Book §3.7). Three
-    // radio buttons in a ToggleGroup (the story explicitly specifies
-    // radio buttons, NOT the Theme ComboBox idiom). DensityManager
-    // persists under its own key and live-applies to every registered
-    // scene/dialog-pane, exactly like ThemeManager.
-    private final DensityManager densityManager;
-    private final ToggleGroup densityGroup;
-    private final Map<DensityMode, RadioButton> densityButtons =
-            new EnumMap<>(DensityMode.class);
-    // Story 279 — global Reduce Motion accessibility flag (UI Design Book
-    // §2.7 / §3.5). A single checkbox; MotionManager persists under its
-    // own key and is a pure observable flag (no scene re-apply).
-    private final MotionManager motionManager;
-    private final CheckBox reduceMotionCheck;
-
-    // ── Project tab controls ─────────────────────────────────────────────────
     /**
-     * Story 298 — "Use journaled persistence (write-ahead journal &amp; crash
-     * recovery)". Mirrors the {@code reduceMotionCheck} idiom: a single checkbox
-     * seeded from + written to the {@link SettingsModel}. Default OFF (§7
-     * Stage&nbsp;4 "ships behind a preference for one release").
+     * The §6.2 dirty-close prompt. Defaults to a real three-button modal
+     * ({@link #promptDirtyClose()}); headless tests inject a stub via
+     * {@link #setDirtyClosePrompt(Supplier)}.
      */
-    private final CheckBox journaledPersistenceCheck;
+    private Supplier<DirtyChoice> dirtyClosePrompt = this::promptDirtyClose;
 
-    // ── Plugins tab controls ─────────────────────────────────────────────────
-    private final TextField pluginScanPathsField;
-
-    // ── Key Bindings tab state ───────────────────────────────────────────────
-    private final Map<DawAction, TextField> keyBindingFields = new EnumMap<>(DawAction.class);
-    private final Map<DawAction, KeyCombination> pendingBindings = new EnumMap<>(DawAction.class);
+    /**
+     * The appearance values the last {@link #applySettings()} published.
+     * The story-294 {@link UiEvent.SettingsApplied} publish is delivered
+     * asynchronously (the managers subscribe {@code ON_UI_THREAD}, i.e. a
+     * later FX pulse), so ThemeManager/DensityManager/MotionManager still
+     * hold pre-apply state when the synchronous post-apply
+     * {@code shell.refreshFromPersisted()} re-seeds the rows. These fields
+     * make {@link #currentPersistedValue(String)} authoritative for what
+     * this dialog just published — without them the edited appearance rows
+     * would visibly snap back to the stale manager values on Apply. The
+     * manager getters remain the fallback before the first Apply.
+     */
+    private ThemeManager.Theme lastAppliedTheme;
+    private DensityMode lastAppliedDensity;
+    private Boolean lastAppliedReduceMotion;
 
     /**
      * Creates a new settings dialog backed by the given model.
@@ -140,149 +153,73 @@ public final class SettingsDialog extends DawgDialog<Void> {
     public SettingsDialog(SettingsModel model) {
         this.model = model;
         catalogue = SettingsCatalogue.create();
+        themeManager = ThemeManager.getDefault();
+        densityManager = DensityManager.getDefault();
+        motionManager = MotionManager.getDefault();
 
         setTitle("Settings");
         setHeaderText("Application Preferences");
-        setGraphic(IconNode.of(DawIcon.SETTINGS, 24));
+        // DawgIcon (Lucide) replaces the legacy IconNode/DawIcon graphics
+        // (UI Design Book §3.6); a non-null header graphic also keeps
+        // DawgDialog's close glyph retracted.
+        setGraphic(DawgIcon.of("settings", DawgIcon.Size.SIZE_24));
 
-        // ── Audio tab ────────────────────────────────────────────────────────
-        sampleRateCombo = new ComboBox<>();
-        sampleRateCombo.getItems().addAll("44100", "48000", "88200", "96000", "176400", "192000");
-        sampleRateCombo.setValue(String.valueOf((int) model.getSampleRate()));
+        // The kept Audio-category trailing node (story-306 non-goal: the
+        // Audio Device Settings dialog is absorbed in story 307).
+        openAudioDeviceDialogButton = new Button("Audio Device Settings…");
+        openAudioDeviceDialogButton.setGraphic(
+                DawgIcon.of("headphones", DawgIcon.Size.SIZE_16));
+        openAudioDeviceDialogButton.getStyleClass().addAll("dawg-button", "size-default");
+        openAudioDeviceDialogButton.setDisable(audioEngineController == null);
+        openAudioDeviceDialogButton.setOnAction(_ -> openAudioDeviceDialog());
 
-        bitDepthCombo = new ComboBox<>();
-        bitDepthCombo.getItems().addAll("16", "24", "32");
-        bitDepthCombo.setValue(String.valueOf(model.getBitDepth()));
+        shell = new SettingsShell(catalogue,
+                this::currentPersistedValue,
+                buildControlHints(),
+                Map.of("audio", openAudioDeviceDialogButton));
 
-        bufferSizeCombo = new ComboBox<>();
-        bufferSizeCombo.getItems().addAll("64", "128", "256", "512", "1024", "2048");
-        bufferSizeCombo.setValue(String.valueOf(model.getBufferSize()));
-
-        Tab audioTab = new Tab("Audio", buildAudioPane());
-        audioTab.setGraphic(IconNode.of(DawIcon.HEADPHONES, TAB_ICON_SIZE));
-        audioTab.setClosable(false);
-
-        // ── Project tab ──────────────────────────────────────────────────────
-        autoSaveCombo = new ComboBox<>();
-        autoSaveCombo.getItems().addAll("30", "60", "120", "300", "600");
-        autoSaveCombo.setValue(String.valueOf(model.getAutoSaveIntervalSeconds()));
-
-        tempoField = new TextField(String.format("%.1f", model.getDefaultTempo()));
-
-        // Story 298 — journaled persistence toggle, seeded from the model.
-        journaledPersistenceCheck = new CheckBox(
-                settingLabel("project.useJournaledPersistence"));
-        journaledPersistenceCheck.setSelected(model.isUseJournaledPersistence());
-
-        Tab projectTab = new Tab("Project", buildProjectPane());
-        projectTab.setGraphic(IconNode.of(DawIcon.FOLDER, TAB_ICON_SIZE));
-        projectTab.setClosable(false);
-
-        // ── Appearance tab ───────────────────────────────────────────────────
-        uiScaleSlider = new Slider(0.5, 3.0, model.getUiScale());
-        uiScaleSlider.setMajorTickUnit(0.5);
-        uiScaleSlider.setMinorTickCount(4);
-        uiScaleSlider.setShowTickLabels(true);
-        uiScaleSlider.setShowTickMarks(true);
-
-        uiScaleValueLabel = new Label(String.format("%.1fx", model.getUiScale()));
-        uiScaleValueLabel.getStyleClass().add("numeric-value");
-        uiScaleSlider.valueProperty().addListener((_, _, newVal) ->
-                uiScaleValueLabel.setText(String.format("%.1fx", newVal.doubleValue())));
-
-        // Story 277 — token-theme chooser (UI Design Book §3.1 / §6
-        // Phase 3). Distinct from story 194's WCAG JSON theme registry;
-        // ThemeManager persists under its own preferences key. The combo
-        // shows the three design-book palettes by localized display name.
-        themeManager = ThemeManager.getDefault();
-        themeCombo = new ComboBox<>();
-        themeCombo.getItems().addAll(ThemeManager.Theme.values());
-        themeCombo.setValue(themeManager.getActiveTheme());
-        themeCombo.setConverter(new StringConverter<>() {
-            @Override
-            public String toString(ThemeManager.Theme theme) {
-                return theme == null ? "" : ThemeManager.displayName(theme);
-            }
-
-            @Override
-            public ThemeManager.Theme fromString(String string) {
-                // Display-only converter: the combo is non-editable, so
-                // JavaFX should never invoke fromString. Returning
-                // DEFAULT_THEME is the safest fallback — it can never be
-                // null, whereas themeCombo.getValue() could return null if
-                // JavaFX invokes fromString before setValue during early
-                // accessibility queries or a styling pass triggered by
-                // the converter being set. If the combo is ever made
-                // editable, a real reverse lookup over the items must be
-                // added here.
-                return ThemeManager.DEFAULT_THEME;
+        shell.setOnApply(this::applySettings);
+        shell.setOnOk(() -> {
+            applySettings();
+            closeShell();
+        });
+        shell.setOnCancel(() -> {
+            if (confirmClose()) {
+                closeShell();
             }
         });
 
-        // Story 278 — density chooser. Three radio buttons in one
-        // ToggleGroup, localized via DensityManager.displayName; the one
-        // matching the current active density is pre-selected. Each
-        // button's userData carries its DensityMode for applySettings().
-        densityManager = DensityManager.getDefault();
-        densityGroup = new ToggleGroup();
-        DensityMode activeDensity = densityManager.getActiveDensity();
-        for (DensityMode mode : DensityMode.values()) {
-            RadioButton rb = new RadioButton(DensityManager.displayName(mode));
-            rb.setToggleGroup(densityGroup);
-            rb.setUserData(mode);
-            rb.setSelected(mode == activeDensity);
-            densityButtons.put(mode, rb);
-        }
+        getDialogPane().setContent(shell);
+        // story 276 §5.9 width bands — the shell needs the LARGE band
+        // (800); its pref height rides on .settings-shell in styles.css.
+        sized(DawgDialog.Size.LARGE);
 
-        // Story 279 — Reduce Motion checkbox. MotionManager persists under
-        // its own key; the checkbox reflects the current flag and is
-        // applied in applySettings(). A tooltip restates the WCAG 2.3.3
-        // intent (cut transitions, keep real-time meters).
-        motionManager = MotionManager.getDefault();
-        reduceMotionCheck = new CheckBox(settingLabel(MotionManager.PREF_KEY));
-        reduceMotionCheck.setSelected(motionManager.isReduceMotion());
-        reduceMotionCheck.setTooltip(
-                new Tooltip(msg("appearance.reduceMotion.tooltip")));
-
-        Tab appearanceTab = new Tab("Appearance", buildAppearancePane());
-        appearanceTab.setGraphic(IconNode.of(DawIcon.MONITOR, TAB_ICON_SIZE));
-        appearanceTab.setClosable(false);
-
-        // ── Key Bindings tab ─────────────────────────────────────────────────
-        Tab keyBindingsTab = new Tab("Key Bindings", buildKeyBindingsPane());
-        keyBindingsTab.setGraphic(IconNode.of(DawIcon.KEYBOARD, TAB_ICON_SIZE));
-        keyBindingsTab.setClosable(false);
-
-        // ── Plugins tab ──────────────────────────────────────────────────────
-        pluginScanPathsField = new TextField(model.getPluginScanPaths());
-        pluginScanPathsField.setPromptText("/path/to/plugins;/another/path");
-
-        Tab pluginsTab = new Tab("Plugins", buildPluginsPane());
-        pluginsTab.setGraphic(IconNode.of(DawIcon.EQUALIZER, TAB_ICON_SIZE));
-        pluginsTab.setClosable(false);
-
-        // ── Assemble ─────────────────────────────────────────────────────────
-        TabPane tabPane = new TabPane(audioTab, projectTab, appearanceTab, keyBindingsTab, pluginsTab);
-        tabPane.setPrefWidth(520);
-        tabPane.setPrefHeight(340);
-
-        getDialogPane().setContent(tabPane);
-        getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
-        // story 276 — §5.9 width band; flat header / accent primary /
-        // tokenized section-header chrome applied by the DawgDialog
-        // super-constructor. TabPane preserved (Non-Goal).
-        sized(DawgDialog.Size.MEDIUM);
+        // The shell owns the visible footer; ONE hidden CANCEL keeps the
+        // Esc/[X] plumbing alive. Its action is filtered through the same
+        // §6.2 dirty guard so an Esc that fires it cannot bypass the prompt.
+        getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        Button hiddenCancel = (Button) getDialogPane().lookupButton(ButtonType.CANCEL);
+        hiddenCancel.setVisible(false);
+        hiddenCancel.setManaged(false);
+        hiddenCancel.addEventFilter(ActionEvent.ACTION, event -> {
+            if (!confirmClose()) {
+                event.consume();
+            }
+        });
 
         // story 278 — register the dialog pane with DensityManager so the
         // Preferences dialog itself reflects the active density and
         // live-updates when the user selects a different density mode.
         densityManager.applyTo(getDialogPane());
 
-        setResultConverter(button -> {
-            if (button == ButtonType.APPLY) {
-                applySettings();
+        setResultConverter(_ -> null);
+
+        // Window [X] (and any Esc path that surfaces as a close request)
+        // routes through the same dirty guard; CANCEL keeps the dialog open.
+        setOnCloseRequest(event -> {
+            if (!confirmClose()) {
+                event.consume();
             }
-            return null;
         });
     }
 
@@ -304,41 +241,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
      */
     public void setAudioEngineController(AudioEngineController controller) {
         this.audioEngineController = controller;
-        if (openAudioDeviceDialogButton != null) {
-            openAudioDeviceDialogButton.setDisable(controller == null);
-        }
-    }
-
-    // ── Tab builders ─────────────────────────────────────────────────────────
-
-    private Node buildAudioPane() {
-        GridPane grid = createGrid();
-
-        Label header = new Label("Audio Settings");
-        header.setGraphic(IconNode.of(DawIcon.HEADPHONES, HEADER_ICON_SIZE));
-        header.setStyle("-fx-font-weight: bold;");
-
-        grid.add(header, 0, 0, 2, 1);
-        grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label(settingLabel("audio.sampleRate") + ":"), 0, 2);
-        grid.add(sampleRateCombo, 1, 2);
-        grid.add(new Label(settingLabel("audio.bitDepth") + ":"), 0, 3);
-        grid.add(bitDepthCombo, 1, 3);
-        grid.add(new Label(settingLabel("audio.bufferSize") + ":"), 0, 4);
-        grid.add(bufferSizeCombo, 1, 4);
-
-        openAudioDeviceDialogButton = new Button("Audio Device Settings\u2026");
-        openAudioDeviceDialogButton.setGraphic(IconNode.of(DawIcon.HEADPHONES, 12));
-        openAudioDeviceDialogButton.setDisable(audioEngineController == null);
-        openAudioDeviceDialogButton.setOnAction(_ -> openAudioDeviceDialog());
-        grid.add(openAudioDeviceDialogButton, 0, 5, 2, 1);
-
-        Label restartHint = new Label("Changes to audio settings may require a restart.");
-        restartHint.setGraphic(IconNode.of(DawIcon.WARNING, 14));
-        restartHint.setStyle("-fx-text-fill: #ff9100; -fx-font-size: 10px;");
-        grid.add(restartHint, 0, 6, 2, 1);
-
-        return grid;
+        openAudioDeviceDialogButton.setDisable(controller == null);
     }
 
     private void openAudioDeviceDialog() {
@@ -349,380 +252,437 @@ public final class SettingsDialog extends DawgDialog<Void> {
         dialog.initOwner(getDialogPane().getScene() != null
                 ? getDialogPane().getScene().getWindow() : null);
         dialog.showAndWait();
-        // Refresh combo values in case the audio dialog persisted new defaults
-        sampleRateCombo.setValue(String.valueOf((int) model.getSampleRate()));
-        bitDepthCombo.setValue(String.valueOf(model.getBitDepth()));
-        bufferSizeCombo.setValue(String.valueOf(model.getBufferSize()));
+        // The audio dialog may have persisted new values — re-seed every
+        // row from the authorities (replaces the old three-combo refresh).
+        shell.refreshFromPersisted();
     }
 
-    private Node buildProjectPane() {
-        GridPane grid = createGrid();
+    // ── Persisted read path (SettingsShell.ValueAccess) ──────────────────────
 
-        Label header = new Label("Project Defaults");
-        header.setGraphic(IconNode.of(DawIcon.FOLDER, HEADER_ICON_SIZE));
-        header.setStyle("-fx-font-weight: bold;");
-
-        grid.add(header, 0, 0, 2, 1);
-        grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label(settingLabel("project.autoSaveIntervalSeconds") + ":"), 0, 2);
-        grid.add(autoSaveCombo, 1, 2);
-        grid.add(new Label(settingLabel("project.defaultTempo") + ":"), 0, 3);
-        grid.add(tempoField, 1, 3);
-
-        // Story 298 — journaled persistence toggle + a one-line §7-Stage-4
-        // caption ("ships behind a preference for one release"), following the
-        // header/separator/field grid idiom used above.
-        grid.add(new Separator(), 0, 4, 2, 1);
-        grid.add(journaledPersistenceCheck, 0, 5, 2, 1);
-        Label journalCaption = new Label(
-                "Captures every change to a write-ahead journal so unsaved work "
-                        + "survives a crash. Ships behind this preference for one release.");
-        journalCaption.setWrapText(true);
-        journalCaption.setStyle("-fx-text-fill: #808080; -fx-font-size: 10px;");
-        grid.add(journalCaption, 0, 6, 2, 1);
-
-        return grid;
+    /**
+     * The persisted value per descriptor id: {@link SettingsModel}
+     * getters for the 17 model-backed ids, the three live managers for
+     * theme/density/motion (overlaid by {@link #lastAppliedTheme} &amp; co.
+     * once an Apply has published — the managers only catch up on a later
+     * FX pulse), and {@code KeyBindingManager} for the key-binding ids.
+     * The CPU-budget policy reads as its persisted short-name String via
+     * the package-private {@link SettingsModel#policyName} mapper (same
+     * package by design).
+     */
+    private Object currentPersistedValue(String id) {
+        if (id.startsWith(KEYBINDING_PREFIX)) {
+            DawAction action = DawAction.valueOf(id.substring(KEYBINDING_PREFIX.length()));
+            return model.getKeyBindingManager().getBinding(action).orElse(null);
+        }
+        return switch (id) {
+            case "audio.sampleRate" -> model.getSampleRate();
+            case "audio.bitDepth" -> model.getBitDepth();
+            case "audio.bufferSize" -> model.getBufferSize();
+            case "audio.mixPrecision" -> model.getMixPrecision();
+            case "audio.srcQuality" -> model.getSrcQuality();
+            case "audio.backend" -> model.getAudioBackend();
+            case "audio.inputDevice" -> model.getAudioInputDevice();
+            case "audio.outputDevice" -> model.getAudioOutputDevice();
+            case "audio.applyLatencyCompensation" -> model.isApplyLatencyCompensation();
+            case "audio.workerPoolSize" -> model.getWorkerPoolSize();
+            case "audio.masterCpuBudgetFraction" -> model.getMasterCpuBudgetFraction();
+            case "audio.masterCpuBudgetPolicy" ->
+                    SettingsModel.policyName(model.getMasterCpuBudgetPolicy());
+            case "project.autoSaveIntervalSeconds" -> model.getAutoSaveIntervalSeconds();
+            case "project.defaultTempo" -> model.getDefaultTempo();
+            case "project.useJournaledPersistence" -> model.isUseJournaledPersistence();
+            case "appearance.uiScale" -> model.getUiScale();
+            case "plugins.scanPaths" -> model.getPluginScanPaths();
+            // Last-published overlay first: after an Apply the managers
+            // are still one async SettingsApplied delivery behind.
+            case ThemeManager.PREF_KEY -> lastAppliedTheme != null
+                    ? lastAppliedTheme : themeManager.getActiveTheme();
+            case DensityManager.PREF_KEY -> lastAppliedDensity != null
+                    ? lastAppliedDensity : densityManager.getActiveDensity();
+            case MotionManager.PREF_KEY -> lastAppliedReduceMotion != null
+                    ? lastAppliedReduceMotion : motionManager.isReduceMotion();
+            // Defensive: an id this dialog does not know reads as its
+            // catalogue default so the row still renders something sane.
+            default -> catalogue.byId(id)
+                    .map(SettingDescriptor::defaultValue).orElse(null);
+        };
     }
 
-    private Node buildAppearancePane() {
-        GridPane grid = createGrid();
+    // ── Render hints ─────────────────────────────────────────────────────────
 
-        Label header = new Label("Appearance");
-        header.setGraphic(IconNode.of(DawIcon.MONITOR, HEADER_ICON_SIZE));
-        header.setStyle("-fx-font-weight: bold;");
+    /**
+     * Per-descriptor {@link SettingRow.ControlHints}: choice options in
+     * the row's VALUE type (so {@code Objects.equals} works against
+     * persisted values), slider bounds mirroring the setter guards,
+     * display converters, localized apply-class badge text (§6.4), and
+     * the shared ↺ reset graphic factory (§5.7 tier 1).
+     */
+    private Map<String, SettingRow.ControlHints> buildControlHints() {
+        String engineBadge = msg("settings.badge.engineReconfigure");
+        String restartBadge = msg("settings.badge.restartRequired");
+        Supplier<Node> resetGraphic = () -> DawgIcon.of("rotate-ccw", DawgIcon.Size.SIZE_16);
 
-        grid.add(header, 0, 0, 2, 1);
-        grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label(settingLabel(ThemeManager.PREF_KEY) + ":"), 0, 2);
-        grid.add(themeCombo, 1, 2);
-        // Visual separator between the theme chooser (the prominent new
-        // affordance) and the UI-scale row keeps the grouping clear —
-        // mirrors the header/separator/fields pattern used elsewhere in
-        // this dialog.
-        grid.add(new Separator(), 0, 3, 2, 1);
-        grid.add(new Label(settingLabel("appearance.uiScale") + ":"), 0, 4);
-        grid.add(uiScaleSlider, 1, 4);
-        grid.add(uiScaleValueLabel, 2, 4);
-
-        // Story 278 — density chooser (UI Design Book §3.7). Separator +
-        // label + the three radios laid out horizontally, following the
-        // header/separator/field grid idiom used above.
-        grid.add(new Separator(), 0, 5, 2, 1);
-        grid.add(new Label(settingLabel(DensityManager.PREF_KEY) + ":"), 0, 6);
-        HBox densityBox = new HBox(12,
-                densityButtons.get(DensityMode.COMPACT),
-                densityButtons.get(DensityMode.COMFORTABLE),
-                densityButtons.get(DensityMode.TOUCH));
-        grid.add(densityBox, 1, 6, 2, 1);
-
-        // Story 279 — Reduce Motion accessibility checkbox. Separator +
-        // the single checkbox on the next row, following the same grid
-        // idiom as the theme / density rows above.
-        grid.add(new Separator(), 0, 7, 2, 1);
-        grid.add(reduceMotionCheck, 1, 8, 2, 1);
-
-        return grid;
-    }
-
-    private Node buildKeyBindingsPane() {
-        VBox vbox = new VBox(8);
-        vbox.setPadding(new Insets(16));
-
-        Label header = new Label("Key Bindings");
-        header.setGraphic(IconNode.of(DawIcon.KEYBOARD, HEADER_ICON_SIZE));
-        header.setStyle("-fx-font-weight: bold;");
-
-        Label instructions = new Label(
-                "Click a shortcut field and press a new key combination to reassign. "
-                        + "Press Escape in the field to clear the binding.");
-        instructions.setGraphic(IconNode.of(DawIcon.INFO, 14));
-        instructions.setStyle("-fx-text-fill: #808080; -fx-font-size: 10px;");
-        instructions.setWrapText(true);
-
-        // Reset to Defaults button
-        Button resetButton = new Button("Reset to Defaults");
-        resetButton.setOnAction(event -> resetKeyBindingsToDefaults());
-
-        HBox buttonBar = new HBox(resetButton);
-        buttonBar.setPadding(new Insets(4, 0, 4, 0));
-
-        VBox contentBox = new VBox(8);
-
-        KeyBindingManager keyBindingManager = model.getKeyBindingManager();
-
-        // Load current bindings into pending map
-        for (DawAction action : DawAction.values()) {
-            Optional<KeyCombination> current = keyBindingManager.getBinding(action);
-            current.ifPresent(kc -> pendingBindings.put(action, kc));
+        Map<String, SettingRow.ControlHints> hints = new HashMap<>();
+        for (SettingDescriptor<?> descriptor : catalogue.descriptors()) {
+            String id = descriptor.id();
+            String badge = switch (descriptor.applyClass()) {
+                case LIVE -> null; // badge omitted entirely (§6.4)
+                case ENGINE_RECONFIGURE -> engineBadge;
+                case RESTART_REQUIRED -> restartBadge;
+            };
+            hints.put(id, new SettingRow.ControlHints(
+                    choiceOptionsFor(id),
+                    sliderMinFor(id), sliderMaxFor(id),
+                    converterFor(id),
+                    badge, resetGraphic));
         }
-
-        // Build rows grouped by category
-        DawAction.Category currentCategory = null;
-        GridPane grid = null;
-        int row = 0;
-
-        for (DawAction action : DawAction.values()) {
-            if (action.category() != currentCategory) {
-                currentCategory = action.category();
-                if (grid != null) {
-                    contentBox.getChildren().add(grid);
-                }
-                Label categoryLabel = new Label(currentCategory.displayName());
-                categoryLabel.setStyle("-fx-font-weight: bold; -fx-font-size: 11px;");
-                contentBox.getChildren().add(categoryLabel);
-                contentBox.getChildren().add(new Separator());
-                grid = createGrid();
-                row = 0;
-            }
-
-            Label nameLabel = new Label(settingLabel("keybinding." + action.name()) + ":");
-            TextField field = new TextField();
-            field.setEditable(false);
-            field.setPrefWidth(180);
-
-            KeyCombination currentBinding = pendingBindings.get(action);
-            if (currentBinding != null) {
-                field.setText(currentBinding.getDisplayText());
-            }
-
-            field.setOnKeyPressed(event -> handleKeyBindingCapture(action, field, event));
-
-            keyBindingFields.put(action, field);
-
-            grid.add(nameLabel, 0, row);
-            grid.add(field, 1, row);
-            row++;
-        }
-        if (grid != null) {
-            contentBox.getChildren().add(grid);
-        }
-
-        ScrollPane scrollPane = new ScrollPane(contentBox);
-        scrollPane.setFitToWidth(true);
-        VBox.setVgrow(scrollPane, Priority.ALWAYS);
-
-        vbox.getChildren().addAll(header, instructions, buttonBar, new Separator(), scrollPane);
-        return vbox;
+        return hints;
     }
 
     /**
-     * Handles key press events in a key binding capture field.
-     * Modifier-only presses are ignored. Escape clears the binding.
+     * Choice options per id. Backend/input/output devices deliberately
+     * get none (the row shows the current value only — no enumeration
+     * until story 307 absorbs the audio dialog).
      */
-    private void handleKeyBindingCapture(DawAction action, TextField field, KeyEvent event) {
-        event.consume();
-
-        // Ignore modifier-only presses
-        switch (event.getCode()) {
-            case SHIFT, CONTROL, ALT, META, COMMAND, WINDOWS, UNDEFINED:
-                return;
-            default:
-                break;
-        }
-
-        // Escape in the field clears the binding
-        if (event.getCode() == javafx.scene.input.KeyCode.ESCAPE
-                && !event.isControlDown() && !event.isShiftDown()
-                && !event.isAltDown() && !event.isMetaDown()) {
-            pendingBindings.remove(action);
-            field.setText("");
-            field.setStyle("");
-            return;
-        }
-
-        // Build the key combination from the event
-        java.util.List<KeyCombination.Modifier> modifiers = new java.util.ArrayList<>();
-        if (event.isShortcutDown()) {
-            modifiers.add(KeyCombination.SHORTCUT_DOWN);
-        }
-        if (event.isShiftDown()) {
-            modifiers.add(KeyCombination.SHIFT_DOWN);
-        }
-        if (event.isAltDown()) {
-            modifiers.add(KeyCombination.ALT_DOWN);
-        }
-
-        KeyCombination newBinding = new javafx.scene.input.KeyCodeCombination(
-                event.getCode(),
-                modifiers.toArray(new KeyCombination.Modifier[0]));
-
-        // Check for conflicts within pending bindings
-        String conflictName = null;
-        for (Map.Entry<DawAction, KeyCombination> entry : pendingBindings.entrySet()) {
-            if (entry.getKey() != action
-                    && entry.getValue().getName().equals(newBinding.getName())) {
-                conflictName = entry.getKey().displayName();
-                break;
-            }
-        }
-
-        if (conflictName != null) {
-            field.setText(newBinding.getDisplayText() + " (conflict: " + conflictName + ")");
-            field.setStyle("-fx-text-fill: red;");
-        } else {
-            pendingBindings.put(action, newBinding);
-            field.setText(newBinding.getDisplayText());
-            field.setStyle("");
-        }
+    private List<?> choiceOptionsFor(String id) {
+        return switch (id) {
+            case "audio.sampleRate" ->
+                    List.of(44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0);
+            case "audio.bitDepth" -> List.of(16, 24, 32);
+            case "audio.bufferSize" -> List.of(64, 128, 256, 512, 1024, 2048);
+            case "audio.mixPrecision" -> List.of(MixPrecision.values());
+            case "audio.srcQuality" -> List.of(QualityTier.values());
+            // The current value is appended by the row when missing.
+            case "audio.workerPoolSize" -> List.of(1, 2, 4, 6, 8, 12, 16);
+            case "audio.masterCpuBudgetPolicy" -> policyOptions();
+            case "project.autoSaveIntervalSeconds" -> List.of(30, 60, 120, 300, 600);
+            case ThemeManager.PREF_KEY -> List.of(ThemeManager.Theme.values());
+            case DensityManager.PREF_KEY -> List.of(DensityMode.values());
+            default -> null;
+        };
     }
 
-    private void resetKeyBindingsToDefaults() {
-        pendingBindings.clear();
-        for (DawAction action : DawAction.values()) {
-            KeyCombination defaultBinding = action.defaultBinding();
-            TextField field = keyBindingFields.get(action);
-            if (defaultBinding != null) {
-                pendingBindings.put(action, defaultBinding);
-                if (field != null) {
-                    field.setText(defaultBinding.getDisplayText());
-                    field.setStyle("");
-                }
-            } else if (field != null) {
-                field.setText("");
-                field.setStyle("");
-            }
-        }
+    /**
+     * Policy options are the persisted short-name Strings: current +
+     * catalogue default (no full enumeration surface until a later story).
+     */
+    private List<String> policyOptions() {
+        String current = SettingsModel.policyName(model.getMasterCpuBudgetPolicy());
+        String defaultName = (String) catalogue.byId("audio.masterCpuBudgetPolicy")
+                .orElseThrow().defaultValue();
+        return current.equals(defaultName)
+                ? List.of(current)
+                : List.of(current, defaultName);
     }
 
-    private Node buildPluginsPane() {
-        GridPane grid = createGrid();
+    /**
+     * Slider lower bounds: uiScale mirrors the old {@code Slider(0.5, 3.0)}
+     * / the {@code setUiScale} guard; the CPU-budget fraction mirrors the
+     * {@code AudioSettingsDialog} slider's 0.01 floor — the closest
+     * expressible bound to {@code setMasterCpuBudgetFraction}'s exclusive
+     * {@code (0.0, 1.0]} guard (a 0.0 slider stop would be rejected on
+     * Apply).
+     */
+    private static double sliderMinFor(String id) {
+        return switch (id) {
+            case "appearance.uiScale" -> 0.5;
+            case "audio.masterCpuBudgetFraction" -> 0.01;
+            default -> 0;
+        };
+    }
 
-        Label header = new Label("Plugins");
-        header.setGraphic(IconNode.of(DawIcon.EQUALIZER, HEADER_ICON_SIZE));
-        header.setStyle("-fx-font-weight: bold;");
+    /** Slider upper bounds — see {@link #sliderMinFor(String)}. */
+    private static double sliderMaxFor(String id) {
+        return switch (id) {
+            case "appearance.uiScale" -> 3.0;
+            case "audio.masterCpuBudgetFraction" -> 1.0;
+            default -> 1;
+        };
+    }
 
-        grid.add(header, 0, 0, 2, 1);
-        grid.add(new Separator(), 0, 1, 2, 1);
-        grid.add(new Label(settingLabel("plugins.scanPaths") + ":"), 0, 2);
-        grid.add(pluginScanPathsField, 1, 2);
+    /**
+     * Display converters for the choice rows whose value's
+     * {@code toString()} is not presentable: sample rate renders as a
+     * whole number ("44100"), theme/density through their managers'
+     * localized {@code displayName}. Enum-valued rows (mix precision,
+     * SRC quality) read fine as names and get none.
+     */
+    private StringConverter<Object> converterFor(String id) {
+        return switch (id) {
+            case "audio.sampleRate" -> displayConverter(value ->
+                    value instanceof Double d
+                            ? String.valueOf((int) d.doubleValue())
+                            : String.valueOf(value));
+            case ThemeManager.PREF_KEY -> displayConverter(value ->
+                    value instanceof ThemeManager.Theme theme
+                            ? ThemeManager.displayName(theme)
+                            : String.valueOf(value));
+            case DensityManager.PREF_KEY -> displayConverter(value ->
+                    value instanceof DensityMode mode
+                            ? DensityManager.displayName(mode)
+                            : String.valueOf(value));
+            default -> null;
+        };
+    }
 
-        Label hint = new Label("Separate multiple paths with semicolons (;).");
-        hint.setGraphic(IconNode.of(DawIcon.INFO, 14));
-        hint.setStyle("-fx-text-fill: #808080; -fx-font-size: 10px;");
-        grid.add(hint, 0, 3, 2, 1);
+    /** Display-only converter — the combos are non-editable, so {@code fromString} never runs. */
+    private static StringConverter<Object> displayConverter(Function<Object, String> display) {
+        return new StringConverter<>() {
+            @Override
+            public String toString(Object object) {
+                return object == null ? "" : display.apply(object);
+            }
 
-        return grid;
+            @Override
+            public Object fromString(String string) {
+                return null; // display-only; never invoked on a non-editable ComboBox
+            }
+        };
+    }
+
+    // ── Close paths (§6.2) ───────────────────────────────────────────────────
+
+    /**
+     * The shared dirty guard for every close path. Clean → close allowed.
+     * Dirty → runs the (injectable) Apply / Discard / Cancel prompt:
+     * APPLY applies then allows the close, DISCARD drops the pending
+     * edits (no write) then allows it, CANCEL keeps the dialog open.
+     *
+     * <p>APPLY and DISCARD both leave the shell clean on purpose: in
+     * JavaFX 26 {@code Dialog.hide()} delegates to {@code close()},
+     * which re-fires {@code DIALOG_CLOSE_REQUEST} — i.e. this guard runs
+     * again on the actual close. A still-dirty shell would re-prompt;
+     * a clean one falls through immediately.</p>
+     *
+     * @return {@code true} when closing may proceed
+     */
+    private boolean confirmClose() {
+        if (!shell.dirtyProperty().get()) {
+            return true;
+        }
+        DirtyChoice choice = dirtyClosePrompt.get();
+        return switch (choice == null ? DirtyChoice.CANCEL : choice) {
+            case APPLY -> {
+                applySettings();
+                yield true;
+            }
+            case DISCARD -> {
+                // Re-seeding from the untouched authorities IS the
+                // discard — nothing is written to model or managers.
+                shell.refreshFromPersisted();
+                yield true;
+            }
+            case CANCEL -> false;
+        };
+    }
+
+    /** Programmatic close from the shell's footer callbacks. */
+    private void closeShell() {
+        setResult(null);
+        hide();
+    }
+
+    /**
+     * The default §6.2 dirty-close prompt: a real three-button
+     * {@link DawgDialog} modal (Apply / Discard / Cancel). Dismissing the
+     * prompt any other way counts as Cancel (the dialog stays open).
+     */
+    private DirtyChoice promptDirtyClose() {
+        DawgDialog<ButtonType> prompt = new DawgDialog<>();
+        prompt.setTitle(msg("settings.dirtyPrompt.title"));
+        prompt.setHeaderText(msg("settings.dirtyPrompt.header"));
+        ButtonType apply = new ButtonType(msg("dialog.apply"), ButtonBar.ButtonData.OK_DONE);
+        ButtonType discard = new ButtonType(msg("settings.dirtyPrompt.discard"),
+                ButtonBar.ButtonData.NO);
+        ButtonType cancel = new ButtonType(msg("dialog.cancel"),
+                ButtonBar.ButtonData.CANCEL_CLOSE);
+        prompt.getDialogPane().getButtonTypes().setAll(discard, cancel, apply);
+        prompt.setResultConverter(buttonType -> buttonType);
+        prompt.initOwner(getDialogPane().getScene() != null
+                ? getDialogPane().getScene().getWindow() : null);
+        Optional<ButtonType> pressed = prompt.showAndWait();
+        if (pressed.isEmpty()) {
+            return DirtyChoice.CANCEL;
+        }
+        if (pressed.get() == apply) {
+            return DirtyChoice.APPLY;
+        }
+        if (pressed.get() == discard) {
+            return DirtyChoice.DISCARD;
+        }
+        return DirtyChoice.CANCEL;
+    }
+
+    /**
+     * Injects a headless-test replacement for the dirty-close prompt.
+     *
+     * @param prompt the stub prompt (must not be {@code null})
+     */
+    void setDirtyClosePrompt(Supplier<DirtyChoice> prompt) {
+        this.dirtyClosePrompt = Objects.requireNonNull(prompt, "prompt must not be null");
     }
 
     // ── Apply ────────────────────────────────────────────────────────────────
 
     /**
-     * Applies the current dialog control values to the settings model.
+     * Applies the shell's pending edits through the same authorities as
+     * the old tabbed dialog (§6.2 — the manager contract does not
+     * change): model setters for every dirty model-backed id
+     * (write-on-dirty), {@code KeyBindingManager} clear-all-then-set with
+     * the pending-else-persisted effective map, then the UNCONDITIONAL
+     * story-294 {@link UiEvent.SettingsApplied} publish carrying
+     * pending-else-current theme/density/motion, then the
+     * {@link SettingsChangeListener}, then a shell re-seed from the
+     * persisted authorities.
      */
     void applySettings() {
-        // Audio
-        String sampleRateText = sampleRateCombo.getValue();
-        if (sampleRateText != null && !sampleRateText.isBlank()) {
-            model.setSampleRate(Double.parseDouble(sampleRateText));
+        Map<String, Object> pendingEdits = shell.pendingEdits();
+
+        for (Map.Entry<String, Object> edit : pendingEdits.entrySet()) {
+            applyModelSetting(edit.getKey(), edit.getValue());
         }
 
-        String bitDepthText = bitDepthCombo.getValue();
-        if (bitDepthText != null && !bitDepthText.isBlank()) {
-            model.setBitDepth(Integer.parseInt(bitDepthText));
-        }
+        applyKeyBindings(pendingEdits);
 
-        String bufferSizeText = bufferSizeCombo.getValue();
-        if (bufferSizeText != null && !bufferSizeText.isBlank()) {
-            model.setBufferSize(Integer.parseInt(bufferSizeText));
-        }
-
-        // Project
-        String autoSaveText = autoSaveCombo.getValue();
-        if (autoSaveText != null && !autoSaveText.isBlank()) {
-            model.setAutoSaveIntervalSeconds(Integer.parseInt(autoSaveText));
-        }
-
-        String tempoText = tempoField.getText();
-        if (tempoText != null && !tempoText.isBlank()) {
-            double tempo = Double.parseDouble(tempoText);
-            // Story 305 — the descriptor validator delegates to the setter
-            // guard, whose range comparisons cannot express NaN rejection
-            // (both are false for NaN), so the call site keeps the pre-305
-            // inline check's silent drop for NaN explicitly.
-            if (!Double.isNaN(tempo)
-                    && catalogue.byId("project.defaultTempo").orElseThrow().accepts(tempo)) {
-                model.setDefaultTempo(tempo);
-            }
-        }
-
-        // Story 298 — journaled persistence toggle.
-        model.setUseJournaledPersistence(journaledPersistenceCheck.isSelected());
-
-        // Appearance
-        model.setUiScale(uiScaleSlider.getValue());
-        // Story 294 — appearance changes now propagate through the shared
-        // EventBus instead of this dialog poking the three managers directly
-        // (Control Synchronization Design Book §6.7). ThemeManager,
-        // DensityManager and MotionManager each subscribe to
-        // UiEvent.SettingsApplied and apply their own slice via their own
-        // existing setter (which still persists + live-reapplies with no
-        // restart). The ids ride as enum name() strings because the SDK event
-        // type must not depend on daw-app's Theme / DensityMode enums.
-        //
-        // The combo / toggle reads here are SEEDED from the managers in the
-        // constructor (a read, not a cross-surface poke), so falling back to
-        // the manager's current value when a control is somehow empty keeps the
-        // published event well-formed (themeId/densityId are @NonNull).
-        ThemeManager.Theme selectedTheme = themeCombo.getValue();
-        if (selectedTheme == null) {
-            selectedTheme = themeManager.getActiveTheme();
-        }
-        Toggle selectedDensityToggle = densityGroup.getSelectedToggle();
-        DensityMode selectedDensity =
-                selectedDensityToggle != null
-                        && selectedDensityToggle.getUserData() instanceof DensityMode mode
-                        ? mode
-                        : densityManager.getActiveDensity();
+        // Story 294 — appearance changes propagate through the shared
+        // EventBus instead of this dialog poking the three managers
+        // directly (Control Synchronization Design Book §6.7). The
+        // publish is UNCONDITIONAL on Apply (today's behaviour), with
+        // pending-else-current values so it is always well-formed.
+        ThemeManager.Theme theme =
+                pendingEdits.get(ThemeManager.PREF_KEY) instanceof ThemeManager.Theme t
+                        ? t : themeManager.getActiveTheme();
+        DensityMode density =
+                pendingEdits.get(DensityManager.PREF_KEY) instanceof DensityMode d
+                        ? d : densityManager.getActiveDensity();
+        boolean reduceMotion =
+                pendingEdits.get(MotionManager.PREF_KEY) instanceof Boolean b
+                        ? b : motionManager.isReduceMotion();
+        // Captured for currentPersistedValue(): the publish below lands on
+        // a later FX pulse, so the shell re-seed at the end of this method
+        // must read the just-published values, not the stale managers.
+        lastAppliedTheme = theme;
+        lastAppliedDensity = density;
+        lastAppliedReduceMotion = reduceMotion;
         EventBusPublisher.publish(new UiEvent.SettingsApplied(
-                Instant.now(),
-                selectedTheme.name(),
-                selectedDensity.name(),
-                reduceMotionCheck.isSelected()));
+                Instant.now(), theme.name(), density.name(), reduceMotion));
 
-        // Plugins
-        String paths = pluginScanPathsField.getText();
-        if (paths != null) {
-            model.setPluginScanPaths(paths);
-        }
-
-        // Key Bindings — apply pending bindings that have no conflicts
-        applyKeyBindings();
-
-        // Notify listener of applied changes
         if (settingsChangeListener != null) {
             settingsChangeListener.onSettingsChanged(model);
+        }
+
+        shell.refreshFromPersisted();
+    }
+
+    /**
+     * Writes one dirty model-backed setting through its {@link SettingsModel}
+     * setter (the same authority as before). Theme/density/motion ride the
+     * SettingsApplied publish instead of a model write, and key bindings
+     * are batched in {@link #applyKeyBindings(Map)} — both are no-ops here.
+     */
+    private void applyModelSetting(String id, Object value) {
+        switch (id) {
+            case "audio.sampleRate" -> model.setSampleRate(((Number) value).doubleValue());
+            case "audio.bitDepth" -> model.setBitDepth(((Number) value).intValue());
+            case "audio.bufferSize" -> model.setBufferSize(((Number) value).intValue());
+            case "audio.mixPrecision" -> model.setMixPrecision((MixPrecision) value);
+            case "audio.srcQuality" -> model.setSrcQuality((QualityTier) value);
+            case "audio.backend" -> model.setAudioBackend((String) value);
+            case "audio.inputDevice" -> model.setAudioInputDevice((String) value);
+            case "audio.outputDevice" -> model.setAudioOutputDevice((String) value);
+            case "audio.applyLatencyCompensation" ->
+                    model.setApplyLatencyCompensation((Boolean) value);
+            case "audio.workerPoolSize" -> model.setWorkerPoolSize(((Number) value).intValue());
+            case "audio.masterCpuBudgetFraction" ->
+                    model.setMasterCpuBudgetFraction(((Number) value).doubleValue());
+            case "audio.masterCpuBudgetPolicy" ->
+                    model.setMasterCpuBudgetPolicy(SettingsModel.parsePolicy((String) value));
+            case "project.autoSaveIntervalSeconds" ->
+                    model.setAutoSaveIntervalSeconds(((Number) value).intValue());
+            case "project.defaultTempo" -> applyDefaultTempo(value);
+            case "project.useJournaledPersistence" ->
+                    model.setUseJournaledPersistence((Boolean) value);
+            case "appearance.uiScale" -> model.setUiScale(((Number) value).doubleValue());
+            case "plugins.scanPaths" -> {
+                if (value != null) {
+                    model.setPluginScanPaths((String) value);
+                }
+            }
+            default -> {
+                // Theme/density/motion (SettingsApplied publish) and
+                // keybinding.* (applyKeyBindings) are handled elsewhere.
+            }
         }
     }
 
     /**
-     * Persists the pending key binding changes to the {@link KeyBindingManager}.
-     * Only non-conflicting bindings are applied.
+     * The default-tempo write keeps the pre-306 semantics: the TEXT row
+     * delivers a raw String; blank and unparseable text are silently
+     * dropped, and the parsed value passes the explicit NaN check plus
+     * the descriptor's setter-delegating validator before the write.
+     * (Story 305 — the validator's range comparisons cannot express NaN
+     * rejection, both being false for NaN, so the call site keeps the
+     * explicit check.)
      */
-    private void applyKeyBindings() {
+    private void applyDefaultTempo(Object value) {
+        double tempo;
+        if (value instanceof Number number) {
+            tempo = number.doubleValue();
+        } else if (value instanceof String text && !text.isBlank()) {
+            try {
+                tempo = Double.parseDouble(text);
+            } catch (NumberFormatException unparseable) {
+                return; // silent drop — invalid text never reaches the model
+            }
+        } else {
+            return;
+        }
+        if (!Double.isNaN(tempo)
+                && catalogue.byId("project.defaultTempo").orElseThrow().accepts(tempo)) {
+            model.setDefaultTempo(tempo);
+        }
+    }
+
+    /**
+     * Persists the effective key bindings — pending edit if present,
+     * else the currently persisted binding — with the existing
+     * clear-all-then-set loop (no transient conflicts while re-assigning).
+     *
+     * @param pendingEdits the shell's pending snapshot; a {@code null}
+     *                     value clears that action's binding
+     */
+    private void applyKeyBindings(Map<String, Object> pendingEdits) {
         KeyBindingManager keyBindingManager = model.getKeyBindingManager();
+
+        // Effective map FIRST (reads must precede the clear).
+        Map<DawAction, KeyCombination> effective = new EnumMap<>(DawAction.class);
+        for (DawAction action : DawAction.values()) {
+            String id = KEYBINDING_PREFIX + action.name();
+            KeyCombination combo;
+            if (pendingEdits.containsKey(id)) {
+                combo = (KeyCombination) pendingEdits.get(id);
+            } else {
+                combo = keyBindingManager.getBinding(action).orElse(null);
+            }
+            if (combo != null) {
+                effective.put(action, combo);
+            }
+        }
 
         // First clear all bindings so we can re-assign without transient conflicts
         for (DawAction action : DawAction.values()) {
             keyBindingManager.setBinding(action, null);
         }
-        // Then apply pending bindings
+        // Then apply the effective bindings
         for (DawAction action : DawAction.values()) {
-            KeyCombination pending = pendingBindings.get(action);
-            if (pending != null) {
-                keyBindingManager.setBinding(action, pending);
+            KeyCombination combo = effective.get(action);
+            if (combo != null) {
+                keyBindingManager.setBinding(action, combo);
             }
         }
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
-
-    private static GridPane createGrid() {
-        GridPane grid = new GridPane();
-        grid.setHgap(12);
-        grid.setVgap(8);
-        grid.setPadding(new Insets(16));
-        return grid;
-    }
 
     /**
      * Resolves a localized string from the shared {@code Messages}
@@ -739,23 +699,17 @@ public final class SettingsDialog extends DawgDialog<Void> {
     }
 
     /**
-     * Resolves a control's label text through its {@link SettingsCatalogue}
-     * descriptor, so the descriptor — not the call site — owns the string.
-     *
-     * @param id the descriptor id (the {@code Preferences} key)
-     * @return the descriptor's resolved label
-     * @throws IllegalStateException if no descriptor exists for the id
-     */
-    private String settingLabel(String id) {
-        return catalogue.byId(id)
-                .orElseThrow(() -> new IllegalStateException("No descriptor for setting: " + id))
-                .label();
-    }
-
-    /**
      * Returns the settings model backing this dialog (for testing).
      */
     SettingsModel getModel() {
         return model;
+    }
+
+    /**
+     * Returns the shell rendering this dialog's body (for testing —
+     * dialog-level tests drive rows and the dirty state through it).
+     */
+    SettingsShell getShell() {
+        return shell;
     }
 }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/icons/DawgIcon.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/icons/DawgIcon.java
@@ -349,7 +349,7 @@ public final class DawgIcon extends Region {
     /**
      * Process-wide cache of parsed icon blueprints. Lucide SVGs are
      * immutable bundled resources, so this map can grow only to the
-     * size of the {@code icons.allowed.txt} whitelist (currently 37
+     * size of the {@code icons.allowed.txt} whitelist (currently 42
      * entries). Concurrent reads are safe.
      */
     private static final ConcurrentHashMap<String, IconBlueprint> BLUEPRINTS =

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingRow.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingRow.java
@@ -1,0 +1,251 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.Node;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+import javafx.util.StringConverter;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * The generic setting row — the §5.4 "workhorse" of the story-306 Rail &amp;
+ * Pane settings shell (Settings View Design Book §5.4). One row type renders
+ * <em>every</em> {@link SettingDescriptor} from the story-305
+ * {@link SettingsCatalogue} by {@link ControlKind}: label column, kind-specific
+ * editor, muted description line, apply-class badge (omitted for
+ * {@link ApplyClass#LIVE}, §6.4) and the per-setting reset ↺ (§5.7 tier 1).
+ *
+ * <p>Follows the {@code Control + SkinBase + package-resource user-agent
+ * stylesheet} convention of {@link com.benesquivelmusic.daw.app.ui.hub.ProjectCard}
+ * ({@code javafx-application-design} skill §3). All state the shell reacts to
+ * — pending {@link #valueProperty() value}, {@link #modifiedProperty()
+ * modified}, {@link #highlightQueryProperty() highlight query},
+ * {@link #armedProperty() armed} — lives on this control; {@link SettingRowSkin}
+ * only renders it.</p>
+ *
+ * <h2>Pending value, not persisted value</h2>
+ *
+ * <p>{@link #valueProperty()} holds the row's <em>pending</em> value (§6.2 —
+ * dirty/apply generalised). The row never writes any model or manager; the
+ * shell diffs pending values against the persisted ones and applies on the
+ * footer's Apply/OK. {@link #modifiedProperty()} compares against the
+ * descriptor's {@link SettingDescriptor#defaultValue() default} (not the
+ * persisted value) — it drives the §5.7 tier-1 reset marker only.</p>
+ *
+ * <h2>Key-capture arming (§6.5, rejection #7)</h2>
+ *
+ * <p>For {@link ControlKind#KEY_CAPTURE} rows, {@link #armedProperty()} gates
+ * capture: the skin's key filter lives on the capture field only and consumes
+ * <em>nothing</em> while disarmed, so ordinary navigation (Up/Down/Tab) is
+ * never globally swallowed. For every other kind the property is inert.</p>
+ *
+ * @see SettingRowSkin
+ * @see SettingDescriptor
+ */
+public final class SettingRow extends Control {
+
+    /** Stable style class — selectable as {@code .setting-row}. */
+    public static final String DEFAULT_STYLE_CLASS = "setting-row";
+
+    /**
+     * Optional per-kind render hints the descriptor does not carry (§5.4).
+     * All components are nullable / best-effort; {@link #none()} is the
+     * hint-free default. The badge text is passed in pre-localized because
+     * the row deliberately never reaches the {@code Messages} bundle — the
+     * shell owns all i18n resolution.
+     *
+     * @param choiceOptions       {@link ControlKind#CHOICE} options in the
+     *                            row's <em>value type</em> (so
+     *                            {@code Objects.equals} works against
+     *                            persisted values); may be {@code null}
+     * @param sliderMin           {@link ControlKind#SLIDER} lower bound (also
+     *                            reused as the {@link ControlKind#STEPPER}
+     *                            bound when explicitly set)
+     * @param sliderMax           {@link ControlKind#SLIDER} upper bound
+     * @param converter           display text for CHOICE options; may be
+     *                            {@code null} (falls back to
+     *                            {@code toString()})
+     * @param badgeText           localized apply-class badge text;
+     *                            {@code null} for {@link ApplyClass#LIVE}
+     *                            (badge omitted entirely, §6.4)
+     * @param resetGraphicFactory per-row ↺ graphic factory; {@code null}
+     *                            falls back to the text glyph U+21BA
+     */
+    public record ControlHints(
+            List<?> choiceOptions,
+            double sliderMin, double sliderMax,
+            StringConverter<Object> converter,
+            String badgeText,
+            Supplier<Node> resetGraphicFactory) {
+
+        private static final ControlHints NONE =
+                new ControlHints(null, 0, 1, null, null, null);
+
+        /** @return the hint-free default {@code (null, 0, 1, null, null, null)} */
+        public static ControlHints none() {
+            return NONE;
+        }
+    }
+
+    private final SettingDescriptor<?> descriptor;
+    private final ControlHints hints;
+
+    /**
+     * True ⇔ the pending value differs from the descriptor default (§5.7
+     * tier 1), compared through {@link #canonicalComparisonValue} so a
+     * TEXT row's numeric String agrees with its boxed default. Declared
+     * before {@link #value} so the value property's {@code invalidated()}
+     * can update it.
+     */
+    private final ReadOnlyBooleanWrapper modified =
+            new ReadOnlyBooleanWrapper(this, "modified", false);
+
+    private final ObjectProperty<Object> value;
+
+    private final StringProperty highlightQuery =
+            new SimpleStringProperty(this, "highlightQuery", "");
+
+    private final BooleanProperty armed =
+            new SimpleBooleanProperty(this, "armed", false);
+
+    /**
+     * Creates a row for {@code descriptor} seeded with the persisted
+     * {@code initialValue}. The editor kind is chosen once, from
+     * {@link SettingDescriptor#controlKind()}, when the skin is built.
+     *
+     * @param descriptor   the story-305 descriptor this row renders; not null
+     * @param initialValue the persisted value at open time; may be
+     *                     {@code null} (e.g. an unbound key binding)
+     * @param hints        render hints; {@code null} is coerced to
+     *                     {@link ControlHints#none()}
+     */
+    public SettingRow(SettingDescriptor<?> descriptor, Object initialValue,
+                      ControlHints hints) {
+        this.descriptor = Objects.requireNonNull(descriptor, "descriptor must not be null");
+        this.hints = hints == null ? ControlHints.none() : hints;
+        this.value = new SimpleObjectProperty<>(this, "value", initialValue) {
+            @Override
+            protected void invalidated() {
+                modified.set(!Objects.equals(
+                        canonicalComparisonValue(descriptor, get()),
+                        descriptor.defaultValue()));
+            }
+        };
+        // The property ctor does not run invalidated() — seed modified here.
+        modified.set(!Objects.equals(
+                canonicalComparisonValue(descriptor, initialValue),
+                descriptor.defaultValue()));
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        // §6.5: the row itself is not a Tab stop — its inner editor is.
+        setFocusTraversable(false);
+    }
+
+    /** @return the descriptor this row renders */
+    public SettingDescriptor<?> descriptor() {
+        return descriptor;
+    }
+
+    /** @return the render hints (never {@code null}) — read by the skin */
+    ControlHints hints() {
+        return hints;
+    }
+
+    /**
+     * @return the row's current (pending) value — two-way with the inner
+     *         control via listener + setter (never {@code bind()}, per the
+     *         two-way-control rule)
+     */
+    public ObjectProperty<Object> valueProperty() {
+        return value;
+    }
+
+    /** @return the current pending value; may be {@code null} */
+    public Object getValue() {
+        return value.get();
+    }
+
+    /** @param v the new pending value; may be {@code null} */
+    public void setValue(Object v) {
+        value.set(v);
+    }
+
+    /**
+     * @return true ⇔ {@code !Objects.equals(value, descriptor.defaultValue())}
+     *         after {@link #canonicalComparisonValue} coercion (§5.7 tier 1)
+     *         — drives the reset button's visible + managed
+     */
+    public ReadOnlyBooleanProperty modifiedProperty() {
+        return modified.getReadOnlyProperty();
+    }
+
+    /** Resets the pending value to {@link SettingDescriptor#defaultValue()}. */
+    public void resetToDefault() {
+        setValue(descriptor.defaultValue());
+    }
+
+    /**
+     * Canonicalizes {@code value} for equality comparison against the
+     * descriptor's default/persisted values. A {@link ControlKind#TEXT}
+     * editor delivers raw {@link String} edits even when the descriptor's
+     * canonical value type is a boxed {@link Double} (the catalogue's
+     * {@code project.defaultTempo} — the only such descriptor), so a
+     * parseable String coerces to Double before {@code Objects.equals};
+     * unparseable text stays a String (a real, silently-droppable edit).
+     * Every other kind/value passes through untouched — those editors
+     * already produce the persisted boxed types. Shared with the shell's
+     * pending-edit diff so the ↺ marker and the dirty state always agree.
+     */
+    static Object canonicalComparisonValue(SettingDescriptor<?> descriptor, Object value) {
+        if (value instanceof String text
+                && descriptor.controlKind() == ControlKind.TEXT
+                && descriptor.defaultValue() instanceof Double) {
+            try {
+                // Same parse as the apply path (SettingsDialog.applyDefaultTempo).
+                return Double.valueOf(text);
+            } catch (NumberFormatException unparseable) {
+                return value;
+            }
+        }
+        return value;
+    }
+
+    /**
+     * @return the §6.1 search highlight query ({@code ""} = none); when it
+     *         matches the label (case/diacritic-insensitive) the skin renders
+     *         the matching span emphasized
+     */
+    public StringProperty highlightQueryProperty() {
+        return highlightQuery;
+    }
+
+    /**
+     * @return the {@link ControlKind#KEY_CAPTURE} arming gate (§6.5,
+     *         rejection #7): capture is active only while armed; inert for
+     *         every other kind
+     */
+    public BooleanProperty armedProperty() {
+        return armed;
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new SettingRowSkin(this);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(
+                SettingRow.class.getResource("setting-row.css"),
+                "setting-row.css not on classpath").toExternalForm();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingRowSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingRowSkin.java
@@ -1,0 +1,595 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import javafx.beans.value.ChangeListener;
+import javafx.css.PseudoClass;
+import javafx.event.EventHandler;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Label;
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.Slider;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+import javafx.stage.DirectoryChooser;
+
+import java.io.File;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Skin for {@link SettingRow} (story 306, Settings View Design Book §5.4,
+ * {@code javafx-application-design} skill §3). A {@code GridPane}:
+ *
+ * <pre>
+ *   col 0 (fixed 180, right-aligned)  col 1 (grows)   col 2        col 3
+ *   label / highlight TextFlow        kind editor     apply badge  reset ↺
+ *                                     description (row 1, muted, wraps)
+ * </pre>
+ *
+ * <h2>Two-way value sync (listener + setter, never {@code bind()})</h2>
+ *
+ * <p>Per the two-way-control rule ({@code feedback_bind_two_way_control_property}),
+ * the editor's own property is never bound. Model→control: a listener on
+ * {@link SettingRow#valueProperty()} sets the editor, guarded by a reentrancy
+ * flag. Control→model: an editor listener sets {@code valueProperty} through
+ * the same flag with an {@code Objects.equals} short-circuit. Editor value
+ * types: {@code Boolean} (toggle), the option object (choice), {@code Double}
+ * (slider), {@code Integer} (stepper), {@code String} (text/path),
+ * {@code KeyCombination}-or-null (key capture).</p>
+ *
+ * <h2>Key-capture arming (§6.5, rejection #7)</h2>
+ *
+ * <p>The capture filter is installed on the capture field only — never the
+ * scene, window or any parent. Disarmed, it consumes <em>nothing</em> except
+ * the ENTER that arms; armed, it consumes modifier-only presses (ignored),
+ * ESCAPE (disarms, binding kept), DELETE/BACK_SPACE (clears + disarms) and any
+ * other key (captured as a {@link KeyCodeCombination} with SHORTCUT/SHIFT/ALT
+ * modifiers, mirroring the old {@code SettingsDialog.handleKeyBindingCapture},
+ * then disarms). Focus loss disarms. The field carries pseudo-class
+ * {@code armed} while armed.</p>
+ *
+ * <p>{@link #dispose()} detaches every listener/filter from the subject it was
+ * attached to (the remembered subject, not a re-resolved one).</p>
+ *
+ * @see SettingRow
+ */
+public final class SettingRowSkin extends SkinBase<SettingRow> {
+
+    /**
+     * Label-column width (§5.4: fixed-width, right-aligned to the control
+     * gutter). A layout constant, not a style literal.
+     */
+    static final double LABEL_COLUMN_WIDTH = 180;
+
+    private static final PseudoClass ARMED = PseudoClass.getPseudoClass("armed");
+
+    private final GridPane grid = new GridPane();
+    private final Label label = new Label();
+    private final Button resetButton = new Button();
+
+    /** Reentrancy flag for the two-way value sync. */
+    private boolean syncing;
+
+    /**
+     * Detach actions, one per attached listener/filter/handler, each closing
+     * over the exact subject it was attached to. Run and cleared by
+     * {@link #dispose()}.
+     */
+    private final List<Runnable> detachers = new ArrayList<>();
+
+    /**
+     * Builds the row layout and wires the kind-specific editor chosen once
+     * from {@link SettingDescriptor#controlKind()}.
+     *
+     * @param row the owning {@link SettingRow}
+     */
+    public SettingRowSkin(SettingRow row) {
+        super(row);
+
+        grid.getStyleClass().add("setting-row-grid");
+        ColumnConstraints labelColumn = new ColumnConstraints();
+        labelColumn.setMinWidth(LABEL_COLUMN_WIDTH);
+        labelColumn.setPrefWidth(LABEL_COLUMN_WIDTH);
+        labelColumn.setMaxWidth(LABEL_COLUMN_WIDTH);
+        ColumnConstraints editorColumn = new ColumnConstraints();
+        editorColumn.setHgrow(Priority.ALWAYS);
+        grid.getColumnConstraints().addAll(labelColumn, editorColumn);
+
+        label.getStyleClass().add("setting-row-label");
+        label.setAlignment(Pos.CENTER_RIGHT);
+        // Fill the fixed column so the right-alignment is visible.
+        label.setMaxWidth(Double.MAX_VALUE);
+        updateLabelContent(row.highlightQueryProperty().get());
+        ChangeListener<String> highlightListener = (_, _, q) -> updateLabelContent(q);
+        row.highlightQueryProperty().addListener(highlightListener);
+        detachers.add(() -> row.highlightQueryProperty().removeListener(highlightListener));
+
+        grid.add(label, 0, 0);
+        grid.add(buildEditor(row), 1, 0);
+
+        Label badge = buildBadge(row);
+        if (badge != null) {
+            grid.add(badge, 2, 0);
+        }
+
+        buildResetButton(row);
+        grid.add(resetButton, 3, 0);
+
+        String description = row.descriptor().description();
+        if (description != null && !description.isBlank()) {
+            Label descriptionLabel = new Label(description);
+            descriptionLabel.getStyleClass().add("setting-row-description");
+            descriptionLabel.setWrapText(true);
+            grid.add(descriptionLabel, 1, 1, 3, 1);
+        }
+
+        getChildren().add(grid);
+    }
+
+    // ── Two-way sync plumbing ─────────────────────────────────────────────────
+
+    /** Control→model leg: guarded, {@code Objects.equals}-short-circuited. */
+    private void setRowValueFromControl(Object newValue) {
+        if (syncing) {
+            return;
+        }
+        SettingRow row = getSkinnable();
+        if (row == null || Objects.equals(row.getValue(), newValue)) {
+            return;
+        }
+        syncing = true;
+        try {
+            row.setValue(newValue);
+        } finally {
+            syncing = false;
+        }
+    }
+
+    /** Model→control leg: runs {@code push} unless a sync is already in flight. */
+    private void runGuarded(Runnable push) {
+        if (syncing) {
+            return;
+        }
+        syncing = true;
+        try {
+            push.run();
+        } finally {
+            syncing = false;
+        }
+    }
+
+    /** Registers the model→control listener on the row's value property. */
+    private void attachRowValueListener(SettingRow row, ChangeListener<Object> listener) {
+        row.valueProperty().addListener(listener);
+        detachers.add(() -> row.valueProperty().removeListener(listener));
+    }
+
+    // ── Editor construction (one kind, chosen once) ───────────────────────────
+
+    private Node buildEditor(SettingRow row) {
+        return switch (row.descriptor().controlKind()) {
+            case TOGGLE -> buildToggle(row);
+            case CHOICE -> buildChoice(row);
+            case SLIDER -> buildSlider(row);
+            case STEPPER -> buildStepper(row);
+            case TEXT -> buildTextField(row);
+            case PATH -> buildPath(row);
+            case KEY_CAPTURE -> buildKeyCapture(row);
+        };
+    }
+
+    /** TOGGLE — a text-less {@link CheckBox}; the row label is the text. */
+    private Node buildToggle(SettingRow row) {
+        CheckBox box = new CheckBox();
+        box.setSelected(Boolean.TRUE.equals(row.getValue()));
+        ChangeListener<Boolean> boxListener = (_, _, selected) -> setRowValueFromControl(selected);
+        box.selectedProperty().addListener(boxListener);
+        detachers.add(() -> box.selectedProperty().removeListener(boxListener));
+        attachRowValueListener(row,
+                (_, _, v) -> runGuarded(() -> box.setSelected(Boolean.TRUE.equals(v))));
+        return box;
+    }
+
+    /**
+     * CHOICE — a {@link ComboBox} over {@code hints.choiceOptions()}. With no
+     * options, items are just the initial value plus the default (no
+     * enumeration/I-O here — device/backend combos show the current value only
+     * until story 307). A value missing from the options is added at the front
+     * rather than lost.
+     */
+    private Node buildChoice(SettingRow row) {
+        ComboBox<Object> combo = new ComboBox<>();
+        List<Object> options = new ArrayList<>();
+        if (row.hints().choiceOptions() != null) {
+            options.addAll(row.hints().choiceOptions());
+        }
+        Object current = row.getValue();
+        if (options.isEmpty()) {
+            if (current != null) {
+                options.add(current);
+            }
+            Object defaultValue = row.descriptor().defaultValue();
+            if (defaultValue != null && !Objects.equals(defaultValue, current)) {
+                options.add(defaultValue);
+            }
+        } else if (current != null && !options.contains(current)) {
+            options.add(0, current);
+        }
+        combo.getItems().setAll(options);
+        if (row.hints().converter() != null) {
+            combo.setConverter(row.hints().converter());
+        }
+        combo.setValue(current);
+        ChangeListener<Object> comboListener = (_, _, v) -> setRowValueFromControl(v);
+        combo.valueProperty().addListener(comboListener);
+        detachers.add(() -> combo.valueProperty().removeListener(comboListener));
+        attachRowValueListener(row, (_, _, v) -> runGuarded(() -> {
+            if (v != null && !combo.getItems().contains(v)) {
+                combo.getItems().add(0, v);
+            }
+            combo.setValue(v);
+        }));
+        return combo;
+    }
+
+    /** SLIDER — a {@link Slider} over the hint bounds plus a numeric value label. */
+    private Node buildSlider(SettingRow row) {
+        double current = row.getValue() instanceof Number n
+                ? n.doubleValue() : row.hints().sliderMin();
+        Slider slider = new Slider(row.hints().sliderMin(), row.hints().sliderMax(), current);
+        Label valueLabel = new Label(formatSliderValue(slider.getValue()));
+        valueLabel.getStyleClass().add("numeric-value");
+        ChangeListener<Number> sliderListener = (_, _, v) -> {
+            valueLabel.setText(formatSliderValue(v.doubleValue()));
+            setRowValueFromControl(v.doubleValue()); // boxes to Double
+        };
+        slider.valueProperty().addListener(sliderListener);
+        detachers.add(() -> slider.valueProperty().removeListener(sliderListener));
+        attachRowValueListener(row, (_, _, v) -> runGuarded(() -> {
+            if (v instanceof Number n) {
+                slider.setValue(n.doubleValue());
+            }
+            valueLabel.setText(formatSliderValue(slider.getValue()));
+        }));
+        slider.setMaxWidth(Double.MAX_VALUE);
+        HBox box = new HBox(slider, valueLabel);
+        box.getStyleClass().add("setting-row-slider-box");
+        box.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(slider, Priority.ALWAYS);
+        return box;
+    }
+
+    /**
+     * Deterministic slider text: {@code %.2f} in {@code Locale.ROOT} with
+     * trailing zeros (and a then-dangling dot) trimmed — 1.50 → "1.5",
+     * 1.00 → "1".
+     */
+    private static String formatSliderValue(double v) {
+        String s = String.format(Locale.ROOT, "%.2f", v);
+        s = s.replaceAll("0+$", "");
+        return s.endsWith(".") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    /**
+     * STEPPER — a minimal integer {@link Spinner} (no descriptor uses it
+     * today, §3.4 canon). Bounds come from the slider hints when explicitly
+     * set; the {@link SettingRow.ControlHints#none()} sentinel pair (0, 1) —
+     * or an empty range — means "unset" and falls back to
+     * {@code 0..Integer.MAX_VALUE}.
+     */
+    private Node buildStepper(SettingRow row) {
+        double hintMin = row.hints().sliderMin();
+        double hintMax = row.hints().sliderMax();
+        int min = 0;
+        int max = Integer.MAX_VALUE;
+        boolean boundsSet = hintMax > hintMin && !(hintMin == 0 && hintMax == 1);
+        if (boundsSet) {
+            min = (int) hintMin;
+            max = (int) hintMax;
+        }
+        int current = row.getValue() instanceof Number n ? n.intValue() : min;
+        Spinner<Integer> spinner = new Spinner<>(min, max, current);
+        ChangeListener<Integer> spinnerListener = (_, _, v) -> setRowValueFromControl(v);
+        spinner.valueProperty().addListener(spinnerListener);
+        detachers.add(() -> spinner.valueProperty().removeListener(spinnerListener));
+        attachRowValueListener(row, (_, _, v) -> runGuarded(() -> {
+            if (v instanceof Number n) {
+                spinner.getValueFactory().setValue(n.intValue());
+            }
+        }));
+        return spinner;
+    }
+
+    /** TEXT — a free-form {@link TextField}; the row value is the raw text. */
+    private Node buildTextField(SettingRow row) {
+        TextField field = new TextField(row.getValue() == null ? "" : String.valueOf(row.getValue()));
+        attachTextSync(row, field);
+        return field;
+    }
+
+    /** Shared TEXT/PATH text↔value sync (String values). */
+    private void attachTextSync(SettingRow row, TextField field) {
+        ChangeListener<String> textListener = (_, _, text) -> setRowValueFromControl(text);
+        field.textProperty().addListener(textListener);
+        detachers.add(() -> field.textProperty().removeListener(textListener));
+        attachRowValueListener(row,
+                (_, _, v) -> runGuarded(() -> field.setText(v == null ? "" : String.valueOf(v))));
+    }
+
+    /**
+     * PATH — a {@link TextField} plus a Browse… button that appends a chosen
+     * directory {@code ;}-separated (§5.4's plugin-scan-paths idiom). The
+     * chooser is skipped when the field has no scene/window (headless safety).
+     */
+    private Node buildPath(SettingRow row) {
+        TextField field = new TextField(row.getValue() == null ? "" : String.valueOf(row.getValue()));
+        attachTextSync(row, field);
+        Button browse = new Button("Browse…");
+        browse.getStyleClass().addAll("dawg-button", "setting-row-browse");
+        browse.setOnAction(_ -> {
+            if (field.getScene() == null || field.getScene().getWindow() == null) {
+                return; // headless safety — no chooser without a window
+            }
+            File dir = new DirectoryChooser().showDialog(field.getScene().getWindow());
+            if (dir == null) {
+                return;
+            }
+            String existing = field.getText();
+            field.setText(existing == null || existing.isBlank()
+                    ? dir.getAbsolutePath()
+                    : existing + ";" + dir.getAbsolutePath());
+        });
+        detachers.add(() -> browse.setOnAction(null));
+        field.setMaxWidth(Double.MAX_VALUE);
+        HBox box = new HBox(field, browse);
+        box.getStyleClass().add("setting-row-path-box");
+        box.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(field, Priority.ALWAYS);
+        return box;
+    }
+
+    /**
+     * KEY_CAPTURE — a non-editable field showing the bound
+     * {@link KeyCombination#getDisplayText() display text} ({@code ""} for
+     * null). Capture is gated by {@link SettingRow#armedProperty()} (§6.5,
+     * rejection #7): click or ENTER-on-focused-field arms; the field-local
+     * filter consumes nothing while disarmed.
+     */
+    private Node buildKeyCapture(SettingRow row) {
+        TextField field = new TextField(keyDisplayText(row.getValue()));
+        field.setEditable(false);
+        field.getStyleClass().add("key-capture");
+
+        ChangeListener<Boolean> armedListener =
+                (_, _, armed) -> field.pseudoClassStateChanged(ARMED, armed);
+        row.armedProperty().addListener(armedListener);
+        detachers.add(() -> row.armedProperty().removeListener(armedListener));
+        field.pseudoClassStateChanged(ARMED, row.armedProperty().get());
+
+        // Model→control is the single text writer — the capture filter below
+        // routes through row.setValue() unguarded so this listener repaints.
+        attachRowValueListener(row,
+                (_, _, v) -> field.setText(keyDisplayText(v)));
+
+        EventHandler<MouseEvent> clickArms = _ -> row.armedProperty().set(true);
+        field.addEventHandler(MouseEvent.MOUSE_CLICKED, clickArms);
+        detachers.add(() -> field.removeEventHandler(MouseEvent.MOUSE_CLICKED, clickArms));
+
+        ChangeListener<Boolean> focusListener = (_, _, focused) -> {
+            if (!focused) {
+                row.armedProperty().set(false);
+            }
+        };
+        field.focusedProperty().addListener(focusListener);
+        detachers.add(() -> field.focusedProperty().removeListener(focusListener));
+
+        // The filter lives on the FIELD only — nothing global, nothing on
+        // parents (§6.5, rejection #7).
+        EventHandler<KeyEvent> captureFilter = event -> handleCaptureKey(row, event);
+        field.addEventFilter(KeyEvent.KEY_PRESSED, captureFilter);
+        detachers.add(() -> field.removeEventFilter(KeyEvent.KEY_PRESSED, captureFilter));
+
+        return field;
+    }
+
+    /**
+     * The armed key-capture state machine (§6.5). Disarmed: consumes nothing
+     * (Up/Down/Tab must propagate — rejection #7) except the ENTER that arms,
+     * which is consumed only because it arms. Armed: modifier-only presses are
+     * consumed and ignored; ESCAPE disarms without clearing; DELETE/BACK_SPACE
+     * clear the binding and disarm; any other key is captured as a
+     * {@link KeyCodeCombination} with SHORTCUT/SHIFT/ALT modifiers (mirroring
+     * the retired {@code SettingsDialog.handleKeyBindingCapture}) and disarms.
+     */
+    private void handleCaptureKey(SettingRow row, KeyEvent event) {
+        if (!row.armedProperty().get()) {
+            if (event.getCode() == KeyCode.ENTER) {
+                row.armedProperty().set(true);
+                event.consume();
+            }
+            return;
+        }
+        switch (event.getCode()) {
+            case SHIFT, CONTROL, ALT, META, COMMAND, WINDOWS, UNDEFINED ->
+                    event.consume(); // modifier-only: ignore, stay armed
+            case ESCAPE -> {
+                row.armedProperty().set(false); // binding kept
+                event.consume();
+            }
+            case DELETE, BACK_SPACE -> {
+                row.setValue(null); // clears the binding; value listener repaints
+                row.armedProperty().set(false);
+                event.consume();
+            }
+            default -> {
+                List<KeyCombination.Modifier> modifiers = new ArrayList<>(3);
+                if (event.isShortcutDown()) {
+                    modifiers.add(KeyCombination.SHORTCUT_DOWN);
+                }
+                if (event.isShiftDown()) {
+                    modifiers.add(KeyCombination.SHIFT_DOWN);
+                }
+                if (event.isAltDown()) {
+                    modifiers.add(KeyCombination.ALT_DOWN);
+                }
+                row.setValue(new KeyCodeCombination(event.getCode(),
+                        modifiers.toArray(KeyCombination.Modifier[]::new)));
+                row.armedProperty().set(false); // one combination per arming
+                event.consume();
+            }
+        }
+    }
+
+    private static String keyDisplayText(Object value) {
+        return value instanceof KeyCombination kc ? kc.getDisplayText() : "";
+    }
+
+    // ── Badge + reset ─────────────────────────────────────────────────────────
+
+    /**
+     * The trailing apply-class badge — omitted entirely for
+     * {@link ApplyClass#LIVE} (§6.4). Text arrives pre-localized via
+     * {@link SettingRow.ControlHints#badgeText()}; the enum name is the
+     * defensive fallback only.
+     */
+    private Label buildBadge(SettingRow row) {
+        ApplyClass applyClass = row.descriptor().applyClass();
+        if (applyClass == ApplyClass.LIVE) {
+            return null;
+        }
+        String text = row.hints().badgeText() != null
+                ? row.hints().badgeText() : applyClass.name();
+        Label badge = new Label(text);
+        badge.getStyleClass().addAll("setting-row-badge",
+                applyClass == ApplyClass.RESTART_REQUIRED ? "badge-restart" : "badge-engine");
+        return badge;
+    }
+
+    /**
+     * The §5.7 tier-1 reset ↺ — visible AND managed only while the row is
+     * modified, so an unmodified row reserves no space for it.
+     */
+    private void buildResetButton(SettingRow row) {
+        resetButton.getStyleClass().addAll("dawg-button", "icon-only", "setting-row-reset");
+        Supplier<Node> factory = row.hints().resetGraphicFactory();
+        if (factory != null) {
+            resetButton.setGraphic(factory.get());
+        } else {
+            resetButton.setText("↺");
+        }
+        resetButton.visibleProperty().bind(row.modifiedProperty());
+        resetButton.managedProperty().bind(row.modifiedProperty());
+        resetButton.setOnAction(_ -> row.resetToDefault());
+    }
+
+    // ── Label highlight (§6.1 / §5.2) ─────────────────────────────────────────
+
+    /**
+     * Renders the label plain, or — when {@code query} matches it case- and
+     * diacritic-insensitively — as a {@link TextFlow} of {@link Text} spans in
+     * the label's graphic slot, the matching span carrying style class
+     * {@code setting-row-highlight}.
+     */
+    private void updateLabelContent(String query) {
+        String text = getSkinnable().descriptor().label();
+        int[] range = query == null || query.isBlank() ? null : matchRange(text, query);
+        if (range == null) {
+            label.setGraphic(null);
+            label.setContentDisplay(ContentDisplay.LEFT);
+            label.setText(text);
+            return;
+        }
+        TextFlow flow = new TextFlow();
+        addSpan(flow, text.substring(0, range[0]), false);
+        addSpan(flow, text.substring(range[0], range[1]), true);
+        addSpan(flow, text.substring(range[1]), false);
+        label.setText("");
+        label.setGraphic(flow);
+        label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+    }
+
+    private static void addSpan(TextFlow flow, String s, boolean highlight) {
+        if (s.isEmpty()) {
+            return;
+        }
+        Text span = new Text(s);
+        span.getStyleClass().add("setting-row-label-text");
+        if (highlight) {
+            span.getStyleClass().add("setting-row-highlight");
+        }
+        flow.getChildren().add(span);
+    }
+
+    /**
+     * Finds {@code query} in {@code label} under NFD + {@code \p{M}}-stripped
+     * + {@code Locale.ROOT}-lowercased normalization (the §6.1 rule), mapping
+     * the normalized hit back to <em>original</em> label indices — NFD can
+     * change string length, so each original code point's normalized length is
+     * tracked.
+     *
+     * @return {@code [startInclusive, endExclusive]} in the original label,
+     *         or {@code null} when the query does not match
+     */
+    private static int[] matchRange(String label, String query) {
+        String normQuery = normalize(query.strip());
+        if (normQuery.isEmpty()) {
+            return null;
+        }
+        StringBuilder normLabel = new StringBuilder(label.length());
+        List<Integer> originIndex = new ArrayList<>(label.length());
+        int i = 0;
+        while (i < label.length()) {
+            int len = Character.charCount(label.codePointAt(i));
+            String piece = normalize(label.substring(i, i + len));
+            for (int k = 0; k < piece.length(); k++) {
+                originIndex.add(i);
+            }
+            normLabel.append(piece);
+            i += len;
+        }
+        int at = normLabel.indexOf(normQuery);
+        if (at < 0) {
+            return null;
+        }
+        int endNorm = at + normQuery.length();
+        int start = originIndex.get(at);
+        int end = endNorm < originIndex.size() ? originIndex.get(endNorm) : label.length();
+        return new int[] {start, end};
+    }
+
+    /** NFD + strip {@code \p{M}} + lowercase(ROOT) — mirrors {@code SettingsSearchIndex}. */
+    private static String normalize(String s) {
+        return Normalizer.normalize(s, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .toLowerCase(Locale.ROOT);
+    }
+
+    @Override
+    public void dispose() {
+        detachers.forEach(Runnable::run);
+        detachers.clear();
+        resetButton.visibleProperty().unbind();
+        resetButton.managedProperty().unbind();
+        resetButton.setOnAction(null);
+        super.dispose();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsNavRail.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsNavRail.java
@@ -1,0 +1,267 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+import javafx.scene.input.KeyEvent;
+
+import java.util.Objects;
+
+/**
+ * Vertical category rail {@link Control} for the story-306 Rail &amp; Pane
+ * settings shell — one row per settings category, with a per-category dirty
+ * marker, search match count and search dimming (Settings View Design Book
+ * §4.A, §5.1, §5.2).
+ *
+ * <p>Follows the {@code Control + SkinBase + package-resource user-agent
+ * stylesheet} convention of {@link com.benesquivelmusic.daw.app.ui.hub.ProjectCard}
+ * and {@link com.benesquivelmusic.daw.app.ui.status.StatusStripCell}
+ * ({@code javafx-application-design} skill §3 Control/Skin split, §8 themeable
+ * via a user-agent stylesheet plus stable style classes). The rail is generic:
+ * it renders {@link NavItem} facts and never imports the settings catalogue or
+ * an icon enum — the shell constructs the items (icons ready-made) and reacts
+ * to {@link #selectedCategoryIdProperty()}.</p>
+ *
+ * <h2>Selection is an accent bar, never a fill (UI Design Book rejection §6)</h2>
+ *
+ * <p>The selected cell is marked by a drawn accent-bar {@code Region} on its
+ * left edge — always present in the scene graph, transparent unless selected
+ * (book §5.3; {@code settings-nav-rail.css}). The category title label never
+ * receives an accent fill.</p>
+ *
+ * <h2>Keyboard contract (book §6.5, rejection #7)</h2>
+ *
+ * <p>The control itself handles exactly four keys while focused:
+ * UP/DOWN move the selection by one item (clamped) and are consumed;
+ * ENTER/RIGHT run the {@link #onActivatePaneProperty() activate-pane action}
+ * (the shell focuses the pane's first row control) and are consumed. Every
+ * other key propagates untouched — the rail never globally swallows
+ * navigation keys.</p>
+ *
+ * @see SettingsNavRailSkin
+ */
+public final class SettingsNavRail extends Control {
+
+    /** Stable style class — selectable as {@code .settings-nav-rail}. */
+    public static final String DEFAULT_STYLE_CLASS = "settings-nav-rail";
+
+    /**
+     * One rail row's reactive facts (book §5.1/§5.2). Constructed by the
+     * shell; identity facts ({@code categoryId}, {@code title}, {@code icon})
+     * are immutable, the search/dirty facts are properties the shell drives
+     * and the skin observes.
+     */
+    public static final class NavItem {
+
+        private final String categoryId;
+        private final String title;
+        private final Node icon;
+
+        /**
+         * Unsaved-edit marker (the {@code •} in book §5.1) — {@code true}
+         * while any setting in this category holds a pending edit.
+         */
+        private final BooleanProperty dirty =
+                new SimpleBooleanProperty(this, "dirty", false);
+
+        /**
+         * Per-category search match count (book §5.2). {@code -1} means "not
+         * searching" (the default) and hides the count label entirely.
+         */
+        private final IntegerProperty matchCount =
+                new SimpleIntegerProperty(this, "matchCount", -1);
+
+        /**
+         * {@code true} while a search is active and this category has no
+         * matches — the skin dims the cell via the {@code dimmed}
+         * pseudo-class (book §5.2).
+         */
+        private final BooleanProperty dimmed =
+                new SimpleBooleanProperty(this, "dimmed", false);
+
+        /**
+         * Creates a rail item.
+         *
+         * @param categoryId the catalogue category id; must not be {@code null}
+         * @param title      the localized category title; must not be {@code null}
+         * @param icon       the ready-made icon node, or {@code null} for none
+         */
+        public NavItem(String categoryId, String title, Node icon) {
+            this.categoryId = Objects.requireNonNull(categoryId, "categoryId must not be null");
+            this.title = Objects.requireNonNull(title, "title must not be null");
+            this.icon = icon;
+        }
+
+        /** @return the catalogue category id this row represents. */
+        public String categoryId() {
+            return categoryId;
+        }
+
+        /** @return the localized category title. */
+        public String title() {
+            return title;
+        }
+
+        /** @return the icon node, or {@code null} if the row has none. */
+        public Node icon() {
+            return icon;
+        }
+
+        /** @return the unsaved-edit {@code •} marker property (book §5.1). */
+        public BooleanProperty dirtyProperty() {
+            return dirty;
+        }
+
+        /** @return the search match-count property; {@code -1} = not searching. */
+        public IntegerProperty matchCountProperty() {
+            return matchCount;
+        }
+
+        /** @return the no-matches-while-searching dimming property (book §5.2). */
+        public BooleanProperty dimmedProperty() {
+            return dimmed;
+        }
+    }
+
+    private final ObservableList<NavItem> items = FXCollections.observableArrayList();
+
+    private final ObjectProperty<String> selectedCategoryId =
+            new SimpleObjectProperty<>(this, "selectedCategoryId", null);
+
+    /**
+     * Action run when ENTER/RIGHT activates the pane (book §6.5). Nullable —
+     * a {@code null} action makes ENTER/RIGHT a consumed no-op (the keys stay
+     * rail-owned either way).
+     */
+    private final ObjectProperty<Runnable> onActivatePane =
+            new SimpleObjectProperty<>(this, "onActivatePane", null);
+
+    /** Creates an empty rail (no items, no selection). */
+    public SettingsNavRail() {
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        setFocusTraversable(true);
+        // Key handling lives on the CONTROL (not the skin) so the §6.5
+        // contract holds independently of skin realization. addEventHandler
+        // (not setOnKeyPressed) leaves the convenience slot free for callers.
+        addEventHandler(KeyEvent.KEY_PRESSED, this::handleRailKey);
+    }
+
+    /**
+     * §6.5 rail keys: UP/DOWN move the selection, ENTER/RIGHT activate the
+     * pane; each of the four is consumed. Any other key falls through
+     * unconsumed (rejection #7 — the rail never swallows navigation keys it
+     * does not own).
+     */
+    private void handleRailKey(KeyEvent event) {
+        switch (event.getCode()) {
+            case UP -> {
+                selectPrevious();
+                event.consume();
+            }
+            case DOWN -> {
+                selectNext();
+                event.consume();
+            }
+            case ENTER, RIGHT -> {
+                Runnable action = onActivatePane.get();
+                if (action != null) {
+                    action.run();
+                }
+                event.consume();
+            }
+            default -> {
+                // Deliberately unconsumed — rejection #7.
+            }
+        }
+    }
+
+    /** @return the mutable item list; the shell populates it in catalogue order. */
+    public ObservableList<NavItem> getItems() {
+        return items;
+    }
+
+    /**
+     * @return the selected category id property; {@code null} = no selection.
+     *         The shell swaps the settings pane on change; the skin marks the
+     *         matching cell with the {@code selected} pseudo-class.
+     */
+    public ObjectProperty<String> selectedCategoryIdProperty() {
+        return selectedCategoryId;
+    }
+
+    /** @return the selected category id, or {@code null} if none. */
+    public String getSelectedCategoryId() {
+        return selectedCategoryId.get();
+    }
+
+    /** @param id the category id to select, or {@code null} to clear. */
+    public void setSelectedCategoryId(String id) {
+        selectedCategoryId.set(id);
+    }
+
+    /** Moves selection up by one item, clamped (keyboard model §6.5). */
+    public void selectPrevious() {
+        moveSelection(-1);
+    }
+
+    /** Moves selection down by one item, clamped (keyboard model §6.5). */
+    public void selectNext() {
+        moveSelection(1);
+    }
+
+    /**
+     * @return the ENTER/RIGHT activate-pane action property (nullable
+     *         {@code Runnable}); the shell installs "focus the pane's first
+     *         visible row control" here (book §6.5)
+     */
+    public ObjectProperty<Runnable> onActivatePaneProperty() {
+        return onActivatePane;
+    }
+
+    /**
+     * Moves the selection by {@code delta} items, clamped to the list. With
+     * no current selection (or a stale id no longer in the list) either
+     * direction selects the first item.
+     */
+    private void moveSelection(int delta) {
+        if (items.isEmpty()) {
+            return;
+        }
+        int current = indexOfCategory(getSelectedCategoryId());
+        int target = current < 0 ? 0 : Math.clamp(current + delta, 0, items.size() - 1);
+        setSelectedCategoryId(items.get(target).categoryId());
+    }
+
+    /** @return the index of {@code id} in {@link #items}, or {@code -1}. */
+    private int indexOfCategory(String id) {
+        if (id == null) {
+            return -1;
+        }
+        for (int i = 0; i < items.size(); i++) {
+            if (id.equals(items.get(i).categoryId())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new SettingsNavRailSkin(this);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(
+                SettingsNavRail.class.getResource("settings-nav-rail.css"),
+                "settings-nav-rail.css not on classpath").toExternalForm();
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsNavRailSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsNavRailSkin.java
@@ -1,0 +1,192 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.css.PseudoClass;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SkinBase;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Skin for {@link SettingsNavRail} (story 306, Settings View Design Book
+ * §5.1/§5.2, {@code javafx-application-design} skill §3). A {@code ScrollPane}
+ * (fit-to-width — the rail scrolls independently of the settings pane, book
+ * §5.1) over a {@code VBox} of one {@code NavCell} per
+ * {@link SettingsNavRail.NavItem}.
+ *
+ * <h2>Cell anatomy</h2>
+ *
+ * <p>Each cell is an {@code HBox}: accent-bar {@code Region} (leftmost, fixed
+ * ~3&nbsp;px, style class {@code settings-nav-accent-bar}) → icon (when the
+ * item has one) → title label → spacer → match-count label
+ * ({@code settings-nav-count}, visible only while searching, i.e.
+ * {@code matchCount >= 0}) → dirty-dot label ({@code settings-nav-dirty},
+ * visible ⇔ {@code dirty}). The accent bar is <em>always</em> in the scene
+ * graph and transparent unless the cell carries the {@code selected}
+ * pseudo-class — selection is a drawn bar, never an accent fill behind the
+ * title (UI Design Book rejection §6, book §5.3). A no-match cell during
+ * search carries the {@code dimmed} pseudo-class (reduced opacity, book
+ * §5.2). Clicking a cell selects its category.</p>
+ *
+ * <h2>Listener lifecycle</h2>
+ *
+ * <p>The skin attaches: a list listener on the control's items, a change
+ * listener on {@code selectedCategoryIdProperty}, and per-item listeners /
+ * label bindings inside each {@code NavCell}. A list change disposes every
+ * cell and re-hooks the per-item listeners on the new cells;
+ * {@link #dispose()} detaches all of them from the <em>remembered</em>
+ * subjects (the item properties outlive the skin) before delegating to the
+ * superclass, so the skin can be swapped without leaking.</p>
+ */
+public final class SettingsNavRailSkin extends SkinBase<SettingsNavRail> {
+
+    private static final PseudoClass SELECTED_PSEUDO_CLASS = PseudoClass.getPseudoClass("selected");
+    private static final PseudoClass DIMMED_PSEUDO_CLASS = PseudoClass.getPseudoClass("dimmed");
+
+    /** The §5.1 unsaved-edits marker glyph. */
+    private static final String DIRTY_DOT = "•";
+
+    private final ScrollPane scrollPane = new ScrollPane();
+    private final VBox cellBox = new VBox();
+    private final List<NavCell> cells = new ArrayList<>();
+
+    // Remembered subjects — dispose() must detach from exactly these
+    // (feedback_listener_accumulation_latent_vs_live).
+    private final ObservableList<SettingsNavRail.NavItem> items;
+    private final ObjectProperty<String> selection;
+
+    private final ListChangeListener<SettingsNavRail.NavItem> itemsListener;
+    private final ChangeListener<String> selectionListener;
+
+    /**
+     * Builds the cells and hooks the items/selection listeners.
+     *
+     * @param rail the owning {@link SettingsNavRail}
+     */
+    public SettingsNavRailSkin(SettingsNavRail rail) {
+        super(rail);
+        this.items = rail.getItems();
+        this.selection = rail.selectedCategoryIdProperty();
+
+        cellBox.getStyleClass().add("settings-nav-cells");
+        scrollPane.setContent(cellBox);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        // The CONTROL is the focus/Tab stop (its key handler owns UP/DOWN/
+        // ENTER/RIGHT, §6.5); the inner ScrollPane must not be a second stop.
+        scrollPane.setFocusTraversable(false);
+        getChildren().add(scrollPane);
+
+        itemsListener = _ -> rebuildCells();
+        items.addListener(itemsListener);
+        selectionListener = (_, _, selectedId) -> applySelection(selectedId);
+        selection.addListener(selectionListener);
+
+        rebuildCells();
+    }
+
+    /** Disposes every existing cell, builds one per item, re-marks selection. */
+    private void rebuildCells() {
+        cells.forEach(NavCell::dispose);
+        cells.clear();
+        for (SettingsNavRail.NavItem item : items) {
+            cells.add(new NavCell(item));
+        }
+        cellBox.getChildren().setAll(cells);
+        applySelection(selection.get());
+    }
+
+    /** Reconciles the {@code selected} pseudo-class across all cells. */
+    private void applySelection(String selectedId) {
+        for (NavCell cell : cells) {
+            cell.updateSelected(selectedId);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        items.removeListener(itemsListener);
+        selection.removeListener(selectionListener);
+        cells.forEach(NavCell::dispose);
+        cells.clear();
+        cellBox.getChildren().clear();
+        super.dispose();
+    }
+
+    /**
+     * One rail row. Its label bindings and the dimmed listener observe the
+     * item's properties (which outlive the skin) — {@link #dispose()}
+     * detaches all of them.
+     */
+    private final class NavCell extends HBox {
+
+        private final SettingsNavRail.NavItem item;
+        private final Label countLabel = new Label();
+        private final Label dirtyLabel = new Label(DIRTY_DOT);
+        private final ChangeListener<Boolean> dimmedListener;
+
+        NavCell(SettingsNavRail.NavItem item) {
+            this.item = item;
+            getStyleClass().add("settings-nav-cell");
+
+            // Accent bar — ALWAYS in the graph; settings-nav-rail.css keeps it
+            // transparent unless the cell is :selected (rejection §6: a drawn
+            // bar, never an accent fill behind the title).
+            Region accentBar = new Region();
+            accentBar.getStyleClass().add("settings-nav-accent-bar");
+
+            Label titleLabel = new Label(item.title());
+            titleLabel.getStyleClass().add("settings-nav-title");
+
+            Region spacer = new Region();
+            HBox.setHgrow(spacer, Priority.ALWAYS);
+
+            countLabel.getStyleClass().add("settings-nav-count");
+            countLabel.textProperty().bind(item.matchCountProperty().asString());
+            countLabel.visibleProperty().bind(item.matchCountProperty().greaterThanOrEqualTo(0));
+            countLabel.managedProperty().bind(countLabel.visibleProperty());
+
+            dirtyLabel.getStyleClass().add("settings-nav-dirty");
+            dirtyLabel.visibleProperty().bind(item.dirtyProperty());
+            dirtyLabel.managedProperty().bind(dirtyLabel.visibleProperty());
+
+            dimmedListener = (_, _, dimmed) ->
+                    pseudoClassStateChanged(DIMMED_PSEUDO_CLASS, dimmed);
+            item.dimmedProperty().addListener(dimmedListener);
+            pseudoClassStateChanged(DIMMED_PSEUDO_CLASS, item.dimmedProperty().get());
+
+            setOnMouseClicked(_ -> getSkinnable().setSelectedCategoryId(item.categoryId()));
+
+            getChildren().add(accentBar);
+            if (item.icon() != null) {
+                getChildren().add(item.icon());
+            }
+            getChildren().addAll(titleLabel, spacer, countLabel, dirtyLabel);
+        }
+
+        /** Flips the {@code selected} pseudo-class from the current selection id. */
+        void updateSelected(String selectedId) {
+            pseudoClassStateChanged(SELECTED_PSEUDO_CLASS, item.categoryId().equals(selectedId));
+        }
+
+        /** Unbinds the labels and detaches the per-item dimmed listener. */
+        void dispose() {
+            countLabel.textProperty().unbind();
+            countLabel.visibleProperty().unbind();
+            countLabel.managedProperty().unbind();
+            dirtyLabel.visibleProperty().unbind();
+            dirtyLabel.managedProperty().unbind();
+            item.dimmedProperty().removeListener(dimmedListener);
+            setOnMouseClicked(null);
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsSearchIndex.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsSearchIndex.java
@@ -1,0 +1,217 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * The §6.1 always-on search index over the story-305
+ * {@link SettingsCatalogue} — pure, in-memory string matching built at
+ * dialog-open time (Settings View Design Book §6.1 / §5.2, story 306).
+ *
+ * <p>Every descriptor's searchable text — label, synonyms, description,
+ * and the titles of the group and category it lives in — is normalized
+ * once at build time: Unicode NFD decomposition, combining marks
+ * ({@code \p{M}}) stripped, lower-cased in {@link Locale#ROOT}. Queries
+ * are normalized identically, so matching is case- and
+ * diacritic-insensitive on both sides ("LÁTENCY" finds "latency").
+ * Because the index is built from the catalogue, a newly catalogued
+ * descriptor is searchable with no extra wiring (§6.1).</p>
+ *
+ * <p>Hits are ranked by {@link MatchField} tier — exact label above
+ * label-contains above synonym above description above group/category
+ * title (§6.1: exact-label hits rank above description hits) — and a
+ * descriptor appears at most once, under its strongest matching field.
+ * Within a tier, hits keep catalogue order.
+ * {@link #matchCountsByCategory(String)} feeds the rail's per-category
+ * match counts and no-match dimming (§5.2) and, by construction,
+ * agrees exactly with {@link #search(String)}'s groupings.</p>
+ *
+ * <p>Deliberately toolkit-free and I/O-free: the index operates on
+ * plain descriptor text only — no JavaFX types, no device enumeration,
+ * no disk usage (§2.7/§6.6 keep the heavier catalogue sources off this
+ * path). Immutable after construction and safe to share.</p>
+ */
+public final class SettingsSearchIndex {
+
+    private static final Pattern COMBINING_MARKS = Pattern.compile("\\p{M}+");
+
+    private final List<IndexedSetting> entries;
+
+    private SettingsSearchIndex(List<IndexedSetting> entries) {
+        this.entries = List.copyOf(entries);
+    }
+
+    /**
+     * Builds the §6.1 index from every descriptor in the catalogue at
+     * open time. Iterates {@link SettingsCatalogue#categories()} so the
+     * index order — and therefore the within-tier result order — is the
+     * canonical catalogue order.
+     *
+     * @param catalogue the story-305 catalogue to index (must not be
+     *                  {@code null})
+     * @return an immutable index over every catalogued descriptor
+     */
+    public static SettingsSearchIndex of(SettingsCatalogue catalogue) {
+        Objects.requireNonNull(catalogue, "catalogue must not be null");
+        List<IndexedSetting> entries = new ArrayList<>();
+        for (SettingsCatalogue.Category category : catalogue.categories()) {
+            String normalizedCategoryTitle = normalize(category.title());
+            for (SettingsCatalogue.Group group : category.groups()) {
+                String normalizedGroupTitle = normalize(group.title());
+                for (SettingDescriptor<?> descriptor : group.settings()) {
+                    entries.add(new IndexedSetting(descriptor,
+                            category.id(), group.id(),
+                            normalize(descriptor.label()),
+                            descriptor.synonyms().stream()
+                                    .map(SettingsSearchIndex::normalize)
+                                    .toList(),
+                            normalize(descriptor.description()),
+                            normalizedGroupTitle,
+                            normalizedCategoryTitle));
+                }
+            }
+        }
+        return new SettingsSearchIndex(entries);
+    }
+
+    /** Rank tiers, strongest first (§6.1: exact-label above description). */
+    public enum MatchField { LABEL_EXACT, LABEL, SYNONYM, DESCRIPTION, TITLE }
+
+    /**
+     * One hit; descriptor plus where it lives and why it matched.
+     *
+     * @param descriptor the matched descriptor
+     * @param categoryId the {@link SettingsCatalogue.Category#id()} the
+     *                   descriptor lives under
+     * @param groupId    the {@link SettingsCatalogue.Group#id()} the
+     *                   descriptor lives under
+     * @param field      the strongest field the query matched
+     */
+    public record Match(SettingDescriptor<?> descriptor, String categoryId,
+                        String groupId, MatchField field) {}
+
+    /**
+     * All hits for the query, ordered: by {@link MatchField} ordinal,
+     * then catalogue order within a tier. Blank/empty (or {@code null})
+     * query — including a query that is blank <em>after</em>
+     * normalization, e.g. bare combining marks — returns an empty list.
+     * Matching is case-insensitive and diacritic-insensitive on both
+     * sides ({@link Normalizer} NFD + strip {@code \p{M}} +
+     * {@code toLowerCase(Locale.ROOT)}). A descriptor appears at most
+     * once, under its strongest field: {@code LABEL_EXACT} = normalized
+     * query equals normalized label; {@code LABEL} = label contains
+     * query; {@code SYNONYM} = any synonym contains query;
+     * {@code DESCRIPTION} = description contains query; {@code TITLE} =
+     * the descriptor's group or category title contains query.
+     *
+     * @param query the raw, un-normalized user query (may be
+     *              {@code null} or blank)
+     * @return the ranked hits, immutable; empty for a blank query
+     */
+    public List<Match> search(String query) {
+        if (query == null || query.isBlank()) {
+            return List.of();
+        }
+        String normalizedQuery = normalize(query);
+        if (normalizedQuery.isBlank()) {
+            return List.of();
+        }
+        // One bucket per tier keeps within-tier catalogue order without
+        // relying on sort stability: entries are visited in catalogue
+        // order and appended to exactly one bucket (strongest field).
+        List<List<Match>> tiers = new ArrayList<>();
+        for (int tier = 0; tier < MatchField.values().length; tier++) {
+            tiers.add(new ArrayList<>());
+        }
+        for (IndexedSetting entry : entries) {
+            MatchField field = strongestField(entry, normalizedQuery);
+            if (field != null) {
+                tiers.get(field.ordinal()).add(new Match(entry.descriptor(),
+                        entry.categoryId(), entry.groupId(), field));
+            }
+        }
+        List<Match> results = new ArrayList<>();
+        for (List<Match> tier : tiers) {
+            results.addAll(tier);
+        }
+        return List.copyOf(results);
+    }
+
+    /**
+     * Per-category hit count for the query (rail counts/dimming, §5.2).
+     * Empty query returns an empty map. Derived directly from
+     * {@link #search(String)} so the counts agree exactly with the
+     * search groupings; categories with zero hits are absent (the rail
+     * treats absence as zero and dims the item).
+     *
+     * @param query the raw, un-normalized user query (may be
+     *              {@code null} or blank)
+     * @return category id to hit count, immutable, keyed in
+     *         first-appearance order of the search results; empty for a
+     *         blank query
+     */
+    public Map<String, Integer> matchCountsByCategory(String query) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (Match match : search(query)) {
+            counts.merge(match.categoryId(), 1, Integer::sum);
+        }
+        return Collections.unmodifiableMap(counts);
+    }
+
+    /**
+     * Classifies an entry against the normalized query.
+     *
+     * @return the strongest matching field, or {@code null} when the
+     *         entry does not match at all
+     */
+    private static MatchField strongestField(IndexedSetting entry,
+                                             String normalizedQuery) {
+        if (entry.normalizedLabel().equals(normalizedQuery)) {
+            return MatchField.LABEL_EXACT;
+        }
+        if (entry.normalizedLabel().contains(normalizedQuery)) {
+            return MatchField.LABEL;
+        }
+        for (String synonym : entry.normalizedSynonyms()) {
+            if (synonym.contains(normalizedQuery)) {
+                return MatchField.SYNONYM;
+            }
+        }
+        if (entry.normalizedDescription().contains(normalizedQuery)) {
+            return MatchField.DESCRIPTION;
+        }
+        if (entry.normalizedGroupTitle().contains(normalizedQuery)
+                || entry.normalizedCategoryTitle().contains(normalizedQuery)) {
+            return MatchField.TITLE;
+        }
+        return null;
+    }
+
+    /**
+     * The §6.1 normalization applied to both indexed text and queries:
+     * NFD decomposition, combining marks stripped, lower-cased in
+     * {@link Locale#ROOT}.
+     */
+    private static String normalize(String text) {
+        String decomposed = Normalizer.normalize(text, Normalizer.Form.NFD);
+        return COMBINING_MARKS.matcher(decomposed).replaceAll("")
+                .toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * One descriptor's pre-normalized searchable text plus its §3.3
+     * taxonomy address, captured at build time in catalogue order.
+     */
+    private record IndexedSetting(
+            SettingDescriptor<?> descriptor, String categoryId, String groupId,
+            String normalizedLabel, List<String> normalizedSynonyms,
+            String normalizedDescription, String normalizedGroupTitle,
+            String normalizedCategoryTitle) {}
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsSearchIndex.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsSearchIndex.java
@@ -19,8 +19,10 @@ import java.util.regex.Pattern;
  * and the titles of the group and category it lives in — is normalized
  * once at build time: Unicode NFD decomposition, combining marks
  * ({@code \p{M}}) stripped, lower-cased in {@link Locale#ROOT}. Queries
- * are normalized identically, so matching is case- and
- * diacritic-insensitive on both sides ("LÁTENCY" finds "latency").
+ * are normalized identically (after stripping leading/trailing
+ * whitespace), so matching is case- and diacritic-insensitive on both
+ * sides ("LÁTENCY" finds "latency") and a pasted {@code " latency "}
+ * finds what {@code "latency"} finds.
  * Because the index is built from the catalogue, a newly catalogued
  * descriptor is searchable with no extra wiring (§6.1).</p>
  *
@@ -102,11 +104,15 @@ public final class SettingsSearchIndex {
      * then catalogue order within a tier. Blank/empty (or {@code null})
      * query — including a query that is blank <em>after</em>
      * normalization, e.g. bare combining marks — returns an empty list.
-     * Matching is case-insensitive and diacritic-insensitive on both
-     * sides ({@link Normalizer} NFD + strip {@code \p{M}} +
-     * {@code toLowerCase(Locale.ROOT)}). A descriptor appears at most
-     * once, under its strongest field: {@code LABEL_EXACT} = normalized
-     * query equals normalized label; {@code LABEL} = label contains
+     * Leading/trailing whitespace is stripped before matching, so a
+     * pasted {@code " latency "} matches exactly what {@code "latency"}
+     * does and filtering agrees with the row skin's highlight range,
+     * which strips identically. Matching is case-insensitive and
+     * diacritic-insensitive on both sides ({@link Normalizer} NFD +
+     * strip {@code \p{M}} + {@code toLowerCase(Locale.ROOT)}). A
+     * descriptor appears at most once, under its strongest field:
+     * {@code LABEL_EXACT} = normalized query equals normalized label;
+     * {@code LABEL} = label contains
      * query; {@code SYNONYM} = any synonym contains query;
      * {@code DESCRIPTION} = description contains query; {@code TITLE} =
      * the descriptor's group or category title contains query.
@@ -119,7 +125,7 @@ public final class SettingsSearchIndex {
         if (query == null || query.isBlank()) {
             return List.of();
         }
-        String normalizedQuery = normalize(query);
+        String normalizedQuery = normalize(query.strip());
         if (normalizedQuery.isBlank()) {
             return List.of();
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsShell.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsShell.java
@@ -1,0 +1,689 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.icons.DawgIcon;
+
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import java.util.Set;
+
+/**
+ * The story-306 Rail &amp; Pane settings shell — the Concept A assembly
+ * that replaces {@code SettingsDialog}'s {@code TabPane} body (Settings
+ * View Design Book §4.A, §7 Stage 2).
+ *
+ * <p>A plain one-off {@link BorderPane} layout ({@code
+ * javafx-application-design} skill §3 — a single-use composite, not a
+ * Control/Skin): top = the always-on §5.2 search bar, left = the
+ * {@link SettingsNavRail}, center = a fit-to-width {@link ScrollPane}
+ * showing the selected category's pane, bottom = the §5.5 footer action
+ * bar (Cancel / Apply / OK — the §5.5 status note and §5.6 restart
+ * banner are story 307). The shell renders <em>every</em> descriptor of
+ * the story-305 {@link SettingsCatalogue} through one generic
+ * {@link SettingRow} per descriptor, built once up front.</p>
+ *
+ * <h2>Pending edits (§6.2 — dirty/apply generalised)</h2>
+ *
+ * <p>Each row holds a <em>pending</em> value; the shell diffs it against
+ * the persisted value from {@link ValueAccess} on every row edit. An
+ * entry exists in the pending map iff the two differ
+ * ({@code Objects.equals}); {@link #dirtyProperty()} and the owning
+ * category's rail {@code •} marker derive reactively. The shell writes
+ * nothing itself — {@code SettingsDialog.applySettings()} consumes
+ * {@link #pendingEdits()} and then calls {@link #refreshFromPersisted()}.</p>
+ *
+ * <h2>Search (§6.1, §5.2)</h2>
+ *
+ * <p>Non-blank query → search mode: the center swaps to a fresh results
+ * pane of the {@link SettingsSearchIndex} hits in rank order, grouped
+ * under "Category · Group" headers in first-appearance order. The row
+ * <em>nodes are reused</em> (moved into the results pane), so pending
+ * state never resets; leaving search restores each category pane's
+ * remembered child list, re-parenting the rows back. Rail items get
+ * per-category match counts and no-match dimming; matched rows get the
+ * query as their highlight.</p>
+ *
+ * <h2>Keyboard (§6.5, rejection #7)</h2>
+ *
+ * <p>The shell filters exactly one key: Ctrl/Cmd-F →
+ * {@link #focusSearch()}. UP/DOWN/ENTER/RIGHT are rail-owned (the rail's
+ * activate-pane action focuses the pane's first row editor), Tab
+ * traversal is native, and Esc is consumed only by the search field —
+ * and only while it has text (an empty-field Esc must reach the dialog's
+ * close semantics). Nothing else is globally swallowed.</p>
+ *
+ * <h2>Key-binding conflict guard</h2>
+ *
+ * <p>Parity with the old dialog: a KEY_CAPTURE row's new combination that
+ * {@code getName()}-equals another key-binding row's current effective
+ * value (pending if edited, else the seeded persisted value) is reverted
+ * to the row's previous value. The guard lives in the shell's row-value
+ * listener behind a reentrancy flag — conflicts stay cross-setting, the
+ * rows stay generic.</p>
+ *
+ * @see SettingsNavRail
+ * @see SettingRow
+ * @see SettingsSearchIndex
+ */
+public final class SettingsShell extends BorderPane {
+
+    /** Stable style class — selectable as {@code .settings-shell}. */
+    public static final String DEFAULT_STYLE_CLASS = "settings-shell";
+
+    /**
+     * Shared bundle for shell chrome strings ({@code Locale.ROOT}, the
+     * codebase-wide convention — Skill §14).
+     */
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
+
+    /** Everything the shell needs that the catalogue does not carry. */
+    public interface ValueAccess {
+
+        /**
+         * @param settingId a catalogue descriptor id
+         * @return the currently persisted value for the setting; may be
+         *         {@code null} (e.g. an unbound key binding)
+         */
+        Object currentValue(String settingId);
+    }
+
+    private final ValueAccess persisted;
+    private final SettingsSearchIndex searchIndex;
+
+    // ── Row / taxonomy indexes (built once, catalogue order) ─────────────────
+    private final Map<String, SettingRow> rowsById = new LinkedHashMap<>();
+    private final Map<String, String> categoryByRowId = new HashMap<>();
+    private final List<SettingRow> keyCaptureRows = new ArrayList<>();
+    private final Map<String, VBox> categoryPanes = new LinkedHashMap<>();
+    /**
+     * Each category pane's permanent child list (title, group headers,
+     * rows, trailing node). Search mode MOVES row nodes into the results
+     * pane; leaving search restores these lists, re-parenting the rows
+     * back — row nodes are reused so pending state never resets (§6.1).
+     */
+    private final Map<String, List<Node>> categoryPaneChildren = new HashMap<>();
+    private final Map<String, SettingsNavRail.NavItem> navItemsByCategory =
+            new LinkedHashMap<>();
+    private final Map<String, String> categoryTitleById = new HashMap<>();
+    private final Map<String, String> groupTitleByKey = new HashMap<>();
+
+    // ── Pending-edit state (§6.2) ────────────────────────────────────────────
+    /** id → pending value; an entry exists iff pending != persisted. */
+    private final Map<String, Object> pending = new LinkedHashMap<>();
+    private final ReadOnlyBooleanWrapper dirty =
+            new ReadOnlyBooleanWrapper(this, "dirty", false);
+
+    // ── Chrome ───────────────────────────────────────────────────────────────
+    private final SettingsNavRail navRail = new SettingsNavRail();
+    private final ScrollPane paneScroll = new ScrollPane();
+    private final VBox paneHost = new VBox();
+    private final TextField searchField = new TextField();
+
+    /** {@code true} while the center shows search results (§6.1). */
+    private boolean searchMode;
+    /** Reentrancy flag for the key-binding conflict revert. */
+    private boolean conflictRevertInFlight;
+    /** {@code true} while {@link #refreshFromPersisted()} re-seeds rows. */
+    private boolean refreshing;
+
+    private Runnable onApply;
+    private Runnable onOk;
+    private Runnable onCancel;
+
+    /**
+     * Builds the full shell: one row per catalogue descriptor, the rail,
+     * the search index and the footer. Cheap and I/O-free — search is
+     * pure in-memory string work and no device/disk source is touched
+     * (story non-goal).
+     *
+     * @param catalogue             the story-305 catalogue to render; not null
+     * @param persisted             persisted-value access per descriptor id; not null
+     * @param hints                 per-descriptor render hints by id; may be
+     *                              {@code null}/partial (missing ids fall back
+     *                              to {@link SettingRow.ControlHints#none()})
+     * @param categoryTrailingNodes extra node appended to a category's pane,
+     *                              by category id (e.g. {@code "audio"} → the
+     *                              Audio Device Settings… button); may be
+     *                              {@code null}
+     */
+    public SettingsShell(SettingsCatalogue catalogue,
+                         ValueAccess persisted,
+                         Map<String, SettingRow.ControlHints> hints,
+                         Map<String, Node> categoryTrailingNodes) {
+        Objects.requireNonNull(catalogue, "catalogue must not be null");
+        this.persisted = Objects.requireNonNull(persisted, "persisted must not be null");
+        this.searchIndex = SettingsSearchIndex.of(catalogue);
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+
+        Map<String, SettingRow.ControlHints> hintsById =
+                hints == null ? Map.of() : hints;
+        Map<String, Node> trailing =
+                categoryTrailingNodes == null ? Map.of() : categoryTrailingNodes;
+
+        buildRows(catalogue, hintsById);
+        buildCategoryPanes(catalogue, trailing);
+        buildNavRail(catalogue);
+
+        setTop(buildSearchBar());
+        setLeft(navRail);
+        setCenter(buildCenter());
+        setBottom(buildFooter());
+
+        // §6.5 — the shell filters EXACTLY one key: Ctrl/Cmd-F focuses
+        // search. Everything else (rail keys, Tab, Esc) is owned closer
+        // to its target; nothing is globally swallowed (rejection #7).
+        addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.F && event.isShortcutDown()) {
+                focusSearch();
+                event.consume();
+            }
+        });
+
+        if (!catalogue.categories().isEmpty()) {
+            navRail.setSelectedCategoryId(catalogue.categories().get(0).id());
+        }
+    }
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    /** One {@link SettingRow} per descriptor, seeded from {@link ValueAccess}. */
+    private void buildRows(SettingsCatalogue catalogue,
+                           Map<String, SettingRow.ControlHints> hintsById) {
+        for (SettingsCatalogue.Category category : catalogue.categories()) {
+            categoryTitleById.put(category.id(), category.title());
+            for (SettingsCatalogue.Group group : category.groups()) {
+                groupTitleByKey.put(groupKey(category.id(), group.id()), group.title());
+                for (SettingDescriptor<?> descriptor : group.settings()) {
+                    String id = descriptor.id();
+                    SettingRow row = new SettingRow(descriptor,
+                            persisted.currentValue(id), hintsById.get(id));
+                    rowsById.put(id, row);
+                    categoryByRowId.put(id, category.id());
+                    if (descriptor.controlKind() == ControlKind.KEY_CAPTURE) {
+                        keyCaptureRows.add(row);
+                    }
+                    row.valueProperty().addListener(
+                            (_, oldValue, newValue) ->
+                                    onRowValueChanged(row, oldValue, newValue));
+                }
+            }
+        }
+    }
+
+    /**
+     * One permanent pane per category: title label (§5.3 — a plain label,
+     * NEVER an accent fill, rejection §6), then per non-empty group a
+     * header + its rows, then the category's trailing node if present.
+     */
+    private void buildCategoryPanes(SettingsCatalogue catalogue,
+                                    Map<String, Node> trailing) {
+        for (SettingsCatalogue.Category category : catalogue.categories()) {
+            List<Node> children = new ArrayList<>();
+            Label title = new Label(category.title());
+            title.getStyleClass().add("settings-category-title");
+            children.add(title);
+            for (SettingsCatalogue.Group group : category.groups()) {
+                if (group.settings().isEmpty()) {
+                    continue; // placeholder taxonomy slots (story 308)
+                }
+                children.add(groupHeader(group.title()));
+                for (SettingDescriptor<?> descriptor : group.settings()) {
+                    children.add(rowsById.get(descriptor.id()));
+                }
+            }
+            Node trailingNode = trailing.get(category.id());
+            if (trailingNode != null) {
+                children.add(trailingNode);
+            }
+            VBox pane = new VBox();
+            pane.getStyleClass().add("settings-category-pane");
+            pane.getChildren().setAll(children);
+            categoryPanes.put(category.id(), pane);
+            categoryPaneChildren.put(category.id(), List.copyOf(children));
+        }
+    }
+
+    /** Rail items in catalogue order; selection swaps the browse pane. */
+    private void buildNavRail(SettingsCatalogue catalogue) {
+        for (SettingsCatalogue.Category category : catalogue.categories()) {
+            SettingsNavRail.NavItem item = new SettingsNavRail.NavItem(
+                    category.id(), category.title(), categoryIcon(category.id()));
+            navItemsByCategory.put(category.id(), item);
+            navRail.getItems().add(item);
+        }
+        navRail.selectedCategoryIdProperty().addListener((_, _, id) -> {
+            if (!searchMode) {
+                showCategory(id);
+            }
+        });
+        // §6.5 ENTER/RIGHT — focus the pane's first visible row editor.
+        navRail.onActivatePaneProperty().set(this::focusFirstRowEditor);
+    }
+
+    /** §5.2 search bar: icon, always-on field, ✕ clear (visible with text). */
+    private Node buildSearchBar() {
+        HBox bar = new HBox();
+        bar.getStyleClass().add("settings-search-bar");
+
+        Node searchIcon = DawgIcon.of("search", DawgIcon.Size.SIZE_16);
+
+        searchField.getStyleClass().add("settings-search-field");
+        searchField.setPromptText(msg("settings.search.prompt"));
+        searchField.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(searchField, Priority.ALWAYS);
+        searchField.textProperty().addListener((_, _, text) -> handleSearchChanged(text));
+        // §6.5 Esc: clear + consume ONLY while the field has text; an
+        // empty-field Esc must propagate so the dialog's close semantics
+        // (dirty prompt included) still work.
+        searchField.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.ESCAPE && !searchField.getText().isEmpty()) {
+                searchField.clear();
+                event.consume();
+            }
+        });
+
+        Button clear = new Button();
+        clear.getStyleClass().addAll("dawg-button", "icon-only", "settings-search-clear");
+        clear.setGraphic(DawgIcon.of("x", DawgIcon.Size.SIZE_16));
+        clear.setAccessibleText(msg("settings.search.clear"));
+        clear.visibleProperty().bind(searchField.textProperty().isNotEmpty());
+        clear.managedProperty().bind(clear.visibleProperty());
+        clear.setOnAction(_ -> searchField.clear());
+
+        bar.getChildren().addAll(searchIcon, searchField, clear);
+        return bar;
+    }
+
+    /** Fit-to-width scroll pane hosting the browse pane or search results. */
+    private Node buildCenter() {
+        paneHost.getStyleClass().add("settings-pane-host");
+        paneScroll.getStyleClass().add("settings-pane");
+        paneScroll.setContent(paneHost);
+        paneScroll.setFitToWidth(true);
+        paneScroll.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        return paneScroll;
+    }
+
+    /**
+     * §5.5 footer: Cancel / Apply / OK only (note + banner are story 307).
+     * Apply is enabled exactly while dirty; OK is the default button,
+     * Cancel the cancel button.
+     */
+    private Node buildFooter() {
+        HBox footer = new HBox();
+        footer.getStyleClass().add("settings-footer");
+
+        Button cancel = new Button(msg("dialog.cancel"));
+        cancel.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        cancel.setCancelButton(true);
+        cancel.setOnAction(_ -> run(onCancel));
+
+        Button apply = new Button(msg("dialog.apply"));
+        apply.getStyleClass().addAll("dawg-button", "size-default");
+        apply.disableProperty().bind(dirty.getReadOnlyProperty().not());
+        apply.setOnAction(_ -> run(onApply));
+
+        Button ok = new Button(msg("dialog.ok"));
+        ok.getStyleClass().addAll("dawg-button", "size-default", "primary");
+        ok.setDefaultButton(true);
+        ok.setOnAction(_ -> run(onOk));
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        footer.getChildren().addAll(spacer, cancel, apply, ok);
+        return footer;
+    }
+
+    // ── Pending edits (§6.2) ─────────────────────────────────────────────────
+
+    /**
+     * The single row-value listener: key-binding conflict guard first
+     * (parity with the old dialog's cross-setting check), then pending
+     * bookkeeping against the persisted value.
+     */
+    private void onRowValueChanged(SettingRow row, Object oldValue, Object newValue) {
+        if (refreshing) {
+            return; // refreshFromPersisted() rebuilds state wholesale below
+        }
+        if (!conflictRevertInFlight
+                && row.descriptor().controlKind() == ControlKind.KEY_CAPTURE
+                && newValue instanceof KeyCombination combo
+                && conflictsWithOtherBinding(row, combo)) {
+            conflictRevertInFlight = true;
+            try {
+                // Re-enters this listener; the nested call records the
+                // reverted (previous) value in the pending bookkeeping.
+                row.setValue(oldValue);
+            } finally {
+                conflictRevertInFlight = false;
+            }
+            return;
+        }
+        recordPending(row, newValue);
+    }
+
+    /**
+     * @return {@code true} if another key-binding row's current effective
+     *         value (its row value — pending if edited, else the seeded
+     *         persisted binding) has the same {@link KeyCombination#getName()
+     *         name}
+     */
+    private boolean conflictsWithOtherBinding(SettingRow row, KeyCombination combo) {
+        for (SettingRow other : keyCaptureRows) {
+            if (other != row
+                    && other.getValue() instanceof KeyCombination existing
+                    && existing.getName().equals(combo.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Diffs a row value against persisted; maintains the pending map.
+     * The diff runs on the canonical comparison value — a TEXT row's
+     * numeric String parses to the persisted boxed type first, see
+     * {@link SettingRow#canonicalComparisonValue} — so typing the
+     * persisted tempo back reads as clean (§6.2: an entry exists iff the
+     * values actually differ). The map keeps the RAW row value: the apply
+     * path still receives exactly what the editor produced.
+     */
+    private void recordPending(SettingRow row, Object value) {
+        String id = row.descriptor().id();
+        if (Objects.equals(SettingRow.canonicalComparisonValue(row.descriptor(), value),
+                persisted.currentValue(id))) {
+            pending.remove(id);
+        } else {
+            pending.put(id, value);
+        }
+        updateDirtyMarkers();
+    }
+
+    /** Recomputes {@link #dirtyProperty()} and every rail {@code •} marker. */
+    private void updateDirtyMarkers() {
+        dirty.set(!pending.isEmpty());
+        Set<String> dirtyCategories = new HashSet<>();
+        for (String id : pending.keySet()) {
+            String categoryId = categoryByRowId.get(id);
+            if (categoryId != null) {
+                dirtyCategories.add(categoryId);
+            }
+        }
+        for (SettingsNavRail.NavItem item : navItemsByCategory.values()) {
+            item.dirtyProperty().set(dirtyCategories.contains(item.categoryId()));
+        }
+    }
+
+    // ── Search (§6.1 / §5.2) ─────────────────────────────────────────────────
+
+    private void handleSearchChanged(String text) {
+        if (text == null || text.isBlank()) {
+            exitSearchMode();
+        } else {
+            enterSearchMode(text);
+        }
+    }
+
+    /**
+     * Search mode: a fresh results pane of the index hits in rank order,
+     * grouped under "Category · Group" headers in first-appearance order.
+     * Matched row nodes are MOVED here (reused, never rebuilt); rail
+     * items get counts and no-match dimming.
+     */
+    private void enterSearchMode(String query) {
+        searchMode = true;
+
+        for (SettingRow row : rowsById.values()) {
+            row.highlightQueryProperty().set("");
+        }
+
+        VBox results = new VBox();
+        results.getStyleClass().add("settings-search-results");
+        Map<String, VBox> sections = new LinkedHashMap<>();
+        for (SettingsSearchIndex.Match match : searchIndex.search(query)) {
+            SettingRow row = rowsById.get(match.descriptor().id());
+            if (row == null) {
+                continue;
+            }
+            row.highlightQueryProperty().set(query);
+            String key = groupKey(match.categoryId(), match.groupId());
+            VBox section = sections.computeIfAbsent(key, k -> {
+                VBox s = new VBox();
+                s.getStyleClass().add("settings-search-section");
+                s.getChildren().add(groupHeader(
+                        categoryTitleById.getOrDefault(match.categoryId(), match.categoryId())
+                                + " · "
+                                + groupTitleByKey.getOrDefault(k, match.groupId())));
+                results.getChildren().add(s);
+                return s;
+            });
+            section.getChildren().add(row); // re-parents the reused node
+        }
+
+        Map<String, Integer> counts = searchIndex.matchCountsByCategory(query);
+        for (SettingsNavRail.NavItem item : navItemsByCategory.values()) {
+            int count = counts.getOrDefault(item.categoryId(), 0);
+            item.matchCountProperty().set(count);
+            item.dimmedProperty().set(count == 0);
+        }
+
+        paneHost.getChildren().setAll(results);
+    }
+
+    /**
+     * Browse mode: restores every category pane's remembered child list
+     * (re-parenting the moved rows back), clears highlights/counts/dims,
+     * and shows the selected category again.
+     */
+    private void exitSearchMode() {
+        searchMode = false;
+        for (SettingRow row : rowsById.values()) {
+            row.highlightQueryProperty().set("");
+        }
+        for (SettingsNavRail.NavItem item : navItemsByCategory.values()) {
+            item.matchCountProperty().set(-1);
+            item.dimmedProperty().set(false);
+        }
+        for (Map.Entry<String, VBox> entry : categoryPanes.entrySet()) {
+            entry.getValue().getChildren()
+                    .setAll(categoryPaneChildren.get(entry.getKey()));
+        }
+        showCategory(navRail.getSelectedCategoryId());
+    }
+
+    private void showCategory(String categoryId) {
+        VBox pane = categoryId == null ? null : categoryPanes.get(categoryId);
+        if (pane == null) {
+            paneHost.getChildren().clear();
+        } else {
+            paneHost.getChildren().setAll(pane);
+        }
+    }
+
+    // ── Public API ───────────────────────────────────────────────────────────
+
+    /** @return {@code true} while any pending edit exists (§6.2) */
+    public ReadOnlyBooleanProperty dirtyProperty() {
+        return dirty.getReadOnlyProperty();
+    }
+
+    /**
+     * @return an unmodifiable snapshot of id → pending value, containing
+     *         only ids where {@code !Objects.equals(pending, persisted)};
+     *         values may be {@code null} (a cleared key binding)
+     */
+    public Map<String, Object> pendingEdits() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(pending));
+    }
+
+    /**
+     * Re-seeds every row from {@link ValueAccess} and clears the pending
+     * state (call after Apply). Runs with the conflict guard and pending
+     * bookkeeping suspended — persisted values are authoritative — then
+     * rebuilds the dirty markers from scratch.
+     */
+    public void refreshFromPersisted() {
+        refreshing = true;
+        try {
+            for (SettingRow row : rowsById.values()) {
+                row.setValue(persisted.currentValue(row.descriptor().id()));
+            }
+        } finally {
+            refreshing = false;
+        }
+        pending.clear();
+        updateDirtyMarkers();
+    }
+
+    /** @param r footer Apply action (may be {@code null}) */
+    public void setOnApply(Runnable r) {
+        this.onApply = r;
+    }
+
+    /** @param r footer OK action (may be {@code null}) */
+    public void setOnOk(Runnable r) {
+        this.onOk = r;
+    }
+
+    /** @param r footer Cancel action (may be {@code null}) */
+    public void setOnCancel(Runnable r) {
+        this.onCancel = r;
+    }
+
+    /** Focuses the search field (the §6.5 Ctrl/Cmd-F target). */
+    public void focusSearch() {
+        searchField.requestFocus();
+    }
+
+    /** @return the navigation rail (tests / keyboard glue) */
+    public SettingsNavRail navRail() {
+        return navRail;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * §6.5 ENTER/RIGHT from the rail: focus the first visible row's first
+     * focus-traversable editor in the active pane. A skinless row (no
+     * realized editor — headless construction) is a silent no-op.
+     */
+    private void focusFirstRowEditor() {
+        SettingRow first = findFirstVisibleRow(paneHost);
+        if (first == null) {
+            return;
+        }
+        Node editor = findFirstFocusTraversable(first);
+        if (editor != null) {
+            editor.requestFocus();
+        }
+    }
+
+    private static SettingRow findFirstVisibleRow(Parent parent) {
+        for (Node child : parent.getChildrenUnmodifiable()) {
+            if (child instanceof SettingRow row && row.isVisible()) {
+                return row;
+            }
+            if (child instanceof Parent nested) {
+                SettingRow row = findFirstVisibleRow(nested);
+                if (row != null) {
+                    return row;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Node findFirstFocusTraversable(Parent parent) {
+        for (Node child : parent.getChildrenUnmodifiable()) {
+            if (child.isFocusTraversable() && !child.isDisabled() && child.isVisible()) {
+                return child;
+            }
+            if (child instanceof Parent nested) {
+                Node node = findFirstFocusTraversable(nested);
+                if (node != null) {
+                    return node;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Group header label — label-small, upper-cased in code the same way
+     * {@code DawgDialog.sectionHeaderText} realises the §3.2 uppercase
+     * rule (JavaFX CSS has no {@code -fx-text-transform}).
+     */
+    private static Label groupHeader(String title) {
+        Label header = new Label(title.toUpperCase(Locale.ROOT));
+        header.getStyleClass().add("settings-group-title");
+        return header;
+    }
+
+    private static String groupKey(String categoryId, String groupId) {
+        return categoryId + "/" + groupId;
+    }
+
+    /**
+     * Category id → ready-made rail icon (UI Design Book §3.6 — Lucide
+     * only; the rail itself never imports an icon type). Unknown ids get
+     * no icon.
+     */
+    private static Node categoryIcon(String categoryId) {
+        String glyph = switch (categoryId) {
+            case "audio" -> "headphones";
+            case "appearance" -> "monitor";
+            case "project" -> "folder";
+            case "recording" -> "mic";
+            case "backups" -> "archive";
+            case "keyBindings" -> "keyboard";
+            case "plugins" -> "plug";
+            case "general" -> "settings";
+            default -> null;
+        };
+        return glyph == null ? null : DawgIcon.of(glyph, DawgIcon.Size.SIZE_16);
+    }
+
+    private static void run(Runnable action) {
+        if (action != null) {
+            action.run();
+        }
+    }
+
+    /**
+     * Key-fallback bundle lookup (the {@code DawgDialog#msg} idiom —
+     * returns the key itself for a missing resource).
+     */
+    private static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (MissingResourceException missing) {
+            return key;
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsShell.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsShell.java
@@ -63,10 +63,11 @@ import java.util.Set;
  * pane of the {@link SettingsSearchIndex} hits in rank order, grouped
  * under "Category · Group" headers in first-appearance order. The row
  * <em>nodes are reused</em> (moved into the results pane), so pending
- * state never resets; leaving search restores each category pane's
- * remembered child list, re-parenting the rows back. Rail items get
- * per-category match counts and no-match dimming; matched rows get the
- * query as their highlight.</p>
+ * state never resets; every query change and leaving search restore each
+ * category pane's remembered child list first, re-parenting the rows
+ * back — only the current results container ever borrows rows. Rail
+ * items get per-category match counts and no-match dimming; matched rows
+ * get the query as their highlight.</p>
  *
  * <h2>Keyboard (§6.5, rejection #7)</h2>
  *
@@ -124,8 +125,9 @@ public final class SettingsShell extends BorderPane {
     /**
      * Each category pane's permanent child list (title, group headers,
      * rows, trailing node). Search mode MOVES row nodes into the results
-     * pane; leaving search restores these lists, re-parenting the rows
-     * back — row nodes are reused so pending state never resets (§6.1).
+     * pane; every query change and leaving search restore these lists,
+     * re-parenting the rows back — row nodes are reused so pending state
+     * never resets (§6.1).
      */
     private final Map<String, List<Node>> categoryPaneChildren = new HashMap<>();
     private final Map<String, SettingsNavRail.NavItem> navItemsByCategory =
@@ -459,6 +461,12 @@ public final class SettingsShell extends BorderPane {
     private void enterSearchMode(String query) {
         searchMode = true;
 
+        // Re-parent every row home BEFORE building the next results pane:
+        // a row that drops out of the match set would otherwise stay
+        // parented to the previous (now detached) results container,
+        // keeping a growing chain of orphan containers reachable while
+        // the user types.
+        restoreCategoryPaneChildren();
         for (SettingRow row : rowsById.values()) {
             row.highlightQueryProperty().set("");
         }
@@ -510,11 +518,19 @@ public final class SettingsShell extends BorderPane {
             item.matchCountProperty().set(-1);
             item.dimmedProperty().set(false);
         }
+        restoreCategoryPaneChildren();
+        showCategory(navRail.getSelectedCategoryId());
+    }
+
+    /**
+     * Restores every category pane's permanent child list, re-parenting
+     * any row a results pane borrowed back to its home pane.
+     */
+    private void restoreCategoryPaneChildren() {
         for (Map.Entry<String, VBox> entry : categoryPanes.entrySet()) {
             entry.getValue().getChildren()
                     .setAll(categoryPaneChildren.get(entry.getKey()));
         }
-        showCategory(navRail.getSelectedCategoryId());
     }
 
     private void showCategory(String categoryId) {

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -67,6 +67,7 @@ browser.audition.stop=Stop preview
 # footer-button / acknowledge strings only. Caller-supplied titles,
 # prompts, and error details stay caller-supplied (already localized at
 # the call site). Section-scoped prefix per the file convention.
+dialog.apply=Apply
 dialog.cancel=Cancel
 dialog.close=Close
 dialog.ok=OK
@@ -272,3 +273,17 @@ settings.group.plugins.manager=Manager
 settings.group.general.startup=Startup
 settings.group.general.language=Language
 settings.group.general.resetProfiles=Reset & profiles
+
+# Settings shell (story 306) — Settings View Design Book §4.A / §5 / §6.
+# Rail & Pane shell chrome: the always-on search field (§6.1/§5.2), the
+# apply-class badges the shell passes into every SettingRow (§6.4), and
+# the §6.2 dirty-close prompt. Footer buttons reuse the dialog.* family
+# above (dialog.cancel / dialog.apply / dialog.ok), as do the prompt's
+# Apply/Cancel buttons. Section-scoped prefix per the file convention.
+settings.search.prompt=Search all settings…
+settings.search.clear=Clear search
+settings.badge.engineReconfigure=Engine reconfigure
+settings.badge.restartRequired=Restart required
+settings.dirtyPrompt.title=Unsaved Changes
+settings.dirtyPrompt.header=Apply your pending settings changes?
+settings.dirtyPrompt.discard=Discard

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/ATTRIBUTION
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/ATTRIBUTION
@@ -10,7 +10,9 @@ project.
 
 Source revision: lucide-icons/lucide v0.469.0 (tag `0.469.0`, late 2024 — the last release before the `alert-triangle` -> `triangle-alert` rename; pinning here keeps the vendored icon names stable)
                  https://github.com/lucide-icons/lucide/tree/0.469.0/icons
-Vendored on:     2026-05-14
+Vendored on:     2026-05-14 (initial set);
+                 2026-07-26 (monitor, keyboard, plug, archive, rotate-ccw
+                 — story 306 settings shell; same pinned tag 0.469.0)
 Lucide was originally forked from Feather (MIT, Cole Bemis 2013-2022)
 and has since been substantially extended by the Lucide Contributors
 (2022-present).

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/archive.svg
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/archive.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="5" x="2" y="3" rx="1" />
+  <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+  <path d="M10 12h4" />
+</svg>

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/icons.allowed.txt
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/icons.allowed.txt
@@ -1,4 +1,5 @@
 alert-triangle
+archive
 bell
 chevron-down
 chevron-left
@@ -13,17 +14,21 @@ folder
 grip-vertical
 headphones
 info
+keyboard
 link
 lock
 mic
+monitor
 music
 pause
 pause-circle
 pencil
 play
 play-circle
+plug
 plus
 repeat
+rotate-ccw
 search
 settings
 skip-back

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/keyboard.svg
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/keyboard.svg
@@ -1,0 +1,21 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 8h.01" />
+  <path d="M12 12h.01" />
+  <path d="M14 8h.01" />
+  <path d="M16 12h.01" />
+  <path d="M18 8h.01" />
+  <path d="M6 8h.01" />
+  <path d="M7 16h10" />
+  <path d="M8 12h.01" />
+  <rect width="20" height="16" x="2" y="4" rx="2" />
+</svg>

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/monitor.svg
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/monitor.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="14" x="2" y="3" rx="2" />
+  <line x1="8" x2="16" y1="21" y2="21" />
+  <line x1="12" x2="12" y1="17" y2="21" />
+</svg>

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/plug.svg
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/plug.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 22v-5" />
+  <path d="M9 8V2" />
+  <path d="M15 8V2" />
+  <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
+</svg>

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/rotate-ccw.svg
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/icons/lucide/rotate-ccw.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+  <path d="M3 3v5h5" />
+</svg>

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/settings/setting-row.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/settings/setting-row.css
@@ -1,0 +1,89 @@
+/*
+ * Story 306 — SettingRow user-agent stylesheet (Rail & Pane settings shell,
+ * Settings View Design Book §5.4).
+ *
+ * Returned by SettingRow#getUserAgentStylesheet(). Self-contained (mirrors
+ * project-card.css, story 296): the local -srw-* tokens carry literal
+ * Palette-A defaults here so a row renders correctly with NO application
+ * stylesheet loaded (e.g. an isolated control test). The author-origin forward
+ * block in styles.css (`.setting-row { -srw-text: -text; -srw-text-mute:
+ * -text-mute; -srw-warn: -warn; -srw-accent: -accent; -srw-accent-soft:
+ * -accent-soft; }`) RE-declares the same tokens from role tokens and WINS by
+ * CSS origin (AUTHOR > USER_AGENT), so a theme overlay re-tints the rows for
+ * free (feedback_control_css_role_token_forwarding,
+ * feedback_css_author_overrides_useragent_duplication). The literal values
+ * below match Palette A in styles.css; TokenValidationTest scans only
+ * styles.css / theme overlays, not control UA sheets, so these literals are by
+ * design.
+ */
+.setting-row {
+    -srw-text:        #B7BCC7;  /* -text        */
+    -srw-text-mute:   #7A808C;  /* -text-mute   */
+    -srw-warn:        #E6B450;  /* -warn        */
+    -srw-accent:      #7C8CFF;  /* -accent      */
+    -srw-accent-soft: rgba(124, 140, 255, 0.14);  /* -accent-soft */
+
+    -fx-padding: 4 0 4 0;
+}
+
+.setting-row .setting-row-grid {
+    -fx-hgap: 8;
+    -fx-vgap: 2;
+}
+
+/* §5.4: fixed-width label column, right-aligned to the control gutter
+   (width is the LABEL_COLUMN_WIDTH layout constant in SettingRowSkin). */
+.setting-row .setting-row-label {
+    -fx-text-fill: -srw-text;
+    -fx-font-size: 12px;
+}
+
+/* Text spans inside the §6.1 highlight TextFlow (Label text-fill does not
+   reach graphic Text nodes — they take -fx-fill directly). */
+.setting-row .setting-row-label-text {
+    -fx-fill: -srw-text;
+    -fx-font-size: 12px;
+}
+
+/* The matching span of the search highlight (§5.2/§6.1). */
+.setting-row .setting-row-highlight {
+    -fx-fill: -srw-accent;
+}
+
+/* One muted description line beneath the control (§5.4). */
+.setting-row .setting-row-description {
+    -fx-text-fill: -srw-text-mute;
+    -fx-font-size: 11px;
+}
+
+/* Apply-class badge (§6.4) — omitted entirely for LIVE by the skin. */
+.setting-row .setting-row-badge {
+    -fx-font-size: 10px;
+}
+.setting-row .setting-row-badge.badge-engine {
+    -fx-text-fill: -srw-text-mute;
+}
+.setting-row .setting-row-badge.badge-restart {
+    -fx-text-fill: -srw-warn;
+}
+
+/* Slider value readout — default fill; the app's .numeric-value (AUTHOR)
+   supplies the mono type scale when styles.css is loaded. */
+.setting-row .numeric-value {
+    -fx-text-fill: -srw-text;
+}
+
+.setting-row .setting-row-slider-box,
+.setting-row .setting-row-path-box {
+    -fx-spacing: 8;
+}
+
+/* Armed key-capture field (§6.5): accent border + accent-soft wash while the
+   row is explicitly armed; disarmed fields are indistinguishable from a plain
+   read-only field (rejection #7 — capture is never ambient). */
+.setting-row .key-capture:armed {
+    -fx-background-color: -srw-accent-soft;
+    -fx-border-color: -srw-accent;
+    -fx-border-width: 1;
+    -fx-border-radius: 4;
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/settings/settings-nav-rail.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/settings/settings-nav-rail.css
@@ -1,0 +1,112 @@
+/*
+ * Story 306 — SettingsNavRail user-agent stylesheet (Rail & Pane settings
+ * shell, Settings View Design Book §4.A / §5.1 / §5.2).
+ *
+ * Returned by SettingsNavRail#getUserAgentStylesheet(). Self-contained
+ * (mirrors project-card.css, story 296): the local -snr-* tokens carry
+ * literal Palette-A defaults here so the rail renders correctly with NO
+ * application stylesheet loaded (e.g. an isolated control test). The
+ * author-origin forward block in styles.css (`.settings-nav-rail {
+ * -snr-surface: -surface-2; … }`) RE-declares the same tokens from role
+ * tokens and WINS by CSS origin (AUTHOR > USER_AGENT), so a theme overlay
+ * re-tints the rail for free (feedback_control_css_role_token_forwarding,
+ * feedback_css_author_overrides_useragent_duplication). The literal values
+ * below match Palette A in styles.css; TokenValidationTest scans only
+ * styles.css / theme overlays, not control UA sheets, so these literals are
+ * by design.
+ */
+.settings-nav-rail {
+    -snr-surface:       #1D1F26;  /* -surface-2   */
+    -snr-surface-hover: #272A33;  /* -surface-3   */
+    -snr-accent:        #7C8CFF;  /* -accent      */
+    -snr-text:          #B7BCC7;  /* -text        */
+    -snr-text-hi:       #ECEEF2;  /* -text-hi     */
+    -snr-text-mute:     #7A808C;  /* -text-mute   */
+    -snr-focus-ring:    #5C8CFF;  /* -focus-ring  */
+
+    -fx-background-color: -snr-surface;
+    /* Resting border is transparent so the :focused ring never reflows
+       layout (UI Design Book hover/focus rule §7.1/§7.3). */
+    -fx-border-color: transparent;
+    -fx-border-width: 1;
+}
+
+.settings-nav-rail:focused {
+    -fx-border-color: -snr-focus-ring;
+}
+
+/* The inner ScrollPane is chrome only — the rail's own fill shows through. */
+.settings-nav-rail .scroll-pane,
+.settings-nav-rail .scroll-pane .viewport {
+    -fx-background-color: transparent;
+    -fx-background-insets: 0;
+    -fx-padding: 0;
+}
+
+/* ── Cells (book §5.1) ── */
+.settings-nav-cell {
+    -fx-alignment: center-left;
+    -fx-spacing: 8;
+    /* Left inset is 0 so the accent bar sits flush against the rail edge;
+       the cell spacing provides the bar → icon/title gap. */
+    -fx-padding: 8 12 8 0;
+    -fx-background-color: transparent;
+}
+
+.settings-nav-cell:hover {
+    -fx-background-color: -snr-surface-hover;
+}
+
+/* Selection = surface-2 fill + the accent bar below — NEVER an accent fill
+   behind the title label (UI Design Book rejection §6, book §5.3). */
+.settings-nav-cell:selected {
+    -fx-background-color: -snr-surface;
+}
+
+/* No matches in this category while a search is active (book §5.2). */
+.settings-nav-cell:dimmed {
+    -fx-opacity: 0.4;
+}
+
+/* ── Accent bar — a drawn Region, ALWAYS in the graph, transparent unless
+   its cell is selected (rejection §6). ── */
+.settings-nav-accent-bar {
+    -fx-min-width: 3;
+    -fx-pref-width: 3;
+    -fx-max-width: 3;
+    -fx-background-color: transparent;
+}
+
+.settings-nav-cell:selected .settings-nav-accent-bar {
+    -fx-background-color: -snr-accent;
+}
+
+/* ── Cell children ── */
+.settings-nav-title {
+    -fx-text-fill: -snr-text;
+}
+
+.settings-nav-cell:selected .settings-nav-title {
+    -fx-text-fill: -snr-text-hi;
+}
+
+/* Per-surface icon re-tint idiom (styles.css §"DawgIcon"): rail icons follow
+   the title text colour, brightening with selection. */
+.settings-nav-cell .dawg-icon {
+    -fx-icon-color: -snr-text;
+}
+
+.settings-nav-cell:selected .dawg-icon {
+    -fx-icon-color: -snr-text-hi;
+}
+
+/* Match count — visible only while searching (matchCount >= 0). */
+.settings-nav-count {
+    -fx-text-fill: -snr-text-mute;
+    -fx-font-size: 10px;
+}
+
+/* Unsaved-edit • marker (book §5.1). */
+.settings-nav-dirty {
+    -fx-text-fill: -snr-accent;
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -2567,3 +2567,191 @@
     -fx-text-fill: -warn;
     -fx-font-size: 11px;
 }
+
+/* ════════════════════════════════════════════════════════════════════
+ * Settings shell — Rail & Pane (story 306)
+ * Settings View Design Book §4.A (shell), §5.1–§5.5 (rail / search /
+ * rows / footer), §6.1 (search), §6.4 (badges), §6.5 (keyboard).
+ * Tokens only (Palette A on .root-pane) — no literal hex, 4 px grid.
+ *
+ * Two-layer control CSS (the ProjectCard precedent): SettingsNavRail
+ * and SettingRow ship self-contained USER_AGENT sheets
+ * (settings-nav-rail.css / setting-row.css) consuming LOCAL -snr-* /
+ * -srw-* tokens with literal Palette-A defaults. The forward blocks
+ * below RE-declare those local tokens from role tokens at AUTHOR
+ * origin (source and target names differ — never a circular lookup),
+ * so a theme overlay re-tints both controls by overriding the role
+ * tokens alone.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* Role-token forwards for the rail's USER_AGENT sheet. */
+.settings-nav-rail {
+    -snr-surface:       -surface-2;
+    -snr-surface-hover: -surface-3;
+    -snr-accent:        -accent;
+    -snr-text:          -text;
+    -snr-text-hi:       -text-hi;
+    -snr-text-mute:     -text-mute;
+    -snr-focus-ring:    -focus-ring;
+
+    -fx-pref-width: 176;
+    -fx-min-width: 144;
+}
+
+/* Role-token forwards for the row's USER_AGENT sheet. */
+.setting-row {
+    -srw-text:        -text;
+    -srw-text-mute:   -text-mute;
+    -srw-warn:        -warn;
+    -srw-accent:      -accent;
+    -srw-accent-soft: -accent-soft;
+}
+
+/* AUTHOR-origin re-statements of the label fills/sizes the UA sheets
+ * carry: the global `.dialog-pane .label` rule above (12 px, -text-hi)
+ * beats any USER_AGENT rule by origin, so every settings label the
+ * design book sizes/tints differently must be re-declared here at
+ * equal-or-higher specificity + later cascade. */
+.settings-nav-cell .settings-nav-title {
+    -fx-text-fill: -text;
+}
+.settings-nav-cell:selected .settings-nav-title {
+    -fx-text-fill: -text-hi;
+}
+.settings-nav-cell .settings-nav-count {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10px;
+}
+.settings-nav-cell .settings-nav-dirty {
+    -fx-text-fill: -accent;
+}
+
+/* Rail icons follow the title fill, brightening with selection (the UA
+ * sheet's §5.1 re-tint) — restated here because the global `.dawg-icon`
+ * -text-hi rule above is AUTHOR origin and beats any USER_AGENT rule
+ * regardless of specificity (the .dock-grip re-tint precedent). */
+.settings-nav-cell .dawg-icon {
+    -fx-icon-color: -text;
+}
+.settings-nav-cell:selected .dawg-icon {
+    -fx-icon-color: -text-hi;
+}
+
+/* The rail's inner ScrollPane is chrome only — keep the global
+ * `.scroll-pane` -surface-1 fill from painting over the rail's
+ * -surface-2 (the UA sheet's transparency loses to AUTHOR origin). */
+.settings-nav-rail .scroll-pane,
+.settings-nav-rail .scroll-pane > .viewport {
+    -fx-background-color: transparent;
+    -fx-background: transparent;
+}
+
+/* §5.4 row label / description / badge type — sizes per the UI-book
+ * scale (Body 12, Caption 11, Label-small 10). */
+.setting-row .setting-row-label {
+    -fx-text-fill: -text;
+    -fx-font-size: 12px;
+}
+.setting-row .setting-row-description {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+}
+.setting-row .setting-row-badge {
+    -fx-font-size: 10px;
+}
+.setting-row .setting-row-badge.badge-engine {
+    -fx-text-fill: -text-mute;
+}
+.setting-row .setting-row-badge.badge-restart {
+    -fx-text-fill: -warn;
+}
+
+/* §6.1 highlight spans are Text nodes in the label's graphic TextFlow —
+ * they take -fx-fill (never -fx-text-fill); `.label` rules cannot reach
+ * them, so these mirror the UA sheet with role tokens directly. */
+.setting-row .setting-row-label-text {
+    -fx-fill: -text;
+}
+.setting-row .setting-row-highlight {
+    -fx-fill: -accent;
+}
+
+/* §6.5 armed key-capture field: accent ring + accent-soft wash while
+ * explicitly armed. Re-stated at AUTHOR origin because the global
+ * `.text-field` border rules would beat the UA sheet's :armed rule. */
+.setting-row .key-capture:armed {
+    -fx-background-color: -accent-soft;
+    -fx-border-color: -accent;
+}
+
+/* ── Shell assembly (§4.A) ── */
+.settings-shell {
+    -fx-background-color: -surface-1;
+    -fx-pref-height: 560;
+}
+
+/* §5.2 always-on search bar. */
+.settings-search-bar {
+    -fx-padding: 8 12 8 12;
+    -fx-spacing: 8;
+    -fx-alignment: center-left;
+    -fx-background-color: -surface-1;
+    -fx-border-color: -line-soft;
+    -fx-border-width: 0 0 1 0;
+}
+.settings-search-field {
+    -fx-background-color: -surface-2;
+}
+.settings-search-clear {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+}
+
+/* §5.3 the scrolling settings pane. */
+.settings-pane,
+.settings-pane > .viewport {
+    -fx-background-color: -surface-1;
+    -fx-background: -surface-1;
+}
+
+.settings-category-pane,
+.settings-search-results {
+    -fx-padding: 16 24 24 24;
+    -fx-spacing: 12;
+}
+.settings-search-section {
+    -fx-spacing: 12;
+}
+
+/* §5.3 pane header — H2 13/600, PLAIN -text-hi: NEVER an accent fill or
+ * accent text-fill (UI Design Book rejection §6). Two-selector form so
+ * it beats `.dialog-pane .label` on equal specificity + later cascade
+ * (the .dawg-dialog-section-header idiom above). */
+.dialog-pane .settings-category-title,
+.settings-category-title {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 13px;
+    -fx-font-weight: 600;
+}
+
+/* Group headers (browse groups and search "Category · Group" headers) —
+ * label-small 10/600 -text-mute, mirroring .dawg-dialog-section-header.
+ * Uppercase is realised in code (DawgDialog.sectionHeaderText idiom;
+ * JavaFX CSS has no -fx-text-transform). */
+.dialog-pane .settings-group-title,
+.settings-group-title {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10px;
+    -fx-font-weight: 600;
+}
+
+/* §5.5 footer — exactly Cancel / Apply / OK (the status note and the
+ * restart banner are story 307). */
+.settings-footer {
+    -fx-padding: 8 16 8 16;
+    -fx-spacing: 8;
+    -fx-alignment: center-right;
+    -fx-background-color: -surface-bg;
+    -fx-border-color: -line-soft;
+    -fx-border-width: 1 0 0 0;
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DirtyApplyGeneralisedTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/DirtyApplyGeneralisedTest.java
@@ -1,0 +1,320 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
+
+import javafx.application.Platform;
+import javafx.event.Event;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Button;
+import javafx.scene.control.DialogEvent;
+import javafx.scene.control.ScrollPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 306 — dirty/apply generalised to <em>every</em> setting (Settings
+ * View Design Book §6.2): an edit to any non-key-binding row makes the
+ * shell dirty and enables the footer Apply; Apply writes the value through
+ * {@link SettingsModel} and clears dirty; closing dirty runs the
+ * Apply / Discard / Cancel prompt (via the package-private
+ * {@code setDirtyClosePrompt} seam), where DISCARD closes without writing
+ * and CANCEL vetoes the close.
+ *
+ * <p>The tests drive the real footer buttons ({@code Button#fire()} is a
+ * no-op while disabled, so a fired Apply also proves it was enabled) and
+ * the real {@code DIALOG_CLOSE_REQUEST} path — in JavaFX 26
+ * {@code Dialog.close()} fires that event and aborts when it is consumed,
+ * so the dialog's {@code setOnCloseRequest} guard is THE universal close
+ * gate. Everything runs headless on the FX thread; no Stage is shown
+ * ({@code HeavyweightDialog.close()} guards {@code stage.isShowing()}).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class DirtyApplyGeneralisedTest {
+
+    private static final String LATENCY_ID = "audio.applyLatencyCompensation";
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    private static SettingsModel newModel() {
+        Preferences prefs = Preferences.userRoot()
+                .node("dirtyApplyGeneralisedTest_" + System.nanoTime());
+        return new SettingsModel(prefs);
+    }
+
+    /**
+     * Walks a node graph collecting instances of {@code type}.
+     * {@code ScrollPane} content is not a child until a skin attaches, so
+     * it is followed explicitly (headless — no skins are realized).
+     */
+    private static <T extends Node> void collectInstances(Node node, Class<T> type, List<T> into) {
+        if (node == null) {
+            return;
+        }
+        if (type.isInstance(node)) {
+            into.add(type.cast(node));
+        }
+        if (node instanceof ScrollPane scrollPane) {
+            collectInstances(scrollPane.getContent(), type, into);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collectInstances(child, type, into);
+            }
+        }
+    }
+
+    /**
+     * Selects {@code categoryId} on the rail (attaching its pane to the
+     * center scroll graph) and returns the {@link SettingRow} rendering
+     * {@code settingId}.
+     */
+    private static SettingRow settingRow(SettingsDialog dialog, String categoryId,
+                                         String settingId) {
+        SettingsShell shell = dialog.getShell();
+        shell.navRail().setSelectedCategoryId(categoryId);
+        List<SettingRow> rows = new ArrayList<>();
+        collectInstances(shell, SettingRow.class, rows);
+        return rows.stream()
+                .filter(row -> settingId.equals(row.descriptor().id()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No row for " + settingId));
+    }
+
+    /** The shell footer's buttons (Cancel / Apply / OK after the spacer). */
+    private static List<Button> footerButtons(SettingsDialog dialog) {
+        Parent footer = (Parent) dialog.getShell().getBottom();
+        List<Button> buttons = new ArrayList<>();
+        for (Node child : footer.getChildrenUnmodifiable()) {
+            if (child instanceof Button button) {
+                buttons.add(button);
+            }
+        }
+        assertThat(buttons).as("footer carries Cancel / Apply / OK").hasSize(3);
+        return buttons;
+    }
+
+    /** Apply is the footer button that is neither the cancel nor the default button. */
+    private static Button applyButton(SettingsDialog dialog) {
+        return footerButtons(dialog).stream()
+                .filter(button -> !button.isCancelButton() && !button.isDefaultButton())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No Apply button in the footer"));
+    }
+
+    private static Button cancelButton(SettingsDialog dialog) {
+        return footerButtons(dialog).stream()
+                .filter(Button::isCancelButton)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No Cancel button in the footer"));
+    }
+
+    /**
+     * The full §6.2 flow over a NON-key-binding setting: an edit enables
+     * the previously disabled Apply, firing Apply writes through
+     * {@link SettingsModel} and clears dirty (Apply disables again), and a
+     * dirty close with an injected DISCARD prompt closes without writing —
+     * the model keeps the <em>applied</em> value, not the re-edited one.
+     */
+    @Test
+    void editEnablesApplyApplyWritesThroughModelAndDiscardClosesWithoutWriting()
+            throws Exception {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            SettingsDialog dialog = new SettingsDialog(model);
+            SettingsShell shell = dialog.getShell();
+            SettingRow row = settingRow(dialog, "audio", LATENCY_ID);
+            boolean initial = model.isApplyLatencyCompensation();
+            Button apply = applyButton(dialog);
+
+            assertThat(shell.dirtyProperty().get()).as("clean at open").isFalse();
+            assertThat(apply.isDisabled()).as("Apply disabled while clean").isTrue();
+
+            // §6.2 — an edit to ANY setting (not just a key binding) is
+            // held as a pending value; nothing is written yet.
+            row.setValue(!initial);
+            assertThat(shell.dirtyProperty().get()).as("edit marks the shell dirty").isTrue();
+            assertThat(apply.isDisabled()).as("Apply enabled once dirty").isFalse();
+            assertThat(model.isApplyLatencyCompensation())
+                    .as("pending edit is not yet written")
+                    .isEqualTo(initial);
+
+            // The real footer path: fire() is a no-op on a disabled button,
+            // so a successful write below also re-proves Apply was enabled.
+            apply.fire();
+            assertThat(model.isApplyLatencyCompensation())
+                    .as("Apply writes the edit through SettingsModel")
+                    .isEqualTo(!initial);
+            assertThat(shell.dirtyProperty().get()).as("Apply clears dirty").isFalse();
+            assertThat(apply.isDisabled()).as("Apply disabled again after Apply").isTrue();
+
+            // Dirty again (back towards the pre-apply value), then close
+            // via the footer Cancel with an injected DISCARD prompt.
+            row.setValue(initial);
+            assertThat(shell.dirtyProperty().get()).isTrue();
+            AtomicInteger promptRuns = new AtomicInteger();
+            dialog.setDirtyClosePrompt(() -> {
+                promptRuns.incrementAndGet();
+                return SettingsDialog.DirtyChoice.DISCARD;
+            });
+            cancelButton(dialog).fire();
+
+            // Exactly once: DISCARD re-seeds the shell before the close
+            // proceeds, so the close-request re-entry of the guard (JavaFX
+            // 26 Dialog.close() always fires DIALOG_CLOSE_REQUEST) finds a
+            // clean shell and must not prompt a second time.
+            assertThat(promptRuns.get())
+                    .as("dirty close ran the prompt exactly once")
+                    .isEqualTo(1);
+            assertThat(model.isApplyLatencyCompensation())
+                    .as("DISCARD closes without writing — the applied value stands")
+                    .isEqualTo(!initial);
+            assertThat(shell.dirtyProperty().get())
+                    .as("DISCARD drops the pending edits")
+                    .isFalse();
+            return null;
+        });
+    }
+
+    /**
+     * The [X]/Esc path surfaces as {@code DIALOG_CLOSE_REQUEST}; a CANCEL
+     * choice from the prompt consumes it (the dialog stays open) and the
+     * pending edit survives untouched. Consumption is asserted on the fired
+     * PAYLOAD: the event is constructed with the dialog as its source and
+     * the dialog's {@code EventHandlerManager} uses the dialog as its event
+     * source, so {@code fixEventSource} (javafx-base 26,
+     * {@code EventHandlerManager.java:238-243}) makes no defensive copy —
+     * {@code isConsumed()} on this very object reflects the guard's veto.
+     * No {@code getSource()} identity is asserted.
+     */
+    @Test
+    void dirtyCloseRequestWithCancelChoiceIsVetoedAndKeepsPendingEdits() throws Exception {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            SettingsDialog dialog = new SettingsDialog(model);
+            SettingRow row = settingRow(dialog, "audio", LATENCY_ID);
+            boolean initial = model.isApplyLatencyCompensation();
+            row.setValue(!initial);
+
+            AtomicInteger promptRuns = new AtomicInteger();
+            dialog.setDirtyClosePrompt(() -> {
+                promptRuns.incrementAndGet();
+                return SettingsDialog.DirtyChoice.CANCEL;
+            });
+
+            DialogEvent closeRequest =
+                    new DialogEvent(dialog, DialogEvent.DIALOG_CLOSE_REQUEST);
+            Event.fireEvent(dialog, closeRequest);
+
+            assertThat(promptRuns.get()).as("dirty close request ran the prompt").isEqualTo(1);
+            assertThat(closeRequest.isConsumed())
+                    .as("CANCEL choice consumes the close request (dialog stays open)")
+                    .isTrue();
+            assertThat(dialog.getShell().pendingEdits())
+                    .as("CANCEL keeps the pending edit intact")
+                    .containsEntry(LATENCY_ID, !initial);
+            assertThat(model.isApplyLatencyCompensation())
+                    .as("nothing was written")
+                    .isEqualTo(initial);
+            return null;
+        });
+    }
+
+    /**
+     * Regression (story-306 fix): the tempo TEXT editor delivers raw
+     * Strings while the persisted value is a boxed Double, so the §6.2
+     * diff runs on the canonical comparison value — typing text
+     * numerically equal to the persisted tempo must NOT leave the shell
+     * stuck dirty (nor the ↺ marker showing), while a real numeric edit
+     * and unparseable text remain pending.
+     */
+    @Test
+    void numericTempoTextEqualToPersistedValueIsNotDirty() throws Exception {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            SettingsDialog dialog = new SettingsDialog(model);
+            SettingsShell shell = dialog.getShell();
+            SettingRow tempo = settingRow(dialog, "project", "project.defaultTempo");
+
+            tempo.setValue("140");
+            assertThat(shell.dirtyProperty().get())
+                    .as("a real tempo edit is dirty")
+                    .isTrue();
+            assertThat(tempo.modifiedProperty().get())
+                    .as("the reset marker shows for a real edit")
+                    .isTrue();
+
+            // Typing the persisted value back ("120.0") — the String must
+            // compare equal to the boxed Double, not stick as dirty forever.
+            tempo.setValue(String.valueOf(model.getDefaultTempo()));
+            assertThat(shell.dirtyProperty().get())
+                    .as("text numerically equal to the persisted tempo is not a pending edit")
+                    .isFalse();
+            assertThat(tempo.modifiedProperty().get())
+                    .as("the reset marker agrees — the text equals the default")
+                    .isFalse();
+
+            // Unparseable text is a genuine (apply-time silently dropped) edit.
+            tempo.setValue("not a tempo");
+            assertThat(shell.dirtyProperty().get())
+                    .as("unparseable text stays a pending edit")
+                    .isTrue();
+            return null;
+        });
+    }
+
+    /** A clean close must not prompt — the guard only fires with pending edits. */
+    @Test
+    void cleanCloseDoesNotRunThePrompt() throws Exception {
+        runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(newModel());
+            AtomicInteger promptRuns = new AtomicInteger();
+            dialog.setDirtyClosePrompt(() -> {
+                promptRuns.incrementAndGet();
+                return SettingsDialog.DirtyChoice.CANCEL;
+            });
+            cancelButton(dialog).fire();
+            assertThat(promptRuns.get()).as("no prompt while clean").isZero();
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/KeyCaptureArmedPerRowTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/KeyCaptureArmedPerRowTest.java
@@ -1,0 +1,225 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.ControlKind;
+import com.benesquivelmusic.daw.app.ui.settings.SettingDescriptor;
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+
+import javafx.application.Platform;
+import javafx.event.Event;
+import javafx.scene.Scene;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 306 — per-row armed key capture (Settings View Design Book §6.5,
+ * rejection #7 / §1.9). A {@code KEY_CAPTURE} {@link SettingRow} captures a
+ * keystroke <em>only</em> while explicitly armed: disarmed, its field-local
+ * filter consumes nothing, so ordinary keys keep flowing (nothing is globally
+ * swallowed); armed, the next non-modifier keystroke becomes the row value,
+ * is consumed, and disarms the row; ESC disarms without clearing the binding.
+ *
+ * <p>Propagation is asserted through a parent-level bubbling
+ * {@code addEventHandler} on the event PAYLOAD (the {@link KeyCode}), never
+ * {@code Event.getSource()} identity — JavaFX rewrites the source per node on
+ * bubble ({@code feedback_javafx_bubbling_event_test_pitfall}). A consumed
+ * event never reaches the parent's bubbling handler; an unconsumed one
+ * always does.</p>
+ *
+ * <h2>Why the disarmed Up/Down check reads the caret, not the parent</h2>
+ *
+ * <p>JavaFX itself maps UP → {@code home()} and DOWN → {@code end()} on every
+ * text input control and auto-consumes them at the target (JavaFX 26
+ * {@code TextInputControlBehavior} constructor key mappings; its catch-all
+ * additionally consumes most unmodified {@code KEY_PRESSED} events). So
+ * Up/Down fired <em>at the field</em> can never reach a parent bubbling
+ * handler on any JavaFX {@code TextField} — armed or not, story or no story.
+ * What the story's rejection-#7 guard actually requires is that the
+ * <em>capture filter</em> passes them through while disarmed, and that is
+ * observable: the filter runs in the capture phase <em>before</em> the
+ * field's own behavior, so the caret only moves if the filter did not
+ * consume. The direct parent-propagation assertion uses an alt-modified
+ * key, which the field's behavior genuinely leaves alone.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class KeyCaptureArmedPerRowTest {
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    /**
+     * A realized KEY_CAPTURE row under a parent whose bubbling handler
+     * records every {@code KEY_PRESSED} payload code that reaches it.
+     */
+    private record Fixture(SettingRow row, TextField field, List<KeyCode> reachedParent) {}
+
+    /**
+     * Builds a row for a <em>real</em> catalogue KEY_CAPTURE descriptor
+     * (any keybinding row — the capture machinery is descriptor-agnostic),
+     * realizes its skin in a Scene, and hooks the parent payload recorder.
+     */
+    private static Fixture buildFixture(Object initialValue) {
+        SettingDescriptor<?> descriptor = SettingsCatalogue.create().categories().stream()
+                .flatMap(category -> category.groups().stream())
+                .flatMap(group -> group.settings().stream())
+                .filter(d -> d.controlKind() == ControlKind.KEY_CAPTURE)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "the catalogue carries no KEY_CAPTURE descriptor"));
+        SettingRow row = new SettingRow(descriptor, initialValue, SettingRow.ControlHints.none());
+        StackPane root = new StackPane(row);
+        new Scene(root, 800, 240);
+        root.applyCss();
+        root.layout();
+        TextField field = (TextField) row.lookup(".key-capture");
+        assertThat(field)
+                .as("the KEY_CAPTURE row's editor is the .key-capture field")
+                .isNotNull();
+        List<KeyCode> reachedParent = new ArrayList<>();
+        root.addEventHandler(KeyEvent.KEY_PRESSED, event -> reachedParent.add(event.getCode()));
+        return new Fixture(row, field, reachedParent);
+    }
+
+    private static void press(TextField field, KeyCode code, boolean alt) {
+        Event.fireEvent(field, new KeyEvent(
+                KeyEvent.KEY_PRESSED, "", "", code, false, false, alt, false));
+    }
+
+    @Test
+    void disarmedRowConsumesNothing() throws Exception {
+        runOnFxThread(() -> {
+            KeyCombination binding = new KeyCodeCombination(KeyCode.J, KeyCombination.ALT_DOWN);
+            Fixture fx = buildFixture(binding);
+
+            // A key the field's own behavior leaves alone bubbles all the
+            // way to the parent — the disarmed filter consumed nothing.
+            press(fx.field(), KeyCode.K, true);
+            assertThat(fx.reachedParent())
+                    .as("disarmed: an alt-modified key must bubble to the parent")
+                    .contains(KeyCode.K);
+
+            // Up/Down pass through the disarmed filter into the field's own
+            // caret handling (see class Javadoc — the toolkit consumes them
+            // at the target, so caret motion is the propagation proof).
+            assertThat(fx.field().getText())
+                    .as("the seeded binding renders display text (caret proof needs it)")
+                    .isNotEmpty();
+            fx.field().positionCaret(0);
+            press(fx.field(), KeyCode.DOWN, false);
+            assertThat(fx.field().getCaretPosition())
+                    .as("disarmed: DOWN must reach the field's own end() handling")
+                    .isEqualTo(fx.field().getText().length());
+            press(fx.field(), KeyCode.UP, false);
+            assertThat(fx.field().getCaretPosition())
+                    .as("disarmed: UP must reach the field's own home() handling")
+                    .isZero();
+
+            // The disarmed filter neither armed nor captured anything.
+            assertThat(fx.row().armedProperty().get()).isFalse();
+            assertThat(fx.row().getValue()).isEqualTo(binding);
+            return null;
+        });
+    }
+
+    @Test
+    void enterArmsThenNextKeystrokeIsCapturedConsumedAndDisarms() throws Exception {
+        runOnFxThread(() -> {
+            Fixture fx = buildFixture(null);
+
+            // ENTER at the disarmed field arms — and is consumed only
+            // because it arms (no double toggling, §6.5).
+            press(fx.field(), KeyCode.ENTER, false);
+            assertThat(fx.row().armedProperty().get()).isTrue();
+            assertThat(fx.reachedParent())
+                    .as("the arming ENTER is consumed by the field's filter")
+                    .doesNotContain(KeyCode.ENTER);
+
+            // Armed: the keystroke becomes the binding, is consumed, and the
+            // row disarms (one combination per arming).
+            press(fx.field(), KeyCode.K, true);
+            assertThat(fx.row().getValue())
+                    .isEqualTo(new KeyCodeCombination(KeyCode.K, KeyCombination.ALT_DOWN));
+            assertThat(fx.row().armedProperty().get()).isFalse();
+            assertThat(fx.reachedParent())
+                    .as("a captured keystroke never reaches the parent")
+                    .doesNotContain(KeyCode.K);
+
+            // Disarmed again: the very same keystroke propagates and the
+            // captured binding stays untouched.
+            press(fx.field(), KeyCode.B, true);
+            assertThat(fx.reachedParent())
+                    .as("after capture the row stops swallowing keys")
+                    .contains(KeyCode.B);
+            assertThat(fx.row().getValue())
+                    .isEqualTo(new KeyCodeCombination(KeyCode.K, KeyCombination.ALT_DOWN));
+            return null;
+        });
+    }
+
+    @Test
+    void escapeDisarmsWithoutClearingAndKeysPropagateAgain() throws Exception {
+        runOnFxThread(() -> {
+            KeyCombination binding = new KeyCodeCombination(KeyCode.J, KeyCombination.ALT_DOWN);
+            Fixture fx = buildFixture(binding);
+
+            fx.row().armedProperty().set(true);
+            press(fx.field(), KeyCode.ESCAPE, false);
+            assertThat(fx.row().armedProperty().get())
+                    .as("ESC disarms the row")
+                    .isFalse();
+            assertThat(fx.row().getValue())
+                    .as("ESC keeps the existing binding")
+                    .isEqualTo(binding);
+            assertThat(fx.reachedParent())
+                    .as("the disarming ESC is consumed (it must not also close the dialog)")
+                    .doesNotContain(KeyCode.ESCAPE);
+
+            // Post-disarm, keys flow again (§6.5 — nothing stays swallowed).
+            press(fx.field(), KeyCode.K, true);
+            assertThat(fx.reachedParent()).contains(KeyCode.K);
+            assertThat(fx.row().getValue()).isEqualTo(binding);
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/NoInlineLiteralsInSettingsShellTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/NoInlineLiteralsInSettingsShellTest.java
@@ -1,0 +1,129 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 306 — the inline-style-literal conformance sentinel (Settings View
+ * Design Book §2.6 / §1.5, rejection #2; pattern:
+ * {@code feedback_ui_overhaul_conformance_sentinel}). The Rail &amp; Pane
+ * shell replaced the old dialog's hard-coded {@code -fx-text-fill: #ff9100}
+ * restart hint, the muted {@code #808080} hints, and the
+ * {@code -fx-font-weight: bold} section headers with semantic tokens in CSS.
+ * This scan proves none of them can creep back: no settings-shell Java
+ * source may carry an inline text-fill hex, font-size, or font-weight
+ * literal — every colour/size/weight lives in a stylesheet.
+ *
+ * <p>Scope: every {@code .java} under
+ * {@code ui/settings/} (recursively — the whole shell package: shell, rail,
+ * row, search index, skins, and the story-305 catalogue types) plus
+ * {@code ui/SettingsDialog.java}, the rewired dialog that used to hold the
+ * offenders.</p>
+ *
+ * <p>Mechanics (shared {@link SourceScanSupport} harness, sibling of
+ * {@code LegacyHardcodedColorAuditTest}): comments are stripped so a Javadoc
+ * mention of a banned token cannot false-match, but string literals are
+ * KEPT — the banned tokens only ever live inside {@code setStyle("…")}
+ * string arguments, so blanking strings would blind the scan. The non-empty
+ * guard pins the expected file set: a broken path must fail loudly, never
+ * let non-presence be "proven" over an empty scan.</p>
+ */
+final class NoInlineLiteralsInSettingsShellTest {
+
+    /**
+     * The §1.5 / rejection-#2 banned inline literals. The text-fill ban
+     * targets hex paints ({@code -fx-text-fill: #…}, whitespace-tolerant);
+     * font-size and font-weight are banned outright — there is no
+     * acceptable inline value for either in shell Java code.
+     */
+    private static final List<Pattern> BANNED_LITERALS = List.of(
+            Pattern.compile("-fx-text-fill:\\s*#"),
+            Pattern.compile("-fx-font-size:"),
+            Pattern.compile("-fx-font-weight:"));
+
+    /** Files the scan must have visited for its "no offenders" claim to mean anything. */
+    private static final List<String> EXPECTED_FILES = List.of(
+            "SettingsDialog.java",
+            "SettingsShell.java",
+            "SettingsNavRail.java",
+            "SettingRow.java",
+            "SettingsSearchIndex.java");
+
+    @Test
+    void settingsShellSourcesCarryNoInlineStyleLiterals() throws IOException {
+        Path module = SourceScanSupport.locateDawAppModule();
+        Path settingsDir = module.resolve(
+                "src/main/java/com/benesquivelmusic/daw/app/ui/settings");
+        Path settingsDialog = module.resolve(
+                "src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java");
+        assertThat(Files.isDirectory(settingsDir))
+                .as("the settings shell sources must live under %s", settingsDir)
+                .isTrue();
+        assertThat(Files.isRegularFile(settingsDialog))
+                .as("the rewired dialog must live at %s", settingsDialog)
+                .isTrue();
+
+        List<Path> scanScope = new ArrayList<>();
+        Files.walkFileTree(settingsDir, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (file.getFileName().toString().endsWith(".java")) {
+                    scanScope.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        scanScope.sort(Path::compareTo);
+        scanScope.add(settingsDialog);
+
+        List<String> scannedNames = new ArrayList<>();
+        List<String> offenders = new ArrayList<>();
+        for (Path file : scanScope) {
+            String name = file.getFileName().toString();
+            scannedNames.add(name);
+            // Strip comments only — the banned tokens live inside string
+            // literals (setStyle arguments), so strings must survive.
+            String code = SourceScanSupport.stripComments(
+                    Files.readString(file, StandardCharsets.UTF_8));
+            for (Pattern banned : BANNED_LITERALS) {
+                if (banned.matcher(code).find()) {
+                    offenders.add(name + "  — contains " + banned.pattern());
+                }
+            }
+        }
+
+        // Guard against a vacuous pass: the scan must have visited the shell
+        // classes this sentinel exists to police.
+        assertThat(scannedNames)
+                .as("the scan must cover the rewired dialog and the four new "
+                        + "shell classes — an incomplete scan cannot prove "
+                        + "non-presence")
+                .contains(EXPECTED_FILES.toArray(String[]::new));
+        assertThat(scannedNames)
+                .as("the settings package scan visited suspiciously few files")
+                .hasSizeGreaterThanOrEqualTo(6);
+
+        offenders.sort(String::compareTo);
+        assertThat(offenders)
+                .as("Story 306 — no settings-shell Java source may carry an "
+                        + "inline style literal (Settings View Design Book "
+                        + "§2.6 / §1.5, rejection #2). Colours, font sizes and "
+                        + "font weights belong in styles.css / the component "
+                        + "user-agent sheets as semantic tokens. "
+                        + "Offenders:%n  %s",
+                        String.join("\n  ", offenders))
+                .isEmpty();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/PerSettingResetTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/PerSettingResetTest.java
@@ -1,0 +1,161 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingDescriptor;
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 306 — per-setting reset, the first §5.7 reset tier (Settings View
+ * Design Book §5.7 tier 1, §5.4). A {@link SettingRow} edited away from its
+ * descriptor {@code default} shows the {@code .setting-row-reset} ↺ marker;
+ * firing it restores the default and removes the marker; an untouched row
+ * shows no marker (invisible AND unmanaged, so it reserves no space).
+ *
+ * <p>The rows under test render <em>real</em> story-305 catalogue
+ * descriptors ({@code audio.sampleRate},
+ * {@code audio.applyLatencyCompensation}) and are exercised off the dialog —
+ * the row is a self-contained {@code Control}, so the reset contract needs no
+ * shell. The edit is driven through the row's inner editor (the CHOICE
+ * {@code ComboBox}), exercising the control→model leg of the two-way sync,
+ * and the post-reset editor state proves the model→control push
+ * ({@code feedback_bind_two_way_control_property} — listener + setter, never
+ * {@code bind()}).</p>
+ *
+ * <p>Headless FX per {@code feedback_javafx_headless_test_pitfalls}: skin
+ * lookups need a {@code Scene} plus {@code applyCss()}/{@code layout()};
+ * FX-thread assertions are captured and rethrown by {@code runOnFxThread}.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class PerSettingResetTest {
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    /** Resolves a real story-305 descriptor by id — never a hand-built stand-in. */
+    private static SettingDescriptor<?> descriptor(String id) {
+        return SettingsCatalogue.create().byId(id).orElseThrow(
+                () -> new AssertionError("catalogue has no descriptor " + id));
+    }
+
+    /**
+     * Realizes the row's skin (Scene + applyCss + layout — skins do not
+     * attach headless without it) and returns the ↺ reset button.
+     */
+    private static Button showAndFindReset(SettingRow row) {
+        StackPane root = new StackPane(row);
+        new Scene(root, 800, 240);
+        root.applyCss();
+        root.layout();
+        Button reset = (Button) row.lookup(".setting-row-reset");
+        assertThat(reset)
+                .as("the row skin exposes the .setting-row-reset button")
+                .isNotNull();
+        return reset;
+    }
+
+    @Test
+    void editedRowShowsMarkerAndResetRestoresTheDefault() throws Exception {
+        runOnFxThread(() -> {
+            SettingDescriptor<?> sampleRate = descriptor("audio.sampleRate");
+            Object defaultValue = sampleRate.defaultValue();
+            assertThat(defaultValue)
+                    .as("audio.sampleRate carries a canonical default")
+                    .isNotNull();
+            SettingRow row = new SettingRow(
+                    sampleRate, defaultValue, SettingRow.ControlHints.none());
+            Button reset = showAndFindReset(row);
+
+            // At the default: no marker, no reserved space (§5.7 tier 1).
+            assertThat(row.modifiedProperty().get()).isFalse();
+            assertThat(reset.isVisible()).isFalse();
+            assertThat(reset.isManaged()).isFalse();
+
+            // Edit through the inner editor (control→model leg), never the
+            // row property directly — the user path.
+            @SuppressWarnings("unchecked")
+            ComboBox<Object> combo = (ComboBox<Object>) row.lookup(".combo-box");
+            assertThat(combo)
+                    .as("the CHOICE row's editor is a ComboBox")
+                    .isNotNull();
+            // Any rate different from the canonical default (never assume
+            // which one the default is).
+            Object edited = Objects.equals(defaultValue, 96000.0) ? 44100.0 : 96000.0;
+            combo.setValue(edited);
+
+            assertThat(row.getValue()).isEqualTo(edited);
+            assertThat(row.modifiedProperty().get()).isTrue();
+            assertThat(reset.isVisible()).isTrue();
+            assertThat(reset.isManaged()).isTrue();
+
+            reset.fire();
+
+            // Reset restores the descriptor default and removes the marker …
+            assertThat(row.getValue()).isEqualTo(defaultValue);
+            assertThat(row.modifiedProperty().get()).isFalse();
+            assertThat(reset.isVisible()).isFalse();
+            assertThat(reset.isManaged()).isFalse();
+            // … and the editor follows (model→control push).
+            assertThat(combo.getValue()).isEqualTo(defaultValue);
+            return null;
+        });
+    }
+
+    @Test
+    void untouchedRowShowsNoMarker() throws Exception {
+        runOnFxThread(() -> {
+            SettingDescriptor<?> latency = descriptor("audio.applyLatencyCompensation");
+            SettingRow row = new SettingRow(
+                    latency, latency.defaultValue(), SettingRow.ControlHints.none());
+            Button reset = showAndFindReset(row);
+
+            assertThat(row.modifiedProperty().get())
+                    .as("a row seeded at its default is not modified")
+                    .isFalse();
+            assertThat(reset.isVisible()).isFalse();
+            assertThat(reset.isManaged()).isFalse();
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RailSelectionUsesAccentBarNotFillTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RailSelectionUsesAccentBarNotFillTest.java
@@ -1,0 +1,238 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
+
+import javafx.application.Platform;
+import javafx.css.PseudoClass;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 306 — rail selection is a drawn accent bar, never an accent fill
+ * (UI Design Book rejection §6, Settings View Design Book §5.3): the
+ * selected {@code .settings-nav-cell} carries the {@code selected}
+ * pseudo-class and contains the always-present
+ * {@code .settings-nav-accent-bar} {@code Region}, and the pane's
+ * {@code .settings-category-title} label is a plain label — no inline
+ * style, no accent-ish style class.
+ *
+ * <p>The shell is built OFF the dialog ({@link SettingsCatalogue#create()}
+ * + a {@link SettingsShell.ValueAccess} over a scratch
+ * {@link SettingsModel} on an isolated {@link Preferences} node) inside a
+ * {@code Scene} with {@code applyCss() + layout()} so the rail skin's
+ * cells are realized before the pseudo-class assertions.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class RailSelectionUsesAccentBarNotFillTest {
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    /**
+     * A shell over a scratch model on an isolated preferences node — every
+     * model getter returns the canonical default; manager/key-binding ids
+     * fall back to their descriptor defaults (no live singleton touched).
+     */
+    private static SettingsShell newShell(SettingsCatalogue catalogue) {
+        Preferences prefs = Preferences.userRoot()
+                .node("railSelectionAccentBarTest_" + System.nanoTime());
+        SettingsModel model = new SettingsModel(prefs);
+        return new SettingsShell(catalogue, valueAccess(catalogue, model), null, null);
+    }
+
+    private static SettingsShell.ValueAccess valueAccess(
+            SettingsCatalogue catalogue, SettingsModel model) {
+        return id -> switch (id) {
+            case "audio.sampleRate" -> model.getSampleRate();
+            case "audio.bitDepth" -> model.getBitDepth();
+            case "audio.mixPrecision" -> model.getMixPrecision();
+            case "audio.srcQuality" -> model.getSrcQuality();
+            case "audio.backend" -> model.getAudioBackend();
+            case "audio.inputDevice" -> model.getAudioInputDevice();
+            case "audio.outputDevice" -> model.getAudioOutputDevice();
+            case "audio.bufferSize" -> model.getBufferSize();
+            case "audio.applyLatencyCompensation" -> model.isApplyLatencyCompensation();
+            case "audio.workerPoolSize" -> model.getWorkerPoolSize();
+            case "audio.masterCpuBudgetFraction" -> model.getMasterCpuBudgetFraction();
+            case "project.autoSaveIntervalSeconds" -> model.getAutoSaveIntervalSeconds();
+            case "project.defaultTempo" -> model.getDefaultTempo();
+            case "project.useJournaledPersistence" -> model.isUseJournaledPersistence();
+            case "appearance.uiScale" -> model.getUiScale();
+            case "plugins.scanPaths" -> model.getPluginScanPaths();
+            // Manager-backed and key-binding ids: the descriptor default IS
+            // the persisted value over an empty node — equivalent, and no
+            // live manager singleton is touched from the test.
+            default -> catalogue.byId(id)
+                    .map(descriptor -> (Object) descriptor.defaultValue())
+                    .orElse(null);
+        };
+    }
+
+    /** Scene + applyCss + layout so skins attach before any lookup. */
+    private static void showInScene(SettingsShell shell) {
+        StackPane root = new StackPane(shell);
+        new Scene(root, 1024, 720);
+        root.applyCss();
+        root.layout();
+    }
+
+    /**
+     * Deep scene-graph walk. {@code ScrollPane} content is not a child
+     * until a skin attaches, so it is followed explicitly; the set
+     * deduplicates nodes reachable both ways once skins have attached.
+     */
+    private static void collectDeep(Node node, Set<Node> into) {
+        if (node == null || !into.add(node)) {
+            return;
+        }
+        if (node instanceof ScrollPane scrollPane) {
+            collectDeep(scrollPane.getContent(), into);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collectDeep(child, into);
+            }
+        }
+    }
+
+    private static List<Node> collectByStyleClass(Node from, String styleClass) {
+        Set<Node> nodes = new LinkedHashSet<>();
+        collectDeep(from, nodes);
+        return nodes.stream()
+                .filter(node -> node.getStyleClass().contains(styleClass))
+                .toList();
+    }
+
+    private static String categoryTitle(SettingsCatalogue catalogue, String categoryId) {
+        return catalogue.categories().stream()
+                .filter(category -> category.id().equals(categoryId))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no category " + categoryId))
+                .title();
+    }
+
+    @Test
+    void selectedCellShouldCarryAccentBarNodeAndSelectedPseudoClass() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            showInScene(shell);
+
+            // Move selection off the default first category to prove the
+            // pseudo-class follows the selection.
+            shell.navRail().setSelectedCategoryId("appearance");
+
+            List<Node> cells = collectByStyleClass(shell, "settings-nav-cell");
+            assertThat(cells)
+                    .as("one realized rail cell per category")
+                    .hasSize(catalogue.categories().size());
+
+            // The accent bar Region is ALWAYS in the graph, in every cell —
+            // selection only changes its paint (rejection §6).
+            for (Node cell : cells) {
+                List<Node> bars = collectByStyleClass(cell, "settings-nav-accent-bar");
+                assertThat(bars)
+                        .as("cell %s carries exactly one accent-bar node", cell)
+                        .hasSize(1);
+                assertThat(bars.get(0))
+                        .as("the accent bar is a drawn Region")
+                        .isInstanceOf(Region.class);
+            }
+
+            PseudoClass selected = PseudoClass.getPseudoClass("selected");
+            List<Node> selectedCells = cells.stream()
+                    .filter(cell -> cell.getPseudoClassStates().contains(selected))
+                    .toList();
+            assertThat(selectedCells)
+                    .as("exactly one cell carries :selected")
+                    .hasSize(1);
+
+            // The selected cell is the appearance cell — identified by its
+            // title label carrying the resolved category title.
+            List<Node> titles =
+                    collectByStyleClass(selectedCells.get(0), "settings-nav-title");
+            assertThat(titles).as("the selected cell has one title label").hasSize(1);
+            assertThat(((Label) titles.get(0)).getText())
+                    .isEqualTo(categoryTitle(catalogue, "appearance"));
+            return null;
+        });
+    }
+
+    @Test
+    void paneCategoryTitleShouldBeAPlainLabelWithoutAccentStyling() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            showInScene(shell);
+            shell.navRail().setSelectedCategoryId("appearance");
+
+            ScrollPane pane = (ScrollPane) shell.lookup(".settings-pane");
+            List<Node> titles =
+                    collectByStyleClass(pane.getContent(), "settings-category-title");
+            assertThat(titles)
+                    .as("the shown pane has exactly one category title")
+                    .hasSize(1);
+
+            Label title = (Label) titles.get(0);
+            assertThat(title.getText())
+                    .isEqualTo(categoryTitle(catalogue, "appearance"));
+            assertThat(title.getStyle())
+                    .as("the category title carries no inline style (rejection §6/§2.6)")
+                    .isEmpty();
+            assertThat(title.getStyleClass())
+                    .as("style classes limited to the contract — a plain label")
+                    .containsExactlyInAnyOrder("label", "settings-category-title");
+            assertThat(title.getStyleClass())
+                    .as("no accent-ish style class on the title (rejection §6)")
+                    .noneMatch(styleClass ->
+                            styleClass.toLowerCase(Locale.ROOT).contains("accent"));
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SearchFiltersAcrossCategoriesTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SearchFiltersAcrossCategoriesTest.java
@@ -265,6 +265,42 @@ class SearchFiltersAcrossCategoriesTest {
     }
 
     @Test
+    void queryChangeShouldReparentDroppedRowsBackToTheirCategoryPane() throws Exception {
+        runOnFxThread(() -> {
+            SettingsShell shell = newShell(SettingsCatalogue.create());
+            showInScene(shell);
+            TextField field = searchField(shell);
+
+            field.setText("latency");
+            Set<Node> nodes = new LinkedHashSet<>();
+            collectDeep(shell, nodes);
+            SettingRow compensation = nodes.stream()
+                    .filter(node -> node instanceof SettingRow row
+                            && "audio.applyLatencyCompensation".equals(row.descriptor().id()))
+                    .map(SettingRow.class::cast)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            "\"latency\" did not surface audio.applyLatencyCompensation"));
+
+            // Narrow to a no-match query while STAYING in search mode: the
+            // row drops out of the match set and must be re-parented to
+            // its home category pane — not left pinned to the previous
+            // (now detached) results container.
+            field.setText("zzzqqq");
+
+            Parent parent = compensation.getParent();
+            assertThat(parent)
+                    .as("the dropped-out row was re-parented somewhere")
+                    .isNotNull();
+            assertThat(parent.getStyleClass())
+                    .as("the dropped-out row is back in its home category pane, "
+                            + "not a stale detached results container")
+                    .contains("settings-category-pane");
+            return null;
+        });
+    }
+
+    @Test
     void exactLabelQueryShouldRankThatDescriptorFirst() {
         SettingsCatalogue catalogue = SettingsCatalogue.create();
         SettingsSearchIndex index = SettingsSearchIndex.of(catalogue);

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SearchFiltersAcrossCategoriesTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SearchFiltersAcrossCategoriesTest.java
@@ -1,0 +1,325 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingDescriptor;
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsSearchIndex;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
+
+import javafx.application.Platform;
+import javafx.css.PseudoClass;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 306 — the §6.1 always-on search over the story-305 catalogue
+ * (Settings View Design Book §2.2, §5.2, §6.1). Typing "latency" surfaces
+ * buffer size, latency compensation and the device rows regardless of the
+ * selected category (synonym hits); matching is case- and
+ * diacritic-insensitive on both sides; a no-match query dims every rail
+ * category; exact-label hits rank above weaker tiers.
+ *
+ * <p>Shell-level tests build the shell OFF the dialog
+ * ({@link SettingsCatalogue#create()} + a {@link SettingsShell.ValueAccess}
+ * over a scratch {@link SettingsModel} on an isolated {@link Preferences}
+ * node) inside a {@code Scene} with {@code applyCss() + layout()}; ranking
+ * assertions drive {@link SettingsSearchIndex} directly (pure in-memory
+ * string work — no toolkit involvement).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class SearchFiltersAcrossCategoriesTest {
+
+    /** The four "latency" hits named by the story AC (book §2.2 example). */
+    private static final List<String> LATENCY_IDS = List.of(
+            "audio.bufferSize",
+            "audio.applyLatencyCompensation",
+            "audio.inputDevice",
+            "audio.outputDevice");
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    /**
+     * A shell over a scratch model on an isolated preferences node — every
+     * model getter returns the canonical default; manager/key-binding ids
+     * fall back to their descriptor defaults (no live singleton touched).
+     */
+    private static SettingsShell newShell(SettingsCatalogue catalogue) {
+        Preferences prefs = Preferences.userRoot()
+                .node("searchFiltersAcrossCategoriesTest_" + System.nanoTime());
+        SettingsModel model = new SettingsModel(prefs);
+        return new SettingsShell(catalogue, valueAccess(catalogue, model), null, null);
+    }
+
+    private static SettingsShell.ValueAccess valueAccess(
+            SettingsCatalogue catalogue, SettingsModel model) {
+        return id -> switch (id) {
+            case "audio.sampleRate" -> model.getSampleRate();
+            case "audio.bitDepth" -> model.getBitDepth();
+            case "audio.mixPrecision" -> model.getMixPrecision();
+            case "audio.srcQuality" -> model.getSrcQuality();
+            case "audio.backend" -> model.getAudioBackend();
+            case "audio.inputDevice" -> model.getAudioInputDevice();
+            case "audio.outputDevice" -> model.getAudioOutputDevice();
+            case "audio.bufferSize" -> model.getBufferSize();
+            case "audio.applyLatencyCompensation" -> model.isApplyLatencyCompensation();
+            case "audio.workerPoolSize" -> model.getWorkerPoolSize();
+            case "audio.masterCpuBudgetFraction" -> model.getMasterCpuBudgetFraction();
+            case "project.autoSaveIntervalSeconds" -> model.getAutoSaveIntervalSeconds();
+            case "project.defaultTempo" -> model.getDefaultTempo();
+            case "project.useJournaledPersistence" -> model.isUseJournaledPersistence();
+            case "appearance.uiScale" -> model.getUiScale();
+            case "plugins.scanPaths" -> model.getPluginScanPaths();
+            // Manager-backed and key-binding ids: the descriptor default IS
+            // the persisted value over an empty node — equivalent, and no
+            // live manager singleton is touched from the test.
+            default -> catalogue.byId(id)
+                    .map(descriptor -> (Object) descriptor.defaultValue())
+                    .orElse(null);
+        };
+    }
+
+    /** Scene + applyCss + layout so skins attach before any lookup. */
+    private static void showInScene(SettingsShell shell) {
+        StackPane root = new StackPane(shell);
+        new Scene(root, 1024, 720);
+        root.applyCss();
+        root.layout();
+    }
+
+    /**
+     * Deep scene-graph walk. {@code ScrollPane} content is not a child
+     * until a skin attaches, so it is followed explicitly; the set
+     * deduplicates nodes reachable both ways once skins have attached.
+     */
+    private static void collectDeep(Node node, Set<Node> into) {
+        if (node == null || !into.add(node)) {
+            return;
+        }
+        if (node instanceof ScrollPane scrollPane) {
+            collectDeep(scrollPane.getContent(), into);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collectDeep(child, into);
+            }
+        }
+    }
+
+    private static TextField searchField(SettingsShell shell) {
+        Node field = shell.lookup(".settings-search-field");
+        assertThat(field).as("the always-on search field").isInstanceOf(TextField.class);
+        return (TextField) field;
+    }
+
+    /**
+     * The descriptor ids of every {@link SettingRow} currently shown in the
+     * settings pane, in graph order (search mode: the results pane).
+     */
+    private static Set<String> visibleRowIds(SettingsShell shell) {
+        ScrollPane pane = (ScrollPane) shell.lookup(".settings-pane");
+        Set<Node> nodes = new LinkedHashSet<>();
+        collectDeep(pane.getContent(), nodes);
+        Set<String> ids = new LinkedHashSet<>();
+        for (Node node : nodes) {
+            if (node instanceof SettingRow row) {
+                ids.add(row.descriptor().id());
+            }
+        }
+        return ids;
+    }
+
+    @Test
+    void typingLatencyShouldSurfaceMatchesFromNonSelectedCategories() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            showInScene(shell);
+
+            // Browse a NON-audio category first — search results must not
+            // depend on the selected category (book §2.2).
+            shell.navRail().setSelectedCategoryId("plugins");
+            searchField(shell).setText("latency");
+
+            assertThat(visibleRowIds(shell))
+                    .as("\"latency\" surfaces the buffer-size, compensation and device rows")
+                    .contains(LATENCY_IDS.toArray(String[]::new));
+
+            // §5.2: the matching category shows a count and is not dimmed.
+            var audioItem = shell.navRail().getItems().stream()
+                    .filter(item -> "audio".equals(item.categoryId()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no audio rail item"));
+            assertThat(audioItem.dimmedProperty().get())
+                    .as("the audio category has matches and is not dimmed")
+                    .isFalse();
+            assertThat(audioItem.matchCountProperty().get())
+                    .as("the audio category shows a match count while searching")
+                    .isGreaterThanOrEqualTo(1);
+            return null;
+        });
+    }
+
+    @Test
+    void searchShouldBeCaseAndDiacriticInsensitive() throws Exception {
+        runOnFxThread(() -> {
+            SettingsShell shell = newShell(SettingsCatalogue.create());
+            showInScene(shell);
+            TextField field = searchField(shell);
+
+            field.setText("latency");
+            Set<String> plainIds = visibleRowIds(shell);
+            assertThat(plainIds).contains(LATENCY_IDS.toArray(String[]::new));
+
+            field.setText("LÁTENCY"); // "LÁTENCY" — case + diacritic
+            assertThat(visibleRowIds(shell))
+                    .as("\"LÁTENCY\" yields exactly the \"latency\" result set")
+                    .containsExactlyElementsOf(plainIds);
+            return null;
+        });
+    }
+
+    @Test
+    void noMatchQueryShouldDimEveryRailCategory() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            showInScene(shell);
+
+            searchField(shell).setText("zzzqqq");
+
+            assertThat(visibleRowIds(shell))
+                    .as("a no-match query shows no rows")
+                    .isEmpty();
+            assertThat(shell.navRail().getItems())
+                    .as("the rail still has every category item")
+                    .isNotEmpty()
+                    .allSatisfy(item -> {
+                        assertThat(item.dimmedProperty().get())
+                                .as("category %s is dimmed", item.categoryId())
+                                .isTrue();
+                        assertThat(item.matchCountProperty().get())
+                                .as("category %s shows a zero count", item.categoryId())
+                                .isZero();
+                    });
+
+            // Skin level: every cell carries the dimmed pseudo-class.
+            Set<Node> nodes = new LinkedHashSet<>();
+            collectDeep(shell, nodes);
+            List<Node> cells = nodes.stream()
+                    .filter(node -> node.getStyleClass().contains("settings-nav-cell"))
+                    .toList();
+            assertThat(cells)
+                    .as("one realized rail cell per category")
+                    .hasSize(catalogue.categories().size());
+            PseudoClass dimmed = PseudoClass.getPseudoClass("dimmed");
+            assertThat(cells).allSatisfy(cell ->
+                    assertThat(cell.getPseudoClassStates())
+                            .as("cell %s carries :dimmed", cell)
+                            .contains(dimmed));
+            return null;
+        });
+    }
+
+    @Test
+    void exactLabelQueryShouldRankThatDescriptorFirst() {
+        SettingsCatalogue catalogue = SettingsCatalogue.create();
+        SettingsSearchIndex index = SettingsSearchIndex.of(catalogue);
+        SettingDescriptor<?> bufferSize = catalogue.byId("audio.bufferSize")
+                .orElseThrow(() -> new AssertionError("audio.bufferSize not catalogued"));
+
+        List<SettingsSearchIndex.Match> matches = index.search(bufferSize.label());
+
+        assertThat(matches).as("the exact label matches at least itself").isNotEmpty();
+        assertThat(matches.get(0).descriptor().id())
+                .as("the exact-label hit ranks first (§6.1)")
+                .isEqualTo("audio.bufferSize");
+        assertThat(matches.get(0).field())
+                .isEqualTo(SettingsSearchIndex.MatchField.LABEL_EXACT);
+    }
+
+    @Test
+    void latencyRankingShouldPlaceLabelHitsAboveSynonymHits() {
+        SettingsSearchIndex index = SettingsSearchIndex.of(SettingsCatalogue.create());
+
+        List<SettingsSearchIndex.Match> matches = index.search("latency");
+        List<String> ids = matches.stream()
+                .map(match -> match.descriptor().id())
+                .toList();
+
+        assertThat(ids).contains(LATENCY_IDS.toArray(String[]::new));
+        // "Apply latency compensation…" is the only label containing the
+        // query — a LABEL-tier hit that must precede every synonym hit.
+        assertThat(ids.get(0)).isEqualTo("audio.applyLatencyCompensation");
+        assertThat(matches.get(0).field()).isEqualTo(SettingsSearchIndex.MatchField.LABEL);
+        for (String synonymId : List.of(
+                "audio.inputDevice", "audio.outputDevice", "audio.bufferSize")) {
+            SettingsSearchIndex.Match match = matches.stream()
+                    .filter(m -> synonymId.equals(m.descriptor().id()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no match for " + synonymId));
+            assertThat(match.field())
+                    .as("%s matches \"latency\" through its synonyms", synonymId)
+                    .isEqualTo(SettingsSearchIndex.MatchField.SYNONYM);
+        }
+        // Rank tiers never weaken back down the list.
+        for (int i = 1; i < matches.size(); i++) {
+            assertThat(matches.get(i).field().ordinal())
+                    .as("result %d keeps tier order", i)
+                    .isGreaterThanOrEqualTo(matches.get(i - 1).field().ordinal());
+        }
+    }
+
+    @Test
+    void indexShouldTreatDiacriticQueryIdenticallyToAsciiQuery() {
+        SettingsSearchIndex index = SettingsSearchIndex.of(SettingsCatalogue.create());
+
+        assertThat(index.search("LÁTENCY"))
+                .as("\"LÁTENCY\" normalizes to \"latency\" (NFD + strip marks + lower-case)")
+                .isNotEmpty()
+                .containsExactlyElementsOf(index.search("latency"));
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SearchFiltersAcrossCategoriesTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SearchFiltersAcrossCategoriesTest.java
@@ -322,4 +322,30 @@ class SearchFiltersAcrossCategoriesTest {
                 .isNotEmpty()
                 .containsExactlyElementsOf(index.search("latency"));
     }
+
+    @Test
+    void indexShouldStripSurroundingWhitespaceFromQuery() {
+        SettingsCatalogue catalogue = SettingsCatalogue.create();
+        SettingsSearchIndex index = SettingsSearchIndex.of(catalogue);
+
+        // Pasted-with-spaces query filters exactly like the bare query —
+        // and therefore agrees with SettingRowSkin's stripped highlight.
+        assertThat(index.search(" latency "))
+                .as("\" latency \" (pasted with spaces) matches what \"latency\" matches")
+                .isNotEmpty()
+                .containsExactlyElementsOf(index.search("latency"));
+        assertThat(index.matchCountsByCategory("\tlatency \n"))
+                .as("rail counts agree for the padded query")
+                .isEqualTo(index.matchCountsByCategory("latency"));
+
+        // Padding must not demote an exact-label hit out of LABEL_EXACT.
+        SettingDescriptor<?> bufferSize = catalogue.byId("audio.bufferSize")
+                .orElseThrow(() -> new AssertionError("audio.bufferSize not catalogued"));
+        List<SettingsSearchIndex.Match> matches =
+                index.search(" " + bufferSize.label() + " ");
+        assertThat(matches).isNotEmpty();
+        assertThat(matches.get(0).descriptor().id()).isEqualTo("audio.bufferSize");
+        assertThat(matches.get(0).field())
+                .isEqualTo(SettingsSearchIndex.MatchField.LABEL_EXACT);
+    }
 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SettingsDialogApplyBehaviorTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SettingsDialogApplyBehaviorTest.java
@@ -3,6 +3,8 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.density.DensityManager;
 import com.benesquivelmusic.daw.app.ui.density.DensityMode;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.event.DefaultEventBus;
 import com.benesquivelmusic.daw.core.event.EventBusPublisher;
@@ -13,16 +15,13 @@ import com.benesquivelmusic.daw.sdk.event.UiEvent;
 import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.Parent;
-import javafx.scene.control.Labeled;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
-import javafx.scene.control.TextField;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -36,16 +35,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 /**
- * Story 305 — the no-UI-change guard. Backing {@code SettingsDialog}'s
- * labels and the tempo validator with {@code SettingsCatalogue}
- * descriptors must be invisible: the five tabs keep their exact titles,
- * every pinned label string still renders byte-identical, Apply still
- * writes the {@code SettingsModel} with the old silent-drop tempo
- * semantics, and the well-formed {@link UiEvent.SettingsApplied} publish
- * (story 294) still fires. If anything here changes, the story is wrong.
+ * Story 306 — the behavioural survivors of the retired
+ * {@code SettingsDialogUnchangedTest} (the story-305 "no visible change"
+ * guard). Story 306 IS the visible change, so the tab-title and pinned
+ * label-string tests died with the {@code TabPane}; what must NOT change
+ * is the Apply write path, re-proven here over the Rail &amp; Pane shell:
+ * an editless Apply round-trips the canonical model defaults, the tempo
+ * TEXT row keeps the old silent-drop semantics (out-of-range and NaN
+ * never reach the model, in-range text is written), and the story-294
+ * {@link UiEvent.SettingsApplied} publish stays well-formed.
+ *
+ * <p>The old dialog re-wrote its seeded combo values on every Apply;
+ * under the §6.2 write-on-dirty contract an untouched dialog writes
+ * nothing at all — the defaults round-trip assertion now pins that an
+ * editless Apply cannot corrupt the model. The tempo edits go through
+ * the generic {@code project.defaultTempo} {@link SettingRow} (whose TEXT
+ * editor delivers raw Strings), replacing the old Project-tab
+ * {@code TextField} traversal.</p>
  */
 @ExtendWith(JavaFxToolkitExtension.class)
-class SettingsDialogUnchangedTest {
+class SettingsDialogApplyBehaviorTest {
+
+    private static final String TEMPO_ID = "project.defaultTempo";
 
     private <T> T runOnFxThread(Callable<T> callable) throws Exception {
         AtomicReference<T> ref = new AtomicReference<>();
@@ -77,33 +88,15 @@ class SettingsDialogUnchangedTest {
 
     private static SettingsModel newModel() {
         Preferences prefs = Preferences.userRoot()
-                .node("settingsDialogUnchangedTest_" + System.nanoTime());
+                .node("settingsDialogApplyBehaviorTest_" + System.nanoTime());
         return new SettingsModel(prefs);
     }
 
     /**
-     * Walks a tab-content graph collecting every {@link Labeled} text
-     * (covers both {@code Label} and {@code CheckBox}). {@code ScrollPane}
-     * content is not a child until a skin attaches, so it is followed
-     * explicitly.
+     * Walks a node graph collecting instances of {@code type}.
+     * {@code ScrollPane} content is not a child until a skin attaches, so
+     * it is followed explicitly (headless — no skins are realized).
      */
-    private static void collectLabeledTexts(Node node, List<String> into) {
-        if (node == null) {
-            return;
-        }
-        if (node instanceof Labeled labeled && labeled.getText() != null) {
-            into.add(labeled.getText());
-        }
-        if (node instanceof ScrollPane scrollPane) {
-            collectLabeledTexts(scrollPane.getContent(), into);
-        }
-        if (node instanceof Parent parent) {
-            for (Node child : parent.getChildrenUnmodifiable()) {
-                collectLabeledTexts(child, into);
-            }
-        }
-    }
-
     private static <T extends Node> void collectInstances(Node node, Class<T> type, List<T> into) {
         if (node == null) {
             return;
@@ -121,62 +114,33 @@ class SettingsDialogUnchangedTest {
         }
     }
 
-    /** The Project tab carries exactly one {@code TextField}: the tempo field. */
-    private static TextField tempoField(SettingsDialog dialog) {
-        TabPane tabPane = (TabPane) dialog.getDialogPane().getContent();
-        Tab projectTab = tabPane.getTabs().stream()
-                .filter(tab -> "Project".equals(tab.getText()))
+    /**
+     * Selects {@code categoryId} on the rail (attaching its pane to the
+     * center scroll graph) and returns the {@link SettingRow} rendering
+     * {@code settingId}.
+     */
+    private static SettingRow settingRow(SettingsDialog dialog, String categoryId,
+                                         String settingId) {
+        SettingsShell shell = dialog.getShell();
+        shell.navRail().setSelectedCategoryId(categoryId);
+        List<SettingRow> rows = new ArrayList<>();
+        collectInstances(shell, SettingRow.class, rows);
+        return rows.stream()
+                .filter(row -> settingId.equals(row.descriptor().id()))
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("No Project tab"));
-        List<TextField> fields = new ArrayList<>();
-        collectInstances(projectTab.getContent(), TextField.class, fields);
-        assertThat(fields).as("the Project tab's only TextField is the tempo field").hasSize(1);
-        return fields.get(0);
+                .orElseThrow(() -> new AssertionError("No row for " + settingId));
+    }
+
+    /**
+     * The generic row rendering {@code project.defaultTempo} — the
+     * replacement for the old "the Project tab's only TextField" helper.
+     */
+    private static SettingRow tempoRow(SettingsDialog dialog) {
+        return settingRow(dialog, "project", TEMPO_ID);
     }
 
     @Test
-    void fiveTabsShouldKeepTheirExactTitlesInOrder() throws Exception {
-        List<String> titles = runOnFxThread(() -> {
-            SettingsDialog dialog = new SettingsDialog(newModel());
-            TabPane tabPane = (TabPane) dialog.getDialogPane().getContent();
-            return tabPane.getTabs().stream().map(Tab::getText).toList();
-        });
-
-        assertThat(titles).containsExactly(
-                "Audio", "Project", "Appearance", "Key Bindings", "Plugins");
-    }
-
-    @Test
-    void pinnedLabelStringsShouldStillRenderByteIdentical() throws Exception {
-        List<String> texts = runOnFxThread(() -> {
-            SettingsDialog dialog = new SettingsDialog(newModel());
-            TabPane tabPane = (TabPane) dialog.getDialogPane().getContent();
-            List<String> collected = new ArrayList<>();
-            for (Tab tab : tabPane.getTabs()) {
-                collectLabeledTexts(tab.getContent(), collected);
-            }
-            return collected;
-        });
-
-        assertThat(texts).contains(
-                "Sample Rate (Hz):",
-                "Bit Depth:",
-                "Buffer Size (frames):",
-                "Auto-Save Interval (seconds):",
-                "Default Tempo (BPM):",
-                "Use journaled persistence (write-ahead journal & crash recovery)",
-                "Theme:",
-                "UI Scale:",
-                "Density:",
-                "Reduce Motion",
-                "Plugin Scan Paths:",
-                // The untouched blanket hint — replacing it with per-setting
-                // apply-class truth on screen is story 306/307, not 305.
-                "Changes to audio settings may require a restart.");
-    }
-
-    @Test
-    void applyWithUntouchedControlsShouldKeepModelDefaults() throws Exception {
+    void applyWithUntouchedRowsShouldKeepModelDefaults() throws Exception {
         SettingsModel model = runOnFxThread(() -> {
             SettingsModel m = newModel();
             SettingsDialog dialog = new SettingsDialog(m);
@@ -184,9 +148,10 @@ class SettingsDialogUnchangedTest {
             return m;
         });
 
-        // The controls seed from the live model, so applying without edits
+        // The rows seed from the live model, so applying without edits
         // must round-trip the canonical defaults (compared against a fresh
-        // model over an empty node, never literals).
+        // model over an empty node, never literals). Under write-on-dirty
+        // nothing is written here — this pins exactly that.
         SettingsModel defaults = newModel();
         assertThat(model.getSampleRate()).isEqualTo(defaults.getSampleRate());
         assertThat(model.getBitDepth()).isEqualTo(defaults.getBitDepth());
@@ -202,42 +167,45 @@ class SettingsDialogUnchangedTest {
     }
 
     @Test
-    void applyShouldStillSilentlyDropOutOfRangeTempo() throws Exception {
+    void applyShouldSilentlyDropOutOfRangeTempo() throws Exception {
         SettingsModel model = runOnFxThread(() -> {
             SettingsModel m = newModel();
             SettingsDialog dialog = new SettingsDialog(m);
-            tempoField(dialog).setText("1000");
+            tempoRow(dialog).setValue("1000");
             dialog.applySettings();
             return m;
         });
 
-        // The descriptor-validator swap must keep the old semantics: an
-        // out-of-range tempo is dropped silently, the model keeps 120.0.
-        assertThat(model.getDefaultTempo()).isCloseTo(120.0, within(0.01));
+        // The descriptor-validator delegation must keep the old semantics:
+        // an out-of-range tempo is dropped silently, the model keeps its
+        // default (120.0).
+        assertThat(model.getDefaultTempo())
+                .isCloseTo(newModel().getDefaultTempo(), within(0.01));
     }
 
     @Test
-    void applyShouldStillSilentlyDropNaNTempo() throws Exception {
+    void applyShouldSilentlyDropNaNTempo() throws Exception {
         SettingsModel model = runOnFxThread(() -> {
             SettingsModel m = newModel();
             SettingsDialog dialog = new SettingsDialog(m);
-            tempoField(dialog).setText("NaN");
+            tempoRow(dialog).setValue("NaN");
             dialog.applySettings();
             return m;
         });
 
         // The setter guard's range comparisons are both false for NaN, so
         // it cannot reject it — the call site must. Pre-305 the inline
-        // range check dropped NaN silently; the model keeps 120.0.
-        assertThat(model.getDefaultTempo()).isCloseTo(120.0, within(0.01));
+        // range check dropped NaN silently; the model keeps its default.
+        assertThat(model.getDefaultTempo())
+                .isCloseTo(newModel().getDefaultTempo(), within(0.01));
     }
 
     @Test
-    void applyShouldStillWriteInRangeTempo() throws Exception {
+    void applyShouldWriteInRangeTempo() throws Exception {
         SettingsModel model = runOnFxThread(() -> {
             SettingsModel m = newModel();
             SettingsDialog dialog = new SettingsDialog(m);
-            tempoField(dialog).setText("150");
+            tempoRow(dialog).setValue("150");
             dialog.applySettings();
             return m;
         });
@@ -246,13 +214,13 @@ class SettingsDialogUnchangedTest {
     }
 
     /**
-     * The story-294 producer contract must survive the label wiring: Apply
+     * The story-294 producer contract must survive the shell swap: Apply
      * still publishes one well-formed {@link UiEvent.SettingsApplied} with
      * the manager-seeded values (the EventBus-swap capture idiom from
      * {@code SettingsDialogTest#applySettingsPublishesWellFormedSettingsAppliedEvent}).
      */
     @Test
-    void applyShouldStillPublishWellFormedSettingsAppliedEvent() throws Exception {
+    void applyShouldPublishWellFormedSettingsAppliedEvent() throws Exception {
         EventBus previous = EventBusPublisher.getDefault();
         // ON_UI_THREAD subscribers run inline on the publish thread — no
         // toolkit needed for the capture.
@@ -266,7 +234,7 @@ class SettingsDialogUnchangedTest {
         AtomicBoolean expectedMotion = new AtomicBoolean();
         try {
             runOnFxThread(() -> {
-                // The dialog seeds its controls from the live managers;
+                // The shell seeds its rows from the live managers;
                 // capture those exact values so the assertions can't drift.
                 expectedTheme.set(ThemeManager.getDefault().getActiveTheme().name());
                 expectedDensity.set(DensityManager.getDefault().getActiveDensity().name());
@@ -295,6 +263,61 @@ class SettingsDialogUnchangedTest {
             EventBusPublisher.setDefault(previous);
             bus.close();
         }
+    }
+
+    /**
+     * Regression (story-306 fix): the {@link UiEvent.SettingsApplied}
+     * publish is delivered asynchronously (the managers subscribe
+     * {@code ON_UI_THREAD} — a later FX pulse), so the synchronous
+     * post-apply {@code refreshFromPersisted()} must NOT re-seed the
+     * appearance rows from the still-stale managers. The rows keep the
+     * values the Apply just published, the shell reads clean against
+     * them, and re-selecting the applied value stays clean. No bus is
+     * installed here, so the managers never see the publish at all —
+     * exactly the mid-flight window the last-applied overlay covers.
+     */
+    @Test
+    void applyShouldKeepEditedAppearanceRowsAtTheirAppliedValues() throws Exception {
+        runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(newModel());
+            SettingsShell shell = dialog.getShell();
+            SettingRow themeRow = settingRow(dialog, "appearance", ThemeManager.PREF_KEY);
+            SettingRow motionRow = settingRow(dialog, "appearance", MotionManager.PREF_KEY);
+
+            ThemeManager.Theme before = ThemeManager.getDefault().getActiveTheme();
+            ThemeManager.Theme edited = Arrays.stream(ThemeManager.Theme.values())
+                    .filter(theme -> theme != before)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Need at least two themes"));
+            boolean motionEdited = !MotionManager.getDefault().isReduceMotion();
+
+            themeRow.setValue(edited);
+            motionRow.setValue(motionEdited);
+            dialog.applySettings();
+
+            assertThat(themeRow.getValue())
+                    .as("theme row keeps the just-applied value (no snap-back "
+                            + "to the not-yet-updated manager)")
+                    .isEqualTo(edited);
+            assertThat(motionRow.getValue())
+                    .as("reduce-motion row keeps the just-applied value")
+                    .isEqualTo(motionEdited);
+            assertThat(shell.dirtyProperty().get())
+                    .as("shell is clean against the applied values")
+                    .isFalse();
+
+            // The applied value is the new diff baseline: moving away is
+            // dirty, re-selecting it is clean — never the stale manager value.
+            themeRow.setValue(before);
+            assertThat(shell.dirtyProperty().get())
+                    .as("editing away from the applied theme is dirty")
+                    .isTrue();
+            themeRow.setValue(edited);
+            assertThat(shell.dirtyProperty().get())
+                    .as("re-selecting the applied theme is clean")
+                    .isFalse();
+            return null;
+        });
     }
 
     /** Polls {@code condition} up to five seconds; returns as soon as it holds. */

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SettingsDialogTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SettingsDialogTest.java
@@ -3,6 +3,8 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.density.DensityManager;
 import com.benesquivelmusic.daw.app.ui.density.DensityMode;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.event.DefaultEventBus;
 import com.benesquivelmusic.daw.core.event.EventBusPublisher;
@@ -11,10 +13,16 @@ import com.benesquivelmusic.daw.sdk.event.EventBus;
 import com.benesquivelmusic.daw.sdk.event.UiEvent;
 
 import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.ScrollPane;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,27 +31,91 @@ import java.util.prefs.Preferences;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * {@code SettingsDialog.applySettings()} contract over the story-306
+ * Rail &amp; Pane shell: the {@code SettingsChangeListener} is notified
+ * after every apply, values edited through the shell's generic
+ * {@link SettingRow}s are persisted to {@link SettingsModel} <em>before</em>
+ * the listener runs, and the story-294 {@link UiEvent.SettingsApplied}
+ * publish stays well-formed. Pre-306 these tests leaned on the old
+ * dialog's unconditional re-write of its seeded combo values; under the
+ * §6.2 write-on-dirty contract each write assertion drives a real shell
+ * row edit instead.
+ */
 @ExtendWith(JavaFxToolkitExtension.class)
 class SettingsDialogTest {
 
-    private <T> T runOnFxThread(java.util.concurrent.Callable<T> callable) throws Exception {
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
         AtomicReference<T> ref = new AtomicReference<>();
-        AtomicReference<Exception> error = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
         Platform.runLater(() -> {
             try {
                 ref.set(callable.call());
-            } catch (Exception e) {
-                error.set(e);
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
             } finally {
                 latch.countDown();
             }
         });
-        latch.await(5, TimeUnit.SECONDS);
-        if (error.get() != null) {
-            throw error.get();
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
         }
         return ref.get();
+    }
+
+    private static SettingsModel newModel() {
+        Preferences prefs = Preferences.userRoot()
+                .node("settingsDialogTest_" + System.nanoTime());
+        return new SettingsModel(prefs);
+    }
+
+    /**
+     * Walks a node graph collecting instances of {@code type}.
+     * {@code ScrollPane} content is not a child until a skin attaches, so
+     * it is followed explicitly (headless — no skins are realized).
+     */
+    private static <T extends Node> void collectInstances(Node node, Class<T> type, List<T> into) {
+        if (node == null) {
+            return;
+        }
+        if (type.isInstance(node)) {
+            into.add(type.cast(node));
+        }
+        if (node instanceof ScrollPane scrollPane) {
+            collectInstances(scrollPane.getContent(), type, into);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collectInstances(child, type, into);
+            }
+        }
+    }
+
+    /**
+     * Selects {@code categoryId} on the rail (attaching its pane to the
+     * center scroll graph) and returns the {@link SettingRow} rendering
+     * {@code settingId}.
+     */
+    private static SettingRow settingRow(SettingsDialog dialog, String categoryId,
+                                         String settingId) {
+        SettingsShell shell = dialog.getShell();
+        shell.navRail().setSelectedCategoryId(categoryId);
+        List<SettingRow> rows = new ArrayList<>();
+        collectInstances(shell, SettingRow.class, rows);
+        return rows.stream()
+                .filter(row -> settingId.equals(row.descriptor().id()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No row for " + settingId));
     }
 
     @Test
@@ -51,32 +123,38 @@ class SettingsDialogTest {
         AtomicBoolean listenerInvoked = new AtomicBoolean(false);
         AtomicReference<SettingsModel> receivedModel = new AtomicReference<>();
 
-        runOnFxThread(() -> {
-            Preferences prefs = Preferences.userRoot().node("settingsDialogTest_" + System.nanoTime());
-            SettingsModel model = new SettingsModel(prefs);
-            SettingsDialog dialog = new SettingsDialog(model);
-            dialog.setSettingsChangeListener(m -> {
+        SettingsModel model = runOnFxThread(() -> {
+            SettingsModel m = newModel();
+            SettingsDialog dialog = new SettingsDialog(m);
+            dialog.setSettingsChangeListener(received -> {
                 listenerInvoked.set(true);
-                receivedModel.set(m);
+                receivedModel.set(received);
             });
+            settingRow(dialog, "audio", "audio.applyLatencyCompensation")
+                    .setValue(!m.isApplyLatencyCompensation());
             dialog.applySettings();
-            return null;
+            return m;
         });
 
         assertThat(listenerInvoked.get()).isTrue();
         assertThat(receivedModel.get()).isNotNull();
+        assertThat(receivedModel.get()).isSameAs(model);
     }
 
     @Test
     void applySettingsShouldNotFailWithoutListener() throws Exception {
-
-        runOnFxThread(() -> {
-            Preferences prefs = Preferences.userRoot().node("settingsDialogTest_" + System.nanoTime());
-            SettingsModel model = new SettingsModel(prefs);
-            SettingsDialog dialog = new SettingsDialog(model);
+        SettingsModel model = runOnFxThread(() -> {
+            SettingsModel m = newModel();
+            SettingsDialog dialog = new SettingsDialog(m);
+            boolean edited = !m.isApplyLatencyCompensation();
+            settingRow(dialog, "audio", "audio.applyLatencyCompensation").setValue(edited);
             dialog.applySettings();
-            return null;
+            return m;
         });
+
+        // No listener registered — the whole write path must still run.
+        assertThat(model.isApplyLatencyCompensation())
+                .isNotEqualTo(newModel().isApplyLatencyCompensation());
     }
 
     @Test
@@ -84,16 +162,18 @@ class SettingsDialogTest {
         AtomicReference<Double> tempoAtCallback = new AtomicReference<>();
 
         runOnFxThread(() -> {
-            Preferences prefs = Preferences.userRoot().node("settingsDialogTest_" + System.nanoTime());
-            SettingsModel model = new SettingsModel(prefs);
-            SettingsDialog dialog = new SettingsDialog(model);
+            SettingsDialog dialog = new SettingsDialog(newModel());
             dialog.setSettingsChangeListener(m -> tempoAtCallback.set(m.getDefaultTempo()));
+            // The TEXT row delivers a raw String; the pending 150 must be
+            // written to the model BEFORE the listener observes it.
+            settingRow(dialog, "project", "project.defaultTempo").setValue("150");
             dialog.applySettings();
             return null;
         });
 
         assertThat(tempoAtCallback.get()).isNotNull();
-        assertThat(tempoAtCallback.get()).isCloseTo(120.0, org.assertj.core.data.Offset.offset(0.01));
+        assertThat(tempoAtCallback.get())
+                .isCloseTo(150.0, org.assertj.core.data.Offset.offset(0.01));
     }
 
     @Test
@@ -101,15 +181,17 @@ class SettingsDialogTest {
         AtomicReference<Double> scaleAtCallback = new AtomicReference<>();
 
         runOnFxThread(() -> {
-            Preferences prefs = Preferences.userRoot().node("settingsDialogTest_" + System.nanoTime());
-            SettingsModel model = new SettingsModel(prefs);
-            SettingsDialog dialog = new SettingsDialog(model);
+            SettingsDialog dialog = new SettingsDialog(newModel());
             dialog.setSettingsChangeListener(m -> scaleAtCallback.set(m.getUiScale()));
+            // SLIDER rows carry Double pending values (§6.2 write-on-dirty).
+            settingRow(dialog, "appearance", "appearance.uiScale").setValue(1.5);
             dialog.applySettings();
             return null;
         });
 
         assertThat(scaleAtCallback.get()).isNotNull();
+        assertThat(scaleAtCallback.get())
+                .isCloseTo(1.5, org.assertj.core.data.Offset.offset(0.01));
     }
 
     /**
@@ -124,8 +206,10 @@ class SettingsDialogTest {
      * must round-trip through {@link ThemeManager.Theme#valueOf} and
      * {@code densityId} through {@link DensityMode#valueOf}, so swapping the two
      * (a {@code DensityMode} name landing in {@code themeId}) would fail. The
-     * expected values are the manager defaults the dialog seeds its controls from,
-     * captured on the FX thread immediately before the apply so they cannot drift.</p>
+     * expected values are the live-manager values the story-306 shell seeds its
+     * appearance rows from, captured on the FX thread immediately before the
+     * apply so they cannot drift — with zero pending edits the publish is
+     * unconditional and carries the managers' current values.</p>
      */
     @Test
     void applySettingsPublishesWellFormedSettingsAppliedEvent() throws Exception {
@@ -142,15 +226,13 @@ class SettingsDialogTest {
         AtomicBoolean expectedMotion = new AtomicBoolean();
         try {
             runOnFxThread(() -> {
-                // The dialog seeds its controls from the live managers; capture
+                // The shell seeds its rows from the live managers; capture
                 // those exact values so the assertions can't drift from the seed.
                 expectedTheme.set(ThemeManager.getDefault().getActiveTheme().name());
                 expectedDensity.set(DensityManager.getDefault().getActiveDensity().name());
                 expectedMotion.set(MotionManager.getDefault().isReduceMotion());
 
-                Preferences prefs = Preferences.userRoot().node("settingsDialogTest_" + System.nanoTime());
-                SettingsModel model = new SettingsModel(prefs);
-                SettingsDialog dialog = new SettingsDialog(model);
+                SettingsDialog dialog = new SettingsDialog(newModel());
                 dialog.applySettings();
                 return null;
             });

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SettingsShellHasRailAndPaneTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SettingsShellHasRailAndPaneTest.java
@@ -1,0 +1,217 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsNavRail;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 306 — the §1.3 replacement proof: the settings surface exposes a
+ * navigation rail, a scrolling settings pane, an always-on search field
+ * and a footer action bar, and it does <em>not</em> expose a
+ * {@code TabPane} (Settings View Design Book §4.A, §7 Stage 2).
+ *
+ * <p>The shell is built OFF the dialog — {@link SettingsCatalogue#create()}
+ * plus a {@link SettingsShell.ValueAccess} over a scratch
+ * {@link SettingsModel} on an isolated {@link Preferences} node — inside a
+ * {@code Scene} with {@code applyCss() + layout()} so skins attach before
+ * lookups (per {@code feedback_javafx_headless_test_pitfalls}). FX-thread
+ * assertions are captured and rethrown by {@link #runOnFxThread}.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class SettingsShellHasRailAndPaneTest {
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    /**
+     * A shell over a scratch model on an isolated preferences node — every
+     * model getter returns the canonical default; manager/key-binding ids
+     * fall back to their descriptor defaults (no live singleton touched).
+     */
+    private static SettingsShell newShell(SettingsCatalogue catalogue) {
+        Preferences prefs = Preferences.userRoot()
+                .node("settingsShellShapeTest_" + System.nanoTime());
+        SettingsModel model = new SettingsModel(prefs);
+        return new SettingsShell(catalogue, valueAccess(catalogue, model), null, null);
+    }
+
+    private static SettingsShell.ValueAccess valueAccess(
+            SettingsCatalogue catalogue, SettingsModel model) {
+        return id -> switch (id) {
+            case "audio.sampleRate" -> model.getSampleRate();
+            case "audio.bitDepth" -> model.getBitDepth();
+            case "audio.mixPrecision" -> model.getMixPrecision();
+            case "audio.srcQuality" -> model.getSrcQuality();
+            case "audio.backend" -> model.getAudioBackend();
+            case "audio.inputDevice" -> model.getAudioInputDevice();
+            case "audio.outputDevice" -> model.getAudioOutputDevice();
+            case "audio.bufferSize" -> model.getBufferSize();
+            case "audio.applyLatencyCompensation" -> model.isApplyLatencyCompensation();
+            case "audio.workerPoolSize" -> model.getWorkerPoolSize();
+            case "audio.masterCpuBudgetFraction" -> model.getMasterCpuBudgetFraction();
+            case "project.autoSaveIntervalSeconds" -> model.getAutoSaveIntervalSeconds();
+            case "project.defaultTempo" -> model.getDefaultTempo();
+            case "project.useJournaledPersistence" -> model.isUseJournaledPersistence();
+            case "appearance.uiScale" -> model.getUiScale();
+            case "plugins.scanPaths" -> model.getPluginScanPaths();
+            // Manager-backed and key-binding ids: the descriptor default IS
+            // the persisted value over an empty node — equivalent, and no
+            // live manager singleton is touched from the test.
+            default -> catalogue.byId(id)
+                    .map(descriptor -> (Object) descriptor.defaultValue())
+                    .orElse(null);
+        };
+    }
+
+    /** Scene + applyCss + layout so skins attach before any lookup. */
+    private static void showInScene(SettingsShell shell) {
+        StackPane root = new StackPane(shell);
+        new Scene(root, 1024, 720);
+        root.applyCss();
+        root.layout();
+    }
+
+    /**
+     * Deep scene-graph walk. {@code ScrollPane} content is not a child
+     * until a skin attaches, so it is followed explicitly; the set
+     * deduplicates nodes reachable both ways once skins have attached.
+     */
+    private static void collectDeep(Node node, Set<Node> into) {
+        if (node == null || !into.add(node)) {
+            return;
+        }
+        if (node instanceof ScrollPane scrollPane) {
+            collectDeep(scrollPane.getContent(), into);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                collectDeep(child, into);
+            }
+        }
+    }
+
+    @Test
+    void shellShouldExposeRailScrollingPaneSearchFieldAndFooter() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            showInScene(shell);
+
+            assertThat(shell.lookup(".settings-nav-rail"))
+                    .as("the §5.1 navigation rail")
+                    .isInstanceOf(SettingsNavRail.class);
+            assertThat(shell.lookup(".settings-pane"))
+                    .as("the §4.A settings pane is a vertically scrolling ScrollPane")
+                    .isInstanceOf(ScrollPane.class);
+            assertThat(shell.lookup(".settings-search-field"))
+                    .as("the §5.2 always-on search field")
+                    .isInstanceOf(TextField.class);
+            assertThat(shell.lookup(".settings-footer"))
+                    .as("the §5.5 footer action bar")
+                    .isNotNull();
+            return null;
+        });
+    }
+
+    @Test
+    void shellShouldNotContainATabPane() throws Exception {
+        runOnFxThread(() -> {
+            SettingsShell shell = newShell(SettingsCatalogue.create());
+            showInScene(shell);
+
+            Set<Node> lookedUp = shell.lookupAll("*");
+            assertThat(lookedUp)
+                    .as("lookupAll scanned a realized graph")
+                    .isNotEmpty()
+                    .noneMatch(TabPane.class::isInstance);
+
+            // Belt and braces: lookupAll cannot see un-attached ScrollPane
+            // content — walk the graph following getContent() explicitly.
+            Set<Node> walked = new LinkedHashSet<>();
+            collectDeep(shell, walked);
+            assertThat(walked)
+                    .as("the explicit deep walk scanned a non-empty graph")
+                    .isNotEmpty()
+                    .noneMatch(TabPane.class::isInstance);
+            return null;
+        });
+    }
+
+    @Test
+    void railShouldCarryOneItemPerCatalogueCategoryInOrder() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+
+            List<String> expectedIds = catalogue.categories().stream()
+                    .map(SettingsCatalogue.Category::id)
+                    .toList();
+            List<String> expectedTitles = catalogue.categories().stream()
+                    .map(SettingsCatalogue.Category::title)
+                    .toList();
+            assertThat(expectedIds)
+                    .as("the catalogue supplies a non-empty taxonomy")
+                    .isNotEmpty();
+
+            assertThat(shell.navRail().getItems().stream()
+                    .map(SettingsNavRail.NavItem::categoryId)
+                    .toList())
+                    .as("one rail item per catalogue category, in catalogue order")
+                    .containsExactlyElementsOf(expectedIds);
+            assertThat(shell.navRail().getItems().stream()
+                    .map(SettingsNavRail.NavItem::title)
+                    .toList())
+                    .as("rail item titles are the resolved category titles")
+                    .containsExactlyElementsOf(expectedTitles);
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
# Rail & Pane Settings Shell with Always-On Search and Per-Setting Reset

## Motivation

Story 305 introduced the §3.4 setting descriptor and catalogued every setting with no visible change. This story spends that seam: it replaces the `TabPane` with the Concept A "Rail & Pane" shell (Settings View Design Book §4.A, §7 Stage 2), renders the *same* descriptors through one generic setting row, and lights up the two affordances the descriptor was built to make generic — always-on search (§6.1) and per-setting reset (§5.7 tier 1).

This directly resolves four book §1 problems that Stage 1 could only catalogue:

- **§1.3 — tabs cap out and don't scale.** The fixed `TabPane` already crowds at five tabs; the Key Bindings tab embeds its own `ScrollPane` because the content doesn't fit; a sixth category overflows the strip (book rejection #3). A vertical rail scales forever and the pane scrolls so no category is height-capped (§5.1, §4.A).
- **§1.4 — no search.** There is no way to type "buffer" and jump to the buffer-size control (book §1.4 — "the central failure" for a discoverability surface). An always-visible search field over the story-305 catalogue fixes this (§2.2, §6.1).
- **§1.5 — inconsistent row idioms and inline styles.** Each pane re-invents its row and hard-codes inline literals — e.g. the restart hint sets `-fx-text-fill: #ff9100; -fx-font-size: 10px;` (`SettingsDialog.java:314`); the book additionally names the plugins hint and the bold section headers. One generic row consuming semantic tokens (§2.6, §5.4) replaces all of it.
- **§1.7 (partial) — no reset.** Today only Key Bindings has a reset (book rejection #6). Per-setting reset arrives here (§5.7 tier 1); per-group/category/all follow in later stages.

Per §7 Stage 2, the four legacy dialogs (`AudioSettingsDialog`, `MetronomeSettingsDialog`, `BackupSettingsDialog`) still open from their old entry points — they are absorbed in stories 307/308. This story reworks only the shell of the general `SettingsDialog`.

## Goals

- **Replace the `TabPane` with the Rail & Pane shell (§4.A).** A vertical category rail on the left (`surface-2` fill per §2.6), a vertically scrolling settings pane on the right, a persistent search field across the top, and a single footer action bar (Cancel / Apply / OK) across the bottom (§5.5). The shell renders the story-305 categories (§3.3) from the catalogue, not from a hand-built tab list.
- **Navigation rail as a `Control` + `Skin` (§5.1).** One row per category, each with its Lucide icon (UI Design Book §3.6 — icon and label never competing for emphasis); the selected row gets a `surface-2` fill plus an accent left bar (a drawn `Rect`/region, **not** a full accent fill on the label — UI Design Book rejection §6, mirrored in book §5.3). The rail scrolls independently of the pane. A category with unsaved edits shows a `•` marker (§5.1). Build it as a `Control`/`Skin`, not an ad-hoc `VBox` (per `javafx-application-design` §3).
- **Generic setting row as a `Control` + `Skin` (§5.4).** One row type drives every descriptor by `controlKind` (toggle / choice / slider / stepper / text / path / key-capture). The label column is fixed-width and right-aligned to the control gutter; the description is one muted line beneath (`text-muted` token); the apply-class badge (live / engine-reconfigure / restart) sits in a trailing column and is omitted for `LIVE` (§5.4, §6.4). No inline hex, no inline font size — every colour/size is a semantic token (§2.6).
- **Tokens replace the inline literals (§2.6, book rejection #2).** Explicitly remove the `-fx-text-fill: #ff9100; -fx-font-size: 10px;` restart hint (`SettingsDialog.java:314`), the muted plugins hint, and the `-fx-font-weight: bold` section headers the book names; the restart/reconfigure note uses the `warn` token (§5.5), hints use `text-muted`, headers use a type-scale token. The category title in the pane header is a plain label, not an accent fill (§5.3, UI Design Book rejection §6).
- **Always-on search over the catalogue (§2.2, §6.1).** A search field filters every category by descriptor `label` + `description` + `synonyms` + category/group titles, in real time, diacritic- and case-insensitive, ranking exact-label hits above description hits (§6.1). Matching rows render with the query highlighted; the rail dims categories with no matches and shows a per-category match count (§5.2). Esc clears the field. The index is built from the story-305 catalogue at open time, so a newly added descriptor is searchable with no extra wiring (§6.1).
- **Per-setting reset (§5.7 tier 1, §5.4).** A modified row (value differs from the descriptor `default`) shows the `↺` modified marker; clicking it resets that one setting to its default. The marker is absent when the value equals default. This is the first of the four §5.7 reset tiers; group/category/all land in stories 307/308/309.
- **Dirty/apply generalised to every setting (§6.2).** Each edited setting is held as a *pending* value separate from the persisted one — generalising today's `pendingBindings` map (`SettingsDialog.java:115`, currently key-bindings only) to all settings. The footer Apply is enabled only when something is dirty; closing with pending edits prompts Apply / Discard / Cancel. Apply still writes `SettingsModel` and still fires the live managers unchanged (§6.2) — the manager contract does not change.
- **Keyboard model, navigation keys never swallowed (§6.5, book rejection #7).** Up/Down in the rail moves category; Enter (or Right) focuses the pane; Tab/Shift-Tab moves between rows; Ctrl/Cmd-F focuses search; Esc closes (prompting if dirty). Key-capture rows capture *only* while explicitly armed (click/Enter to arm, Esc to disarm) so ordinary navigation is never globally swallowed — the §1.9 fix lands structurally here even though the Key Bindings *category* is still a plain catalogue rendering.
- Tests:
  - `SettingsShellHasRailAndPaneTest` (new): the surface exposes a navigation rail, a scrolling settings pane, a search field, and a footer action bar; it does **not** expose a `TabPane` (proves the §1.3 replacement). Extract the pure rail/pane assembly off the toolkit where possible; test scene-graph shape with `runAndWait`, capturing+rethrowing assertions inside any FX runnable (per `feedback_javafx_headless_test_pitfalls.md`).
  - `SearchFiltersAcrossCategoriesTest` (new): typing "latency" surfaces buffer size, latency compensation, and the device-related rows regardless of category (book §2.2 example); a no-match string dims all rail categories; the match is case- and diacritic-insensitive and ranks the exact-label hit first.
  - `PerSettingResetTest` (new): editing a setting away from its descriptor default shows the `↺` marker; clicking it restores the default and removes the marker; an unmodified setting shows no marker.
  - `NoInlineLiteralsInSettingsShellTest` (new): a source-scan over the new shell asserts no `-fx-text-fill: #`, no `-fx-font-size:`, no `-fx-font-weight:` literals (the §1.5 / rejection #2 contract), mirroring the `@HardcodedColorAllowed` audit-scan pattern (`feedback_ui_overhaul_conformance_sentinel.md`) — comment-stripped and non-blank-guarded so it is not a presence scan.
  - `DirtyApplyGeneralisedTest` (new): an edit to any setting (not just a key binding) enables Apply; Apply writes the value through `SettingsModel` and clears dirty; closing dirty prompts before discarding.
  - `KeyCaptureArmedPerRowTest` (new): a key-capture row swallows a keystroke only after it is armed and stops after Esc disarms it; an un-armed key-capture row lets Up/Down propagate to rail navigation (the rejection #7 / §1.9 guard). Test typed events via a parent `addEventFilter` on the payload, not `Event.getSource()` identity (`feedback_javafx_bubbling_event_test_pitfall.md`).
  - `RailSelectionUsesAccentBarNotFillTest` (new): the selected rail row carries the accent left-bar node / style class and the category-title label does **not** carry an accent text-fill (UI Design Book rejection §6).

## Non-Goals

- **No absorbing of the four dialogs (§7 Stage 2 boundary).** `AudioSettingsDialog`, `MetronomeSettingsDialog`, and `BackupSettingsDialog` keep their existing entry points; the Audio category still shows the "Audio Device Settings…" button (`openAudioDeviceDialogButton`, `SettingsDialog.java:306-310`) until story 307 removes it. This story reworks the general shell only.
- **No per-group / per-category / restore-all reset.** Only the per-setting `↺` (§5.7 tier 1) ships here. Group reset (story 307), category reset (story 308), and the guarded "Restore all defaults" (story 309) follow.
- **No scope labels on screen.** The descriptor carries `scope` (story 305) but the §3.2 scope tag in the pane header (§5.3) and per-row overrides are surfaced in story 309. (The pane header may show the category title now; the *scope* chip is 309.)
- **No import/export and no first-run wizard.** Those are story 309 (§5.9, §7 Stage 5).
- **No embedded-panel docking (Concept B).** The surface stays a modal/dialog; promotion to a dockable view is deferred (§4.B, §7 Stage 5 "optionally"). It is therefore not registered with the `DockManager` (stories 285/286).
- **No restart banner beyond the per-row badge.** The contextual footer note (§5.5) and the dedicated restart banner naming the dirty setting (§5.6) land with the audio absorb (story 307), where a `RESTART_REQUIRED` setting (audio backend) actually becomes dirty in-surface.
- **No change to `SettingsModel`, `LiveSettingsApplier`, or the live managers.** All "keep" (§1.10); the shell renders over them.

## Technical Notes

- Files: new `daw-app/.../ui/settings/SettingsShell.java` (the §4.A rail+pane+search+footer assembly; may host or replace the body of `SettingsDialog`), `daw-app/.../ui/settings/SettingsNavRail.java` + skin (§5.1, a `Control`/`Skin`), `daw-app/.../ui/settings/SettingRow.java` + skin (§5.4, the generic row `Control`/`Skin`), `daw-app/.../ui/settings/SettingsSearchIndex.java` (§6.1, built from the story-305 `SettingsCatalogue`); edits to `daw-app/.../ui/SettingsDialog.java` (swap the `TabPane` body for the shell; keep the Apply/live-manager wiring) and `styles.css` (rail `surface-2`, accent left-bar, row tokens, `warn`/`text-muted` — replacing the removed inline literals). Present in the tree (line numbers are locators — grep before editing): `SettingsDialog.java` (line 42), `SettingsModel.java` (line 17), `LiveSettingsApplier.java` (line 23), the three managers (`ui/theme/ThemeManager.java`, `ui/density/DensityManager.java`, `ui/motion/MotionManager.java`).
- The setting row and nav cell are `Control` + `Skin`, not ad-hoc `GridPane`/`VBox` (book §5.1/§5.4 cross-ref to `javafx-application-design` §3). Scope/dirty/modified state are `Property` bindings on the row so the rail's `•` marker and the footer's Apply-enabled state derive reactively (§6.2, `javafx-application-design` §4).
- Inline-literal removal is the explicit §2.6 / rejection #2 work. The book names the offenders; the live one is the `#ff9100` restart hint near `SettingsDialog.java:314` (a locator — grep the hex before editing). Replace each with a token; the `NoInlineLiteralsInSettingsShellTest` source-scan is the conformance sentinel (pattern: `feedback_ui_overhaul_conformance_sentinel.md`). The accent-bar-not-fill rule for rail selection and the pane title follows `feedback_javafx_api_verification_in_stories.md` (a reused accent box leaks over a drawn bar unless overridden) and `feedback_ui_design_philosophy.md` (one accent, tokens not hex).
- `-accent-soft` / `surface-2` / `warn` / `text-muted` are the established semantic tokens (story 260, UI Design Book §3); verify each exists in the token set before use and derive any missing one as a low-alpha derivative of an existing token rather than a raw hex (`feedback_control_css_role_token_forwarding.md`). Java-side colours derive from the resolved CSS, never a hard-coded mirror (`feedback_iconnode_tint_from_resolved_css.md`).
- Search ranking and highlight operate on plain descriptor text (label/description/synonyms) — no I/O, no FX-thread hazard. Heavier catalogue sources (device list, disk usage) are *not* pulled here; they remain off-thread in their own stages (§2.7/§6.6).
- Control-Sync cross-reference: Apply continues to drive the live managers exactly as `SettingsDialog` does today. The `SettingsVM`/`SettingsApplied` types are owned by **story 294** (migrate the settings surface onto the shared wiring) and are not yet in the source tree (story 294 is a spec too); this shell does not introduce them. Story 294 can later route the shell's Apply through a `SettingsApplied` event without re-touching the rail/row/search — they bind to descriptor state, not to the event bus.
- The §1.3 line refs and the inline-literal line refs are from the design book and may have drifted; treat the book's as locators, not exact addresses (the verified live ones are cited above) — grep the current `SettingsDialog.java` for `TabPane`, the hex literals, and `-fx-font-weight: bold` before editing.
- SKILL refs: `javafx-application-design` §3 (rail + row as `Control`/`Skin`), §4 (Property bindings for dirty/modified/selection), §11 (any future async pulled into the shell stays off FX), §15 (no globally-swallowed navigation keys — the §6.5 / rejection #7 contract). UI Design Book §3 (tokens), §3.6 (Lucide icons), rejection §6 (title is a label, not an accent fill). `research-daw` §4 (the scope/apply-class vocabulary the rows display).
- Reference: Settings View Design Book §4.A (Rail & Pane), §5.1–§5.5 (rail/search/header/row/footer), §6.1 (search index), §6.2 (dirty/apply), §6.5 (keyboard), §7 Stage 2, rejections #2/#3/#6/#7. Sibling stories: 305 (the descriptor/catalogue this shell renders — hard dependency), 307 (absorbs the audio dialog into this shell; adds the restart banner and per-group reset), 308 (absorbs Recording/Backups), 309 (scope labels, import/export, wizard, restore-all), 192 (command palette — the pattern for the §6.1/Concept C search-focus mode and the search ranking), 260 (semantic tokens), 277/278/279 (the `LIVE` managers Apply still drives), 010 (keyboard shortcuts — the focus-search binding and the Key Bindings category), 286 (View/Layout menu — where a future "Settings" deep link / dockable promotion would register).
