### PR TITLE
309-setting-scope-labels-import-export-profiles-and-first-run-wizard

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -55,6 +55,8 @@ import com.benesquivelmusic.daw.app.ui.dock.Dockable;
 import com.benesquivelmusic.daw.app.ui.layout.BuiltInLayouts;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.app.ui.settings.BackupSettingsAccess;
+import com.benesquivelmusic.daw.app.ui.settings.FirstRunWizard;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
 import com.benesquivelmusic.daw.sdk.persistence.BackupRetentionPolicy;
 
 import javafx.animation.FadeTransition;
@@ -1346,10 +1348,89 @@ public final class MainController {
      * lists recent projects; Start offers New / Open / Restore / Import.
      */
     public void showWelcomeIfNoProjectOpen() {
+        // Story 309 §4.D — the first-run wizard auto-shows exactly once,
+        // before the Welcome flow (its showAndWait completes first).
+        maybeShowFirstRunWizard();
         if (projectManager != null
                 && projectManager.getCurrentProject() == null
                 && projectLifecycleController != null) {
             projectLifecycleController.showWelcome();
+        }
+    }
+
+    /**
+     * Story 309 §4.D — auto-shows the first-run wizard when the
+     * {@link SettingsModel} first-run flag is unset (the pure
+     * {@link FirstRunWizard#shouldAutoShow} seam decides). Completing or
+     * skipping sets the flag, so this fires at most once per install.
+     */
+    private void maybeShowFirstRunWizard() {
+        if (settingsModel != null && FirstRunWizard.shouldAutoShow(settingsModel)) {
+            showSetupWizard();
+        }
+    }
+
+    /**
+     * Story 309 §4.D — shows the first-run wizard (auto-show at startup,
+     * and re-openable from Settings ▸ General ▸ Startup via the
+     * {@code setOnRunSetupWizard} seam). The wizard is a thin linear
+     * sequencer over the catalogue descriptors; Finish routes the
+     * collected values through {@link #applyWizardEdits} — the settings
+     * dialog's existing Apply path — while Skip applies nothing.
+     */
+    void showSetupWizard() {
+        FirstRunWizard wizard = new FirstRunWizard(
+                SettingsCatalogue.create(), settingsModel, audioEngineController);
+        var host = new com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog<Void>();
+        host.setTitle(wizard.title());
+        host.setHeaderText(wizard.title());
+        host.getDialogPane().setContent(wizard);
+        host.setResultConverter(_ -> null);
+        if (rootPane != null && rootPane.getScene() != null) {
+            host.initOwner(rootPane.getScene().getWindow());
+        }
+        Runnable closeHost = () -> {
+            // Showing-guarded: the abnormal-close Skip below runs AFTER
+            // the host is already hidden ([X] / the header close glyph).
+            if (host.isShowing()) {
+                host.setResult(null);
+                host.hide();
+            }
+        };
+        wizard.setOnFinished(edits -> {
+            applyWizardEdits(edits);
+            closeHost.run();
+        });
+        wizard.setOnSkipped(closeHost);
+        host.showAndWait();
+        // Story 309 — an abnormal close ([X] or the header close glyph)
+        // triggers neither Finish nor Skip; treat the dismissal as Skip so
+        // the first-run flag is still set and the wizard never auto-nags
+        // on later launches (it stays re-openable from General ▸ Startup).
+        wizard.skipIfNoOutcome();
+        wizard.close(); // idempotent — belt-and-braces teardown
+    }
+
+    /**
+     * Story 309 §4.D — bulk-applies the wizard's collected values through
+     * the SAME Apply path as manual edits: seed a fully wired settings
+     * dialog's shell rows as pending edits, then {@code applySettings()}
+     * (persistence + the SettingsApplied publish + engine-reconfigure +
+     * {@link LiveSettingsApplier} all ride along; values identical to the
+     * persisted ones stay non-pending and write nothing). The dialog is
+     * never shown; detaching its audio controller afterwards tears down
+     * the discovery its wiring started (an in-flight engine-reconfigure
+     * keeps its own captured references and completes normally).
+     */
+    private void applyWizardEdits(java.util.Map<String, Object> edits) {
+        SettingsDialog dialog = createSettingsDialog();
+        try {
+            var shell = dialog.getShell();
+            edits.forEach((id, value) ->
+                    shell.settingRow(id).ifPresent(row -> row.setValue(value)));
+            dialog.applySettings();
+        } finally {
+            dialog.setAudioEngineController(null);
         }
     }
 
@@ -3808,6 +3889,9 @@ public final class MainController {
             dialog.setBackupSettingsAccess(backupAccess);
         }
         dialog.setSettingsChangeListener(model -> applyLiveSettings(model, previousPluginPaths));
+        // Story 309 §4.D — General ▸ Startup's "Run setup wizard…" re-opens
+        // the first-run wizard on demand.
+        dialog.setOnRunSetupWizard(this::showSetupWizard);
         return dialog;
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -545,10 +545,17 @@ public final class SettingsDialog extends DawgDialog<Void> {
         }
     }
 
-    /** Unmounts the §5.9 profile sheet (its I/O task stays reusable). */
+    /**
+     * Unmounts the §5.9 profile sheet and tears down its in-flight I/O
+     * (§2.7 — a late result is discarded, never applied). A closed
+     * {@code SettingsProfileIO} never restarts, so the field is nulled
+     * and the next {@link #showProfileSheet()} builds a fresh sheet.
+     */
     void hideProfileSheet() {
         if (profileSheet != null) {
+            profileSheet.dispose();
             contentStack.getChildren().remove(profileSheet);
+            profileSheet = null;
         }
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -14,6 +14,7 @@ import com.benesquivelmusic.daw.app.ui.settings.RecordingSettingsAccess;
 import com.benesquivelmusic.daw.app.ui.settings.SettingDescriptor;
 import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
 import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileSheet;
 import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 import com.benesquivelmusic.daw.core.event.EventBusPublisher;
@@ -46,6 +47,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.util.Duration;
 import javafx.util.StringConverter;
@@ -226,6 +228,27 @@ public final class SettingsDialog extends DawgDialog<Void> {
     private Supplier<DirtyChoice> dirtyClosePrompt = this::promptDirtyClose;
 
     /**
+     * Story 309 §5.7 tier 4 — the guard before "Restore all defaults",
+     * the single guarded bulk action (every other reset tier stays
+     * unguarded and pending-only). Defaults to a real
+     * {@link DawgDialog#confirm} modal; headless tests inject a stub via
+     * {@link #setRestoreAllConfirm(Supplier)} (the
+     * {@code setDirtyClosePrompt} seam pattern).
+     */
+    private Supplier<Boolean> restoreAllConfirm = this::promptRestoreAllConfirm;
+
+    /**
+     * Story 309 — the dialog body host: the shell plus the §5.9 profile
+     * sheet overlay (an in-surface scrim, never a nested modal —
+     * rejection #1).
+     */
+    private final StackPane contentStack = new StackPane();
+    /** Lazily built §5.9 import/export sheet (story 309). */
+    private SettingsProfileSheet profileSheet;
+    /** Story 309 §4.D — re-open seam for the first-run wizard (General ▸ Startup). */
+    private Runnable onRunSetupWizard;
+
+    /**
      * The appearance values the last {@link #applySettings()} published.
      * The story-294 {@link UiEvent.SettingsApplied} publish is delivered
      * asynchronously (the managers subscribe {@code ON_UI_THREAD}, i.e. a
@@ -280,7 +303,11 @@ public final class SettingsDialog extends DawgDialog<Void> {
                 Map.of(
                         "audio/device", buildAudioDeviceUtilities(),
                         "audio/performance", buildAudioPerformanceTelemetry(),
-                        "backups/diskUsage", buildDiskUsageVisual()));
+                        "backups/diskUsage", buildDiskUsageVisual(),
+                        // Story 309 — General gains its two ancillary
+                        // groups; its taxonomy slots stay descriptor-empty.
+                        "general/startup", buildGeneralStartupNode(),
+                        "general/resetProfiles", buildResetProfilesNode()));
         shell.settingRow("audio.backend").orElseThrow().valueProperty()
                 .addListener((_, _, backend) -> {
                     refreshWasapiMode(backend);
@@ -303,7 +330,10 @@ public final class SettingsDialog extends DawgDialog<Void> {
             }
         });
 
-        getDialogPane().setContent(shell);
+        // Story 309 — the shell sits in a StackPane so the §5.9 profile
+        // sheet can overlay it in-surface (never a nested modal).
+        contentStack.getChildren().add(shell);
+        getDialogPane().setContent(contentStack);
         // story 276 §5.9 width bands — the shell needs the LARGE band
         // (800); its pref height rides on .settings-shell in styles.css.
         sized(DawgDialog.Size.LARGE);
@@ -402,6 +432,124 @@ public final class SettingsDialog extends DawgDialog<Void> {
         diskUsagePie.setLabelsVisible(false);
         diskUsagePie.setPrefSize(260, 200);
         return diskUsagePie;
+    }
+
+    /**
+     * Story 309 §4.D — General ▸ Startup: the "Run setup wizard…"
+     * re-open affordance, routed through the {@link #setOnRunSetupWizard}
+     * seam ({@code MainController} wires it to show the wizard). A no-op
+     * until a seam is attached (bare test dialogs).
+     */
+    private Node buildGeneralStartupNode() {
+        Button runWizard = new Button(msg("settings.general.runWizard"));
+        runWizard.getStyleClass().addAll("dawg-button", "size-default");
+        runWizard.setId("settings-run-setup-wizard");
+        runWizard.setOnAction(_ -> {
+            Runnable seam = onRunSetupWizard;
+            if (seam != null) {
+                seam.run();
+            }
+        });
+        HBox box = new HBox(runWizard);
+        box.getStyleClass().add("settings-general-startup");
+        return box;
+    }
+
+    /**
+     * Story 309 §5.7/§5.9 — General ▸ Reset &amp; profiles: the profile
+     * sheet opener and the tier-4 guarded "Restore all defaults".
+     */
+    private Node buildResetProfilesNode() {
+        Button openSheet = new Button(msg("settings.profile.open"));
+        openSheet.getStyleClass().addAll("dawg-button", "size-default");
+        openSheet.setId("settings-open-profile-sheet");
+        openSheet.setOnAction(_ -> showProfileSheet());
+
+        Button restoreAll = new Button(msg("settings.restoreAll.button"));
+        restoreAll.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        restoreAll.setId("settings-restore-all-defaults");
+        restoreAll.setOnAction(_ -> restoreAllDefaults());
+
+        HBox box = new HBox(openSheet, restoreAll);
+        box.getStyleClass().add("settings-reset-profiles");
+        return box;
+    }
+
+    /**
+     * Story 309 §5.7 tier 4 — the single guarded bulk action: confirm
+     * (injectable — {@link #setRestoreAllConfirm}), then reset EVERY row
+     * to its descriptor default and drive the SAME Apply path as manual
+     * edits ({@link #applySettings()}), so live managers re-theme and the
+     * engine re-arms exactly as individual edits do (the Control-Sync
+     * cross-reference). Cancel changes nothing — not even pending state.
+     */
+    void restoreAllDefaults() {
+        if (!Boolean.TRUE.equals(restoreAllConfirm.get())) {
+            return;
+        }
+        shell.resetAll();
+        applySettings();
+    }
+
+    /** The production tier-4 confirm — a real {@link DawgDialog#confirm} modal. */
+    private boolean promptRestoreAllConfirm() {
+        DawgDialog<ButtonType> prompt = DawgDialog.confirm(
+                msg("settings.restoreAll.title"),
+                msg("settings.restoreAll.message"),
+                msg("settings.restoreAll.confirm"));
+        prompt.initOwner(getDialogPane().getScene() != null
+                ? getDialogPane().getScene().getWindow() : null);
+        return prompt.showAndWait()
+                .map(pressed -> pressed.getButtonData() == ButtonBar.ButtonData.OK_DONE)
+                .orElse(false);
+    }
+
+    /**
+     * Injects a headless-test replacement for the restore-all confirm
+     * (the {@link #setDirtyClosePrompt(Supplier)} seam pattern).
+     *
+     * @param confirm the stub confirm (must not be {@code null})
+     */
+    void setRestoreAllConfirm(Supplier<Boolean> confirm) {
+        this.restoreAllConfirm = Objects.requireNonNull(confirm, "confirm must not be null");
+    }
+
+    /**
+     * Story 309 §4.D — attaches the "Run setup wizard…" action General ▸
+     * Startup routes through ({@code MainController} shows the wizard).
+     *
+     * @param action the wizard opener, or {@code null} to detach
+     */
+    public void setOnRunSetupWizard(Runnable action) {
+        this.onRunSetupWizard = action;
+    }
+
+    /**
+     * Story 309 §5.9 — mounts the profile sheet over the shell. Applied
+     * imports seed the SHELL rows as pending edits and run
+     * {@link #applySettings()} — the one Apply path, never a parallel one.
+     */
+    void showProfileSheet() {
+        if (profileSheet == null) {
+            profileSheet = new SettingsProfileSheet(catalogue,
+                    this::currentPersistedValue,
+                    applied -> {
+                        applied.forEach((id, value) -> shell.settingRow(id)
+                                .ifPresent(row -> row.setValue(value)));
+                        applySettings();
+                    },
+                    this::hideProfileSheet);
+        }
+        if (!contentStack.getChildren().contains(profileSheet)) {
+            contentStack.getChildren().add(profileSheet);
+        }
+    }
+
+    /** Unmounts the §5.9 profile sheet (its I/O task stays reusable). */
+    void hideProfileSheet() {
+        if (profileSheet != null) {
+            contentStack.getChildren().remove(profileSheet);
+        }
     }
 
     private static HBox utilityLine(String labelText, Node value) {
@@ -910,6 +1058,11 @@ public final class SettingsDialog extends DawgDialog<Void> {
 
     private void closeBackgroundWork() {
         backgroundWorkClosed = true;
+        // Story 309 §2.7 — closing the surface tears down any in-flight
+        // profile import/export; a late result is discarded, never applied.
+        if (profileSheet != null) {
+            profileSheet.dispose();
+        }
         cancelDeviceEventSubscription();
         DeviceEnumerationTask task = deviceEnumerationTask;
         deviceEnumerationTask = null;

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsModel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsModel.java
@@ -44,6 +44,16 @@ public final class SettingsModel {
     // ── Plugin keys ──────────────────────────────────────────────────────────
     private static final String KEY_PLUGIN_SCAN_PATHS = "plugins.scanPaths";
 
+    // ── General keys ─────────────────────────────────────────────────────────
+    /**
+     * Story 309 §4.D — the first-run wizard flag. Internal application
+     * state, not a user-facing setting (Settings View Design Book
+     * rejection #5): it has NO catalogue descriptor and renders NO row —
+     * see the documented exclusion in
+     * {@code SettingsCatalogueCompletenessTest}.
+     */
+    private static final String KEY_FIRST_RUN_WIZARD = "general.firstRunWizardCompleted";
+
     // ── Defaults ─────────────────────────────────────────────────────────────
     static final double DEFAULT_SAMPLE_RATE = 96_000.0;
     static final int DEFAULT_BIT_DEPTH = 24;
@@ -76,6 +86,12 @@ public final class SettingsModel {
      */
     static final String DEFAULT_THEME_ID = "dark-accessible";
     static final String DEFAULT_PLUGIN_SCAN_PATHS = "";
+    /**
+     * Default for the story-309 first-run wizard flag: {@code false} on a
+     * fresh preferences node, so the wizard auto-shows exactly once and
+     * never again after completion or skip.
+     */
+    static final boolean DEFAULT_FIRST_RUN_WIZARD_COMPLETED = false;
     /** Empty backend name means "auto-select best available". */
     static final String DEFAULT_AUDIO_BACKEND = "";
     /** Empty device name means "use default device". */
@@ -148,6 +164,7 @@ public final class SettingsModel {
     private int workerPoolSize;
     private double masterCpuBudgetFraction;
     private DegradationPolicy masterCpuBudgetPolicy;
+    private boolean firstRunWizardCompleted;
     private KeyBindingManager keyBindingManager;
 
     /**
@@ -207,6 +224,8 @@ public final class SettingsModel {
         masterCpuBudgetFraction = storedMasterFraction;
         masterCpuBudgetPolicy = parsePolicy(
                 prefs.get(KEY_MASTER_CPU_BUDGET_POLICY, DEFAULT_MASTER_CPU_BUDGET_POLICY));
+        firstRunWizardCompleted = prefs.getBoolean(
+                KEY_FIRST_RUN_WIZARD, DEFAULT_FIRST_RUN_WIZARD_COMPLETED);
     }
 
     /** Parses a persisted policy short-name into a {@link DegradationPolicy}. Forward compatible. */
@@ -602,6 +621,31 @@ public final class SettingsModel {
         prefs.put(KEY_PLUGIN_SCAN_PATHS, paths);
     }
 
+    // ── General ──────────────────────────────────────────────────────────────
+
+    /**
+     * Returns whether the story-309 first-run wizard has already run
+     * (completed <em>or</em> skipped). Internal application state, not a
+     * user-facing setting — no catalogue descriptor renders it.
+     *
+     * @return {@code true} once the wizard has run; {@code false} on a
+     *         fresh install (the wizard auto-shows exactly once)
+     */
+    public boolean isFirstRunWizardCompleted() {
+        return firstRunWizardCompleted;
+    }
+
+    /**
+     * Marks the first-run wizard as run (completed or skipped) and
+     * persists the change so it never auto-shows again.
+     *
+     * @param completed {@code true} once the wizard has run
+     */
+    public void setFirstRunWizardCompleted(boolean completed) {
+        this.firstRunWizardCompleted = completed;
+        prefs.putBoolean(KEY_FIRST_RUN_WIZARD, completed);
+    }
+
     // ── Key Bindings ────────────────────────────────────────────────────────
 
     /**
@@ -622,6 +666,10 @@ public final class SettingsModel {
 
     /**
      * Resets all settings to their default values and persists the changes.
+     *
+     * <p>The story-309 first-run wizard flag is deliberately excluded —
+     * it is internal state, not a setting, and restoring defaults must
+     * never re-trigger the wizard's auto-show.</p>
      */
     public void resetToDefaults() {
         setSampleRate(DEFAULT_SAMPLE_RATE);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizard.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizard.java
@@ -1,0 +1,485 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.AudioEngineController;
+import com.benesquivelmusic.daw.app.ui.SettingsModel;
+import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.density.DensityMode;
+import com.benesquivelmusic.daw.app.ui.icons.DawgIcon;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
+import javafx.beans.property.ReadOnlyIntegerProperty;
+import javafx.beans.property.ReadOnlyIntegerWrapper;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.util.StringConverter;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The §4.D first-run wizard — story 309, Concept D: a thin LINEAR
+ * sequencer over the SAME story-305 catalogue descriptors, never a
+ * parallel form. Three steps — audio device → appearance → project
+ * defaults — then "you're set up". No branching, no per-feature
+ * onboarding beyond first sound.
+ *
+ * <p>Each step renders fresh generic {@link SettingRow}s (the §5.4 rows
+ * contract) for its descriptor set; the audio step REUSES the story-307
+ * {@link DeviceEnumerationTask} for off-thread device discovery (a
+ * {@code null} {@link AudioEngineController} skips enumeration
+ * gracefully — the rows still render with the persisted values).
+ * Completing OR skipping sets the {@link SettingsModel} first-run flag,
+ * so the wizard never auto-shows again; the {@code onFinished} callback
+ * hands the collected values to a caller-side glue that seeds the
+ * settings dialog's shell rows and drives the existing
+ * {@code applySettings()} path (the Control-Sync cross-reference — no
+ * parallel apply path).</p>
+ *
+ * <p>Structure for testability: this pane owns the step state
+ * ({@link #currentStepProperty()}, {@link #nextStep()},
+ * {@link #previousStep()}, {@link #skip()}, {@link #finish()}); the
+ * window wrapper is caller-side ({@code MainController} hosts it in a
+ * {@code DawgDialog}), and the auto-show decision is the pure seam
+ * {@link #shouldAutoShow(SettingsModel)}.</p>
+ *
+ * <p>Chrome: plain label step titles — never an accent fill (§5.3,
+ * rejection #6); tokens only; every progress affordance is instant and
+ * Reduce-Motion-safe (no animation of any kind).</p>
+ */
+public final class FirstRunWizard extends BorderPane implements AutoCloseable {
+
+    /** Stable style class — selectable as {@code .first-run-wizard}. */
+    public static final String DEFAULT_STYLE_CLASS = "first-run-wizard";
+
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
+    private static final Logger LOG = Logger.getLogger(FirstRunWizard.class.getName());
+
+    /** The three descriptor steps (§4.D), in the fixed linear order. */
+    private static final List<List<String>> STEP_IDS = List.of(
+            List.of("audio.backend", "audio.inputDevice", "audio.outputDevice",
+                    "audio.applyLatencyCompensation"),
+            List.of(ThemeManager.PREF_KEY, DensityManager.PREF_KEY,
+                    "appearance.uiScale", MotionManager.PREF_KEY),
+            List.of("project.defaultTempo", "project.autoSaveIntervalSeconds"));
+    private static final List<String> STEP_TITLE_KEYS = List.of(
+            "wizard.step.audio", "wizard.step.appearance", "wizard.step.project");
+    /** The trailing "you're set up" page index. */
+    private static final int DONE_STEP = STEP_IDS.size();
+
+    private final SettingsModel model;
+    // Captured-once manager singletons (the capture-swappable-singleton
+    // discipline) — current-value reads for the appearance step.
+    private final ThemeManager themeManager;
+    private final DensityManager densityManager;
+    private final MotionManager motionManager;
+
+    private final Map<String, SettingRow> rowsById = new LinkedHashMap<>();
+    private final List<List<SettingRow>> stepRows = new ArrayList<>();
+
+    private final ReadOnlyIntegerWrapper currentStep =
+            new ReadOnlyIntegerWrapper(this, "currentStep", 0);
+
+    private final Label titleLabel = new Label();
+    private final Label captionLabel = new Label();
+    private final Label enumerationProgress = new Label();
+    private final VBox contentBox = new VBox();
+    private final Button backButton = new Button(msg("wizard.back"));
+    private final Button nextButton = new Button(msg("wizard.next"));
+    private final Button skipButton = new Button(msg("wizard.skip"));
+
+    private final DeviceEnumerationTask enumerationTask;
+
+    private Consumer<Map<String, Object>> onFinished;
+    private Runnable onSkipped;
+    private boolean closed;
+    /** {@code true} once {@link #finish()} or {@link #skip()} ran. */
+    private boolean outcomeRecorded;
+
+    /**
+     * The pure auto-show seam: show the wizard iff the first-run flag is
+     * unset. Completing or skipping sets the flag — the wizard never
+     * auto-shows twice.
+     *
+     * @param model the shared settings model; not null
+     * @return {@code true} when the wizard should auto-show at startup
+     */
+    public static boolean shouldAutoShow(SettingsModel model) {
+        Objects.requireNonNull(model, "model must not be null");
+        return !model.isFirstRunWizardCompleted();
+    }
+
+    /**
+     * Builds the wizard over the catalogue descriptors, seeded with the
+     * currently persisted values.
+     *
+     * @param catalogue  the story-305 catalogue; not null
+     * @param model      the shared settings model (current values + the
+     *                   first-run flag); not null
+     * @param controller the live audio controller for the audio step's
+     *                   device enumeration, or {@code null} to skip
+     *                   enumeration (rows still render)
+     */
+    public FirstRunWizard(SettingsCatalogue catalogue,
+                          SettingsModel model,
+                          AudioEngineController controller) {
+        Objects.requireNonNull(catalogue, "catalogue must not be null");
+        this.model = Objects.requireNonNull(model, "model must not be null");
+        this.themeManager = ThemeManager.getDefault();
+        this.densityManager = DensityManager.getDefault();
+        this.motionManager = MotionManager.getDefault();
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+
+        buildRows(catalogue);
+        buildChrome();
+
+        if (controller == null) {
+            enumerationTask = null;
+        } else {
+            enumerationTask = new DeviceEnumerationTask(controller,
+                    this::applyEnumerationResult,
+                    this::showEnumerationProgress,
+                    failure -> LOG.log(Level.WARNING,
+                            "First-run wizard device enumeration failed", failure));
+            enumerationTask.start(
+                    Objects.toString(rowsById.get("audio.backend").getValue(), ""),
+                    Objects.toString(rowsById.get("audio.outputDevice").getValue(), ""));
+            rowsById.get("audio.backend").valueProperty().addListener(
+                    (_, _, backend) -> enumerationTask.start(
+                            Objects.toString(backend, ""),
+                            Objects.toString(
+                                    rowsById.get("audio.outputDevice").getValue(), "")));
+        }
+
+        showStep(0);
+    }
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    /**
+     * One fresh {@link SettingRow} per wizard descriptor — the same
+     * generic row the shell renders (§5.4), never a new form. Hints are
+     * a wizard-local subset of the dialog's (choice options, slider
+     * bounds, display converters, apply-class badges) for exactly these
+     * ten descriptors; display names delegate to the manager authorities.
+     */
+    private void buildRows(SettingsCatalogue catalogue) {
+        for (List<String> ids : STEP_IDS) {
+            List<SettingRow> rows = new ArrayList<>();
+            for (String id : ids) {
+                SettingDescriptor<?> descriptor = catalogue.byId(id).orElseThrow(
+                        () -> new IllegalStateException("Not catalogued: " + id));
+                SettingRow row = new SettingRow(descriptor, currentValue(id), hintsFor(descriptor));
+                // §3.2 cue parity with the shell — keyed off Scope only.
+                switch (descriptor.scope()) {
+                    case PROJECT_DEFAULTS ->
+                            row.setScopeCueText(msg("settings.scope.cue.projectDefaults"));
+                    case THIS_PROJECT ->
+                            row.setScopeCueText(msg("settings.scope.cue.thisProject"));
+                    case APPLICATION, AUDIO_DEVICE -> { }
+                }
+                rowsById.put(id, row);
+                rows.add(row);
+            }
+            stepRows.add(List.copyOf(rows));
+        }
+    }
+
+    /** The persisted value per wizard descriptor id (model + managers). */
+    private Object currentValue(String id) {
+        return switch (id) {
+            case "audio.backend" -> model.getAudioBackend();
+            case "audio.inputDevice" -> model.getAudioInputDevice();
+            case "audio.outputDevice" -> model.getAudioOutputDevice();
+            case "audio.applyLatencyCompensation" -> model.isApplyLatencyCompensation();
+            case ThemeManager.PREF_KEY -> themeManager.getActiveTheme();
+            case DensityManager.PREF_KEY -> densityManager.getActiveDensity();
+            case MotionManager.PREF_KEY -> motionManager.isReduceMotion();
+            case "appearance.uiScale" -> model.getUiScale();
+            case "project.defaultTempo" -> model.getDefaultTempo();
+            case "project.autoSaveIntervalSeconds" -> model.getAutoSaveIntervalSeconds();
+            default -> throw new IllegalStateException("Not a wizard setting: " + id);
+        };
+    }
+
+    private SettingRow.ControlHints hintsFor(SettingDescriptor<?> descriptor) {
+        String badge = switch (descriptor.applyClass()) {
+            case LIVE -> null; // badge omitted entirely (§6.4)
+            case ENGINE_RECONFIGURE -> msg("settings.badge.engineReconfigure");
+            case RESTART_REQUIRED -> msg("settings.badge.restartRequired");
+        };
+        List<?> options = switch (descriptor.id()) {
+            case ThemeManager.PREF_KEY -> List.of(ThemeManager.Theme.values());
+            case DensityManager.PREF_KEY -> List.of(DensityMode.values());
+            case "project.autoSaveIntervalSeconds" -> List.of(30, 60, 120, 300, 600);
+            default -> null; // device combos wait for asynchronous discovery
+        };
+        double sliderMin = "appearance.uiScale".equals(descriptor.id()) ? 0.5 : 0;
+        double sliderMax = "appearance.uiScale".equals(descriptor.id()) ? 3.0 : 1;
+        StringConverter<Object> converter = switch (descriptor.id()) {
+            case "audio.backend", "audio.inputDevice", "audio.outputDevice" ->
+                    displayConverter(value -> value instanceof String name && name.isBlank()
+                            ? msg("audio.device.automatic") : String.valueOf(value));
+            case ThemeManager.PREF_KEY ->
+                    displayConverter(value -> value instanceof ThemeManager.Theme theme
+                            ? ThemeManager.displayName(theme) : String.valueOf(value));
+            case DensityManager.PREF_KEY ->
+                    displayConverter(value -> value instanceof DensityMode mode
+                            ? DensityManager.displayName(mode) : String.valueOf(value));
+            default -> null;
+        };
+        return new SettingRow.ControlHints(options, sliderMin, sliderMax, converter,
+                badge, () -> DawgIcon.of("rotate-ccw", DawgIcon.Size.SIZE_16));
+    }
+
+    /** Display-only converter — the combos are non-editable. */
+    private static StringConverter<Object> displayConverter(Function<Object, String> display) {
+        return new StringConverter<>() {
+            @Override
+            public String toString(Object object) {
+                return object == null ? "" : display.apply(object);
+            }
+
+            @Override
+            public Object fromString(String string) {
+                return null; // never invoked on a non-editable ComboBox
+            }
+        };
+    }
+
+    private void buildChrome() {
+        titleLabel.getStyleClass().add("first-run-wizard-title");
+        captionLabel.getStyleClass().add("first-run-wizard-caption");
+        enumerationProgress.setText(msg("settings.group.recomputing"));
+        enumerationProgress.getStyleClass().add("first-run-wizard-progress");
+        enumerationProgress.setManaged(false);
+        enumerationProgress.setVisible(false);
+        VBox header = new VBox(titleLabel, captionLabel);
+        header.getStyleClass().add("first-run-wizard-header");
+        setTop(header);
+
+        contentBox.getStyleClass().add("first-run-wizard-rows");
+        setCenter(contentBox);
+
+        skipButton.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        skipButton.setId("first-run-wizard-skip");
+        skipButton.setOnAction(_ -> skip());
+        backButton.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        backButton.setId("first-run-wizard-back");
+        backButton.setOnAction(_ -> previousStep());
+        nextButton.getStyleClass().addAll("dawg-button", "size-default", "primary");
+        nextButton.setId("first-run-wizard-next");
+        nextButton.setOnAction(_ -> {
+            if (currentStep.get() == DONE_STEP) {
+                finish();
+            } else {
+                nextStep();
+            }
+        });
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        HBox buttons = new HBox(skipButton, spacer, backButton, nextButton);
+        buttons.getStyleClass().add("first-run-wizard-buttons");
+        setBottom(buttons);
+    }
+
+    // ── Step state (linear, no branching) ────────────────────────────────────
+
+    /** @return the current page index: steps 0–2, then {@code 3} = done */
+    public ReadOnlyIntegerProperty currentStepProperty() {
+        return currentStep.getReadOnlyProperty();
+    }
+
+    /** @return the current page index */
+    public int getCurrentStep() {
+        return currentStep.get();
+    }
+
+    /** @return the number of pages (three descriptor steps + done) */
+    public int stepCount() {
+        return DONE_STEP + 1;
+    }
+
+    /**
+     * @return the current step's rows (empty on the done page) — the
+     *         same generic {@link SettingRow} instances the step renders
+     */
+    public List<SettingRow> currentStepRows() {
+        int step = currentStep.get();
+        return step < DONE_STEP ? stepRows.get(step) : List.of();
+    }
+
+    /** Advances one page (clamped at the done page). */
+    public void nextStep() {
+        showStep(Math.min(currentStep.get() + 1, DONE_STEP));
+    }
+
+    /** Goes back one page (clamped at the first step). */
+    public void previousStep() {
+        showStep(Math.max(currentStep.get() - 1, 0));
+    }
+
+    private void showStep(int step) {
+        currentStep.set(step);
+        boolean done = step == DONE_STEP;
+        titleLabel.setText(done ? msg("wizard.step.done") : msg(STEP_TITLE_KEYS.get(step)));
+        captionLabel.setVisible(!done);
+        captionLabel.setManaged(!done);
+        if (!done) {
+            captionLabel.setText(MessageFormat.format(
+                    msg("wizard.step.caption"), step + 1, STEP_IDS.size()));
+        }
+        if (done) {
+            Label doneMessage = new Label(msg("wizard.done.message"));
+            doneMessage.getStyleClass().add("first-run-wizard-done");
+            doneMessage.setWrapText(true);
+            contentBox.getChildren().setAll(doneMessage);
+        } else {
+            List<Node> children = new ArrayList<>(stepRows.get(step));
+            if (step == 0 && enumerationTask != null) {
+                children.add(enumerationProgress);
+            }
+            contentBox.getChildren().setAll(children);
+        }
+        backButton.setDisable(step == 0);
+        nextButton.setText(done ? msg("wizard.finish") : msg("wizard.next"));
+        skipButton.setVisible(!done);
+        skipButton.setManaged(!done);
+    }
+
+    // ── Outcomes ─────────────────────────────────────────────────────────────
+
+    /**
+     * @return every wizard row's current value, id → value in step order.
+     *         Values identical to the persisted ones become non-pending
+     *         when seeded into the shell, so an untouched wizard writes
+     *         nothing (the §6.2 write-on-dirty contract).
+     */
+    public Map<String, Object> collectedEdits() {
+        Map<String, Object> edits = new LinkedHashMap<>();
+        rowsById.forEach((id, row) -> edits.put(id, row.getValue()));
+        return edits;
+    }
+
+    /** @param callback receives {@link #collectedEdits()} on Finish; may be null */
+    public void setOnFinished(Consumer<Map<String, Object>> callback) {
+        this.onFinished = callback;
+    }
+
+    /** @param callback runs on Skip (nothing is applied); may be null */
+    public void setOnSkipped(Runnable callback) {
+        this.onSkipped = callback;
+    }
+
+    /**
+     * Completes the wizard: sets the first-run flag (never auto-shows
+     * again) and hands the collected values to {@code onFinished} — the
+     * caller applies them through the settings dialog's existing Apply
+     * path. Also tears down the audio-step enumeration.
+     */
+    public void finish() {
+        outcomeRecorded = true;
+        model.setFirstRunWizardCompleted(true);
+        Map<String, Object> edits = collectedEdits();
+        close();
+        if (onFinished != null) {
+            onFinished.accept(edits);
+        }
+    }
+
+    /**
+     * Skips the wizard: sets the first-run flag (never auto-shows again)
+     * and applies NOTHING. Also tears down the audio-step enumeration.
+     */
+    public void skip() {
+        outcomeRecorded = true;
+        model.setFirstRunWizardCompleted(true);
+        close();
+        if (onSkipped != null) {
+            onSkipped.run();
+        }
+    }
+
+    /**
+     * @return whether {@link #finish()} or {@link #skip()} has recorded
+     *         this wizard's outcome (the story-309 abnormal-close guard)
+     */
+    public boolean hasOutcome() {
+        return outcomeRecorded;
+    }
+
+    /**
+     * Story 309 — the abnormal-close safety net. A wizard dismissed
+     * without Finish or Skip (window [X], the host dialog's header close
+     * glyph) would otherwise leave the first-run flag unset and auto-show
+     * again on EVERY launch — an auto-nag the "never auto-shows again"
+     * contract forbids. Dismissal is a choice: treat it as {@link #skip()}
+     * (the wizard stays re-openable from General ▸ Startup). A no-op once
+     * an outcome is recorded; the host calls this after its
+     * {@code showAndWait()} returns.
+     */
+    public void skipIfNoOutcome() {
+        if (!outcomeRecorded) {
+            skip();
+        }
+    }
+
+    /** @return the resolved wizard window title (for the host window) */
+    public String title() {
+        return msg("wizard.firstRun.title");
+    }
+
+    // ── Device enumeration (story 307 reuse) ─────────────────────────────────
+
+    /** FX thread — the task marshals results through FxDispatcher. */
+    private void applyEnumerationResult(DeviceEnumerationTask.Result result) {
+        rowsById.get("audio.backend").replaceChoiceOptions(result.backendNames());
+        rowsById.get("audio.inputDevice")
+                .replaceChoiceOptions(result.inputDeviceNames(), "");
+        rowsById.get("audio.outputDevice")
+                .replaceChoiceOptions(result.outputDeviceNames(), "");
+    }
+
+    private void showEnumerationProgress(boolean running) {
+        enumerationProgress.setManaged(running);
+        enumerationProgress.setVisible(running);
+    }
+
+    /** Tears down the audio-step enumeration; idempotent. */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (enumerationTask != null) {
+            enumerationTask.close();
+        }
+    }
+
+    private static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (MissingResourceException missing) {
+            return key;
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingRow.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingRow.java
@@ -128,6 +128,23 @@ public final class SettingRow extends Control {
             new SimpleBooleanProperty(this, "armed", false);
 
     /**
+     * Story 309 §5.3/§5.4 — pre-localized per-row scope-override chip text,
+     * set once by the shell BEFORE the skin attaches when this row's
+     * {@link SettingDescriptor#scope() scope} differs from its category's
+     * modal scope. {@code null} (the default) renders no chip. Like
+     * {@link ControlHints#badgeText()}, the text arrives resolved — the
+     * row deliberately never touches the {@code Messages} bundle.
+     */
+    private String scopeChipText;
+
+    /**
+     * Story 309 §3.2 — pre-localized "applies to…" cue text, set once by
+     * the shell BEFORE the skin attaches for {@code PROJECT_DEFAULTS} /
+     * {@code THIS_PROJECT} rows. {@code null} (the default) renders no cue.
+     */
+    private String scopeCueText;
+
+    /**
      * Creates a row for {@code descriptor} seeded with the persisted
      * {@code initialValue}. The editor kind is chosen once, from
      * {@link SettingDescriptor#controlKind()}, when the skin is built.
@@ -168,6 +185,36 @@ public final class SettingRow extends Control {
     /** @return the render hints (never {@code null}) — read by the skin */
     ControlHints hints() {
         return hints;
+    }
+
+    /**
+     * One-shot pre-skin setter for the §5.3 per-row scope-override chip
+     * (story 309). Call before the skin attaches; the skin reads it once.
+     *
+     * @param text the resolved scope display name, or {@code null} for none
+     */
+    void setScopeChipText(String text) {
+        this.scopeChipText = text;
+    }
+
+    /** @return the resolved scope-chip text, or {@code null} — read by the skin */
+    String scopeChipText() {
+        return scopeChipText;
+    }
+
+    /**
+     * One-shot pre-skin setter for the §3.2 "applies to…" cue (story 309).
+     * Call before the skin attaches; the skin reads it once.
+     *
+     * @param text the resolved cue text, or {@code null} for none
+     */
+    void setScopeCueText(String text) {
+        this.scopeCueText = text;
+    }
+
+    /** @return the resolved cue text, or {@code null} — read by the skin */
+    String scopeCueText() {
+        return scopeCueText;
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingRowSkin.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingRowSkin.java
@@ -132,9 +132,22 @@ public final class SettingRowSkin extends SkinBase<SettingRow> {
         grid.add(label, 0, 0);
         grid.add(buildEditor(row), 1, 0);
 
+        // Story 309 §5.3/§5.4 — the trailing column pairs the per-row
+        // scope-override chip (when the shell set one) with the §6.4
+        // apply-class badge. Both are static labels: nothing to detach.
+        Label scopeChip = buildScopeChip(row);
         Label badge = buildBadge(row);
-        if (badge != null) {
-            grid.add(badge, 2, 0);
+        if (scopeChip != null || badge != null) {
+            HBox trailing = new HBox();
+            trailing.getStyleClass().add("setting-row-trailing");
+            trailing.setAlignment(Pos.CENTER_LEFT);
+            if (scopeChip != null) {
+                trailing.getChildren().add(scopeChip);
+            }
+            if (badge != null) {
+                trailing.getChildren().add(badge);
+            }
+            grid.add(trailing, 2, 0);
         }
 
         buildResetButton(row);
@@ -146,6 +159,16 @@ public final class SettingRowSkin extends SkinBase<SettingRow> {
             descriptionLabel.getStyleClass().add("setting-row-description");
             descriptionLabel.setWrapText(true);
             grid.add(descriptionLabel, 1, 1, 3, 1);
+        }
+
+        // Story 309 §3.2 — the muted "applies to…" cue under the
+        // description (pre-localized by the shell, keyed off Scope only).
+        String cue = row.scopeCueText();
+        if (cue != null && !cue.isBlank()) {
+            Label cueLabel = new Label(cue);
+            cueLabel.getStyleClass().add("setting-row-scope-cue");
+            cueLabel.setWrapText(true);
+            grid.add(cueLabel, 1, 2, 3, 1);
         }
 
         getChildren().add(grid);
@@ -486,6 +509,23 @@ public final class SettingRowSkin extends SkinBase<SettingRow> {
     }
 
     // ── Badge + reset ─────────────────────────────────────────────────────────
+
+    /**
+     * Story 309 §5.3 — the per-row scope-override chip, rendered only when
+     * the shell resolved chip text (this row's scope differs from its
+     * category's modal scope). Text arrives pre-localized via
+     * {@link SettingRow#scopeChipText()}; a {@code null} text renders
+     * nothing.
+     */
+    private Label buildScopeChip(SettingRow row) {
+        String text = row.scopeChipText();
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        Label chip = new Label(text);
+        chip.getStyleClass().add("setting-row-scope-chip");
+        return chip;
+    }
 
     /**
      * The trailing apply-class badge — omitted entirely for

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsCatalogue.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsCatalogue.java
@@ -132,7 +132,15 @@ public final class SettingsCatalogue {
     private final List<SettingDescriptor<?>> descriptors;
     private final Map<String, SettingDescriptor<?>> descriptorsById;
 
-    private SettingsCatalogue(List<Category> categories) {
+    /**
+     * Package-private (not {@code private}) as a story-309 test seam:
+     * scope-chip tests build a SYNTHETIC catalogue whose category id
+     * collides with a real category name while carrying deliberately
+     * different descriptor scopes — the by-construction proof that scope
+     * chips derive from descriptors, never a category-name map.
+     * Production always goes through {@link #create()}.
+     */
+    SettingsCatalogue(List<Category> categories) {
         this.categories = List.copyOf(categories);
         List<SettingDescriptor<?>> flattened = new ArrayList<>();
         Map<String, SettingDescriptor<?>> index = new LinkedHashMap<>();
@@ -673,7 +681,9 @@ public final class SettingsCatalogue {
     }
 
     /**
-     * An empty §3.3 taxonomy slot — General (story-309 territory), the
+     * An empty §3.3 taxonomy slot — the General groups (story 309 fills
+     * startup/resetProfiles with group-level ancillary visuals — wizard
+     * button, reset &amp; profile actions — never descriptors), the
      * Plugins "Manager" slot, and the Backups "Disk usage" slot, which
      * story 308 fills with a group-level visual rather than descriptors.
      */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsProfileIO.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsProfileIO.java
@@ -1,0 +1,505 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
+import com.benesquivelmusic.daw.core.concurrent.DawScope;
+
+import javafx.scene.input.KeyCombination;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * The §6.3 settings-profile format plus its off-thread file I/O — story
+ * 309 (Settings View Design Book §5.9, §6.3, §6.6).
+ *
+ * <h2>Format (pure, static, toolkit-free)</h2>
+ *
+ * <p>A profile is a diffable, deterministic, line-based text file: one
+ * comment header line ({@code # dawg-settings-profile v1} — no
+ * timestamps, so identical settings always serialise identically), then
+ * one {@code scopeTag|key=value} line per selected descriptor in
+ * catalogue order. Value serialisation follows the descriptor's
+ * {@link SettingDescriptor#defaultValue() default-value} type
+ * (Boolean/Integer/Double/String via {@code toString}/parse, enums via
+ * {@code name()}), except {@link ControlKind#KEY_CAPTURE} descriptors
+ * (whose defaults may be {@code null}) which serialise the
+ * {@link KeyCombination#getName() combination name} — or the explicit
+ * {@value #UNBOUND_MARKER} marker for a cleared binding, so an unbound
+ * action round-trips.</p>
+ *
+ * <p>The scope tag is written for the reader's benefit (a hand-editable,
+ * §3.2-scoped file) but on import the DESCRIPTOR is the scope authority
+ * — a stale or edited tag never overrides
+ * {@link ProfileScope#of(SettingDescriptor)} (canonical value from the
+ * authority, never a hint).</p>
+ *
+ * <h2>Validation (§6.3 "report, don't fail whole")</h2>
+ *
+ * <p>{@link #parseAndValidate} never aborts: an unknown key, an
+ * unparseable value, or a value the descriptor's
+ * {@link SettingDescriptor#accepts validator} rejects (the canonical
+ * {@code SettingsModel} setter guard, story 305 — no parallel check)
+ * each produce one {@link Reject}; every other entry is applied.
+ * Non-finite doubles are rejected at parse (the NaN call-site-guard
+ * convention: the range guards cannot express NaN rejection).</p>
+ *
+ * <h2>Threading (§2.7/§6.6 — the third canonical off-thread case)</h2>
+ *
+ * <p>File reads/writes run on a virtual thread inside a
+ * shutdown-on-failure {@link DawScope} (the {@link DeviceEnumerationTask}
+ * pattern: generation guard, {@link FxDispatcher#runOnFx} dispatch,
+ * injectable dispatcher seam for tests, {@link #close()} tears down
+ * in-flight I/O without joining on the FX thread). Import
+ * <em>validation</em> deliberately runs inside the FX-dispatched
+ * callback, not on the worker: catalogue validators share one scratch
+ * model and are documented FX-thread-only — only the raw file text
+ * crosses the thread boundary, and parsing ~a hundred lines is
+ * microseconds, never I/O.</p>
+ */
+public final class SettingsProfileIO implements AutoCloseable {
+
+    /** The versioned header the first profile line carries (as a comment). */
+    public static final String HEADER = "dawg-settings-profile v1";
+
+    /**
+     * Explicit round-trippable marker for a cleared key binding. Only
+     * ever read for {@link ControlKind#KEY_CAPTURE} descriptors, so a
+     * String-typed setting whose value happens to equal it is unaffected.
+     */
+    static final String UNBOUND_MARKER = "<none>";
+
+    private static final String KEYBINDING_PREFIX = "keybinding.";
+
+    /**
+     * The §5.9 sheet's five scope checkboxes: the four §3.2 scopes with
+     * Key Bindings carved out of Application ({@code keybinding.*} is a
+     * user-recognisable profile unit of its own — the §5.9 mockup's
+     * checkbox list), leaving "Application" as the remaining
+     * APPLICATION-scope descriptors.
+     */
+    public enum ProfileScope {
+        APPLICATION("application"),
+        PROJECT_DEFAULTS("projectDefaults"),
+        THIS_PROJECT("thisProject"),
+        AUDIO_DEVICE("audioDevice"),
+        KEY_BINDINGS("keyBindings");
+
+        private final String tag;
+
+        ProfileScope(String tag) {
+            this.tag = tag;
+        }
+
+        /** @return the stable lower-camel tag written before {@code |} */
+        public String tag() {
+            return tag;
+        }
+
+        /**
+         * The profile scope a descriptor belongs to — the authority the
+         * import filter trusts (never the file's tag).
+         */
+        public static ProfileScope of(SettingDescriptor<?> descriptor) {
+            Objects.requireNonNull(descriptor, "descriptor must not be null");
+            if (descriptor.id().startsWith(KEYBINDING_PREFIX)) {
+                return KEY_BINDINGS;
+            }
+            return switch (descriptor.scope()) {
+                case APPLICATION -> APPLICATION;
+                case PROJECT_DEFAULTS -> PROJECT_DEFAULTS;
+                case THIS_PROJECT -> THIS_PROJECT;
+                case AUDIO_DEVICE -> AUDIO_DEVICE;
+            };
+        }
+    }
+
+    /** Why one profile entry was not applied (§6.3 reject report). */
+    public enum RejectKind {
+        /** The line is not {@code scopeTag|key=value}. */
+        MALFORMED_LINE,
+        /** No catalogue descriptor carries this key. */
+        UNKNOWN_SETTING,
+        /** The value text does not parse as the descriptor's value type. */
+        UNPARSEABLE_VALUE,
+        /**
+         * The parsed value was rejected by the descriptor's validator —
+         * the canonical {@code SettingsModel} setter guard (story 305).
+         */
+        REJECTED_BY_VALIDATOR
+    }
+
+    /**
+     * One rejected profile entry.
+     *
+     * @param key  the entry's key (or the raw line for a malformed line)
+     * @param kind why it was rejected
+     * @param value the offending raw value text ({@code ""} when the
+     *              line never yielded one)
+     */
+    public record Reject(String key, RejectKind kind, String value) {
+        public Reject {
+            Objects.requireNonNull(key, "key must not be null");
+            Objects.requireNonNull(kind, "kind must not be null");
+            Objects.requireNonNull(value, "value must not be null");
+        }
+    }
+
+    /**
+     * An import's outcome: the applied id → value map (catalogue-order,
+     * values in the descriptors' canonical types; a key-binding value may
+     * be {@code null} for an explicit {@value #UNBOUND_MARKER}) plus the
+     * §6.3 reject report.
+     */
+    public record ImportOutcome(Map<String, Object> applied, List<Reject> rejects) {
+        public ImportOutcome {
+            // LinkedHashMap copy preserves catalogue/file order; a plain
+            // Map.copyOf would reject the null unbound-binding values.
+            Map<String, Object> orderedCopy = new LinkedHashMap<>(applied);
+            applied = java.util.Collections.unmodifiableMap(orderedCopy);
+            rejects = List.copyOf(rejects);
+        }
+    }
+
+    // ── Pure format (toolkit-free; unit-tested off-toolkit) ──────────────────
+
+    /**
+     * Serialises the selected scopes' descriptors to profile text —
+     * deterministic (catalogue order, no timestamps), diffable, and
+     * machine-shareable (§6.3 "studio standard … reproducible setups").
+     *
+     * @param catalogue the story-305 catalogue; not null
+     * @param scopes    the selected profile scopes; not null
+     * @param values    current-value access per descriptor id (the
+     *                  dialog's persisted read path); not null
+     * @return the profile text
+     */
+    public static String serialize(SettingsCatalogue catalogue,
+                                   Set<ProfileScope> scopes,
+                                   Function<String, Object> values) {
+        Objects.requireNonNull(catalogue, "catalogue must not be null");
+        Objects.requireNonNull(scopes, "scopes must not be null");
+        Objects.requireNonNull(values, "values must not be null");
+        StringBuilder out = new StringBuilder("# ").append(HEADER).append('\n');
+        for (SettingDescriptor<?> descriptor : catalogue.descriptors()) {
+            ProfileScope scope = ProfileScope.of(descriptor);
+            if (!scopes.contains(scope)) {
+                continue;
+            }
+            out.append(scope.tag()).append('|').append(descriptor.id()).append('=')
+                    .append(serializeValue(descriptor, values.apply(descriptor.id())))
+                    .append('\n');
+        }
+        return out.toString();
+    }
+
+    /**
+     * Parses profile text and validates every entry through the matching
+     * descriptor's {@link SettingDescriptor#accepts validator}. Never
+     * aborts; entries outside the selected scopes are silently skipped
+     * (the §5.9 checkboxes select what to include, they are not errors).
+     *
+     * @param catalogue the story-305 catalogue; not null
+     * @param scopes    the selected profile scopes; not null
+     * @param text      the profile text; not null
+     * @return applied map + reject report
+     */
+    public static ImportOutcome parseAndValidate(SettingsCatalogue catalogue,
+                                                 Set<ProfileScope> scopes,
+                                                 String text) {
+        Objects.requireNonNull(catalogue, "catalogue must not be null");
+        Objects.requireNonNull(scopes, "scopes must not be null");
+        Objects.requireNonNull(text, "text must not be null");
+        Map<String, Object> applied = new LinkedHashMap<>();
+        List<Reject> rejects = new ArrayList<>();
+        for (String line : text.lines().toList()) {
+            String entry = line.strip();
+            if (entry.isEmpty() || entry.startsWith("#")) {
+                continue;
+            }
+            int bar = entry.indexOf('|');
+            int eq = entry.indexOf('=', Math.max(bar + 1, 0));
+            if (bar <= 0 || eq <= bar + 1) {
+                rejects.add(new Reject(entry, RejectKind.MALFORMED_LINE, ""));
+                continue;
+            }
+            String key = entry.substring(bar + 1, eq);
+            String raw = entry.substring(eq + 1);
+            Optional<SettingDescriptor<?>> descriptor = catalogue.byId(key);
+            if (descriptor.isEmpty()) {
+                rejects.add(new Reject(key, RejectKind.UNKNOWN_SETTING, raw));
+                continue;
+            }
+            // The DESCRIPTOR decides the scope — the file's tag is a hint.
+            if (!scopes.contains(ProfileScope.of(descriptor.get()))) {
+                continue;
+            }
+            Object value;
+            try {
+                value = parseValue(descriptor.get(), raw);
+            } catch (RuntimeException unparseable) {
+                rejects.add(new Reject(key, RejectKind.UNPARSEABLE_VALUE, raw));
+                continue;
+            }
+            if (!descriptor.get().accepts(value)) {
+                rejects.add(new Reject(key, RejectKind.REJECTED_BY_VALIDATOR, raw));
+                continue;
+            }
+            applied.put(key, value);
+        }
+        return new ImportOutcome(applied, rejects);
+    }
+
+    /** One value → profile text, by the descriptor's canonical type. */
+    static String serializeValue(SettingDescriptor<?> descriptor, Object value) {
+        if (descriptor.controlKind() == ControlKind.KEY_CAPTURE) {
+            return value instanceof KeyCombination combination
+                    ? combination.getName() : UNBOUND_MARKER;
+        }
+        // Enum.name(), never toString() — display overrides must not leak
+        // into the persistent format.
+        return value instanceof Enum<?> enumValue
+                ? enumValue.name() : String.valueOf(value);
+    }
+
+    /**
+     * One profile text value → the descriptor's canonical type. Throws
+     * (→ {@link RejectKind#UNPARSEABLE_VALUE}) for text that does not
+     * parse; boolean parsing is strict ({@code true}/{@code false} only)
+     * and doubles must be finite (the NaN call-site-guard convention —
+     * a range validator cannot reject NaN itself).
+     */
+    static Object parseValue(SettingDescriptor<?> descriptor, String raw) {
+        if (descriptor.controlKind() == ControlKind.KEY_CAPTURE) {
+            return UNBOUND_MARKER.equals(raw) ? null : KeyCombination.valueOf(raw);
+        }
+        return switch (descriptor.defaultValue()) {
+            case Boolean _ -> parseStrictBoolean(raw);
+            case Integer _ -> Integer.valueOf(raw);
+            case Double _ -> parseFiniteDouble(raw);
+            case Enum<?> enumDefault -> enumValue(enumDefault.getDeclaringClass(), raw);
+            case null, default -> raw;
+        };
+    }
+
+    private static Boolean parseStrictBoolean(String raw) {
+        if ("true".equals(raw)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equals(raw)) {
+            return Boolean.FALSE;
+        }
+        throw new IllegalArgumentException("not a boolean: " + raw);
+    }
+
+    private static Double parseFiniteDouble(String raw) {
+        double value = Double.parseDouble(raw);
+        if (!Double.isFinite(value)) {
+            throw new IllegalArgumentException("not a finite number: " + raw);
+        }
+        return value;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Object enumValue(Class<? extends Enum> enumClass, String raw) {
+        return Enum.valueOf(enumClass, raw);
+    }
+
+    // ── Off-thread I/O (the DeviceEnumerationTask pattern) ───────────────────
+
+    private final SettingsCatalogue catalogue;
+    private final Consumer<ImportOutcome> onImported;
+    private final Consumer<Path> onExported;
+    private final Consumer<Boolean> onRunningChanged;
+    private final Consumer<Throwable> onFailed;
+    private final Consumer<Runnable> fxDispatcher;
+    private final AtomicLong generation = new AtomicLong();
+    private final AtomicReference<DawScope> activeScope = new AtomicReference<>();
+    private final AtomicReference<Thread> coordinator = new AtomicReference<>();
+
+    private volatile boolean closed;
+
+    /** Creates a production task whose callbacks are always posted to JavaFX. */
+    public SettingsProfileIO(SettingsCatalogue catalogue,
+                             Consumer<ImportOutcome> onImported,
+                             Consumer<Path> onExported,
+                             Consumer<Boolean> onRunningChanged,
+                             Consumer<Throwable> onFailed) {
+        this(catalogue, onImported, onExported, onRunningChanged, onFailed,
+                FxDispatcher::runOnFx);
+    }
+
+    /** Test seam for observing the dispatch boundary without starting JavaFX. */
+    SettingsProfileIO(SettingsCatalogue catalogue,
+                      Consumer<ImportOutcome> onImported,
+                      Consumer<Path> onExported,
+                      Consumer<Boolean> onRunningChanged,
+                      Consumer<Throwable> onFailed,
+                      Consumer<Runnable> fxDispatcher) {
+        this.catalogue = Objects.requireNonNull(catalogue, "catalogue must not be null");
+        this.onImported = Objects.requireNonNull(onImported, "onImported must not be null");
+        this.onExported = Objects.requireNonNull(onExported, "onExported must not be null");
+        this.onRunningChanged = Objects.requireNonNull(
+                onRunningChanged, "onRunningChanged must not be null");
+        this.onFailed = Objects.requireNonNull(onFailed, "onFailed must not be null");
+        this.fxDispatcher = Objects.requireNonNull(fxDispatcher, "fxDispatcher must not be null");
+    }
+
+    /**
+     * Starts (or replaces) an export. {@code valuesSnapshot} must be
+     * captured on the FX thread by the caller — the worker only
+     * serialises the immutable snapshot and writes the file, so shell
+     * state is never read off-thread. Returns before any I/O begins.
+     *
+     * @param file           the destination file
+     * @param scopes         the selected profile scopes
+     * @param valuesSnapshot id → current value for every selected descriptor
+     */
+    public void startExport(Path file,
+                            Set<ProfileScope> scopes,
+                            Map<String, Object> valuesSnapshot) {
+        Objects.requireNonNull(file, "file must not be null");
+        Objects.requireNonNull(scopes, "scopes must not be null");
+        Objects.requireNonNull(valuesSnapshot, "valuesSnapshot must not be null");
+        Map<String, Object> snapshot = new LinkedHashMap<>(valuesSnapshot);
+        Set<ProfileScope> selected = Set.copyOf(scopes);
+        startWork("settings-profile-export", "write", () -> {
+            String text = serialize(catalogue, selected, snapshot::get);
+            Files.writeString(file, text, StandardCharsets.UTF_8);
+            return (Runnable) () -> onExported.accept(file);
+        });
+    }
+
+    /**
+     * Starts (or replaces) an import from {@code file}. The file read
+     * runs on a virtual thread; parse + validation run inside the
+     * FX-dispatched callback (catalogue validators are FX-thread-only —
+     * see the class Javadoc). Returns before any I/O begins.
+     */
+    public void startImport(Path file, Set<ProfileScope> scopes) {
+        Objects.requireNonNull(file, "file must not be null");
+        startImport(scopes, () -> Files.readString(file, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Test seam: an import over an arbitrary (possibly slow) content
+     * source — production routes {@link #startImport(Path, Set)} here.
+     */
+    void startImport(Set<ProfileScope> scopes, Callable<String> source) {
+        Objects.requireNonNull(scopes, "scopes must not be null");
+        Objects.requireNonNull(source, "source must not be null");
+        Set<ProfileScope> selected = Set.copyOf(scopes);
+        startWork("settings-profile-import", "read", () -> {
+            String text = source.call();
+            return (Runnable) () ->
+                    onImported.accept(parseAndValidate(catalogue, selected, text));
+        });
+    }
+
+    /**
+     * Shared coordinator start: bumps the generation (invalidating any
+     * queued callbacks of a prior run), cancels in-flight work, and forks
+     * {@code work} inside a fresh scope on a coordinator virtual thread.
+     * The work returns the success callback to dispatch.
+     */
+    private void startWork(String name, String subtaskName, Callable<Runnable> work) {
+        if (closed) {
+            return;
+        }
+        long requestGeneration = generation.incrementAndGet();
+        cancelActive();
+        dispatchIfCurrent(requestGeneration, () -> onRunningChanged.accept(true));
+
+        Thread worker = Thread.ofVirtual().name(name)
+                .unstarted(() -> runScoped(requestGeneration, name, subtaskName, work));
+        coordinator.set(worker);
+        worker.start();
+    }
+
+    private void runScoped(long requestGeneration,
+                           String name,
+                           String subtaskName,
+                           Callable<Runnable> work) {
+        DawScope scope = DawScope.openShutdownOnFailure(name);
+        try (scope) {
+            activeScope.set(scope);
+            var io = scope.fork(subtaskName, work);
+            scope.joinAll();
+            Runnable onSucceeded = io.resultNow();
+            dispatchIfCurrent(requestGeneration, () -> {
+                onSucceeded.run();
+                onRunningChanged.accept(false);
+            });
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            dispatchIfCurrent(requestGeneration, () -> onRunningChanged.accept(false));
+        } catch (ExecutionException | CancellationException failure) {
+            dispatchIfCurrent(requestGeneration, () -> {
+                onFailed.accept(rootCause(failure));
+                onRunningChanged.accept(false);
+            });
+        } catch (RuntimeException failure) {
+            dispatchIfCurrent(requestGeneration, () -> {
+                onFailed.accept(failure);
+                onRunningChanged.accept(false);
+            });
+        } finally {
+            activeScope.compareAndSet(scope, null);
+            coordinator.compareAndSet(Thread.currentThread(), null);
+        }
+    }
+
+    private void dispatchIfCurrent(long requestGeneration, Runnable callback) {
+        fxDispatcher.accept(() -> {
+            if (!closed && generation.get() == requestGeneration) {
+                callback.run();
+            }
+        });
+    }
+
+    private static Throwable rootCause(Throwable failure) {
+        return failure.getCause() == null ? failure : failure.getCause();
+    }
+
+    /** Cancels in-flight work without joining on the caller (normally FX) thread. */
+    private void cancelActive() {
+        DawScope scope = activeScope.get();
+        if (scope != null) {
+            scope.cancel();
+        }
+        Thread worker = coordinator.getAndSet(null);
+        if (worker != null) {
+            worker.interrupt();
+        }
+    }
+
+    /**
+     * Invalidates queued callbacks and interrupts the owned scope —
+     * closing the sheet tears down in-flight I/O (§2.7). Deliberately
+     * non-blocking; the coordinator closes/joins its own scope.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        generation.incrementAndGet();
+        cancelActive();
+        fxDispatcher.accept(() -> onRunningChanged.accept(false));
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsProfileSheet.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsProfileSheet.java
@@ -1,0 +1,344 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.FileChooser;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * The §5.9 import/export "Settings profile" sheet — story 309, reachable
+ * from General ▸ Reset &amp; profiles.
+ *
+ * <p>An <em>in-surface overlay</em>, never a nested modal (rejection #1):
+ * a {@code StackPane} scrim over the settings shell following the
+ * {@code PerformanceStageView} overlay precedent — a dedicated
+ * {@code -surface-overlay} backdrop carries the dimming so the panel
+ * above stays fully opaque; clicking the scrim (outside the panel)
+ * dismisses. The owning {@code SettingsDialog} mounts/unmounts this node
+ * in its content stack.</p>
+ *
+ * <p>Per-scope checkboxes select which {@link SettingsProfileIO.ProfileScope
+ * profile scopes} to include (§5.9's checkbox list — Application /
+ * Project defaults / This project / Audio device / Key Bindings). Export
+ * snapshots the selected descriptors' current values ON the FX thread and
+ * hands the immutable snapshot to {@link SettingsProfileIO}; import reads
+ * the file off-thread and applies the validated values through the
+ * dialog-supplied callback — which seeds the SHELL rows as pending edits
+ * and drives the existing {@code applySettings()} path, so a bulk import
+ * re-themes and re-arms exactly as manual edits do (the Control-Sync
+ * cross-reference; no parallel apply path). Rejects render with the
+ * severity tokens ({@code -warn} for validator rejects, {@code -danger}
+ * for unknown/unparseable entries).</p>
+ *
+ * <p>The {@link FileChooser} is skipped when the sheet has no
+ * scene/window (headless safety — the {@code SettingRowSkin} PATH-browse
+ * precedent); tests drive {@link #exportTo(Path)} /
+ * {@link #importFrom(Path)} directly.</p>
+ */
+public final class SettingsProfileSheet extends StackPane {
+
+    /** Stable style class — selectable as {@code .settings-profile-sheet-overlay}. */
+    public static final String DEFAULT_STYLE_CLASS = "settings-profile-sheet-overlay";
+
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
+            "com.benesquivelmusic.daw.app.i18n.Messages", Locale.ROOT);
+
+    private final SettingsCatalogue catalogue;
+    private final Function<String, Object> currentValues;
+    private final Consumer<Map<String, Object>> applyImported;
+    private final Runnable onClose;
+    private final SettingsProfileIO io;
+
+    private final Map<SettingsProfileIO.ProfileScope, CheckBox> scopeChecks =
+            new EnumMap<>(SettingsProfileIO.ProfileScope.class);
+    private final Label progressLabel = new Label();
+    private final Label statusLabel = new Label();
+    private final VBox rejectsBox = new VBox();
+
+    /**
+     * Builds the sheet.
+     *
+     * @param catalogue     the story-305 catalogue; not null
+     * @param currentValues current-value access per descriptor id (the
+     *                      dialog's persisted read path); not null
+     * @param applyImported dialog-side bulk apply: seeds shell rows as
+     *                      pending edits then runs {@code applySettings()};
+     *                      not null
+     * @param onClose       unmounts the sheet from the dialog's content
+     *                      stack; not null
+     */
+    public SettingsProfileSheet(SettingsCatalogue catalogue,
+                                Function<String, Object> currentValues,
+                                Consumer<Map<String, Object>> applyImported,
+                                Runnable onClose) {
+        this.catalogue = Objects.requireNonNull(catalogue, "catalogue must not be null");
+        this.currentValues = Objects.requireNonNull(currentValues,
+                "currentValues must not be null");
+        this.applyImported = Objects.requireNonNull(applyImported,
+                "applyImported must not be null");
+        this.onClose = Objects.requireNonNull(onClose, "onClose must not be null");
+        this.io = new SettingsProfileIO(catalogue,
+                this::onImported, this::onExported, this::onRunningChanged, this::onFailed);
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+
+        // PerformanceStageView precedent: the translucent backdrop is a
+        // dedicated Region so the panel stays fully opaque.
+        Region backdrop = new Region();
+        backdrop.getStyleClass().add("settings-profile-sheet-backdrop");
+
+        VBox panel = buildPanel();
+        StackPane scrim = new StackPane(backdrop, panel);
+        scrim.setOnMouseClicked(event -> {
+            if (event.getTarget() == scrim || event.getTarget() == backdrop) {
+                dismiss();
+            }
+        });
+        getChildren().add(scrim);
+    }
+
+    private VBox buildPanel() {
+        Label title = new Label(msg("settings.profile.title"));
+        title.getStyleClass().add("settings-profile-sheet-title");
+
+        Label scopesLabel = new Label(msg("settings.profile.scopes"));
+        scopesLabel.getStyleClass().add("settings-profile-status");
+        VBox scopes = new VBox(scopesLabel);
+        scopes.getStyleClass().add("settings-profile-scopes");
+        for (SettingsProfileIO.ProfileScope scope
+                : SettingsProfileIO.ProfileScope.values()) {
+            CheckBox check = new CheckBox(
+                    msg("settings.profile.scope." + scope.tag()));
+            check.setId("profile-scope-" + scope.tag());
+            check.setSelected(true);
+            scopeChecks.put(scope, check);
+            scopes.getChildren().add(check);
+        }
+
+        Button exportButton = new Button(msg("settings.profile.export"));
+        exportButton.getStyleClass().addAll("dawg-button", "size-default");
+        exportButton.setId("settings-profile-export");
+        exportButton.setOnAction(_ -> chooseAndExport());
+
+        Button importButton = new Button(msg("settings.profile.import"));
+        importButton.getStyleClass().addAll("dawg-button", "size-default");
+        importButton.setId("settings-profile-import");
+        importButton.setOnAction(_ -> chooseAndImport());
+
+        Button closeButton = new Button(msg("settings.profile.close"));
+        closeButton.getStyleClass().addAll("dawg-button", "size-default", "secondary");
+        closeButton.setId("settings-profile-close");
+        closeButton.setOnAction(_ -> dismiss());
+
+        HBox actions = new HBox(exportButton, importButton, closeButton);
+        actions.getStyleClass().add("settings-profile-actions");
+
+        progressLabel.getStyleClass().add("settings-profile-progress");
+        progressLabel.setText(msg("settings.profile.progress"));
+        progressLabel.setManaged(false);
+        progressLabel.setVisible(false);
+
+        statusLabel.getStyleClass().add("settings-profile-status");
+        statusLabel.setManaged(false);
+        statusLabel.setVisible(false);
+        statusLabel.setWrapText(true);
+
+        rejectsBox.getStyleClass().add("settings-profile-rejects");
+
+        VBox panel = new VBox(title, scopes, actions, progressLabel, statusLabel, rejectsBox);
+        panel.getStyleClass().add("settings-profile-sheet");
+        panel.setMaxWidth(Region.USE_PREF_SIZE);
+        panel.setMaxHeight(Region.USE_PREF_SIZE);
+        return panel;
+    }
+
+    // ── Actions ──────────────────────────────────────────────────────────────
+
+    /** @return the scopes whose checkboxes are currently ticked */
+    Set<SettingsProfileIO.ProfileScope> selectedScopes() {
+        EnumSet<SettingsProfileIO.ProfileScope> selected =
+                EnumSet.noneOf(SettingsProfileIO.ProfileScope.class);
+        scopeChecks.forEach((scope, check) -> {
+            if (check.isSelected()) {
+                selected.add(scope);
+            }
+        });
+        return selected;
+    }
+
+    private void chooseAndExport() {
+        if (getScene() == null || getScene().getWindow() == null) {
+            return; // headless safety — no chooser without a window
+        }
+        FileChooser chooser = profileChooser();
+        File file = chooser.showSaveDialog(getScene().getWindow());
+        if (file != null) {
+            exportTo(file.toPath());
+        }
+    }
+
+    private void chooseAndImport() {
+        if (getScene() == null || getScene().getWindow() == null) {
+            return; // headless safety — no chooser without a window
+        }
+        FileChooser chooser = profileChooser();
+        File file = chooser.showOpenDialog(getScene().getWindow());
+        if (file != null) {
+            importFrom(file.toPath());
+        }
+    }
+
+    private static FileChooser profileChooser() {
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle(msg("settings.profile.title"));
+        chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter(
+                msg("settings.profile.fileType"), "*.dawgprofile", "*.txt"));
+        return chooser;
+    }
+
+    /**
+     * Exports the selected scopes to {@code file}. The values snapshot is
+     * captured HERE on the FX thread; the worker only serialises + writes.
+     */
+    void exportTo(Path file) {
+        clearReport();
+        Set<SettingsProfileIO.ProfileScope> scopes = selectedScopes();
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        for (SettingDescriptor<?> descriptor : catalogue.descriptors()) {
+            if (scopes.contains(SettingsProfileIO.ProfileScope.of(descriptor))) {
+                snapshot.put(descriptor.id(), currentValues.apply(descriptor.id()));
+            }
+        }
+        io.startExport(file, scopes, snapshot);
+    }
+
+    /**
+     * Imports the selected scopes from {@code file} (off-thread read).
+     * Public within the unexported {@code ui.settings} package (the
+     * module exports nothing, so this stays module-internal): the
+     * FileChooser path routes here, and the {@code ..app.ui} dialog-level
+     * tests drive the composed import-apply loop through it directly.
+     *
+     * @param file the profile file to read; not null
+     */
+    public void importFrom(Path file) {
+        clearReport();
+        io.startImport(file, selectedScopes());
+    }
+
+    // ── SettingsProfileIO callbacks (FX thread) ──────────────────────────────
+
+    private void onRunningChanged(boolean running) {
+        progressLabel.setManaged(running);
+        progressLabel.setVisible(running);
+    }
+
+    private void onExported(Path file) {
+        showStatus(MessageFormat.format(
+                msg("settings.profile.exported"), file.getFileName()));
+    }
+
+    private void onImported(SettingsProfileIO.ImportOutcome outcome) {
+        // Bulk apply FIRST (seed rows + applySettings — the existing
+        // path), then report what was and was not applied.
+        applyImported.accept(outcome.applied());
+        showStatus(MessageFormat.format(
+                msg("settings.profile.imported"), outcome.applied().size()));
+        renderRejects(outcome);
+    }
+
+    private void onFailed(Throwable failure) {
+        String message = failure.getMessage() == null || failure.getMessage().isBlank()
+                ? failure.getClass().getSimpleName() : failure.getMessage();
+        Label line = new Label(MessageFormat.format(
+                msg("settings.profile.failed"), message));
+        line.getStyleClass().add("settings-profile-reject-danger");
+        line.setWrapText(true);
+        rejectsBox.getChildren().setAll(line);
+    }
+
+    private void renderRejects(SettingsProfileIO.ImportOutcome outcome) {
+        rejectsBox.getChildren().clear();
+        if (outcome.rejects().isEmpty()) {
+            return;
+        }
+        Label header = new Label(msg("settings.profile.rejects.header"));
+        header.getStyleClass().add("settings-profile-rejects-header");
+        rejectsBox.getChildren().add(header);
+        for (SettingsProfileIO.Reject reject : outcome.rejects()) {
+            Label line = new Label(MessageFormat.format(
+                    msg("settings.profile.reject." + reasonKey(reject.kind())),
+                    reject.key(), reject.value()));
+            // Severity tokens (§2.6): a validator reject is a -warn (the
+            // value was understood but out of range); an unknown or
+            // unparseable entry is a -danger (the profile is damaged).
+            line.getStyleClass().add(
+                    reject.kind() == SettingsProfileIO.RejectKind.REJECTED_BY_VALIDATOR
+                            ? "settings-profile-reject-warn"
+                            : "settings-profile-reject-danger");
+            line.setWrapText(true);
+            rejectsBox.getChildren().add(line);
+        }
+    }
+
+    private static String reasonKey(SettingsProfileIO.RejectKind kind) {
+        return switch (kind) {
+            case MALFORMED_LINE -> "malformed";
+            case UNKNOWN_SETTING -> "unknown";
+            case UNPARSEABLE_VALUE -> "unparseable";
+            case REJECTED_BY_VALIDATOR -> "invalid";
+        };
+    }
+
+    private void showStatus(String text) {
+        statusLabel.setText(text);
+        statusLabel.setManaged(true);
+        statusLabel.setVisible(true);
+    }
+
+    private void clearReport() {
+        statusLabel.setManaged(false);
+        statusLabel.setVisible(false);
+        statusLabel.setText("");
+        rejectsBox.getChildren().clear();
+    }
+
+    private void dismiss() {
+        onClose.run();
+    }
+
+    /**
+     * Tears down in-flight I/O (§2.7 — closing the surface cancels the
+     * work; a late result is discarded, never applied). Called by the
+     * owning dialog when the sheet unmounts or the dialog hides.
+     */
+    public void dispose() {
+        io.close();
+    }
+
+    private static String msg(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (MissingResourceException missing) {
+            return key;
+        }
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsProfileSheet.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsProfileSheet.java
@@ -322,13 +322,17 @@ public final class SettingsProfileSheet extends StackPane {
     }
 
     private void dismiss() {
+        // §2.7 — closing the sheet cancels its in-flight I/O regardless
+        // of how the owner unmounts; disposing again there is a no-op.
+        dispose();
         onClose.run();
     }
 
     /**
      * Tears down in-flight I/O (§2.7 — closing the surface cancels the
-     * work; a late result is discarded, never applied). Called by the
-     * owning dialog when the sheet unmounts or the dialog hides.
+     * work; a late result is discarded, never applied). Called by
+     * {@link #dismiss()} and by the owning dialog when the sheet unmounts
+     * or the dialog hides — idempotent, so both may run.
      */
     public void dispose() {
         io.close();

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsShell.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/SettingsShell.java
@@ -4,6 +4,7 @@ import com.benesquivelmusic.daw.app.ui.icons.DawgIcon;
 
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
+import javafx.css.PseudoClass;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Button;
@@ -76,11 +77,14 @@ import java.util.Set;
  * <h2>Keyboard (§6.5, rejection #7)</h2>
  *
  * <p>The shell filters exactly one key: Ctrl/Cmd-F →
- * {@link #focusSearch()}. UP/DOWN/ENTER/RIGHT are rail-owned (the rail's
- * activate-pane action focuses the pane's first row editor), Tab
+ * {@link #focusSearch()}, which also enters the story-309 §4.C
+ * search-focus mode (the rail dims until Esc or focus loss restores it —
+ * Concept C as a mode of A). UP/DOWN/ENTER/RIGHT are rail-owned (the
+ * rail's activate-pane action focuses the pane's first row editor), Tab
  * traversal is native, and Esc is consumed only by the search field —
- * and only while it has text (an empty-field Esc must reach the dialog's
- * close semantics). Nothing else is globally swallowed.</p>
+ * and only while it has text (an empty-field Esc still restores the rail
+ * but must reach the dialog's close semantics). Nothing else is globally
+ * swallowed.</p>
  *
  * <h2>Key-binding conflict guard</h2>
  *
@@ -99,6 +103,17 @@ public final class SettingsShell extends BorderPane {
 
     /** Stable style class — selectable as {@code .settings-shell}. */
     public static final String DEFAULT_STYLE_CLASS = "settings-shell";
+
+    /**
+     * Story 309 §4.C — the rail-level search-focus dim (Concept C as a
+     * mode of A). Applied to the nav rail while search focus mode is
+     * active; {@code settings-nav-rail.css} gives every cell the same
+     * 0.4-opacity treatment as no-match dimming. Rail-level (not per
+     * {@code NavItem}) so it composes with the §5.2 per-category
+     * match-count dimming without either source fighting the other.
+     */
+    private static final PseudoClass SEARCH_FOCUS_PSEUDO_CLASS =
+            PseudoClass.getPseudoClass("search-focus");
 
     /**
      * Shared bundle for shell chrome strings ({@code Locale.ROOT}, the
@@ -162,6 +177,8 @@ public final class SettingsShell extends BorderPane {
 
     /** {@code true} while the center shows search results (§6.1). */
     private boolean searchMode;
+    /** Story 309 §4.C — {@code true} while the search-focus rail dim is active. */
+    private boolean searchFocusMode;
     /** Reentrancy flag for the key-binding conflict revert. */
     private boolean conflictRevertInFlight;
     /** {@code true} while {@link #refreshFromPersisted()} re-seeds rows. */
@@ -246,12 +263,22 @@ public final class SettingsShell extends BorderPane {
                            Map<String, SettingRow.ControlHints> hintsById) {
         for (SettingsCatalogue.Category category : catalogue.categories()) {
             categoryTitleById.put(category.id(), category.title());
+            Scope categoryModalScope = modalScope(category).orElse(null);
             for (SettingsCatalogue.Group group : category.groups()) {
                 groupTitleByKey.put(groupKey(category.id(), group.id()), group.title());
                 for (SettingDescriptor<?> descriptor : group.settings()) {
                     String id = descriptor.id();
                     SettingRow row = new SettingRow(descriptor,
                             persisted.currentValue(id), hintsById.get(id));
+                    // Story 309 §5.3/§3.2 — per-row scope override chip
+                    // (scope differs from the category's modal scope) and
+                    // the "applies to…" cue, both resolved HERE: the row
+                    // never touches the bundle (the badgeText contract).
+                    if (categoryModalScope != null
+                            && descriptor.scope() != categoryModalScope) {
+                        row.setScopeChipText(scopeDisplayName(descriptor.scope()));
+                    }
+                    row.setScopeCueText(scopeCueText(descriptor.scope()));
                     rowsById.put(id, row);
                     descriptorsById.put(id, descriptor);
                     rowsByGroup.computeIfAbsent(groupKey(category.id(), group.id()),
@@ -286,7 +313,10 @@ public final class SettingsShell extends BorderPane {
             for (SettingsCatalogue.Group group : category.groups()) {
                 Node ancillary = groupAncillary.get(groupKey(category.id(), group.id()));
                 if (group.settings().isEmpty() && ancillary == null) {
-                    continue; // placeholder taxonomy slots (story 309 areas)
+                    // Placeholder taxonomy slots (general/language today —
+                    // story 309 filled startup/resetProfiles with group
+                    // ancillary visuals, never descriptors).
+                    continue;
                 }
                 children.add(groupHeader(category.id(), group));
                 for (SettingDescriptor<?> descriptor : group.settings()) {
@@ -309,9 +339,15 @@ public final class SettingsShell extends BorderPane {
     }
 
     /**
-     * §5.3 pane header: the plain title label plus the uniform §5.7
+     * §5.3 pane header: the plain title label, the story-309 "Scope: …"
+     * chip naming the category's modal scope, plus the uniform §5.7
      * tier-3 ⋯ menu carrying "Reset {category} to defaults" (story 308).
      * The title keeps the {@code settings-category-title} style class.
+     *
+     * <p>The chip derives from the category's descriptors — never a
+     * hard-coded category map (§1.8 fix, rejection #8). A descriptor-less
+     * category (General) has no scope to derive, so it renders no chip —
+     * the documented story-309 choice.</p>
      */
     private Node categoryHeader(SettingsCatalogue.Category category) {
         Label title = new Label(category.title());
@@ -330,9 +366,66 @@ public final class SettingsShell extends BorderPane {
         reset.setOnAction(_ -> resetCategory(category.id()));
         menu.getItems().add(reset);
 
-        HBox header = new HBox(title, spacer, menu);
+        HBox header = new HBox(title);
+        modalScope(category).ifPresent(scope -> {
+            Label chip = new Label(MessageFormat.format(
+                    msg("settings.scope.prefix"), scopeDisplayName(scope)));
+            chip.getStyleClass().add("settings-scope-chip");
+            chip.setId("settings-scope-chip-" + category.id());
+            header.getChildren().add(chip);
+        });
+        header.getChildren().addAll(spacer, menu);
         header.getStyleClass().add("settings-category-header");
         return header;
+    }
+
+    /**
+     * Story 309 §5.3 — the category's <em>modal</em> (most frequent)
+     * descriptor scope, ties broken deterministically toward the
+     * first-encountered scope in catalogue order. Empty for a category
+     * with zero descriptors (General).
+     */
+    private static Optional<Scope> modalScope(SettingsCatalogue.Category category) {
+        Map<Scope, Integer> counts = new LinkedHashMap<>();
+        for (SettingsCatalogue.Group group : category.groups()) {
+            for (SettingDescriptor<?> descriptor : group.settings()) {
+                counts.merge(descriptor.scope(), 1, Integer::sum);
+            }
+        }
+        Scope modal = null;
+        int best = 0;
+        for (Map.Entry<Scope, Integer> entry : counts.entrySet()) {
+            // Strictly-greater keeps the FIRST-encountered scope on ties
+            // (LinkedHashMap preserves catalogue encounter order).
+            if (entry.getValue() > best) {
+                modal = entry.getKey();
+                best = entry.getValue();
+            }
+        }
+        return Optional.ofNullable(modal);
+    }
+
+    /** The canonical §3.2 scope display names ({@code research-daw} §4). */
+    private static String scopeDisplayName(Scope scope) {
+        return msg(switch (scope) {
+            case APPLICATION -> "settings.scope.application";
+            case PROJECT_DEFAULTS -> "settings.scope.projectDefaults";
+            case THIS_PROJECT -> "settings.scope.thisProject";
+            case AUDIO_DEVICE -> "settings.scope.audioDevice";
+        });
+    }
+
+    /**
+     * The §3.2 "applies to…" cue — keyed off {@link Scope} only:
+     * PROJECT_DEFAULTS reads "applies to new projects", THIS_PROJECT
+     * "applies to the open project"; the other scopes carry no cue.
+     */
+    private static String scopeCueText(Scope scope) {
+        return switch (scope) {
+            case PROJECT_DEFAULTS -> msg("settings.scope.cue.projectDefaults");
+            case THIS_PROJECT -> msg("settings.scope.cue.thisProject");
+            case APPLICATION, AUDIO_DEVICE -> null;
+        };
     }
 
     /** Rail items in catalogue order; selection swaps the browse pane. */
@@ -366,11 +459,22 @@ public final class SettingsShell extends BorderPane {
         searchField.textProperty().addListener((_, _, text) -> handleSearchChanged(text));
         // §6.5 Esc: clear + consume ONLY while the field has text; an
         // empty-field Esc must propagate so the dialog's close semantics
-        // (dirty prompt included) still work.
+        // (dirty prompt included) still work. Story 309 §4.C: any Esc in
+        // the field also restores the rail from search-focus dim —
+        // WITHOUT changing what is consumed.
         searchField.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            if (event.getCode() == KeyCode.ESCAPE && !searchField.getText().isEmpty()) {
-                searchField.clear();
-                event.consume();
+            if (event.getCode() == KeyCode.ESCAPE) {
+                exitSearchFocusMode();
+                if (!searchField.getText().isEmpty()) {
+                    searchField.clear();
+                    event.consume();
+                }
+            }
+        });
+        // Story 309 §4.C — leaving the field restores the rail too.
+        searchField.focusedProperty().addListener((_, _, focused) -> {
+            if (!focused) {
+                exitSearchFocusMode();
             }
         });
 
@@ -729,9 +833,29 @@ public final class SettingsShell extends BorderPane {
         this.onCancel = r;
     }
 
-    /** Focuses the search field (the §6.5 Ctrl/Cmd-F target). */
+    /**
+     * Focuses the search field (the §6.5 Ctrl/Cmd-F target) and enters
+     * the story-309 §4.C search-focus mode: the rail dims (Concept C as
+     * a mode of A) until Esc or focus loss restores it.
+     */
     public void focusSearch() {
         searchField.requestFocus();
+        enterSearchFocusMode();
+    }
+
+    /** @return whether the §4.C search-focus rail dim is active (story 309) */
+    public boolean isSearchFocusDimActive() {
+        return searchFocusMode;
+    }
+
+    private void enterSearchFocusMode() {
+        searchFocusMode = true;
+        navRail.pseudoClassStateChanged(SEARCH_FOCUS_PSEUDO_CLASS, true);
+    }
+
+    private void exitSearchFocusMode() {
+        searchFocusMode = false;
+        navRail.pseudoClassStateChanged(SEARCH_FOCUS_PSEUDO_CLASS, false);
     }
 
     /** @return the navigation rail (tests / keyboard glue) */
@@ -823,6 +947,23 @@ public final class SettingsShell extends BorderPane {
                 entry.getValue().forEach(SettingRow::resetToDefault);
             }
         }
+    }
+
+    /**
+     * §5.7 tier 4 (story 309): resets every row of every category to its
+     * descriptor default. Pending-only, exactly like tiers 1–3 — nothing
+     * is persisted until the caller drives Apply. The confirm guard lives
+     * with the caller ({@code SettingsDialog}'s "Restore all defaults"),
+     * not here: the shell stays write-free.
+     */
+    public void resetAll() {
+        // Clear every key-capture row FIRST: the per-row conflict guard
+        // reverts a value another key row currently holds, so two
+        // swapped bindings could otherwise veto each other's defaults.
+        // The interim nulls are plain pending edits the default-reset
+        // below immediately overwrites.
+        keyCaptureRows.forEach(row -> row.setValue(null));
+        rowsById.values().forEach(SettingRow::resetToDefault);
     }
 
     /** @return whether the pending-only restart banner is currently visible */

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -342,3 +342,58 @@ settings.restartBanner=Restart required for: {0}. Changes apply when you relaunc
 settings.dirtyPrompt.title=Unsaved Changes
 settings.dirtyPrompt.header=Apply your pending settings changes?
 settings.dirtyPrompt.discard=Discard
+
+# Story 309 — scope labels (§2.3/§3.2/§5.3): the four canonical scope
+# display names (research-daw §4 — used consistently in chip, sheet and
+# cue), the pane-header chip prefix, and the reach cues.
+settings.scope.prefix=Scope: {0}
+settings.scope.application=Application
+settings.scope.projectDefaults=Project defaults
+settings.scope.thisProject=This project
+settings.scope.audioDevice=Audio device
+settings.scope.cue.projectDefaults=applies to new projects
+settings.scope.cue.thisProject=applies to the open project
+
+# Story 309 — General ▸ Startup / Reset & profiles (§4.D, §5.7 tier 4).
+settings.general.runWizard=Run setup wizard…
+settings.restoreAll.button=Restore all defaults…
+settings.restoreAll.title=Restore All Defaults
+settings.restoreAll.message=Reset every setting to its default value? This applies immediately and cannot be undone.
+settings.restoreAll.confirm=Restore
+
+# Story 309 — import/export profile sheet (§5.9/§6.3).
+settings.profile.open=Settings profile…
+settings.profile.title=Settings profile
+settings.profile.scopes=Include scopes
+settings.profile.scope.application=Application
+settings.profile.scope.projectDefaults=Project defaults
+settings.profile.scope.thisProject=This project
+settings.profile.scope.audioDevice=Audio device
+settings.profile.scope.keyBindings=Key Bindings
+settings.profile.export=Export current settings…
+settings.profile.import=Import settings from a file…
+settings.profile.close=Close
+settings.profile.fileType=DAWG settings profile
+settings.profile.progress=▷ working…
+settings.profile.exported=Profile exported to {0}.
+settings.profile.imported={0} settings imported and applied.
+settings.profile.failed=Profile operation failed: {0}
+settings.profile.rejects.header=Some entries were not applied:
+settings.profile.reject.malformed={0} — not a profile entry
+settings.profile.reject.unknown={0} — unknown setting
+settings.profile.reject.unparseable={0} — value "{1}" could not be read
+settings.profile.reject.invalid={0} — value "{1}" was rejected by validation
+
+# Story 309 — first-run wizard (§4.D, Concept D): a thin linear
+# sequencer over the same catalogue descriptors.
+wizard.firstRun.title=First-run setup
+wizard.step.caption=Step {0} of {1}
+wizard.step.audio=Audio device
+wizard.step.appearance=Appearance
+wizard.step.project=Project defaults
+wizard.step.done=You're set up
+wizard.done.message=You're set up. Everything here lives in Settings if you want to change it later.
+wizard.next=Next
+wizard.back=Back
+wizard.skip=Skip
+wizard.finish=Finish

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/settings/setting-row.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/settings/setting-row.css
@@ -22,6 +22,7 @@
     -srw-warn:        #E6B450;  /* -warn        */
     -srw-accent:      #7C8CFF;  /* -accent      */
     -srw-accent-soft: rgba(124, 140, 255, 0.14);  /* -accent-soft */
+    -srw-line-soft:   #22242C;  /* -line-soft   */
 
     -fx-padding: 4 0 4 0;
 }
@@ -54,6 +55,31 @@
 .setting-row .setting-row-description {
     -fx-text-fill: -srw-text-mute;
     -fx-font-size: 11px;
+}
+
+/* Story 309 §5.3 — trailing column pairing the per-row scope-override
+   chip with the apply-class badge. */
+.setting-row .setting-row-trailing {
+    -fx-spacing: 4;
+}
+
+/* Story 309 §5.3 — the per-row scope-override chip: muted text in a
+   soft-line outline, never a coloured fill (the notification-pill
+   restraint; UI Design Book §7.2 one-accent rule). */
+.setting-row .setting-row-scope-chip {
+    -fx-text-fill: -srw-text-mute;
+    -fx-font-size: 10px;
+    -fx-border-color: -srw-line-soft;
+    -fx-border-width: 1;
+    -fx-border-radius: 8;
+    -fx-padding: 0 8 0 8;
+}
+
+/* Story 309 §3.2 — the muted "applies to…" reach cue under the
+   description (keyed off Scope only; text pre-localized by the shell). */
+.setting-row .setting-row-scope-cue {
+    -fx-text-fill: -srw-text-mute;
+    -fx-font-size: 10px;
 }
 
 /* Apply-class badge (§6.4) — omitted entirely for LIVE by the skin. */

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/settings/settings-nav-rail.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/settings/settings-nav-rail.css
@@ -68,6 +68,15 @@
     -fx-opacity: 0.4;
 }
 
+/* Story 309 §4.C — search-focus mode (Concept C as a mode of A): while
+   the search field owns focus the WHOLE rail dims with the same 0.4
+   treatment. Rail-level pseudo-class (set by the shell) so it composes
+   with per-cell :dimmed above — both target the same opacity value, so
+   the two dim sources never fight. */
+.settings-nav-rail:search-focus .settings-nav-cell {
+    -fx-opacity: 0.4;
+}
+
 /* ── Accent bar — a drawn Region, ALWAYS in the graph, transparent unless
    its cell is selected (rejection §6). ── */
 .settings-nav-accent-bar {

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -2613,6 +2613,7 @@
     -srw-warn:        -warn;
     -srw-accent:      -accent;
     -srw-accent-soft: -accent-soft;
+    -srw-line-soft:   -line-soft;
 }
 
 /* AUTHOR-origin re-statements of the label fills/sizes the UA sheets
@@ -2672,6 +2673,20 @@
 }
 .setting-row .setting-row-badge.badge-restart {
     -fx-text-fill: -warn;
+}
+
+/* Story 309 §5.3/§3.2 — per-row scope chip and "applies to…" cue.
+ * Restated at AUTHOR because the global `.dialog-pane .label` rule
+ * (12 px, -text-hi) beats the UA sheet by origin (two-selector idiom). */
+.dialog-pane .setting-row-scope-chip,
+.setting-row-scope-chip {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10px;
+}
+.dialog-pane .setting-row-scope-cue,
+.setting-row-scope-cue {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10px;
 }
 
 /* §6.1 highlight spans are Text nodes in the label's graphic TextFlow —
@@ -2887,4 +2902,134 @@
 .settings-footer-status {
     -fx-text-fill: -warn;
     -fx-font-size: 11px;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ * Story 309 — scope chips, Reset & profiles, profile sheet, wizard
+ * (Settings View Design Book §2.3/§5.3 scope labels, §5.7 tier 4,
+ * §5.9/§6.3 import/export, §4.D first-run wizard). Tokens only, 4 px
+ * grid; two-selector idiom wherever `.dialog-pane .label` competes.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* §5.3 pane-header "Scope: …" chip — muted text in a soft outline on
+ * surface-2, never a coloured fill (the one-accent rule §7.2). */
+.dialog-pane .settings-scope-chip,
+.settings-scope-chip {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10px;
+    -fx-background-color: -surface-2;
+    -fx-background-radius: 8;
+    -fx-border-color: -line-soft;
+    -fx-border-width: 1;
+    -fx-border-radius: 8;
+    -fx-padding: 2 8 2 8;
+}
+
+/* General ▸ Startup / Reset & profiles ancillary rows. */
+.settings-general-startup,
+.settings-reset-profiles {
+    -fx-spacing: 8;
+    -fx-alignment: center-left;
+}
+
+/* §5.9 profile sheet — in-surface overlay, never a nested modal
+ * (rejection #1; PerformanceStageView scrim precedent: the dimming
+ * lives on a dedicated backdrop so the panel stays opaque). */
+.settings-profile-sheet-backdrop {
+    -fx-background-color: -surface-overlay;
+    -fx-opacity: 0.82;
+}
+.settings-profile-sheet {
+    -fx-background-color: -surface-1;
+    -fx-background-radius: 8;
+    -fx-border-color: -line-soft;
+    -fx-border-width: 1;
+    -fx-border-radius: 8;
+    -fx-padding: 16;
+    -fx-spacing: 12;
+    -fx-min-width: 360;
+}
+.dialog-pane .settings-profile-sheet-title,
+.settings-profile-sheet-title {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 13px;
+    -fx-font-weight: 600;
+}
+.settings-profile-scopes {
+    -fx-spacing: 4;
+}
+.settings-profile-actions {
+    -fx-spacing: 8;
+    -fx-alignment: center-left;
+}
+.dialog-pane .settings-profile-progress,
+.settings-profile-progress {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+}
+.dialog-pane .settings-profile-status,
+.settings-profile-status {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+}
+/* §6.3 reject report — severity tokens: -warn for a validator reject
+ * (understood but out of range), -danger for an unknown / unparseable
+ * entry (the profile itself is damaged). */
+.settings-profile-rejects {
+    -fx-spacing: 4;
+}
+.dialog-pane .settings-profile-rejects-header,
+.settings-profile-rejects-header {
+    -fx-text-fill: -warn;
+    -fx-font-size: 11px;
+}
+.dialog-pane .settings-profile-reject-warn,
+.settings-profile-reject-warn {
+    -fx-text-fill: -warn;
+    -fx-font-size: 11px;
+}
+.dialog-pane .settings-profile-reject-danger,
+.settings-profile-reject-danger {
+    -fx-text-fill: -danger;
+    -fx-font-size: 11px;
+}
+
+/* §4.D first-run wizard — plain label step titles (rejection #6), no
+ * accent fills, no animation (instant / Reduce-Motion-safe). */
+.first-run-wizard {
+    -fx-background-color: -surface-1;
+    -fx-padding: 16;
+}
+.first-run-wizard-header {
+    -fx-spacing: 4;
+    -fx-padding: 0 0 8 0;
+}
+.dialog-pane .first-run-wizard-title,
+.first-run-wizard-title {
+    -fx-text-fill: -text-hi;
+    -fx-font-size: 13px;
+    -fx-font-weight: 600;
+}
+.dialog-pane .first-run-wizard-caption,
+.first-run-wizard-caption {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 11px;
+}
+.first-run-wizard-rows {
+    -fx-spacing: 12;
+}
+.dialog-pane .first-run-wizard-done,
+.first-run-wizard-done {
+    -fx-text-fill: -text;
+    -fx-font-size: 12px;
+}
+.dialog-pane .first-run-wizard-progress,
+.first-run-wizard-progress {
+    -fx-text-fill: -text-mute;
+    -fx-font-size: 10px;
+}
+.first-run-wizard-buttons {
+    -fx-spacing: 8;
+    -fx-alignment: center-right;
+    -fx-padding: 8 0 0 0;
 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FirstRunWizardShowsOnceTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FirstRunWizardShowsOnceTest.java
@@ -1,0 +1,287 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.density.DensityManager;
+import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
+import com.benesquivelmusic.daw.app.ui.settings.FirstRunWizard;
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 309 — the §4.D first-run wizard (Concept D): with the first-run
+ * flag unset the auto-show decision is true and the wizard sequences
+ * audio → appearance → project-defaults over generic {@link SettingRow}
+ * instances (the same §5.4 rows, never a parallel form); completing —
+ * and, separately, skipping — sets the flag, so it never auto-shows
+ * again; and the General ▸ Startup re-open seam exists on the settings
+ * dialog.
+ *
+ * <p>Tested at the decision seam ({@code FirstRunWizard.shouldAutoShow})
+ * and the pane API — headless, no window. The literal
+ * {@code DawApplication.start} → {@code MainController
+ * .showWelcomeIfNoProjectOpen} auto-show wiring is not exercisable
+ * in-process (MainController is never FXML-loaded in tests — the known
+ * literal-test gap); the decision seam plus the {@code showSetupWizard}
+ * glue it calls are what this class pins.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class FirstRunWizardShowsOnceTest {
+
+    private static final List<String> AUDIO_STEP = List.of(
+            "audio.backend", "audio.inputDevice", "audio.outputDevice",
+            "audio.applyLatencyCompensation");
+    private static final List<String> APPEARANCE_STEP = List.of(
+            ThemeManager.PREF_KEY, DensityManager.PREF_KEY,
+            "appearance.uiScale", MotionManager.PREF_KEY);
+    private static final List<String> PROJECT_STEP = List.of(
+            "project.defaultTempo", "project.autoSaveIntervalSeconds");
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(30, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    private static SettingsModel newModel() {
+        Preferences prefs = Preferences.userRoot()
+                .node("firstRunWizardShowsOnceTest_" + System.nanoTime());
+        return new SettingsModel(prefs);
+    }
+
+    private static List<String> rowIds(FirstRunWizard wizard) {
+        return wizard.currentStepRows().stream()
+                .map(row -> row.descriptor().id())
+                .toList();
+    }
+
+    @Test
+    void autoShowDecisionShouldFollowTheFirstRunFlag() {
+        SettingsModel model = newModel();
+        assertThat(FirstRunWizard.shouldAutoShow(model))
+                .as("a fresh install auto-shows the wizard")
+                .isTrue();
+        model.setFirstRunWizardCompleted(true);
+        assertThat(FirstRunWizard.shouldAutoShow(model))
+                .as("once the flag is set the wizard never auto-shows again")
+                .isFalse();
+        assertThat(FirstRunWizard.shouldAutoShow(newModel()))
+                .as("the flag is per-preferences-node state")
+                .isTrue();
+    }
+
+    @Test
+    void wizardShouldSequenceTheThreeStepsOverSettingRowsAndFinishSetsTheFlag()
+            throws Exception {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            FirstRunWizard wizard = new FirstRunWizard(
+                    SettingsCatalogue.create(), model, null /* no enumeration */);
+
+            // Linear sequence: audio → appearance → project → done.
+            assertThat(wizard.getCurrentStep()).isZero();
+            assertThat(rowIds(wizard)).containsExactlyElementsOf(AUDIO_STEP);
+            wizard.nextStep();
+            assertThat(rowIds(wizard)).containsExactlyElementsOf(APPEARANCE_STEP);
+            wizard.previousStep();
+            assertThat(rowIds(wizard))
+                    .as("back is linear too — no branching")
+                    .containsExactlyElementsOf(AUDIO_STEP);
+            wizard.nextStep();
+            wizard.nextStep();
+            assertThat(rowIds(wizard)).containsExactlyElementsOf(PROJECT_STEP);
+
+            // EDIT a step row: the map handed to onFinished must carry the
+            // edited ROW VALUE — collectedEdits() returning descriptor
+            // defaults would silently factory-reset every wizard-step
+            // setting on Finish while keeping the keySet identical.
+            SettingRow tempoRow = wizard.currentStepRows().stream()
+                    .filter(row -> "project.defaultTempo".equals(row.descriptor().id()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no tempo row"));
+            assertThat(tempoRow.descriptor().defaultValue())
+                    .as("precondition: 150.0 is a NON-default tempo")
+                    .isNotEqualTo(150.0);
+            tempoRow.setValue(150.0);
+
+            wizard.nextStep();
+            assertThat(wizard.getCurrentStep())
+                    .as("the trailing page is \"you're set up\"")
+                    .isEqualTo(3);
+            assertThat(wizard.currentStepRows()).isEmpty();
+
+            // Every step renders SettingRow instances (§5.4 — the same
+            // generic rows, not new forms).
+            wizard.previousStep();
+            assertThat(wizard.currentStepRows())
+                    .isNotEmpty()
+                    .allSatisfy(row -> assertThat(row).isInstanceOf(SettingRow.class));
+            wizard.nextStep();
+
+            AtomicReference<Map<String, Object>> finished = new AtomicReference<>();
+            wizard.setOnFinished(finished::set);
+            wizard.finish();
+
+            assertThat(model.isFirstRunWizardCompleted())
+                    .as("completing sets the flag")
+                    .isTrue();
+            assertThat(FirstRunWizard.shouldAutoShow(model))
+                    .as("the next launch does not auto-show")
+                    .isFalse();
+            assertThat(finished.get())
+                    .as("finish hands the collected values to the apply glue")
+                    .isNotNull();
+            assertThat(finished.get().keySet())
+                    .containsExactlyInAnyOrderElementsOf(
+                            List.of(AUDIO_STEP, APPEARANCE_STEP, PROJECT_STEP).stream()
+                                    .flatMap(List::stream)
+                                    .toList());
+            assertThat(finished.get())
+                    .as("finish hands the EDITED row value to the apply glue "
+                            + "— never the descriptor default")
+                    .containsEntry("project.defaultTempo", 150.0);
+            return null;
+        });
+    }
+
+    /**
+     * Story 309 review P1 — an abnormal close ([X] or the host dialog's
+     * header close glyph) triggers neither {@code finish()} nor
+     * {@code skip()}; the host's {@code skipIfNoOutcome()} safety net
+     * must treat the dismissal as Skip so the first-run flag is still
+     * set and the wizard never auto-nags on later launches.
+     */
+    @Test
+    void abnormalCloseWithoutAnOutcomeShouldCountAsSkip() throws Exception {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            FirstRunWizard wizard = new FirstRunWizard(
+                    SettingsCatalogue.create(), model, null);
+            AtomicInteger skips = new AtomicInteger();
+            wizard.setOnSkipped(skips::incrementAndGet);
+
+            assertThat(wizard.hasOutcome())
+                    .as("[X]-dismissal records no outcome of its own")
+                    .isFalse();
+            // The host-side abnormal-close hook: showSetupWizard calls
+            // this after showAndWait() returns.
+            wizard.skipIfNoOutcome();
+
+            assertThat(wizard.hasOutcome()).isTrue();
+            assertThat(model.isFirstRunWizardCompleted())
+                    .as("the outcome-less path still sets the flag — the "
+                            + "wizard never auto-nags")
+                    .isTrue();
+            assertThat(FirstRunWizard.shouldAutoShow(model)).isFalse();
+            assertThat(skips.get())
+                    .as("abnormal close routed through the Skip path")
+                    .isEqualTo(1);
+
+            // Idempotent — a second safety-net call is a no-op.
+            wizard.skipIfNoOutcome();
+            assertThat(skips.get()).isEqualTo(1);
+
+            // And after a real Finish the safety net must NOT fire Skip.
+            SettingsModel finishedModel = newModel();
+            FirstRunWizard finishedWizard = new FirstRunWizard(
+                    SettingsCatalogue.create(), finishedModel, null);
+            AtomicBoolean skippedAfterFinish = new AtomicBoolean();
+            finishedWizard.setOnSkipped(() -> skippedAfterFinish.set(true));
+            finishedWizard.finish();
+            finishedWizard.skipIfNoOutcome();
+            assertThat(finishedWizard.hasOutcome()).isTrue();
+            assertThat(skippedAfterFinish)
+                    .as("a finished wizard's safety net is a no-op")
+                    .isFalse();
+            return null;
+        });
+    }
+
+    @Test
+    void skippingShouldSetTheFlagAndApplyNothing() throws Exception {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            FirstRunWizard wizard = new FirstRunWizard(
+                    SettingsCatalogue.create(), model, null);
+            AtomicBoolean skipped = new AtomicBoolean();
+            AtomicBoolean finishedRan = new AtomicBoolean();
+            wizard.setOnSkipped(() -> skipped.set(true));
+            wizard.setOnFinished(_ -> finishedRan.set(true));
+
+            wizard.skip();
+
+            assertThat(model.isFirstRunWizardCompleted())
+                    .as("skipping also sets the flag — the wizard never "
+                            + "auto-shows twice")
+                    .isTrue();
+            assertThat(skipped).isTrue();
+            assertThat(finishedRan)
+                    .as("skip applies nothing — the finish path never runs")
+                    .isFalse();
+            return null;
+        });
+    }
+
+    @Test
+    void generalStartupShouldCarryTheReopenSeam() throws Exception {
+        runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(newModel());
+            AtomicBoolean opened = new AtomicBoolean();
+            dialog.setOnRunSetupWizard(() -> opened.set(true));
+
+            dialog.selectCategory("general");
+            dialog.getDialogPane().applyCss();
+            dialog.getDialogPane().layout();
+            Node node = dialog.getDialogPane().lookup("#settings-run-setup-wizard");
+            assertThat(node)
+                    .as("General ▸ Startup carries \"Run setup wizard…\"")
+                    .isInstanceOf(Button.class);
+
+            ((Button) node).fire();
+            assertThat(opened)
+                    .as("the button routes through the dialog's re-open seam")
+                    .isTrue();
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/NoInlineLiteralsInSettingsShellTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/NoInlineLiteralsInSettingsShellTest.java
@@ -59,7 +59,11 @@ final class NoInlineLiteralsInSettingsShellTest {
             "SettingsShell.java",
             "SettingsNavRail.java",
             "SettingRow.java",
-            "SettingsSearchIndex.java");
+            "SettingsSearchIndex.java",
+            // Story 309 additions — profile I/O + sheet and the wizard.
+            "SettingsProfileIO.java",
+            "SettingsProfileSheet.java",
+            "FirstRunWizard.java");
 
     @Test
     void settingsShellSourcesCarryNoInlineStyleLiterals() throws IOException {

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProfileImportDrivesApplyPathTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProfileImportDrivesApplyPathTest.java
@@ -1,0 +1,120 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileSheet;
+
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Story 309 §6.3 — the COMPOSED import-apply loop: the §5.9 sheet's
+ * import outcome flows through {@code SettingsDialog.showProfileSheet()}'s
+ * apply callback (seed shell rows as pending edits →
+ * {@code applySettings()}) into the PERSISTED {@link SettingsModel} —
+ * "applies only the valid ones". Exercises the REAL
+ * {@code startImport(Path, Set)} file read with the production
+ * {@code FxDispatcher} (complementing {@code ProfileIoOffFxThreadTest}'s
+ * seam-level coverage): a real profile file with two non-default valid
+ * values persists both, while a validator-rejected entry (tempo guard
+ * 20..999) is NOT applied and IS surfaced in the sheet UI.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ProfileImportDrivesApplyPathTest {
+
+    @Test
+    void importedProfileShouldPersistValidValuesAndSurfaceTheReject(
+            @TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("studio.dawgprofile");
+        Files.writeString(file, """
+                # dawg-settings-profile v1
+                application|appearance.uiScale=1.75
+                application|project.useJournaledPersistence=true
+                projectDefaults|project.defaultTempo=5000
+                """, StandardCharsets.UTF_8);
+
+        SettingsModel model = Story307TestSupport.model("profileImportApplyPath");
+        double defaultTempo = model.getDefaultTempo();
+        assertThat(model.getUiScale())
+                .as("precondition: 1.75 is a NON-default uiScale")
+                .isNotEqualTo(1.75);
+        assertThat(model.isUseJournaledPersistence())
+                .as("precondition: journaled persistence defaults off")
+                .isFalse();
+
+        SettingsDialog dialog = Story307TestSupport.onFx(() -> {
+            SettingsDialog created = new SettingsDialog(model);
+            created.showProfileSheet();
+            return created;
+        });
+        SettingsProfileSheet sheet = Story307TestSupport.onFx(() ->
+                (SettingsProfileSheet) dialog.getDialogPane()
+                        .lookup(".settings-profile-sheet-overlay"));
+        assertThat(sheet)
+                .as("showProfileSheet mounted the sheet in-surface")
+                .isNotNull();
+
+        try {
+            Story307TestSupport.onFx(() -> {
+                sheet.importFrom(file);
+                return null;
+            });
+
+            // The worker reads the file, the outcome crosses the REAL
+            // FxDispatcher, the apply callback seeds the shell rows and
+            // runs applySettings() — wait for PERSISTENCE, the end of
+            // the composed loop.
+            waitUntil(() -> model.getUiScale() == 1.75
+                    && model.isUseJournaledPersistence());
+
+            assertThat(model.getUiScale())
+                    .as("valid appearance.uiScale PERSISTED through applySettings()")
+                    .isEqualTo(1.75);
+            assertThat(model.isUseJournaledPersistence())
+                    .as("valid project.useJournaledPersistence PERSISTED")
+                    .isTrue();
+            assertThat(model.getDefaultTempo())
+                    .as("the validator-rejected tempo (guard 20..999) was NOT applied")
+                    .isCloseTo(defaultTempo, within(0.001));
+
+            Story307TestSupport.onFx(() -> {
+                assertThat(dialog.getShell().pendingEdits())
+                        .as("the loop drove the real Apply path — nothing "
+                                + "is left pending")
+                        .isEmpty();
+                Node reject = sheet.lookup(".settings-profile-reject-warn");
+                assertThat(reject)
+                        .as("the validator reject is surfaced in the sheet UI "
+                                + "with the -warn severity")
+                        .isInstanceOf(Label.class);
+                assertThat(((Label) reject).getText())
+                        .contains("project.defaultTempo");
+                return null;
+            });
+        } finally {
+            Story307TestSupport.onFx(() -> {
+                sheet.dispose();
+                return null;
+            });
+        }
+    }
+
+    /** Polls {@code condition} up to ten seconds; returns as soon as it holds. */
+    private static void waitUntil(BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < deadline && !condition.getAsBoolean()) {
+            Thread.sleep(10);
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProfileSheetDismissalCancelsIoTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProfileSheetDismissalCancelsIoTest.java
@@ -1,0 +1,149 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileSheet;
+
+import javafx.scene.control.Button;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 309 — the §5.9 profile sheet's dismissal lifecycle honours §2.7
+ * ("closing the surface cancels in-flight work; a late result is
+ * discarded, never applied"). Two guarantees, both dialog-level:
+ * dismissing the sheet deadens its I/O — an import driven on the old
+ * reference afterwards never reaches the model — and because a closed
+ * {@code SettingsProfileIO} never restarts,
+ * {@code SettingsDialog.hideProfileSheet()} nulls the field so the next
+ * {@code showProfileSheet()} mounts a FRESH sheet rather than the dead
+ * disposed one.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ProfileSheetDismissalCancelsIoTest {
+
+    @Test
+    void hideThenReshowShouldMountAFreshSheet() throws Exception {
+        SettingsModel model = Story307TestSupport.model("profileSheetHideReshow");
+        SettingsDialog dialog = Story307TestSupport.onFx(() -> {
+            SettingsDialog created = new SettingsDialog(model);
+            created.showProfileSheet();
+            return created;
+        });
+        try {
+            SettingsProfileSheet first = Story307TestSupport.onFx(() ->
+                    (SettingsProfileSheet) dialog.getDialogPane()
+                            .lookup(".settings-profile-sheet-overlay"));
+            assertThat(first)
+                    .as("showProfileSheet mounted the sheet in-surface")
+                    .isNotNull();
+
+            Story307TestSupport.onFx(() -> {
+                dialog.hideProfileSheet();
+                assertThat(dialog.getDialogPane()
+                        .lookup(".settings-profile-sheet-overlay"))
+                        .as("hideProfileSheet unmounted the sheet")
+                        .isNull();
+                return null;
+            });
+
+            SettingsProfileSheet second = Story307TestSupport.onFx(() -> {
+                dialog.showProfileSheet();
+                return (SettingsProfileSheet) dialog.getDialogPane()
+                        .lookup(".settings-profile-sheet-overlay");
+            });
+            assertThat(second)
+                    .as("re-showing mounted a sheet again")
+                    .isNotNull();
+            assertThat(second)
+                    .as("the reopened sheet is a FRESH instance — a closed "
+                            + "profile I/O task never restarts, so remounting "
+                            + "the disposed sheet would leave Import/Export "
+                            + "dead")
+                    .isNotSameAs(first);
+        } finally {
+            Story307TestSupport.onFx(() -> {
+                dialog.hideProfileSheet();
+                return null;
+            });
+        }
+    }
+
+    @Test
+    void dismissalShouldDeadenAnImportDrivenOnTheOldSheet(
+            @TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("studio.dawgprofile");
+        Files.writeString(file, """
+                # dawg-settings-profile v1
+                application|appearance.uiScale=1.75
+                """, StandardCharsets.UTF_8);
+
+        SettingsModel model = Story307TestSupport.model("profileSheetDismissIo");
+        double uiScaleBefore = model.getUiScale();
+        assertThat(uiScaleBefore)
+                .as("precondition: 1.75 is a NON-default uiScale")
+                .isNotEqualTo(1.75);
+
+        SettingsDialog dialog = Story307TestSupport.onFx(() -> {
+            SettingsDialog created = new SettingsDialog(model);
+            created.showProfileSheet();
+            return created;
+        });
+        SettingsProfileSheet sheet = Story307TestSupport.onFx(() ->
+                (SettingsProfileSheet) dialog.getDialogPane()
+                        .lookup(".settings-profile-sheet-overlay"));
+        assertThat(sheet)
+                .as("showProfileSheet mounted the sheet in-surface")
+                .isNotNull();
+
+        // The Close button routes through the sheet's private dismiss()
+        // — the same path a scrim click takes.
+        Story307TestSupport.onFx(() -> {
+            Button close = (Button) sheet.lookup("#settings-profile-close");
+            assertThat(close).as("the sheet carries its Close button").isNotNull();
+            close.fire();
+            assertThat(dialog.getDialogPane()
+                    .lookup(".settings-profile-sheet-overlay"))
+                    .as("dismissal unmounted the sheet from the dialog")
+                    .isNull();
+            return null;
+        });
+
+        // Drive an import on the OLD, dismissed reference — §2.7 says
+        // this must never be applied.
+        Story307TestSupport.onFx(() -> {
+            sheet.importFrom(file);
+            return null;
+        });
+
+        // A closed SettingsProfileIO returns from startWork synchronously,
+        // so nothing should ever arrive; the bounded poll exists only to
+        // catch a regression where the import actually proceeds (a local
+        // one-line file completes well inside 500 ms).
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(500);
+        while (System.nanoTime() < deadline) {
+            assertThat(model.getUiScale())
+                    .as("the dismissed sheet's import never reaches the model")
+                    .isEqualTo(uiScaleBefore);
+            Thread.sleep(25);
+        }
+
+        Story307TestSupport.onFx(() -> {
+            assertThat(sheet.lookup(".settings-profile-progress").isVisible())
+                    .as("the dead import never showed progress — the closed "
+                            + "task dispatches nothing")
+                    .isFalse();
+            return null;
+        });
+        assertThat(model.getUiScale())
+                .as("the model still holds its pre-dismissal value")
+                .isEqualTo(uiScaleBefore);
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectDefaultCueTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ProjectDefaultCueTest.java
@@ -1,0 +1,131 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 309 — the §3.2 "applies to…" reach cue (the rejection-#8 guard).
+ * A {@code PROJECT_DEFAULTS} row reads "applies to new projects"; a
+ * {@code THIS_PROJECT} row reads "applies to the open project"; the cue
+ * is keyed off {@code Scope} only.
+ *
+ * <p>§3.2 dual-reach note, documented here on purpose: "Default Tempo"
+ * ({@code project.defaultTempo}) is <em>stored</em> as a default for
+ * future projects — that is its scope and its cue — while
+ * {@code LiveSettingsApplier} additionally live-applies it to the open
+ * project on Apply. The secondary live application is behaviour, not
+ * scope (see the {@code Scope.PROJECT_DEFAULTS} Javadoc); the cue
+ * deliberately names the storage reach.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ProjectDefaultCueTest {
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    private static SettingsShell newShell(SettingsCatalogue catalogue) {
+        Preferences prefs = Preferences.userRoot()
+                .node("projectDefaultCueTest_" + System.nanoTime());
+        SettingsModel model = new SettingsModel(prefs);
+        SettingsShell.ValueAccess access = id -> switch (id) {
+            case "project.defaultTempo" -> model.getDefaultTempo();
+            case "project.autoSaveIntervalSeconds" -> model.getAutoSaveIntervalSeconds();
+            case "project.useJournaledPersistence" -> model.isUseJournaledPersistence();
+            case "appearance.uiScale" -> model.getUiScale();
+            // Every other id: the descriptor default IS the persisted value
+            // over an empty node — no live singleton touched.
+            default -> catalogue.byId(id)
+                    .map(descriptor -> (Object) descriptor.defaultValue())
+                    .orElse(null);
+        };
+        return new SettingsShell(catalogue, access, null, null);
+    }
+
+    private static String cueTextOf(SettingRow row) {
+        Node cue = row.lookup(".setting-row-scope-cue");
+        return cue instanceof Label label ? label.getText() : null;
+    }
+
+    @Test
+    void projectDefaultAndThisProjectRowsShouldCarryTheirReachCues() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            StackPane root = new StackPane(shell);
+            new Scene(root, 1024, 720);
+
+            // PROJECT_DEFAULTS — "Default Tempo" (also live-applied to the
+            // open project by LiveSettingsApplier; see the class Javadoc).
+            shell.selectCategory("project");
+            root.applyCss();
+            root.layout();
+            SettingRow tempo = shell.settingRow("project.defaultTempo").orElseThrow();
+            assertThat(cueTextOf(tempo))
+                    .as("a PROJECT_DEFAULTS row cues its storage reach")
+                    .isEqualTo("applies to new projects");
+
+            // THIS_PROJECT — the metronome click gain (round-trips through
+            // the project XML, story 308).
+            shell.selectCategory("recording");
+            root.applyCss();
+            root.layout();
+            SettingRow clickGain = shell.settingRow("metronome.clickGain").orElseThrow();
+            assertThat(cueTextOf(clickGain))
+                    .as("a THIS_PROJECT row cues the open project")
+                    .isEqualTo("applies to the open project");
+
+            // APPLICATION — no cue at all (the cue is keyed off Scope only).
+            shell.selectCategory("appearance");
+            root.applyCss();
+            root.layout();
+            SettingRow uiScale = shell.settingRow("appearance.uiScale").orElseThrow();
+            assertThat(uiScale.lookup(".setting-row-scope-cue"))
+                    .as("an APPLICATION row renders no reach cue")
+                    .isNull();
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RestoreAllDefaultsIsGuardedTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/RestoreAllDefaultsIsGuardedTest.java
@@ -1,0 +1,208 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Story 309 — §5.7 tier 4, the ONE guarded bulk action: General ▸ Reset
+ * &amp; profiles ▸ "Restore all defaults" prompts for confirmation
+ * (injectable supplier seam — never a real modal here); confirming
+ * resets EVERY descriptor to its default and drives the SAME
+ * {@code applySettings()} path as manual edits (persisted defaults are
+ * asserted, not just pending state); cancelling changes nothing at all.
+ * Every other reset tier (per-setting 306, per-group 307, per-category
+ * 308) stays unguarded and pending-only.
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class RestoreAllDefaultsIsGuardedTest {
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(30, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    private static SettingsModel newModel() {
+        Preferences prefs = Preferences.userRoot()
+                .node("restoreAllDefaultsIsGuardedTest_" + System.nanoTime());
+        return new SettingsModel(prefs);
+    }
+
+    @Test
+    void restoreAllShouldPromptAndOnlyApplyDefaultsOnConfirm() throws Exception {
+        runOnFxThread(() -> {
+            // Persist NON-defaults across several categories BEFORE the
+            // dialog opens, so the rows seed dirty-relative-to-default.
+            SettingsModel model = newModel();
+            model.setDefaultTempo(150.0);
+            model.setUiScale(2.0);
+            model.setBufferSize(512);
+            DawAction rebindable = DawAction.values()[0];
+            KeyCombination custom = new KeyCodeCombination(
+                    KeyCode.F24, KeyCombination.SHORTCUT_DOWN);
+            model.getKeyBindingManager().setBinding(rebindable, custom);
+            // A NULL-default action too (nine DawActions ship unbound):
+            // restore-all must CLEAR a custom binding here — falling back
+            // to the persisted binding would let it silently survive.
+            DawAction nullDefaultAction = DawAction.TOGGLE_PRE_ROLL;
+            assertThat(nullDefaultAction.defaultBinding())
+                    .as("precondition: TOGGLE_PRE_ROLL has no default binding")
+                    .isNull();
+            KeyCombination customOnNullDefault = new KeyCodeCombination(
+                    KeyCode.F23, KeyCombination.SHORTCUT_DOWN);
+            model.getKeyBindingManager().setBinding(
+                    nullDefaultAction, customOnNullDefault);
+
+            SettingsDialog dialog = new SettingsDialog(model);
+            AtomicInteger prompts = new AtomicInteger();
+            dialog.setRestoreAllConfirm(() -> {
+                prompts.incrementAndGet();
+                return false; // CANCEL
+            });
+
+            // Realize General so the Reset & profiles affordance is live.
+            // The DialogPane already sits in the dialog's own scene —
+            // applyCss/layout on it attach the skins for the lookup.
+            dialog.selectCategory("general");
+            dialog.getDialogPane().applyCss();
+            dialog.getDialogPane().layout();
+            Node node = dialog.getDialogPane().lookup("#settings-restore-all-defaults");
+            assertThat(node)
+                    .as("General ▸ Reset & profiles carries the tier-4 action")
+                    .isInstanceOf(Button.class);
+            Button restoreAll = (Button) node;
+
+            // ── Cancel: the action PROMPTED and nothing changed. ──
+            restoreAll.fire();
+            assertThat(prompts.get())
+                    .as("the tier-4 action is guarded by a confirm")
+                    .isEqualTo(1);
+            assertThat(model.getDefaultTempo()).isCloseTo(150.0, within(0.01));
+            assertThat(model.getUiScale()).isCloseTo(2.0, within(0.01));
+            assertThat(model.getBufferSize()).isEqualTo(512);
+            assertThat(model.getKeyBindingManager().getBinding(rebindable))
+                    .contains(custom);
+            assertThat(model.getKeyBindingManager().getBinding(nullDefaultAction))
+                    .contains(customOnNullDefault);
+            SettingsShell shell = dialog.getShell();
+            assertThat(shell.pendingEdits())
+                    .as("cancel leaves not even pending state behind")
+                    .isEmpty();
+
+            // ── Confirm: every descriptor resets AND persists. ──
+            dialog.setRestoreAllConfirm(() -> {
+                prompts.incrementAndGet();
+                return true; // CONFIRM
+            });
+            restoreAll.fire();
+            assertThat(prompts.get()).isEqualTo(2);
+
+            SettingsModel defaults = newModel();
+            assertThat(model.getDefaultTempo())
+                    .as("project.defaultTempo persisted back to default")
+                    .isCloseTo(defaults.getDefaultTempo(), within(0.01));
+            assertThat(model.getUiScale())
+                    .as("appearance.uiScale persisted back to default")
+                    .isCloseTo(defaults.getUiScale(), within(0.01));
+            assertThat(model.getBufferSize())
+                    .as("audio.bufferSize persisted back to default")
+                    .isEqualTo(defaults.getBufferSize());
+            assertThat(model.getKeyBindingManager().getBinding(rebindable))
+                    .as("the customized key binding persisted back to its default")
+                    .isEqualTo(Optional.ofNullable(rebindable.defaultBinding()));
+            assertThat(model.getKeyBindingManager().getBinding(nullDefaultAction))
+                    .as("a custom binding on a null-default action is EMPTY "
+                            + "after restore-all — persisted, not just pending")
+                    .isEmpty();
+            assertThat(shell.settingRow("keybinding." + nullDefaultAction.name())
+                    .orElseThrow().getValue())
+                    .as("the null-default key row reads its (null) default")
+                    .isNull();
+
+            // Spot-check rows across categories: every row reads its
+            // descriptor default (post-apply the shell re-seeded from the
+            // persisted authorities) and no pending edit survives.
+            for (String id : new String[] {
+                    "audio.bufferSize", "appearance.uiScale", "project.defaultTempo",
+                    "metronome.clickGain", "backups.keepDaily", "plugins.scanPaths"}) {
+                SettingRow row = shell.settingRow(id).orElseThrow();
+                assertThat(row.getValue())
+                        .as("row %s reads its descriptor default after restore-all", id)
+                        .isEqualTo(row.descriptor().defaultValue());
+            }
+            assertThat(shell.pendingEdits())
+                    .as("the tier-4 restore drove the real Apply path — "
+                            + "nothing is left pending")
+                    .isEmpty();
+            assertThat(shell.dirtyProperty().get()).isFalse();
+            return null;
+        });
+    }
+
+    /**
+     * The reset tiers below tier 4 stay unguarded: a per-category reset
+     * never consults the confirm supplier.
+     */
+    @Test
+    void lowerResetTiersShouldStayUnguarded() throws Exception {
+        runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(newModel());
+            AtomicInteger prompts = new AtomicInteger();
+            dialog.setRestoreAllConfirm(() -> {
+                prompts.incrementAndGet();
+                return false;
+            });
+
+            dialog.getShell().resetCategory("appearance");
+            dialog.getShell().resetGroup("project", "defaults");
+            assertThat(prompts.get())
+                    .as("tiers 1–3 never prompt (§5.7 — only the bulk "
+                            + "restore-all is guarded)")
+                    .isZero();
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ScopeChipReflectsDescriptorTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/ScopeChipReflectsDescriptorTest.java
@@ -1,0 +1,294 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.Scope;
+import com.benesquivelmusic.daw.app.ui.settings.SettingDescriptor;
+import com.benesquivelmusic.daw.app.ui.settings.SettingRow;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
+import com.benesquivelmusic.daw.app.ui.settings.SyntheticCatalogues;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 309 — the §1.8 / rejection-#8 fix: scope is finally visible
+ * (Settings View Design Book §2.3, §3.2, §5.3). The pane header carries a
+ * "Scope: …" chip naming the category's MODAL descriptor scope, and a row
+ * whose scope differs from that modal scope renders its own override chip.
+ *
+ * <p>The chip must derive from the descriptors, never a hard-coded
+ * category map — proven by construction: the expected modal scope is
+ * recomputed here from the catalogue's descriptors for EVERY category
+ * (most-frequent scope, first-encountered tie-break), and every header
+ * chip must agree with it. The named categories (audio → "Audio device",
+ * appearance/plugins → "Application", project → "Project defaults") pin
+ * the §3.2 display vocabulary on top.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ScopeChipReflectsDescriptorTest {
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    /** A shell over a scratch model on an isolated preferences node. */
+    private static SettingsShell newShell(SettingsCatalogue catalogue) {
+        Preferences prefs = Preferences.userRoot()
+                .node("scopeChipReflectsDescriptorTest_" + System.nanoTime());
+        SettingsModel model = new SettingsModel(prefs);
+        return new SettingsShell(catalogue, valueAccess(catalogue, model), null, null);
+    }
+
+    private static SettingsShell.ValueAccess valueAccess(
+            SettingsCatalogue catalogue, SettingsModel model) {
+        return id -> switch (id) {
+            case "audio.sampleRate" -> model.getSampleRate();
+            case "audio.bitDepth" -> model.getBitDepth();
+            case "audio.mixPrecision" -> model.getMixPrecision();
+            case "audio.srcQuality" -> model.getSrcQuality();
+            case "audio.backend" -> model.getAudioBackend();
+            case "audio.inputDevice" -> model.getAudioInputDevice();
+            case "audio.outputDevice" -> model.getAudioOutputDevice();
+            case "audio.bufferSize" -> model.getBufferSize();
+            case "audio.applyLatencyCompensation" -> model.isApplyLatencyCompensation();
+            case "audio.workerPoolSize" -> model.getWorkerPoolSize();
+            case "audio.masterCpuBudgetFraction" -> model.getMasterCpuBudgetFraction();
+            case "project.autoSaveIntervalSeconds" -> model.getAutoSaveIntervalSeconds();
+            case "project.defaultTempo" -> model.getDefaultTempo();
+            case "project.useJournaledPersistence" -> model.isUseJournaledPersistence();
+            case "appearance.uiScale" -> model.getUiScale();
+            case "plugins.scanPaths" -> model.getPluginScanPaths();
+            default -> catalogue.byId(id)
+                    .map(descriptor -> (Object) descriptor.defaultValue())
+                    .orElse(null);
+        };
+    }
+
+    /** Scene + applyCss + layout so skins attach before any lookup. */
+    private static StackPane showInScene(SettingsShell shell) {
+        StackPane root = new StackPane(shell);
+        new Scene(root, 1024, 720);
+        root.applyCss();
+        root.layout();
+        return root;
+    }
+
+    private static void selectAndRealize(SettingsShell shell, StackPane root,
+                                         String categoryId) {
+        shell.selectCategory(categoryId);
+        root.applyCss();
+        root.layout();
+    }
+
+    /**
+     * The test's OWN modal-scope computation over the catalogue — the
+     * by-construction proof that the chip is descriptor-derived: most
+     * frequent scope, ties broken toward the first-encountered scope.
+     */
+    private static Scope expectedModalScope(SettingsCatalogue.Category category) {
+        Map<Scope, Integer> counts = new LinkedHashMap<>();
+        for (SettingsCatalogue.Group group : category.groups()) {
+            for (SettingDescriptor<?> descriptor : group.settings()) {
+                counts.merge(descriptor.scope(), 1, Integer::sum);
+            }
+        }
+        Scope modal = null;
+        int best = 0;
+        for (Map.Entry<Scope, Integer> entry : counts.entrySet()) {
+            if (entry.getValue() > best) {
+                modal = entry.getKey();
+                best = entry.getValue();
+            }
+        }
+        return modal;
+    }
+
+    /** The canonical §3.2 display names (research-daw §4). */
+    private static String displayName(Scope scope) {
+        return switch (scope) {
+            case APPLICATION -> "Application";
+            case PROJECT_DEFAULTS -> "Project defaults";
+            case THIS_PROJECT -> "This project";
+            case AUDIO_DEVICE -> "Audio device";
+        };
+    }
+
+    @Test
+    void headerChipShouldNameTheCanonicalScopePerCategory() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            StackPane root = showInScene(shell);
+
+            Map<String, String> expected = Map.of(
+                    "audio", "Audio device",
+                    "appearance", "Application",
+                    "plugins", "Application",
+                    "project", "Project defaults");
+            for (Map.Entry<String, String> entry : expected.entrySet()) {
+                selectAndRealize(shell, root, entry.getKey());
+                Node chip = shell.lookup("#settings-scope-chip-" + entry.getKey());
+                assertThat(chip)
+                        .as("the %s pane header carries a scope chip", entry.getKey())
+                        .isInstanceOf(Label.class);
+                assertThat(((Label) chip).getText())
+                        .as("the %s chip names its §3.2 scope", entry.getKey())
+                        .isEqualTo("Scope: " + entry.getValue());
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void everyHeaderChipShouldAgreeWithTheDescriptorDerivedModalScope() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            StackPane root = showInScene(shell);
+
+            for (SettingsCatalogue.Category category : catalogue.categories()) {
+                selectAndRealize(shell, root, category.id());
+                Scope modal = expectedModalScope(category);
+                Node chip = shell.lookup("#settings-scope-chip-" + category.id());
+                if (modal == null) {
+                    // A descriptor-less category (General) has no scope to
+                    // derive — the chip is omitted (the story-309 choice).
+                    assertThat(chip)
+                            .as("descriptor-less category %s renders no chip",
+                                    category.id())
+                            .isNull();
+                } else {
+                    assertThat(chip)
+                            .as("category %s renders a chip", category.id())
+                            .isInstanceOf(Label.class);
+                    assertThat(((Label) chip).getText())
+                            .as("category %s chip derives from its descriptors' "
+                                    + "modal scope, never a category-name map",
+                                    category.id())
+                            .isEqualTo("Scope: " + displayName(modal));
+                }
+            }
+            return null;
+        });
+    }
+
+    /**
+     * The discriminating proof the two production-catalogue tests above
+     * cannot give (they recompute the expectation from the SAME
+     * catalogue): a SYNTHETIC catalogue whose category id is a real
+     * category name ({@code "audio"}) but whose descriptors' modal scope
+     * is deliberately different (the real APPLICATION-scoped appearance
+     * descriptors). Any {@code switch (category.id())} map matching
+     * today's catalogue would render "Audio device" here and fail.
+     */
+    @Test
+    void syntheticCatalogueShouldProveDerivationFromDescriptorsNotACategoryNameMap()
+            throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue synthetic =
+                    SyntheticCatalogues.audioNamedButApplicationScoped();
+            SettingsCatalogue.Category category = synthetic.categories().get(0);
+            assertThat(category.id()).isEqualTo("audio");
+            assertThat(expectedModalScope(category))
+                    .as("precondition: the synthetic modal scope deliberately "
+                            + "differs from the real audio category's AUDIO_DEVICE")
+                    .isEqualTo(Scope.APPLICATION);
+
+            SettingsShell shell = newShell(synthetic);
+            StackPane root = showInScene(shell);
+            selectAndRealize(shell, root, "audio");
+            Node chip = shell.lookup("#settings-scope-chip-audio");
+            assertThat(chip)
+                    .as("the synthetic audio pane header carries a scope chip")
+                    .isInstanceOf(Label.class);
+            assertThat(((Label) chip).getText())
+                    .as("the chip derives APPLICATION from the descriptors — "
+                            + "a name-keyed category map would say \"Audio device\"")
+                    .isEqualTo("Scope: Application");
+            return null;
+        });
+    }
+
+    @Test
+    void rowWhoseScopeDiffersFromItsCategoryShouldShowAPerRowOverride() throws Exception {
+        runOnFxThread(() -> {
+            SettingsCatalogue catalogue = SettingsCatalogue.create();
+            SettingsShell shell = newShell(catalogue);
+            StackPane root = showInScene(shell);
+
+            // Project is PROJECT_DEFAULTS-modal; useJournaledPersistence is
+            // an APPLICATION descriptor inside it → per-row override chip.
+            selectAndRealize(shell, root, "project");
+            SettingRow journaled = shell.settingRow("project.useJournaledPersistence")
+                    .orElseThrow();
+            Node overrideChip = journaled.lookup(".setting-row-scope-chip");
+            assertThat(overrideChip)
+                    .as("the APPLICATION row in a Project-defaults category "
+                            + "carries a per-row scope chip")
+                    .isInstanceOf(Label.class);
+            assertThat(((Label) overrideChip).getText()).isEqualTo("Application");
+
+            // A row matching its category's modal scope renders no chip.
+            SettingRow tempo = shell.settingRow("project.defaultTempo").orElseThrow();
+            assertThat(tempo.lookup(".setting-row-scope-chip"))
+                    .as("a modal-scope row renders no override chip")
+                    .isNull();
+
+            // Recording is THIS_PROJECT-modal; metronome.enabled is
+            // APPLICATION → override chip there too.
+            selectAndRealize(shell, root, "recording");
+            SettingRow metronomeEnabled = shell.settingRow("metronome.enabled")
+                    .orElseThrow();
+            Node recordingChip = metronomeEnabled.lookup(".setting-row-scope-chip");
+            assertThat(recordingChip).isInstanceOf(Label.class);
+            assertThat(((Label) recordingChip).getText()).isEqualTo("Application");
+
+            SettingRow clickGain = shell.settingRow("metronome.clickGain").orElseThrow();
+            assertThat(clickGain.lookup(".setting-row-scope-chip"))
+                    .as("a THIS_PROJECT row in the THIS_PROJECT-modal category "
+                            + "renders no override chip")
+                    .isNull();
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SearchFocusModeDimsRailTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/SearchFocusModeDimsRailTest.java
@@ -1,0 +1,247 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsShell;
+
+import javafx.application.Platform;
+import javafx.css.PseudoClass;
+import javafx.event.Event;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 309 — the §4.C search-focus mode (Concept C as a <em>mode</em>
+ * of Concept A, never a separate surface). Ctrl/Cmd-F focuses the
+ * always-on search field AND dims the rail (the rail-level
+ * {@code :search-focus} pseudo-class carrying the same 0.4 treatment as
+ * no-match dimming); Esc restores the rail. §6.5 stays intact: nothing
+ * is globally swallowed, and the search-field Esc is consumed only
+ * while the field has text.
+ *
+ * <p>The key event is asserted through a parent {@code addEventFilter}
+ * on the PAYLOAD ({@code getCode()} + {@code isShortcutDown()}), never
+ * {@code Event.getSource()} identity — JavaFX rewrites the source per
+ * node ({@code feedback_javafx_bubbling_event_test_pitfall}).</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class SearchFocusModeDimsRailTest {
+
+    private static final PseudoClass SEARCH_FOCUS =
+            PseudoClass.getPseudoClass("search-focus");
+
+    private <T> T runOnFxThread(Callable<T> callable) throws Exception {
+        AtomicReference<T> ref = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                ref.set(callable.call());
+            } catch (Throwable t) {
+                // Capture AssertionError too — an FX-thread assertion must
+                // fail the test, not vanish into the FX exception handler.
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+                .as("FX task completed within the timeout")
+                .isTrue();
+        Throwable thrown = error.get();
+        if (thrown instanceof Error e) {
+            throw e;
+        }
+        if (thrown instanceof Exception e) {
+            throw e;
+        }
+        return ref.get();
+    }
+
+    private static SettingsShell newShell(SettingsCatalogue catalogue) {
+        Preferences prefs = Preferences.userRoot()
+                .node("searchFocusModeDimsRailTest_" + System.nanoTime());
+        SettingsModel model = new SettingsModel(prefs);
+        SettingsShell.ValueAccess access = id -> switch (id) {
+            case "appearance.uiScale" -> model.getUiScale();
+            default -> catalogue.byId(id)
+                    .map(descriptor -> (Object) descriptor.defaultValue())
+                    .orElse(null);
+        };
+        return new SettingsShell(catalogue, access, null, null);
+    }
+
+    /** Shortcut modifier set for both platforms (control on Windows, meta on macOS). */
+    private static KeyEvent shortcutF() {
+        return new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.F,
+                false, true, false, true);
+    }
+
+    private static KeyEvent escape() {
+        return new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE,
+                false, false, false, false);
+    }
+
+    private record ObservedKey(KeyCode code, boolean shortcutDown) {}
+
+    @Test
+    void shortcutFShouldFocusSearchAndDimTheRailAndEscShouldRestore() throws Exception {
+        runOnFxThread(() -> {
+            SettingsShell shell = newShell(SettingsCatalogue.create());
+            StackPane root = new StackPane(shell);
+            Scene scene = new Scene(root, 1024, 720);
+            root.applyCss();
+            root.layout();
+
+            // Parent-level capture filter recording the PAYLOAD — never
+            // getSource() identity (the bubbling-event pitfall).
+            List<ObservedKey> observed = new ArrayList<>();
+            root.addEventFilter(KeyEvent.KEY_PRESSED, event ->
+                    observed.add(new ObservedKey(event.getCode(), event.isShortcutDown())));
+
+            Event.fireEvent(shell, shortcutF());
+
+            assertThat(observed)
+                    .as("the parent capture filter saw the shortcut-F payload")
+                    .contains(new ObservedKey(KeyCode.F, true));
+            Node field = shell.lookup(".settings-search-field");
+            assertThat(field).isInstanceOf(TextField.class);
+            assertThat(scene.getFocusOwner())
+                    .as("Ctrl/Cmd-F focuses the always-on search field")
+                    .isSameAs(field);
+            assertThat(shell.isSearchFocusDimActive())
+                    .as("the §4.C rail dim engages with search focus")
+                    .isTrue();
+            assertThat(shell.navRail().getPseudoClassStates())
+                    .as("the rail carries :search-focus")
+                    .contains(SEARCH_FOCUS);
+
+            // Empty-field Esc: restores the rail and — per §6.5 — is NOT
+            // consumed by the field (the dialog's close semantics remain
+            // reachable). The parent-level bubbling handler proves it.
+            List<KeyCode> bubbledToParent = new ArrayList<>();
+            root.addEventHandler(KeyEvent.KEY_PRESSED,
+                    event -> bubbledToParent.add(event.getCode()));
+            Event.fireEvent(field, escape());
+
+            assertThat(shell.isSearchFocusDimActive())
+                    .as("Esc restores the rail")
+                    .isFalse();
+            assertThat(shell.navRail().getPseudoClassStates())
+                    .doesNotContain(SEARCH_FOCUS);
+            assertThat(bubbledToParent)
+                    .as("an empty-field Esc still propagates (nothing globally "
+                            + "swallowed — §6.5)")
+                    .contains(KeyCode.ESCAPE);
+            return null;
+        });
+    }
+
+    /**
+     * The NON-Esc exit: in production, clicking or Tabbing out of the
+     * search field must restore the rail via the field's
+     * {@code focusedProperty} listener — without it the rail would stay
+     * dimmed at 0.4 for the rest of the session.
+     */
+    @Test
+    void focusLossShouldRestoreTheRailWithoutEsc() throws Exception {
+        runOnFxThread(() -> {
+            SettingsShell shell = newShell(SettingsCatalogue.create());
+            StackPane root = new StackPane(shell);
+            Scene scene = new Scene(root, 1024, 720);
+            // A SHOWN stage (headless Glass platform): only a focused
+            // window makes focusedProperty live — and the exit path under
+            // test IS the field's focus-loss listener.
+            Stage stage = new Stage();
+            stage.setScene(scene);
+            stage.show();
+            try {
+                root.applyCss();
+                root.layout();
+
+                Event.fireEvent(shell, shortcutF());
+                TextField field = (TextField) shell.lookup(".settings-search-field");
+                assertThat(field.isFocused())
+                        .as("the field genuinely holds focus in the shown window")
+                        .isTrue();
+                assertThat(shell.isSearchFocusDimActive()).isTrue();
+                assertThat(shell.navRail().getPseudoClassStates())
+                        .contains(SEARCH_FOCUS);
+
+                // Move focus to another node in the realized scene — the
+                // focus-loss path, no Esc involved.
+                shell.navRail().requestFocus();
+
+                assertThat(scene.getFocusOwner())
+                        .as("focus actually left the search field")
+                        .isSameAs(shell.navRail());
+                assertThat(shell.isSearchFocusDimActive())
+                        .as("losing search focus restores the rail")
+                        .isFalse();
+                assertThat(shell.navRail().getPseudoClassStates())
+                        .as(":search-focus is cleared on focus loss")
+                        .doesNotContain(SEARCH_FOCUS);
+            } finally {
+                stage.hide();
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void searchFocusDimShouldComposeWithMatchCountDimmingAndTextEscClears() throws Exception {
+        runOnFxThread(() -> {
+            SettingsShell shell = newShell(SettingsCatalogue.create());
+            StackPane root = new StackPane(shell);
+            new Scene(root, 1024, 720);
+            root.applyCss();
+            root.layout();
+
+            Event.fireEvent(shell, shortcutF());
+            assertThat(shell.isSearchFocusDimActive()).isTrue();
+
+            // Typing a query while in focus mode: the §5.2 per-category
+            // match-count dimming still works — the two dim sources must
+            // compose without fighting (SearchFiltersAcrossCategoriesTest
+            // semantics unchanged).
+            TextField field = (TextField) shell.lookup(".settings-search-field");
+            field.setText("latency");
+            var audioItem = shell.navRail().getItems().stream()
+                    .filter(item -> "audio".equals(item.categoryId()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no audio rail item"));
+            assertThat(audioItem.dimmedProperty().get())
+                    .as("the matching category is still not item-dimmed while "
+                            + "search focus mode is active")
+                    .isFalse();
+            assertThat(audioItem.matchCountProperty().get()).isGreaterThanOrEqualTo(1);
+            assertThat(shell.isSearchFocusDimActive())
+                    .as("typing keeps the focus dim (the field still owns focus)")
+                    .isTrue();
+
+            // Non-empty-field Esc: clears the text (consumed — existing
+            // §6.5 semantics) and restores the rail.
+            Event.fireEvent(field, escape());
+            assertThat(field.getText()).isEmpty();
+            assertThat(shell.isSearchFocusDimActive()).isFalse();
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ExportImportRoundTripTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ExportImportRoundTripTest.java
@@ -1,0 +1,183 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileIO.ImportOutcome;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileIO.ProfileScope;
+import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
+
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 309 — the §6.3 profile round-trip contract: exporting a scope
+ * and re-importing it restores identical values, and the exported
+ * profile contains ONLY the selected scopes' keys ({@code keybinding.*}
+ * absent when only Application is selected — Key Bindings is its own
+ * §5.9 checkbox, carved out of the APPLICATION scope).
+ *
+ * <p>Pure parse/serialise tests over {@link SettingsProfileIO}'s static
+ * format functions — deliberately off-toolkit
+ * ({@code feedback_javafx_headless_test_pitfalls}); the off-FX-thread
+ * I/O side lives in {@code ProfileIoOffFxThreadTest}.</p>
+ */
+class ExportImportRoundTripTest {
+
+    private final SettingsCatalogue catalogue = SettingsCatalogue.create();
+
+    /** Descriptor ids belonging to one profile scope, catalogue order. */
+    private List<String> idsOf(ProfileScope scope) {
+        return catalogue.descriptors().stream()
+                .filter(descriptor -> ProfileScope.of(descriptor) == scope)
+                .map(SettingDescriptor::id)
+                .toList();
+    }
+
+    /** Non-comment profile lines. */
+    private static List<String> entryLines(String text) {
+        return text.lines()
+                .filter(line -> !line.isBlank() && !line.startsWith("#"))
+                .toList();
+    }
+
+    private static String keyOf(String entryLine) {
+        return entryLine.substring(entryLine.indexOf('|') + 1, entryLine.indexOf('='));
+    }
+
+    /**
+     * Current values: catalogue defaults overlaid with a few deliberate
+     * APPLICATION-scope non-defaults, so the round-trip proves value
+     * transport (not just default echo).
+     */
+    private Function<String, Object> valuesWith(Map<String, Object> overrides) {
+        return id -> overrides.containsKey(id)
+                ? overrides.get(id)
+                : catalogue.byId(id)
+                        .map(descriptor -> (Object) descriptor.defaultValue())
+                        .orElse(null);
+    }
+
+    @Test
+    void applicationExportShouldContainOnlyApplicationKeysAndRoundTrip() {
+        ThemeManager.Theme nonDefaultTheme = Arrays.stream(ThemeManager.Theme.values())
+                .filter(theme -> theme != ThemeManager.DEFAULT_THEME)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Need at least two themes"));
+        Map<String, Object> overrides = new HashMap<>();
+        overrides.put("appearance.uiScale", 2.0);
+        overrides.put("project.useJournaledPersistence", true);
+        overrides.put("metronome.enabled", false);
+        overrides.put("plugins.scanPaths", "C:/studio/plugins");
+        overrides.put(ThemeManager.PREF_KEY, nonDefaultTheme);
+        Function<String, Object> values = valuesWith(overrides);
+
+        String text = SettingsProfileIO.serialize(
+                catalogue, Set.of(ProfileScope.APPLICATION), values);
+
+        // Only the selected scope's keys — exactly, in catalogue order.
+        List<String> lines = entryLines(text);
+        assertThat(lines.stream().map(ExportImportRoundTripTest::keyOf).toList())
+                .containsExactlyElementsOf(idsOf(ProfileScope.APPLICATION));
+        assertThat(lines)
+                .allSatisfy(line -> assertThat(line).startsWith("application|"));
+        assertThat(lines)
+                .as("Key Bindings is its own checkbox — keybinding.* keys are "
+                        + "ABSENT from an Application-only export")
+                .noneMatch(line -> keyOf(line).startsWith("keybinding."));
+
+        // Re-import restores identical values (canonical types included).
+        ImportOutcome outcome = SettingsProfileIO.parseAndValidate(
+                catalogue, Set.of(ProfileScope.APPLICATION), text);
+        assertThat(outcome.rejects()).isEmpty();
+        Map<String, Object> expected = new LinkedHashMap<>();
+        for (String id : idsOf(ProfileScope.APPLICATION)) {
+            expected.put(id, values.apply(id));
+        }
+        assertThat(outcome.applied()).containsExactlyEntriesOf(expected);
+        assertThat(outcome.applied().get("appearance.uiScale")).isEqualTo(2.0);
+        assertThat(outcome.applied().get(ThemeManager.PREF_KEY))
+                .isEqualTo(nonDefaultTheme);
+    }
+
+    @Test
+    void exportShouldBeDeterministicDiffableAndTimestampFree() {
+        Function<String, Object> values = valuesWith(Map.of());
+        Set<ProfileScope> scopes = Set.of(
+                ProfileScope.APPLICATION, ProfileScope.PROJECT_DEFAULTS);
+
+        String first = SettingsProfileIO.serialize(catalogue, scopes, values);
+        String second = SettingsProfileIO.serialize(catalogue, scopes, values);
+
+        assertThat(second)
+                .as("identical settings serialise identically (no timestamps, "
+                        + "stable order — §6.3 diffable)")
+                .isEqualTo(first);
+        assertThat(first.lines().findFirst().orElseThrow())
+                .isEqualTo("# " + SettingsProfileIO.HEADER);
+        assertThat(entryLines(first)).hasSize(
+                idsOf(ProfileScope.APPLICATION).size()
+                        + idsOf(ProfileScope.PROJECT_DEFAULTS).size());
+    }
+
+    @Test
+    void keyBindingsScopeShouldRoundTripBoundAndExplicitlyUnboundBindings() {
+        List<String> keyBindingIds = idsOf(ProfileScope.KEY_BINDINGS);
+        assertThat(keyBindingIds).hasSizeGreaterThanOrEqualTo(2);
+        String boundId = keyBindingIds.get(0);
+        String unboundId = keyBindingIds.get(1);
+        KeyCombination bound = new KeyCodeCombination(
+                KeyCode.F24, KeyCombination.SHORTCUT_DOWN);
+        Map<String, Object> overrides = new HashMap<>();
+        overrides.put(boundId, bound);
+        overrides.put(unboundId, null);
+        Function<String, Object> values = valuesWith(overrides);
+
+        String text = SettingsProfileIO.serialize(
+                catalogue, Set.of(ProfileScope.KEY_BINDINGS), values);
+
+        assertThat(entryLines(text))
+                .allSatisfy(line ->
+                        assertThat(keyOf(line)).startsWith("keybinding."));
+        assertThat(text).contains(boundId + "=" + bound.getName());
+        assertThat(text).contains(unboundId + "=" + SettingsProfileIO.UNBOUND_MARKER);
+
+        ImportOutcome outcome = SettingsProfileIO.parseAndValidate(
+                catalogue, Set.of(ProfileScope.KEY_BINDINGS), text);
+        assertThat(outcome.rejects()).isEmpty();
+        assertThat(outcome.applied().get(boundId))
+                .as("a bound combination round-trips through getName()/valueOf")
+                .isEqualTo(bound);
+        assertThat(outcome.applied())
+                .as("an explicitly cleared binding round-trips as null")
+                .containsKey(unboundId);
+        assertThat(outcome.applied().get(unboundId)).isNull();
+    }
+
+    @Test
+    void importShouldSkipEntriesOutsideTheSelectedScopes() {
+        Function<String, Object> values = valuesWith(Map.of());
+        // A profile carrying BOTH scopes, imported with only one selected.
+        String text = SettingsProfileIO.serialize(catalogue,
+                Set.of(ProfileScope.APPLICATION, ProfileScope.AUDIO_DEVICE), values);
+
+        ImportOutcome outcome = SettingsProfileIO.parseAndValidate(
+                catalogue, Set.of(ProfileScope.AUDIO_DEVICE), text);
+
+        assertThat(outcome.rejects()).isEmpty();
+        assertThat(outcome.applied().keySet())
+                .as("only the selected scope's entries are applied; the rest "
+                        + "are skipped, not errors")
+                .containsExactlyElementsOf(idsOf(ProfileScope.AUDIO_DEVICE));
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ImportValidatesAndSurfacesRejectsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ImportValidatesAndSurfacesRejectsTest.java
@@ -1,0 +1,138 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileIO.ImportOutcome;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileIO.ProfileScope;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileIO.Reject;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileIO.RejectKind;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 309 — the §6.3 "report, don't fail whole" import contract: a
+ * profile with invalid entries applies every valid value and surfaces
+ * each rejected key with a reason, never aborting the whole import.
+ *
+ * <p>The rejection must flow through the DESCRIPTOR validator — the
+ * story-305 delegation to the canonical {@code SettingsModel} setter
+ * guard, not a parallel check. Proven two ways: (1) the import's
+ * accept/reject decision must agree with
+ * {@link SettingDescriptor#accepts} for the same values, and (2) the
+ * acceptance boundary must be EXACTLY the setter guard's 20..999 BPM
+ * range — a parallel check would have to duplicate those numbers to
+ * pass.</p>
+ */
+class ImportValidatesAndSurfacesRejectsTest {
+
+    private final SettingsCatalogue catalogue = SettingsCatalogue.create();
+
+    private static final Set<ProfileScope> SCOPES = Set.of(
+            ProfileScope.APPLICATION, ProfileScope.PROJECT_DEFAULTS);
+
+    @Test
+    void invalidEntriesShouldBeReportedWithoutAbortingTheImport() {
+        String profile = """
+                # dawg-settings-profile v1
+                projectDefaults|project.defaultTempo=5000.0
+                application|appearance.uiScale=1.5
+                application|bogus.key=42
+                application|backups.keepDaily=banana
+                application|project.useJournaledPersistence=true
+                """;
+
+        ImportOutcome outcome =
+                SettingsProfileIO.parseAndValidate(catalogue, SCOPES, profile);
+
+        // Every VALID value applied — including ones after a reject: the
+        // import never aborts (§6.3).
+        assertThat(outcome.applied())
+                .containsEntry("appearance.uiScale", 1.5)
+                .containsEntry("project.useJournaledPersistence", true)
+                .hasSize(2);
+
+        // Each invalid entry is one reject with key + reason.
+        assertThat(outcome.rejects()).containsExactly(
+                new Reject("project.defaultTempo",
+                        RejectKind.REJECTED_BY_VALIDATOR, "5000.0"),
+                new Reject("bogus.key", RejectKind.UNKNOWN_SETTING, "42"),
+                new Reject("backups.keepDaily",
+                        RejectKind.UNPARSEABLE_VALUE, "banana"));
+    }
+
+    @Test
+    void rejectionShouldFlowThroughTheDescriptorValidatorNotAParallelCheck() {
+        SettingDescriptor<?> tempo = catalogue.byId("project.defaultTempo")
+                .orElseThrow(() -> new AssertionError("tempo not catalogued"));
+
+        // The SettingsModel.setDefaultTempo guard is 20.0..999.0 BPM —
+        // the import boundary must match it exactly AND agree with the
+        // descriptor's accepts() (the same delegated guard) per value.
+        assertTempoDecision(tempo, 20.0, true);
+        assertTempoDecision(tempo, 999.0, true);
+        assertTempoDecision(tempo, 19.5, false);
+        assertTempoDecision(tempo, 1000.0, false);
+        assertTempoDecision(tempo, 5000.0, false);
+    }
+
+    private void assertTempoDecision(SettingDescriptor<?> tempo,
+                                     double value,
+                                     boolean accepted) {
+        assertThat(tempo.accepts(value))
+                .as("the canonical setter-guard decision for %s", value)
+                .isEqualTo(accepted);
+
+        String profile = String.format(Locale.ROOT,
+                "projectDefaults|project.defaultTempo=%s\n", value);
+        ImportOutcome outcome =
+                SettingsProfileIO.parseAndValidate(catalogue, SCOPES, profile);
+        if (accepted) {
+            assertThat(outcome.applied())
+                    .as("%s BPM imports (the guard accepts it)", value)
+                    .containsEntry("project.defaultTempo", value);
+            assertThat(outcome.rejects()).isEmpty();
+        } else {
+            assertThat(outcome.applied()).isEmpty();
+            assertThat(outcome.rejects())
+                    .as("%s BPM is rejected BY THE VALIDATOR", value)
+                    .containsExactly(new Reject("project.defaultTempo",
+                            RejectKind.REJECTED_BY_VALIDATOR,
+                            String.format(Locale.ROOT, "%s", value)));
+        }
+    }
+
+    @Test
+    void malformedLinesShouldRejectWithoutStoppingLaterEntries() {
+        String profile = """
+                # dawg-settings-profile v1
+                this is not an entry
+                application|appearance.uiScale=1.25
+                """;
+
+        ImportOutcome outcome =
+                SettingsProfileIO.parseAndValidate(catalogue, SCOPES, profile);
+
+        assertThat(outcome.applied()).containsEntry("appearance.uiScale", 1.25);
+        assertThat(outcome.rejects()).containsExactly(
+                new Reject("this is not an entry", RejectKind.MALFORMED_LINE, ""));
+    }
+
+    @Test
+    void nonFiniteDoublesShouldBeUnparseableNotSilentlyAccepted() {
+        // NaN passes a `x < 20 || x > 999` guard (both comparisons are
+        // false), so the format rejects non-finite numbers at parse — the
+        // NaN call-site-guard convention (story 305).
+        String profile = "projectDefaults|project.defaultTempo=NaN\n";
+
+        ImportOutcome outcome =
+                SettingsProfileIO.parseAndValidate(catalogue, SCOPES, profile);
+
+        assertThat(outcome.applied()).isEmpty();
+        assertThat(outcome.rejects()).containsExactly(
+                new Reject("project.defaultTempo",
+                        RejectKind.UNPARSEABLE_VALUE, "NaN"));
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ProfileIoOffFxThreadTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ProfileIoOffFxThreadTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
@@ -32,6 +33,7 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -282,7 +284,9 @@ class ProfileIoOffFxThreadTest {
      * via {@code path.getFileSystem().provider()} and only calls
      * {@code newByteChannel} (which receives the UNWRAPPED delegate so
      * the platform provider works normally); every other provider /
-     * file-system operation fails fast so any unexpected access is loud.
+     * file-system operation — including {@code toFile()}, which would
+     * bypass the provider entirely — fails fast so any unexpected
+     * access is loud.
      */
     private static Path readThreadRecordingPath(Path delegate,
                                                 AtomicReference<Thread> readThread) {
@@ -526,6 +530,19 @@ class ProfileIoOffFxThreadTest {
             @Override
             public Path toRealPath(LinkOption... options) throws IOException {
                 return delegate.toRealPath(options);
+            }
+
+            @Override
+            public File toFile() {
+                // Deliberately not delegated: a File hands callers a way to read
+                // the profile without the recording provider observing the open.
+                throw new UnsupportedOperationException(
+                        "toFile() would bypass the thread-recording provider");
+            }
+
+            @Override
+            public Iterator<Path> iterator() {
+                return delegate.iterator();
             }
 
             @Override

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ProfileIoOffFxThreadTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/ProfileIoOffFxThreadTest.java
@@ -1,0 +1,577 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileIO.ImportOutcome;
+import com.benesquivelmusic.daw.app.ui.settings.SettingsProfileIO.ProfileScope;
+
+import javafx.application.Platform;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 309 — profile I/O is the third canonical §2.7/§6.6 off-thread
+ * case (after device enumeration 307 and disk usage 308): reads/writes
+ * run on a virtual thread inside a {@code DawScope}, only results cross
+ * to the FX thread through the {@code FxDispatcher} seam, and a slow
+ * import never blocks the FX thread. Closing the task tears down
+ * in-flight I/O (structured-concurrency cancellation).
+ *
+ * <p>FX-thread assertions are captured + rethrown; the dispatcher is the
+ * injected queue seam so the dispatch boundary is observable without a
+ * live pulse (the {@code DeviceEnumerationOffFxThreadTest} pattern).
+ * The PURE parse/serialise round-trip is deliberately tested
+ * off-toolkit in the sibling {@code ExportImportRoundTripTest} /
+ * {@code ImportValidatesAndSurfacesRejectsTest}.</p>
+ */
+@ExtendWith(JavaFxToolkitExtension.class)
+class ProfileIoOffFxThreadTest {
+
+    private final SettingsCatalogue catalogue = SettingsCatalogue.create();
+
+    @Test
+    void slowImportDoesNotBlockFxAndOutcomeCrossesTheDispatcher() throws Exception {
+        CountDownLatch releaseRead = new CountDownLatch(1);
+        AtomicBoolean readOnFx = new AtomicBoolean(true);
+        AtomicReference<Thread> readThread = new AtomicReference<>();
+        BlockingQueue<Runnable> fxPosts = new LinkedBlockingQueue<>();
+        AtomicReference<ImportOutcome> outcome = new AtomicReference<>();
+
+        Callable<String> slowSource = () -> {
+            readThread.set(Thread.currentThread());
+            readOnFx.set(Platform.isFxApplicationThread());
+            releaseRead.await(); // the injected fake SLOW source
+            return "# " + SettingsProfileIO.HEADER + "\n"
+                    + "application|appearance.uiScale=1.25\n";
+        };
+
+        AtomicReference<SettingsProfileIO> taskReference = new AtomicReference<>();
+        AtomicReference<Throwable> startFailure = new AtomicReference<>();
+        CountDownLatch startReturnedOnFx = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                SettingsProfileIO created = new SettingsProfileIO(catalogue,
+                        outcome::set, _ -> { }, _ -> { },
+                        failure -> { throw new AssertionError(failure); },
+                        fxPosts::add);
+                created.startImport(Set.of(ProfileScope.APPLICATION), slowSource);
+                taskReference.set(created);
+            } catch (Throwable failure) {
+                startFailure.set(failure);
+            } finally {
+                startReturnedOnFx.countDown();
+            }
+        });
+        // start() returned on the FX thread WHILE the source is still
+        // blocked — the slow import cannot block the surface.
+        assertThat(startReturnedOnFx.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(startFailure.get()).isNull();
+        SettingsProfileIO task = taskReference.get();
+        assertThat(task).isNotNull();
+
+        // The running=true progress callback proves start posted through
+        // the dispatcher seam.
+        runPostedOnFx(fxPosts.poll(10, TimeUnit.SECONDS));
+        releaseRead.countDown();
+        while (outcome.get() == null) {
+            runPostedOnFx(fxPosts.poll(10, TimeUnit.SECONDS));
+        }
+
+        assertThat(readOnFx.get())
+                .as("the file read ran OFF the FX thread")
+                .isFalse();
+        assertThat(readThread.get()).isNotNull();
+        assertThat(readThread.get().isVirtual())
+                .as("the reader is a virtual thread (DawScope fork)")
+                .isTrue();
+        assertThat(outcome.get().rejects()).isEmpty();
+        assertThat(outcome.get().applied())
+                .containsEntry("appearance.uiScale", 1.25);
+        onFx(() -> { task.close(); return null; });
+    }
+
+    /**
+     * The REAL {@code startImport(Path, Set)} entry point — no injected
+     * source seam. Proves: (a) the profile FILE's values arrive through
+     * the dispatcher seam; (b) the calling (FX) thread returns from
+     * {@code startImport} before the outcome is delivered; and (c) — via
+     * the thread-recording {@link Path} below, whose provider observes
+     * the {@code Files.readString} channel open — the file read itself
+     * runs on a worker virtual thread, never on the caller. (c) is the
+     * discriminator: an eager caller-thread read in the Path overload
+     * would record the FX thread and fail here.
+     */
+    @Test
+    void realPathImportReadsInsideTheWorkerAndDeliversTheFileValues(
+            @TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("studio.dawgprofile");
+        Files.writeString(file, "# " + SettingsProfileIO.HEADER + "\n"
+                + "application|appearance.uiScale=1.75\n", StandardCharsets.UTF_8);
+        AtomicReference<Thread> readThread = new AtomicReference<>();
+        Path recordingFile = readThreadRecordingPath(file, readThread);
+
+        BlockingQueue<Runnable> fxPosts = new LinkedBlockingQueue<>();
+        AtomicReference<ImportOutcome> outcome = new AtomicReference<>();
+        AtomicBoolean outcomeBeforeReturn = new AtomicBoolean();
+        Thread fxThread = onFx(Thread::currentThread);
+
+        SettingsProfileIO task = onFx(() -> {
+            SettingsProfileIO created = new SettingsProfileIO(catalogue,
+                    outcome::set, _ -> { }, _ -> { },
+                    failure -> { throw new AssertionError(failure); },
+                    fxPosts::add);
+            created.startImport(recordingFile, Set.of(ProfileScope.APPLICATION));
+            outcomeBeforeReturn.set(outcome.get() != null);
+            return created;
+        });
+        assertThat(outcomeBeforeReturn)
+                .as("startImport(Path, Set) returned before the outcome arrived")
+                .isFalse();
+
+        while (outcome.get() == null) {
+            runPostedOnFx(fxPosts.poll(10, TimeUnit.SECONDS));
+        }
+
+        assertThat(outcome.get().rejects()).isEmpty();
+        assertThat(outcome.get().applied())
+                .as("the outcome carries the FILE's value through the dispatcher")
+                .containsEntry("appearance.uiScale", 1.75);
+        assertThat(readThread.get())
+                .as("the Path overload actually opened the file")
+                .isNotNull();
+        assertThat(readThread.get())
+                .as("the file read never ran on the FX (calling) thread")
+                .isNotSameAs(fxThread);
+        assertThat(readThread.get().isVirtual())
+                .as("the reader is a worker virtual thread (DawScope fork)")
+                .isTrue();
+        onFx(() -> { task.close(); return null; });
+    }
+
+    @Test
+    void exportWritesTheProfileFileOffTheFxThread(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("studio.dawgprofile");
+        BlockingQueue<Runnable> fxPosts = new LinkedBlockingQueue<>();
+        AtomicReference<Path> exported = new AtomicReference<>();
+
+        // The FX-thread-captured snapshot the sheet would build: every
+        // APPLICATION descriptor's default.
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        for (SettingDescriptor<?> descriptor : catalogue.descriptors()) {
+            if (ProfileScope.of(descriptor) == ProfileScope.APPLICATION) {
+                snapshot.put(descriptor.id(), descriptor.defaultValue());
+            }
+        }
+
+        SettingsProfileIO task = onFx(() -> {
+            SettingsProfileIO created = new SettingsProfileIO(catalogue,
+                    _ -> { }, exported::set, _ -> { },
+                    failure -> { throw new AssertionError(failure); },
+                    fxPosts::add);
+            created.startExport(file, Set.of(ProfileScope.APPLICATION), snapshot);
+            return created;
+        });
+
+        while (exported.get() == null) {
+            runPostedOnFx(fxPosts.poll(10, TimeUnit.SECONDS));
+        }
+
+        assertThat(exported.get()).isEqualTo(file);
+        String written = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(written)
+                .as("the worker wrote exactly the deterministic serialisation")
+                .isEqualTo(SettingsProfileIO.serialize(
+                        catalogue, Set.of(ProfileScope.APPLICATION), snapshot::get));
+        onFx(() -> { task.close(); return null; });
+    }
+
+    @Test
+    void closeTearsDownAnInFlightImportWithoutJoiningTheFxThread() throws Exception {
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch interrupted = new CountDownLatch(1);
+        BlockingQueue<Runnable> fxPosts = new LinkedBlockingQueue<>();
+
+        Callable<String> blockedSource = () -> {
+            entered.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException cancelled) {
+                interrupted.countDown();
+                throw cancelled;
+            }
+            return "";
+        };
+
+        SettingsProfileIO task = onFx(() -> {
+            SettingsProfileIO created = new SettingsProfileIO(catalogue,
+                    _ -> { }, _ -> { }, _ -> { }, _ -> { }, fxPosts::add);
+            created.startImport(Set.of(ProfileScope.APPLICATION), blockedSource);
+            return created;
+        });
+        assertThat(entered.await(10, TimeUnit.SECONDS)).isTrue();
+
+        try {
+            CountDownLatch closeReturnedOnFx = new CountDownLatch(1);
+            AtomicReference<Throwable> closeFailure = new AtomicReference<>();
+            Platform.runLater(() -> {
+                try {
+                    task.close();
+                } catch (Throwable failure) {
+                    closeFailure.set(failure);
+                } finally {
+                    closeReturnedOnFx.countDown();
+                }
+            });
+            assertThat(closeReturnedOnFx.await(5, TimeUnit.SECONDS))
+                    .as("close() is non-blocking on the FX thread")
+                    .isTrue();
+            assertThat(closeFailure.get()).isNull();
+            assertThat(interrupted.await(5, TimeUnit.SECONDS))
+                    .as("closing the sheet cancels the in-flight read "
+                            + "(structured-concurrency teardown, §2.7)")
+                    .isTrue();
+        } finally {
+            // Belt and braces: if close() ever stopped interrupting, this
+            // release keeps the suite from hanging on the blocked fork.
+            release.countDown();
+        }
+    }
+
+    /**
+     * A delegating {@link Path} whose file system provider records the
+     * thread that opens the read channel — the honest pin that the real
+     * {@code startImport(Path, Set)} overload performs its file read
+     * inside the worker. {@code Files.readString} resolves the provider
+     * via {@code path.getFileSystem().provider()} and only calls
+     * {@code newByteChannel} (which receives the UNWRAPPED delegate so
+     * the platform provider works normally); every other provider /
+     * file-system operation fails fast so any unexpected access is loud.
+     */
+    private static Path readThreadRecordingPath(Path delegate,
+                                                AtomicReference<Thread> readThread) {
+        FileSystemProvider real = delegate.getFileSystem().provider();
+        FileSystemProvider recording = new FileSystemProvider() {
+            @Override
+            public SeekableByteChannel newByteChannel(Path path,
+                                                      Set<? extends OpenOption> options,
+                                                      FileAttribute<?>... attrs)
+                    throws IOException {
+                readThread.set(Thread.currentThread());
+                return real.newByteChannel(delegate, options, attrs);
+            }
+
+            @Override
+            public String getScheme() {
+                return real.getScheme();
+            }
+
+            @Override
+            public FileSystem newFileSystem(URI uri, Map<String, ?> env) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public FileSystem getFileSystem(URI uri) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Path getPath(URI uri) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public DirectoryStream<Path> newDirectoryStream(
+                    Path dir, DirectoryStream.Filter<? super Path> filter) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void createDirectory(Path dir, FileAttribute<?>... attrs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void delete(Path path) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void copy(Path source, Path target, CopyOption... options) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void move(Path source, Path target, CopyOption... options) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isSameFile(Path path, Path path2) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isHidden(Path path) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public FileStore getFileStore(Path path) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void checkAccess(Path path, AccessMode... modes) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <V extends FileAttributeView> V getFileAttributeView(
+                    Path path, Class<V> type, LinkOption... options) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <A extends BasicFileAttributes> A readAttributes(
+                    Path path, Class<A> type, LinkOption... options) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Map<String, Object> readAttributes(
+                    Path path, String attributes, LinkOption... options) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void setAttribute(Path path, String attribute, Object value,
+                                     LinkOption... options) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        FileSystem recordingFileSystem = new FileSystem() {
+            @Override
+            public FileSystemProvider provider() {
+                return recording;
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean isOpen() {
+                return true;
+            }
+
+            @Override
+            public boolean isReadOnly() {
+                return true;
+            }
+
+            @Override
+            public String getSeparator() {
+                return delegate.getFileSystem().getSeparator();
+            }
+
+            @Override
+            public Iterable<Path> getRootDirectories() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<FileStore> getFileStores() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Set<String> supportedFileAttributeViews() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Path getPath(String first, String... more) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public PathMatcher getPathMatcher(String syntaxAndPattern) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public UserPrincipalLookupService getUserPrincipalLookupService() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public WatchService newWatchService() {
+                throw new UnsupportedOperationException();
+            }
+        };
+        return new Path() {
+            @Override
+            public FileSystem getFileSystem() {
+                return recordingFileSystem;
+            }
+
+            @Override
+            public boolean isAbsolute() {
+                return delegate.isAbsolute();
+            }
+
+            @Override
+            public Path getRoot() {
+                return delegate.getRoot();
+            }
+
+            @Override
+            public Path getFileName() {
+                return delegate.getFileName();
+            }
+
+            @Override
+            public Path getParent() {
+                return delegate.getParent();
+            }
+
+            @Override
+            public int getNameCount() {
+                return delegate.getNameCount();
+            }
+
+            @Override
+            public Path getName(int index) {
+                return delegate.getName(index);
+            }
+
+            @Override
+            public Path subpath(int beginIndex, int endIndex) {
+                return delegate.subpath(beginIndex, endIndex);
+            }
+
+            @Override
+            public boolean startsWith(Path other) {
+                return delegate.startsWith(other);
+            }
+
+            @Override
+            public boolean endsWith(Path other) {
+                return delegate.endsWith(other);
+            }
+
+            @Override
+            public Path normalize() {
+                return delegate.normalize();
+            }
+
+            @Override
+            public Path resolve(Path other) {
+                return delegate.resolve(other);
+            }
+
+            @Override
+            public Path relativize(Path other) {
+                return delegate.relativize(other);
+            }
+
+            @Override
+            public URI toUri() {
+                return delegate.toUri();
+            }
+
+            @Override
+            public Path toAbsolutePath() {
+                return delegate.toAbsolutePath();
+            }
+
+            @Override
+            public Path toRealPath(LinkOption... options) throws IOException {
+                return delegate.toRealPath(options);
+            }
+
+            @Override
+            public WatchKey register(WatchService watcher,
+                                     WatchEvent.Kind<?>[] events,
+                                     WatchEvent.Modifier... modifiers) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int compareTo(Path other) {
+                return delegate.compareTo(other);
+            }
+
+            @Override
+            public String toString() {
+                return delegate.toString();
+            }
+        };
+    }
+
+    private static void runPostedOnFx(Runnable posted) throws Exception {
+        assertThat(posted).as("a callback was dispatched").isNotNull();
+        onFx(() -> { posted.run(); return null; });
+    }
+
+    private static <T> T onFx(Callable<T> callable) throws Exception {
+        AtomicReference<T> value = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                value.set(callable.call());
+            } catch (Throwable thrown) {
+                failure.set(thrown);
+            } finally {
+                done.countDown();
+            }
+        });
+        assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+        if (failure.get() instanceof Error e) {
+            throw e;
+        }
+        if (failure.get() instanceof Exception e) {
+            throw e;
+        }
+        return value.get();
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/SettingsCatalogueCompletenessTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/SettingsCatalogueCompletenessTest.java
@@ -26,13 +26,23 @@ import static org.assertj.core.api.Assertions.assertThat;
  * and one key-binding descriptor per {@link DawAction} must all be
  * present in {@link SettingsCatalogue}, under the pinned §3.3 taxonomy.
  *
- * <p>The single documented exclusion is {@code appearance.themeId} — a
- * dead legacy key whose live replacement is
- * {@link ThemeManager#PREF_KEY} (see the catalogue's Javadoc).</p>
+ * <p>Two documented exclusions: {@code appearance.themeId} — a dead
+ * legacy key whose live replacement is {@link ThemeManager#PREF_KEY}
+ * (see the catalogue's Javadoc) — and the story-309
+ * {@code general.firstRunWizardCompleted} first-run wizard flag, which
+ * is internal application state, not a user-facing setting (Settings
+ * View Design Book rejection #5): it gets NO descriptor and NO row.</p>
  */
 class SettingsCatalogueCompletenessTest {
 
     private static final String EXCLUDED_DEAD_THEME_KEY = "appearance.themeId";
+    /**
+     * Story 309 — the first-run wizard flag ({@code SettingsModel
+     * .KEY_FIRST_RUN_WIZARD}): internal state written by completing or
+     * skipping the wizard, never rendered as a setting (rejection #5).
+     */
+    private static final String EXCLUDED_FIRST_RUN_WIZARD_KEY =
+            "general.firstRunWizardCompleted";
 
     private final SettingsCatalogue catalogue = SettingsCatalogue.create();
 
@@ -84,7 +94,12 @@ class SettingsCatalogueCompletenessTest {
         // Non-empty guard: an accidental rename of the KEY_ convention must
         // not let this test pass vacuously.
         assertThat(reflectedKeys).isNotEmpty();
+        // Prove the excluded keys actually exist before excluding them —
+        // a silent rename must fail here, not vacuously pass below.
+        assertThat(reflectedKeys)
+                .contains(EXCLUDED_DEAD_THEME_KEY, EXCLUDED_FIRST_RUN_WIZARD_KEY);
         reflectedKeys.remove(EXCLUDED_DEAD_THEME_KEY);
+        reflectedKeys.remove(EXCLUDED_FIRST_RUN_WIZARD_KEY);
 
         Set<String> modelBackedIds = catalogue.descriptors().stream()
                 .map(SettingDescriptor::id)
@@ -190,7 +205,9 @@ class SettingsCatalogueCompletenessTest {
                 .containsExactly("startup", "language", "resetProfiles");
         for (SettingsCatalogue.Group group : general.groups()) {
             assertThat(group.settings())
-                    .as("placeholder group general.%s stays empty (story-309 territory)",
+                    .as("general.%s stays descriptor-empty by design — story 309 "
+                            + "mounts ancillary visuals (wizard button, reset & "
+                            + "profile actions) there, never descriptors",
                             group.id())
                     .isEmpty();
         }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/SyntheticCatalogues.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/SyntheticCatalogues.java
@@ -1,0 +1,40 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import java.util.List;
+
+/**
+ * Story 309 — synthetic {@link SettingsCatalogue} fixtures for the
+ * scope-chip tests. A synthetic catalogue reuses REAL descriptors under
+ * a deliberately misleading category id (a real category name whose
+ * actual modal scope differs), so any {@code switch (category.id())}
+ * shortcut in the shell fails loudly while genuine descriptor-scope
+ * derivation passes. Lives in {@code ui.settings} to reach the
+ * package-private {@link SettingsCatalogue} constructor; public so the
+ * {@code ..app.ui} chip tests (patched into the same module by surefire)
+ * can use it.
+ */
+public final class SyntheticCatalogues {
+
+    private SyntheticCatalogues() {
+    }
+
+    /**
+     * A one-category catalogue whose id is {@code "audio"} (the REAL
+     * audio category's modal scope is AUDIO_DEVICE) but whose descriptors
+     * are the real appearance descriptors — every one APPLICATION-scoped.
+     * A hard-coded category-name map would label this pane "Audio
+     * device"; descriptor derivation must say "Application".
+     *
+     * @return the synthetic catalogue
+     */
+    public static SettingsCatalogue audioNamedButApplicationScoped() {
+        SettingsCatalogue real = SettingsCatalogue.create();
+        SettingsCatalogue.Category appearance = real.categories().stream()
+                .filter(category -> "appearance".equals(category.id()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "no appearance category in the real catalogue"));
+        return new SettingsCatalogue(List.of(new SettingsCatalogue.Category(
+                "audio", "Audio", appearance.groups())));
+    }
+}


### PR DESCRIPTION
# Setting Scope Labels, Import / Export Profiles, and First-Run Wizard

## Motivation

With all four legacy dialogs absorbed (stories 307–308) and the Rail & Pane shell rendering every setting from the story-305 catalogue (story 306), the descriptor seam can now carry the last three cross-cutting capabilities the Settings View Design Book defines. Stage 5 (§7) surfaces the scope tags everywhere (§3.2), adds the import/export profile sheet (§5.9, §6.3), and adds the first-run wizard (Concept D, §4.D) — all generic over the descriptor, none a per-setting special case.

This closes the book's remaining §1 problems:

- **§1.8 / rejection #8 — scope is invisible.** App vs. project-defaults vs. this-project vs. audio-device is mixed with no on-screen cue; a user changing "Default Tempo" cannot tell it is a project-default that `LiveSettingsApplier` *also* pushes into the open project (book §1.8). Story 305 recorded each descriptor's `scope`; this story finally shows it (§2.3, §5.3) — a chip in the pane header for the category's common scope, with per-row overrides, plus an "applies to new projects" / "applies to the open project" cue.
- **§1.7 — no import, no export, no restore-all.** The Java `Preferences` store supports all of it; the UI exposed none (book §1.7). Story 306 added per-setting reset, 307 per-group, 308 per-category; this story adds the §5.7 tier-4 guarded "Restore all defaults" and the §5.9/§6.3 import/export profile so a studio-standard config is shareable across machines.
- **Onboarding (§4.D).** A new user faces the full surface with no path to first sound. The first-run wizard (Concept D) is a thin linear sequencer — audio device → appearance → project defaults — over the *same* descriptors (§4.D: "not a parallel implementation"), getting the user playing in three steps, after which everything lives in the Rail & Pane surface.

Per §7 Stage 5, this is the capstone; the optional promotion to an embedded dockable panel (Concept B) stays on the roadmap.

## Goals

- **Scope chip surfaced everywhere (§2.3, §3.2, §5.3).** The pane header shows a "Scope: …" chip naming the category's most common scope (`Application` / `Project defaults` / `This project` / `Audio device`); individual rows whose scope differs from the category show a per-row scope override (§5.3, §5.4). A project-default setting carries an "applies to new projects" cue; a this-project setting carries "applies to the open project". The chip text comes from the story-305 descriptor `scope`; nothing is hard-coded per category. This fixes §1.8 / rejection #8 without changing any stored value (§3.2 note).
- **Import / export profile sheet (§5.9, §6.3).** A "Settings profile" sheet (reachable from General ▸ Reset & profiles) offers Export current settings to a file and Import settings from a file, with per-scope checkboxes (Application / Audio / Key Bindings / …) selecting which §3.2 scopes to include (§5.9). A profile is a portable file of `key → value` pairs scoped by §3.2 (§6.3). Export writes the selected scopes; import validates each value through the matching `SettingsModel` setter guard (the descriptor `validator`) and applies only the valid ones, surfacing rejected entries rather than failing whole (§5.9, §6.3).
- **Profile I/O off the FX thread (§2.7, §6.6).** Reading and writing the profile file is I/O on a background virtual thread with a progress affordance; only the result (applied values + the reject report) touches the FX thread via `Platform.runLater`. A large profile import never blocks the surface. Use structured concurrency so cancelling the sheet tears down in-flight I/O (`java-26.agent.md` Project Loom).
- **Restore all defaults (§5.7 tier 4).** General ▸ Reset & profiles ▸ "Restore all defaults" resets every descriptor to its default. It is guarded by a confirm (the one irreversible bulk action — §5.7), consistent with "reversibility before confirmation" (§2.5). This completes the four-tier reset model (per-setting 306, per-group 307, per-category 308, all 309).
- **First-run wizard over the descriptors (§4.D, Concept D).** On first launch (detected via a `Preferences` first-run flag), a short linear wizard sequences three steps — audio device → appearance → project defaults — each rendering the *same* setting rows (§5.4) for the relevant descriptors, ending with "you're set up". It is a thin sequencer over the catalogue, not a parallel form (§4.D). After completion (or skip), the flag is set and the wizard never auto-shows again; the same settings live in the Rail & Pane surface. The wizard is re-openable from General.
- **Search-focus mode folds in (Concept C as a mode of A, §4.C).** Ctrl/Cmd-F (story 306's focus-search binding) dims the rail and foregrounds the search field — Concept C as a *mode* of Concept A (§4.C recommendation), not a separate surface. (Story 306 shipped the search field; this story adds the dim-rail focus affordance per §4.C.)
- **Tokens, never literals (§2.6).** The scope chip, the reject-report severity, the wizard chrome, and the confirm dialog use semantic tokens (`text-muted` for the "applies to…" cue, severity tokens for rejects/warnings), not inline hex/font-weight (rejection #2). The wizard step titles are plain labels, not accent fills (§5.3).
- Tests:
  - `ScopeChipReflectsDescriptorTest` (new): the Audio category header chip reads "Audio device", the Appearance/Plugins header reads "Application", and Project reads "Project defaults"; a row whose scope differs from its category shows a per-row override; the chip text derives from the descriptor `scope`, not a hard-coded category map (the §1.8 fix).
  - `ProjectDefaultCueTest` (new): "Default Tempo" shows the "applies to new projects" cue (and, per §3.2, is documented as also live-applied to the open project), distinguishing it from a `THIS_PROJECT` setting's "applies to the open project" cue (the rejection #8 guard).
  - `ExportImportRoundTripTest` (new): exporting the Application scope and re-importing it restores identical values; an exported profile contains only the selected scopes' keys.
  - `ImportValidatesAndSurfacesRejectsTest` (new): importing a profile with one out-of-range value applies every valid value and reports the rejected key without aborting the whole import (the §6.3 "report, don't fail whole" contract); the reject is validated through the descriptor `validator` (the existing `SettingsModel` setter guard), not a parallel check.
  - `ProfileIoOffFxThreadTest` (new): profile read/write runs on a non-FX thread and applies via `Platform.runLater`; a large/slow import does not block the surface (substitute a fake slow file source). Capture+rethrow assertions made inside an FX runnable (`feedback_javafx_headless_test_pitfalls.md`); extract the profile parse/serialise as a pure function and test off-toolkit.
  - `RestoreAllDefaultsIsGuardedTest` (new): "Restore all defaults" prompts for confirmation; confirming resets every descriptor to default; cancelling changes nothing.
  - `FirstRunWizardShowsOnceTest` (new): with the first-run flag unset the wizard auto-shows and sequences audio → appearance → project-defaults over the shared rows; completing/skipping sets the flag; the next launch does not auto-show; the wizard is re-openable from General.
  - `SearchFocusModeDimsRailTest` (new): Ctrl/Cmd-F focuses the search field and applies the rail-dim affordance; Esc restores the rail (Concept C-as-mode, §4.C). Test the typed key event via a parent `addEventFilter` on the payload, not `Event.getSource()` identity (`feedback_javafx_bubbling_event_test_pitfall.md`).

## Non-Goals

- **No change to stored values or `Preferences` schema.** The scope chip *labels* the reach (§3.2 note: "no stored-value change"); import/export reads and writes existing keys through existing setters. No key is renamed or migrated.
- **No new `THIS_PROJECT` persistence machinery.** Surfacing the `THIS_PROJECT` chip does not, by itself, build per-project storage for settings that lack it; those settings persist where they do today, and any net-new project-file field is a separate, flagged concern (`feedback_scope_fix_defer_tangential.md`), not built here.
- **No embedded-panel promotion (Concept B).** Promoting the surface to a dockable view via the `DockManager` (stories 285/286) stays on the roadmap (§4.B, §7 Stage 5 "optionally"). The surface remains modal/dialog.
- **No cloud sync / no profile registry.** Import/export is a local file (§6.3). A shared-profile service, versioned profiles, or a migration tool between app versions are out of scope.
- **No multi-step branching wizard.** Concept D is a *short linear* sequencer (audio → appearance → project defaults, §4.D); no conditional branches, no per-feature onboarding beyond first sound.
- **No new search engine.** Story 306 shipped search (§6.1); this story only adds the Concept C dim-rail focus *mode* (§4.C), not a new index or ranking.
- **No live-preview strip (Concept E).** The Appearance-group preview (§4.E) is a separate, deferred affordance; this story does not build it.

## Technical Notes

- Files: edits to `daw-app/.../ui/settings/SettingsShell.java` (render the scope chip + per-row override + "applies to…" cue from descriptor `scope`; add the General ▸ Reset & profiles section; add the Concept C dim-rail focus mode), new `daw-app/.../ui/settings/SettingsProfileIO.java` (the §6.3 profile read/write + per-scope filtering, off-thread), new `daw-app/.../ui/settings/SettingsProfileSheet.java` (the §5.9 import/export sheet), new `daw-app/.../ui/settings/FirstRunWizard.java` (the §4.D linear sequencer over the catalogue), and `styles.css` (scope-chip, reject-severity, wizard chrome tokens). Present in the tree (line numbers are locators — grep before editing): `SettingsModel.java` (line 17), `SettingsDialog.java` (line 42), the three live managers (`ThemeManager`/`DensityManager`/`MotionManager`, stories 277/278/279).
- The scope chip is pure descriptor read-out: the category chip names the modal (most common) scope of the category's descriptors; a row whose `scope` differs renders its own chip (§5.3/§5.4). The "applies to new projects" vs. "applies to the open project" cue is keyed off `PROJECT_DEFAULTS` vs. `THIS_PROJECT` (§3.2). Use the canonical scope display names (`research-daw` §4 — App / Project defaults / This project / Audio device) consistently; the §3.2 note about `defaultTempo`/`autoSaveIntervalSeconds` (project-default *and* live-applied) is the example to get right (rejection #8).
- Profile I/O is the third canonical §2.7/§6.6 off-thread case (after device enumeration 307, disk usage 308). Run read/write on a virtual thread / `StructuredTaskScope` (cancellable on sheet close — `java-26.agent.md` Project Loom §2), show a progress affordance, and apply results + the reject report via `Platform.runLater`. Import validation goes through the descriptor `validator` (the existing `SettingsModel` setter guard, story 305), so import reuses the canonical validation, not a parallel one (`feedback_prefer_existing_conventions.md`). Parse/serialise the profile as a pure function and unit-test it off-toolkit (`feedback_javafx_headless_test_pitfalls.md`).
- The profile format is a simple, portable `key → value` file scoped by §3.2 (e.g. a properties/JSON file keyed by `Preferences` key with a scope tag per entry). Keep it diffable and machine-shareable (§6.3 "studio standard … reproducible setups"). Per-scope checkboxes (§5.9) filter which descriptors are written/read.
- The first-run wizard reuses the story-306 `SettingRow` (`Control`/`Skin`) for each step's controls — it is a sequencer over descriptors, not new forms (§4.D). Detect first run via a `Preferences` flag through `SettingsModel`; set it on completion or skip. The wizard's audio step reuses the off-thread device enumeration from story 307; do not re-implement enumeration.
- Tokens: scope chip, "applies to…" cue (`text-muted`), reject report (severity tokens), and confirm dialog use story-260 semantic tokens (UI Design Book §3), never inline hex/font-weight (rejection #2). Wizard step titles are plain labels (§5.3, UI Design Book rejection §6). Java-side colours derive from resolved CSS (`feedback_iconnode_tint_from_resolved_css.md`).
- The "Restore all defaults" confirm follows the "reversibility before confirmation" principle cited in §2.5 (mirroring the Project Manager Design Book §2.5) — it is the single guarded bulk action; every other reset (per-setting/group/category) is unguarded and instant.
- Control-Sync cross-reference: importing a profile or restoring defaults drives the same Apply path (live managers + engine-reconfigure) as a manual edit, so a bulk change re-themes/re-arms exactly as individual edits do. **Story 294** (migrate the settings surface onto the shared wiring) owns the `SettingsVM` / `SettingsApplied` event a bulk Apply will eventually publish; until it lands, this story routes bulk Apply through the existing `LiveSettingsApplier` + the story-307 engine-reconfigure path — so story 294 can later add the single `SettingsApplied` publish without re-touching the profile/wizard code. (Both 294 and this story are specs; neither `SettingsVM` nor this surface has code yet.)
- Accessibility: the scope chip, reject report, and wizard must remain legible under all themes including the WCAG-accessible set (story 194) — derive contrast from resolved tokens, do not assume the dark palette. Progress affordances are instant / Reduce-Motion-safe (story 279).
- Per `feedback_scope_fix_defer_tangential.md`, adjacent finds (e.g. a setting whose `THIS_PROJECT` chip implies storage it lacks, or a key with no clean profile representation) are flagged against the backlog, not auto-fixed here.
- SKILL refs: `javafx-application-design` §11 (profile I/O off FX), §3 (wizard rows + profile sheet as `Control`/`Skin`), §4 (scope/dirty state as `Property` bindings; the chip binds to descriptor scope), §15 (no FX-thread blocking on I/O; no globally-swallowed keys in the wizard). `java-26.agent.md` Project Loom §2 (structured concurrency for profile I/O). `research-daw` §4 (the four scope names, used consistently in chip, sheet, and cue).
- Reference: Settings View Design Book §1.7 (no import/export/reset), §1.8 (scope invisible), §2.3 (scope always labelled), §2.5 (reversible), §3.2 (the four scopes), §4.C (search-focus mode), §4.D (first-run wizard), §5.3 (scope chip), §5.7 (restore-all tier), §5.9 (import/export sheet), §6.3 (profiles), §6.6 (concurrency), §7 Stage 5, Appendix A, rejections #2/#6/#8. Sibling stories: 305 (descriptor scope + validator — hard dependency), 306 (shell + search + per-setting reset — hard dependency), 307 (audio absorb + device enumeration the wizard reuses), 308 (Recording/Backups absorb + per-category reset), 192 (command palette — the Concept C search-focus mode pattern), 194 (WCAG-accessible themes — the chip/report must stay legible), 277/278/279 (the live managers a bulk import drives), 260 (semantic tokens), 010 (the focus-search binding), 285/286 (Dock/Layout — where the deferred Concept B embedded-panel promotion would register).
