### PR TITLE
310-asio-driver-enumeration-and-lifecycle.md implementation.

### DIFF
--- a/daw-app/pom.xml
+++ b/daw-app/pom.xml
@@ -159,15 +159,15 @@
                          This <configuration> replaces (does not merge with)
                          the parent pluginManagement argLine, so the parent's
                          enable-native-access flag is repeated here to preserve
-                         native access for the daw.core FFM bindings (granted by
-                         module name now that daw.core is a named module) and
-                         the headless backend's native code paths. daw.app is
+                         native access for the named daw.core engine bindings,
+                         the daw.sdk ASIO bindings, and the headless backend's
+                         native code paths. daw.app is
                          granted too (story 279): MotionManager's
                          PlatformMotionHint performs an FFM downcall to
                          user32!SystemParametersInfoW for OS reduce-motion
                          detection. ALL-UNNAMED is retained for test-only code
                          on the unnamed classpath. -->
-                    <argLine>--enable-native-access=daw.core,daw.app,ALL-UNNAMED
+                    <argLine>--enable-native-access=daw.core,daw.sdk,daw.app,ALL-UNNAMED
                         -Dglass.platform=Headless
                         -Dmonocle.platform=Headless
                         -Dprism.order=sw
@@ -337,8 +337,9 @@
                                 <argument>${project.build.directory}/daw-runtime</argument>
                                 <argument>--module</argument>
                                 <argument>daw.app/com.benesquivelmusic.daw.app.DawLauncher</argument>
-                                <!-- Grant restricted native access to the two
+                                <!-- Grant restricted native access to the three
                                      named modules that perform FFM downcalls:
+                                     daw.sdk (ASIO),
                                      daw.core (PortAudio/FluidSynth/CLAP/codec
                                      bindings) and daw.app (story 279 —
                                      MotionManager's user32!SystemParametersInfoW
@@ -347,7 +348,7 @@
                                      module on first downcall; in a future JDK
                                      the warning becomes a hard error. -->
                                 <argument>--java-options</argument>
-                                <argument>--enable-native-access=daw.core,daw.app</argument>
+                                <argument>--enable-native-access=daw.core,daw.sdk,daw.app</argument>
                                 <argument>--dest</argument>
                                 <argument>${project.build.directory}/dist/app-image</argument>
                                 <!-- Ship the CMake-built native libraries

--- a/daw-core/native/asio/CMakeLists.txt
+++ b/daw-core/native/asio/CMakeLists.txt
@@ -41,6 +41,12 @@ if(NOT WIN32)
     return()
 endif()
 
+if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(FATAL_ERROR
+        "asioshim: only Windows x64 is supported (CMAKE_SIZEOF_VOID_P="
+        "${CMAKE_SIZEOF_VOID_P}). Configure the generator with -A x64.")
+endif()
+
 # Fail loudly when ASIO_SDK_DIR is set but does not contain the SDK.
 set(_asio_common "${ASIO_SDK_DIR}/common")
 set(_asio_host   "${ASIO_SDK_DIR}/host")
@@ -52,6 +58,24 @@ foreach(_dir ${_asio_common} ${_asio_host} ${_asio_pc})
             "Steinberg ASIO SDK tree (missing: ${_dir}). Either point "
             "ASIO_SDK_DIR at a real SDK extract or unset it to skip "
             "this target.")
+    endif()
+endforeach()
+
+set(_asio_required_files
+    "${_asio_common}/asio.h"
+    "${_asio_common}/asiosys.h"
+    "${_asio_common}/iasiodrv.h"
+    "${_asio_common}/asio.cpp"
+    "${_asio_host}/asiodrivers.h"
+    "${_asio_host}/asiodrivers.cpp"
+    "${_asio_pc}/asiolist.h"
+    "${_asio_pc}/asiolist.cpp"
+)
+foreach(_file ${_asio_required_files})
+    if(NOT EXISTS "${_file}")
+        message(FATAL_ERROR
+            "asioshim: ASIO_SDK_DIR=${ASIO_SDK_DIR} is missing required "
+            "SDK host-glue file: ${_file}")
     endif()
 endforeach()
 

--- a/daw-core/native/asio/README.md
+++ b/daw-core/native/asio/README.md
@@ -1,17 +1,23 @@
-# asioshim — native FFM bridge for ASIO driver capability queries
+# asioshim — native FFM bridge for ASIO host lifecycle and capabilities
 
 This directory hosts the native shared library (`asioshim.dll`) that the
 JVM loads via FFM (`SymbolLookup.libraryLookup("asioshim", arena)`) to
 talk to a Steinberg ASIO driver.
 
-The Java side lives in
-`daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioCapabilityShim.java`
-and `AsioFormatChangeShim.java`.
+The Java side lives in `AsioDriverShim.java`, `AsioCapabilityShim.java`,
+`AsioControlThread.java`, `AsioFormatChangeShim.java`, and the public
+`AsioDriverInfo.java` display value under
+`daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/`.
 
 ## Exported symbols
 
 | Symbol | Wraps | Used by |
 | --- | --- | --- |
+| `int asioshim_listDrivers(void* rows, int* count)` | SDK `AsioDrivers` registry list | `AsioBackend.listDevices` |
+| `int asioshim_loadDriver(const char* name)` | indexed SDK host-glue open + `ASIOInit` | `AsioBackend.open` |
+| `int asioshim_getDriverName(void* name, int capacity)` | active lifecycle state | driver display/diagnostics |
+| `int asioshim_getDriverInfo(void* info)` | normalized `ASIODriverInfo` | driver display/diagnostics |
+| `void asioshim_unloadDriver()` | `ASIOExit` + SDK COM release | `AsioBackend.close` |
 | `int asioshim_getBufferSize(int* min, int* max, int* preferred, int* granularity)` | `ASIOGetBufferSize` | `AsioBackend.bufferSizeRange` |
 | `int asioshim_canSampleRate(double rate)` | `ASIOCanSampleRate` | `AsioBackend.supportedSampleRates` |
 | `int asioshim_getSampleRate(double* outRate)` | `ASIOGetSampleRate` | controller after a driver-initiated reset |
@@ -40,6 +46,56 @@ ASCII NUL-terminated `name`, then four `int32`s for `index`,
 `*outCount` is the buffer capacity; on `ASE_OK` it is overwritten with
 the actual entry count.
 
+## Driver lifecycle and ABI
+
+`asioshim_listDrivers` writes one fixed 168-byte record per installed x64
+driver:
+
+| Offset | Type | Meaning |
+| --- | --- | --- |
+| `0` | `char name[128]` | SDK description and canonical Java `DeviceId`/load key |
+| `128` | `char clsid[40]` | canonical `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}` CLSID |
+
+Both strings are printable ASCII and NUL-terminated. `*count` is
+capacity-in / actual-written-out: the result is capped at the input capacity.
+A zero-capacity call succeeds with `*count == 0`; a positive capacity requires
+a non-null row buffer. Enumeration uses indexed protected operations from the
+SDK's `AsioDrivers` host glue, so a registry subkey name need not equal the
+display description and names are not truncated to the legacy 32-byte
+`getDriverNames` helper buffer.
+
+`asioshim_getDriverInfo` does **not** expose native `ASIODriverInfo` memory.
+It writes a stable 264-byte FFM record instead:
+
+| Offset | Type | Meaning |
+| --- | --- | --- |
+| `0` | `int32` | ASIO host API version |
+| `4` | `int32` | vendor driver version |
+| `8` | `char name[128]` | initialized driver name |
+| `136` | `char errorMessage[128]` | driver status/error text |
+
+`asioshim_loadDriver` tears down any driver previously loaded through the
+native lifecycle before opening the replacement. It zeroes `ASIODriverInfo`,
+sets `asioVersion = 2` and `sysRef = GetDesktopWindow()`, and only publishes
+active state after `ASIOInit` returns `ASE_OK`. A failed init immediately
+releases the COM driver and clears state. `asioshim_unloadDriver` is idempotent.
+
+The Java `AudioBackend` contract rejects a second `open` while a stream is
+open. To switch devices, close the backend and then open the new `DeviceId`;
+the observable order is callback uninstall, `ASIOExit`, COM release, then the
+next driver's load/init. `DeviceId.defaultFor("ASIO")` resolves to the first
+enumerated driver and fails clearly when the snapshot is empty. If a vendor
+publishes duplicate descriptions, the first SDK registry entry is the
+deterministic load target because the story contract intentionally uses the
+driver name as the ID.
+
+Every capability export and `asioshim_openControlPanel` is guarded by active
+driver state. Before `asioshim_loadDriver` succeeds it returns its documented
+graceful-absence/failure value without calling the SDK. Settings screens that
+probe a closed backend therefore see fallback buffer/rate menus and empty
+clock/channel/panel capabilities; they are refreshed against the real driver
+after open.
+
 ## Building
 
 The shim links against the **Steinberg ASIO SDK**, which Steinberg's
@@ -52,7 +108,8 @@ licence forbids us from redistributing. To build:
    (or set the environment variable `ASIO_SDK_DIR` to the same path):
 
    ```bash
-   cmake -S lib -B target/build -DASIO_SDK_DIR=C:/asiosdk -A x64
+   cmake -S lib -B target/build -DBUILD_ASIO_SHIM=ON \
+         -DASIO_SDK_DIR=C:/asiosdk -A x64
    cmake --build target/build --config Release
    ```
 
@@ -98,7 +155,10 @@ green build.
 
 ## Threading
 
-All FFM downcalls run on the calling thread (typically the JavaFX
-thread when the Audio Settings dialog opens), never on the audio
-render thread. Mid-stream rate changes route through
-`AsioFormatChangeShim` (story 218), not these capability queries.
+All enumeration, lifecycle, capability, and control-panel FFM downcalls run on
+the dedicated daemon platform thread named `asio-control`, never the JavaFX or
+audio render thread. This keeps the SDK's COM initialization, driver creation,
+calls, exit, and release in one apartment. `AsioFormatChangeShim` uses a shared
+FFM arena because its upcall is invoked from the vendor driver's callback
+thread. Windows C `long` is 32-bit even on x64, so the callback ABI is
+normalized to `int32_t` / `ValueLayout.JAVA_INT`, not Java `long`.

--- a/daw-core/native/asio/asioshim.cpp
+++ b/daw-core/native/asio/asioshim.cpp
@@ -5,72 +5,37 @@
 // Story 130 / 213 — Driver-Reported Buffer Size and Sample-Rate
 // Enumeration. Story 218 — Format-change host-callback bridge.
 //
-// Threading: all symbols are called from the JVM thread that holds the
-// Audio Settings dialog (typically the JavaFX thread). They must never
-// be called from the audio render thread.
+// Threading: all host downcalls are serialized by the JVM's dedicated
+// `asio-control` platform thread. They must never be called from the audio
+// render thread. The only cross-thread entrypoint is the driver-owned
+// format-change callback trampoline at the bottom of this file.
 
-#if defined(_WIN32)
-#  define ASIOSHIM_EXPORT extern "C" __declspec(dllexport)
-#else
-#  define ASIOSHIM_EXPORT extern "C" __attribute__((visibility("default")))
-#endif
+#define ASIOSHIM_EXPORTS
+#include "asioshim.h"
+#include "asiosys.h"
+#include "asio.h"
+#include "asiodrivers.h"
 
+#include <windows.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
 
-// The Steinberg ASIO SDK headers live under ${ASIO_SDK_DIR}/common.
-// We forward-declare the few entry points we use so this translation
-// unit compiles without the SDK on disk; CMake links the actual
-// implementations from the SDK's host glue (asio.cpp / asiodrivers.cpp).
-//
-// The Steinberg SDK uses the type ASIOError (an int) and ASIOSampleRate
-// (a double).
-typedef long ASIOError;
-typedef double ASIOSampleRate;
+#define ASIOSHIM_EXPORT ASIOSHIM_API
 
-extern "C" ASIOError ASIOGetBufferSize(long* minSize, long* maxSize,
-                                       long* preferredSize, long* granularity);
-extern "C" ASIOError ASIOCanSampleRate(ASIOSampleRate sampleRate);
-extern "C" ASIOError ASIOGetSampleRate(ASIOSampleRate* sampleRate);
-extern "C" ASIOError ASIOSetSampleRate(ASIOSampleRate sampleRate);
-extern "C" ASIOError ASIOControlPanel(void);
+// Defined by the SDK's common/asio.cpp; the indexed host-glue open path
+// assigns the single process-wide IASIO instance before ASIOInit.
+extern IASIO* theAsioDriver;
 
-// ASIOClockSource as defined in Steinberg's asio.h. The Steinberg
-// declaration uses long (32-bit) integer fields and a 32-byte
-// fixed-length name buffer (ASCII, NUL-terminated). The shim's FFM
-// contract normalises that layout into a fixed 48-byte struct with
-// int32 fields so the Java side does not need to track the SDK's
-// platform-dependent long width.
-struct ASIOClockSource {
-    long index;
-    long associatedChannel;
-    long associatedGroup;
-    long isCurrentSource;
-    char name[32];
-};
-extern "C" ASIOError ASIOGetClockSources(ASIOClockSource* clocks, long* numSources);
-extern "C" ASIOError ASIOSetClockSource(long reference);
-
-// ASIOGetChannels reports the device's input / output channel counts.
-extern "C" ASIOError ASIOGetChannels(long* numInputChannels, long* numOutputChannels);
-
-// ASIOChannelInfo as defined in Steinberg's asio.h. The Steinberg
-// declaration uses long (32-bit on Windows) integer fields, an
-// ASIOSampleType enum (long), and a 32-byte fixed-length name buffer
-// (ASCII, NUL-terminated). The shim's FFM contract normalises that
-// layout into a fixed 56-byte struct with int32 fields so the Java
-// side does not need to track the SDK's platform-dependent long width.
-struct ASIOChannelInfo {
-    long channel;       // on input,  the channel index (0..numInputs-1) or output (0..numOutputs-1)
-    long isInput;       // on input,  1 = input, 0 = output
-    long isActive;      // on output, 1 = enabled in driver
-    long channelGroup;  // on output, driver's stereo-pair / group id
-    long type;          // on output, ASIOSampleType
-    char name[32];      // on output, ASCII NUL-terminated
-};
-extern "C" ASIOError ASIOGetChannelInfo(ASIOChannelInfo* info);
+static_assert(sizeof(long) == 4,
+              "asioshim requires the Windows LLP64 32-bit C long ABI");
 
 // Steinberg's ASE_OK is 0 in the SDK, but the FFM contract documented
 // in AsioCapabilityShim and AsioFormatChangeShim normalises "OK" to 1
@@ -79,21 +44,265 @@ extern "C" ASIOError ASIOGetChannelInfo(ASIOChannelInfo* info);
 namespace {
     constexpr int SHIM_OK = 1;
     constexpr int SHIM_FAIL = 0;
-    constexpr ASIOError ASE_OK = 0;
     // Subset of Steinberg ASIO error codes used at the FFM boundary.
     // Steinberg defines ASE_NotPresent = -1000 in asio.h, but the shim
     // contract documented in AsioBackend / AsioCapabilityShim normalises
     // "driver does not provide a control panel" to 0 so the Java side
     // can treat any negative value as a generic failure without parsing
     // the SDK's full error enum.
-    constexpr ASIOError ASE_NotPresent = -1000;
     constexpr int SHIM_NOT_PRESENT = 0;
     constexpr int SHIM_GENERIC_FAIL = -1;
+
+    constexpr int DRIVER_CAPACITY = 64;
+    constexpr int DRIVER_NAME_BYTES = 128;
+    constexpr int DRIVER_CLSID_BYTES = 40;
+    constexpr int DRIVER_RECORD_STRIDE = DRIVER_NAME_BYTES + DRIVER_CLSID_BYTES;
+    constexpr int DRIVER_INFO_STRIDE = 264;
+
+    std::mutex g_driverMutex;
+    class ShimAsioDrivers final : public AsioDrivers {
+    public:
+        long count() {
+            return asioGetNumDev();
+        }
+
+        bool nameAt(long index, char* name, int capacity) {
+            return asioGetDriverName(index, name, capacity) == 0;
+        }
+
+        bool clsidAt(long index, CLSID* clsid) {
+            return asioGetDriverCLSID(index, clsid) == 0;
+        }
+
+        bool loadAt(long index) {
+            void* driver = nullptr;
+            if (asioOpenDriver(index, &driver) != 0 || !driver) {
+                return false;
+            }
+            theAsioDriver = static_cast<IASIO*>(driver);
+            curIndex = index;
+            return true;
+        }
+    };
+
+    std::unique_ptr<ShimAsioDrivers> g_drivers;
+    bool g_driverLoaded = false;
+    ASIODriverInfo g_driverInfo{};
+    std::array<char, DRIVER_NAME_BYTES> g_activeDriverName{};
+
+    ShimAsioDrivers& driverList() {
+        if (!g_drivers) {
+            g_drivers = std::make_unique<ShimAsioDrivers>();
+        }
+        return *g_drivers;
+    }
+
+    void copyFixedAscii(unsigned char* destination, std::size_t capacity,
+                        const char* source,
+                        std::size_t sourceCapacity = static_cast<std::size_t>(-1)) {
+        std::memset(destination, 0, capacity);
+        if (!source || capacity == 0) {
+            return;
+        }
+        std::size_t count = 0;
+        while (count + 1 < capacity && count < sourceCapacity
+                && source[count] != '\0') {
+            unsigned char value = static_cast<unsigned char>(source[count]);
+            destination[count] = (value >= 0x20 && value <= 0x7e) ? value : '?';
+            ++count;
+        }
+    }
+
+    std::array<char, DRIVER_CLSID_BYTES> formatClsid(const CLSID& value) {
+        std::array<char, DRIVER_CLSID_BYTES> clsid{};
+        wchar_t wide[DRIVER_CLSID_BYTES]{};
+        if (StringFromGUID2(value, wide, DRIVER_CLSID_BYTES) <= 0) {
+            return clsid;
+        }
+        int converted = WideCharToMultiByte(
+                CP_ACP, 0, wide, -1, clsid.data(), DRIVER_CLSID_BYTES,
+                nullptr, nullptr);
+        if (converted <= 0) {
+            clsid.fill('\0');
+        }
+        clsid.back() = '\0';
+        return clsid;
+    }
+
+    void unloadDriverLocked() {
+        if (g_driverLoaded) {
+            ASIOExit();
+        }
+        if (g_drivers) {
+            g_drivers->removeCurrentDriver();
+            g_drivers.reset();
+        }
+        g_driverLoaded = false;
+        g_driverInfo = {};
+        g_activeDriverName.fill('\0');
+    }
+}
+
+// ─── Driver enumeration and lifecycle (story 310) ──────────────────────────
+
+ASIOSHIM_EXPORT int asioshim_listDrivers(void* outArray, int* outCount) {
+    if (!outCount) {
+        return SHIM_FAIL;
+    }
+    int capacity = *outCount;
+    *outCount = 0;
+    if (capacity < 0) {
+        return SHIM_FAIL;
+    }
+    if (capacity == 0) {
+        return SHIM_OK;
+    }
+    if (!outArray) {
+        return SHIM_FAIL;
+    }
+    capacity = std::min(capacity, DRIVER_CAPACITY);
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    try {
+        // Closed-state enumeration is a self-contained COM snapshot. Construct
+        // and destroy it on asio-control rather than retaining CoInitialize
+        // until a later load. While a driver is active, reuse its manager so
+        // the SDK's process-global `asioDrivers` pointer is not disturbed.
+        std::unique_ptr<ShimAsioDrivers> localSnapshot;
+        ShimAsioDrivers* snapshot = nullptr;
+        if (g_driverLoaded && g_drivers) {
+            snapshot = g_drivers.get();
+        } else {
+            localSnapshot = std::make_unique<ShimAsioDrivers>();
+            snapshot = localSnapshot.get();
+        }
+        std::array<std::array<char, DRIVER_NAME_BYTES>, DRIVER_CAPACITY> storage{};
+        long found = snapshot->count();
+        int written = std::min(capacity,
+                static_cast<int>(std::max(0L, found)));
+        auto* bytes = static_cast<unsigned char*>(outArray);
+        for (int index = 0; index < written; ++index) {
+            if (!snapshot->nameAt(index, storage[index].data(), DRIVER_NAME_BYTES)) {
+                storage[index][0] = '\0';
+            }
+            unsigned char* row = bytes + (index * DRIVER_RECORD_STRIDE);
+            copyFixedAscii(row, DRIVER_NAME_BYTES, storage[index].data());
+            CLSID driverClsid{};
+            auto clsid = snapshot->clsidAt(index, &driverClsid)
+                    ? formatClsid(driverClsid)
+                    : std::array<char, DRIVER_CLSID_BYTES>{};
+            copyFixedAscii(row + DRIVER_NAME_BYTES, DRIVER_CLSID_BYTES,
+                           clsid.data());
+        }
+        *outCount = written;
+        return SHIM_OK;
+    } catch (...) {
+        *outCount = 0;
+        return SHIM_FAIL;
+    }
+}
+
+ASIOSHIM_EXPORT int asioshim_loadDriver(const char* driverName) {
+    if (!driverName || driverName[0] == '\0') {
+        return SHIM_FAIL;
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    try {
+        // The Steinberg host glue supports one current driver. Re-loading on
+        // the same control thread always exits and releases the old COM object
+        // before attempting the replacement.
+        unloadDriverLocked();
+        std::array<char, DRIVER_NAME_BYTES> mutableName{};
+        copyFixedAscii(reinterpret_cast<unsigned char*>(mutableName.data()),
+                       mutableName.size(), driverName);
+        g_drivers = std::make_unique<ShimAsioDrivers>();
+        long matchingIndex = -1;
+        long count = std::min(driverList().count(),
+                              static_cast<long>(DRIVER_CAPACITY));
+        for (long index = 0; index < count; ++index) {
+            std::array<char, DRIVER_NAME_BYTES> installedName{};
+            if (driverList().nameAt(index, installedName.data(), DRIVER_NAME_BYTES)
+                    && std::strcmp(installedName.data(), mutableName.data()) == 0) {
+                matchingIndex = index;
+                break;
+            }
+        }
+        if (matchingIndex < 0 || !driverList().loadAt(matchingIndex)) {
+            unloadDriverLocked();
+            return SHIM_FAIL;
+        }
+
+        g_driverInfo = {};
+        g_driverInfo.asioVersion = 2;
+        g_driverInfo.sysRef = GetDesktopWindow();
+        ASIOError status = ASIOInit(&g_driverInfo);
+        if (status != ASE_OK) {
+            unloadDriverLocked();
+            return SHIM_FAIL;
+        }
+        g_driverLoaded = true;
+        copyFixedAscii(
+                reinterpret_cast<unsigned char*>(g_activeDriverName.data()),
+                g_activeDriverName.size(), mutableName.data());
+        return SHIM_OK;
+    } catch (...) {
+        unloadDriverLocked();
+        return SHIM_FAIL;
+    }
+}
+
+ASIOSHIM_EXPORT int asioshim_getDriverName(void* outName, int nameCapacity) {
+    if (!outName || nameCapacity <= 0) {
+        return SHIM_FAIL;
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    auto* destination = static_cast<unsigned char*>(outName);
+    if (!g_driverLoaded) {
+        destination[0] = '\0';
+        return SHIM_FAIL;
+    }
+    copyFixedAscii(destination, static_cast<std::size_t>(nameCapacity),
+                   g_activeDriverName.data());
+    return SHIM_OK;
+}
+
+ASIOSHIM_EXPORT int asioshim_getDriverInfo(void* outInfo) {
+    if (!outInfo) {
+        return SHIM_FAIL;
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    auto* row = static_cast<unsigned char*>(outInfo);
+    std::memset(row, 0, DRIVER_INFO_STRIDE);
+    if (!g_driverLoaded) {
+        return SHIM_FAIL;
+    }
+    int32_t asioVersion = static_cast<int32_t>(g_driverInfo.asioVersion);
+    int32_t driverVersion = static_cast<int32_t>(g_driverInfo.driverVersion);
+    std::memcpy(row, &asioVersion, sizeof(asioVersion));
+    std::memcpy(row + 4, &driverVersion, sizeof(driverVersion));
+    copyFixedAscii(row + 8, DRIVER_NAME_BYTES,
+                   g_driverInfo.name[0] == '\0'
+                           ? g_activeDriverName.data() : g_driverInfo.name,
+                   g_driverInfo.name[0] == '\0'
+                           ? g_activeDriverName.size()
+                           : sizeof(g_driverInfo.name));
+    copyFixedAscii(row + 136, DRIVER_NAME_BYTES, g_driverInfo.errorMessage,
+                   sizeof(g_driverInfo.errorMessage));
+    return SHIM_OK;
+}
+
+ASIOSHIM_EXPORT void asioshim_unloadDriver(void) {
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    unloadDriverLocked();
 }
 
 ASIOSHIM_EXPORT int asioshim_getBufferSize(int* min, int* max,
                                            int* preferred, int* granularity) {
     if (!min || !max || !preferred || !granularity) {
+        return SHIM_FAIL;
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        *min = *max = *preferred = *granularity = 0;
         return SHIM_FAIL;
     }
     long mn = 0, mx = 0, pr = 0, gr = 0;
@@ -109,12 +318,21 @@ ASIOSHIM_EXPORT int asioshim_getBufferSize(int* min, int* max,
 }
 
 ASIOSHIM_EXPORT int asioshim_canSampleRate(double rate) {
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        return SHIM_FAIL;
+    }
     return (ASIOCanSampleRate(static_cast<ASIOSampleRate>(rate)) == ASE_OK)
            ? SHIM_OK : SHIM_FAIL;
 }
 
 ASIOSHIM_EXPORT int asioshim_getSampleRate(double* outRate) {
     if (!outRate) {
+        return SHIM_FAIL;
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        *outRate = 0.0;
         return SHIM_FAIL;
     }
     ASIOSampleRate sr = 0.0;
@@ -127,6 +345,10 @@ ASIOSHIM_EXPORT int asioshim_getSampleRate(double* outRate) {
 }
 
 ASIOSHIM_EXPORT int asioshim_setSampleRate(double rate) {
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        return SHIM_FAIL;
+    }
     return (ASIOSetSampleRate(static_cast<ASIOSampleRate>(rate)) == ASE_OK)
            ? SHIM_OK : SHIM_FAIL;
 }
@@ -142,6 +364,10 @@ ASIOSHIM_EXPORT int asioshim_setSampleRate(double rate) {
 //   SHIM_NOT_PRESENT (0)   — ASE_NotPresent; driver has no control panel.
 //   SHIM_GENERIC_FAIL (-1) — any other ASIOError; driver-side failure.
 ASIOSHIM_EXPORT int asioshim_openControlPanel(void) {
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        return SHIM_GENERIC_FAIL;
+    }
     ASIOError err = ASIOControlPanel();
     if (err == ASE_OK) {
         return SHIM_OK;
@@ -172,6 +398,11 @@ ASIOSHIM_EXPORT int asioshim_openControlPanel(void) {
 ASIOSHIM_EXPORT int asioshim_getClockSources(void* outArray, int* outCount) {
     if (!outArray || !outCount) {
         if (outCount) *outCount = 0;
+        return SHIM_FAIL;
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        *outCount = 0;
         return SHIM_FAIL;
     }
     int capacity = *outCount;
@@ -230,6 +461,10 @@ ASIOSHIM_EXPORT int asioshim_getClockSources(void* outArray, int* outCount) {
 // (ASE_InvalidMode → driver rejects clock change while streaming,
 //  ASE_NotPresent  → unknown clock source id, etc).
 ASIOSHIM_EXPORT int asioshim_setClockSource(int reference) {
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        return static_cast<int>(ASE_NotPresent);
+    }
     return static_cast<int>(ASIOSetClockSource(static_cast<long>(reference)));
 }
 
@@ -245,6 +480,12 @@ ASIOSHIM_EXPORT int asioshim_getChannelCount(int* outInputs, int* outOutputs) {
     if (!outInputs || !outOutputs) {
         if (outInputs) *outInputs = 0;
         if (outOutputs) *outOutputs = 0;
+        return SHIM_FAIL;
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        *outInputs = 0;
+        *outOutputs = 0;
         return SHIM_FAIL;
     }
     long ins = 0, outs = 0;
@@ -281,6 +522,10 @@ ASIOSHIM_EXPORT int asioshim_getChannelInfo(int channelIndex, int isInput,
     if (!outInfo || channelIndex < 0) {
         return SHIM_FAIL;
     }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded) {
+        return SHIM_FAIL;
+    }
     ASIOChannelInfo info{};
     info.channel = channelIndex;
     info.isInput = (isInput != 0) ? 1 : 0;
@@ -311,16 +556,14 @@ ASIOSHIM_EXPORT int asioshim_getChannelInfo(int channelIndex, int isInput,
 // ─── Format-change host-callback bridge (story 218) ─────────────────
 //
 // The JVM passes a single function pointer matching ASIO's
-// asioMessage(long, long, void*, double*) -> long signature. We store
-// it in a process-global slot the SDK's installed callback table
+// asioMessage(long, long, void*, double*) -> long signature. Retaining the
+// SDK's native `long` spelling makes the trampoline function-pointer type
+// directly assignable to ASIOCallbacks::asioMessage; the static_assert above
+// guarantees that Java's JAVA_INT descriptor remains ABI-exact. We store it
+// in a process-global slot the SDK's installed callback table
 // reads when the driver fires kAsioResetRequest / kAsioBufferSizeChange
 // / kAsioResyncRequest. The Java upcall is responsible for mapping
 // each selector onto AudioDeviceEvent.FormatChangeRequested.
-
-extern "C" {
-    typedef long (*asio_message_fn)(long selector, long value,
-                                    void* message, double* opt);
-}
 
 namespace {
     std::atomic<asio_message_fn> g_asioMessageCallback{nullptr};
@@ -339,8 +582,8 @@ ASIOSHIM_EXPORT void uninstallAsioMessageCallback() {
 // that the host-side glue (asiodrivers.cpp) routes through this
 // trampoline. The trampoline is referenced from the SDK glue when
 // asioshim is built with -DASIOSHIM_TRAMPOLINE.
-ASIOSHIM_EXPORT long asioshim_messageTrampoline(long selector, long value,
-                                                void* message, double* opt) {
+ASIOSHIM_EXPORT long asioshim_messageTrampoline(
+        long selector, long value, void* message, double* opt) {
     asio_message_fn cb = g_asioMessageCallback.load(std::memory_order_acquire);
     if (cb == nullptr) {
         return 0;

--- a/daw-core/native/asio/asioshim.cpp
+++ b/daw-core/native/asio/asioshim.cpp
@@ -220,8 +220,14 @@ ASIOSHIM_EXPORT int asioshim_loadDriver(const char* driverName) {
                               static_cast<long>(DRIVER_CAPACITY));
         for (long index = 0; index < count; ++index) {
             std::array<char, DRIVER_NAME_BYTES> installedName{};
-            if (driverList().nameAt(index, installedName.data(), DRIVER_NAME_BYTES)
-                    && std::strcmp(installedName.data(), mutableName.data()) == 0) {
+            if (!driverList().nameAt(index, installedName.data(), DRIVER_NAME_BYTES)) {
+                continue;
+            }
+            std::array<char, DRIVER_NAME_BYTES> installedAscii{};
+            copyFixedAscii(
+                    reinterpret_cast<unsigned char*>(installedAscii.data()),
+                    installedAscii.size(), installedName.data(), installedName.size());
+            if (std::strcmp(installedAscii.data(), mutableName.data()) == 0) {
                 matchingIndex = index;
                 break;
             }

--- a/daw-core/native/asio/asioshim.h
+++ b/daw-core/native/asio/asioshim.h
@@ -33,6 +33,26 @@
 // ──────────────────────────────────────────────────────────────────
 // Pointer ABIs
 // ──────────────────────────────────────────────────────────────────
+// All capability and control-panel exports require a successfully loaded
+// driver. Callers must use asioshim_loadDriver first; unloaded calls fail
+// without entering the Steinberg SDK. None of these lifecycle/capability
+// exports may be invoked on the audio render thread.
+//
+// `asioshim_listDrivers` writes a fixed 168-byte struct per entry:
+//   offset   0..128  char name[128]   ASCII, NUL-terminated
+//   offset 128..168  char clsid[40]   canonical GUID string, NUL-terminated
+// `*outCount` is capacity-in / actual-written-out. Actual is always capped
+// at the input capacity. Capacity zero is a successful no-op; negative
+// capacity or a null output buffer with positive capacity fails. Driver names
+// are the canonical load keys and device ids; CLSIDs are diagnostic metadata.
+//
+// `asioshim_getDriverInfo` writes a fixed 264-byte normalized record:
+//   offset   0..4    int32 asioVersion
+//   offset   4..8    int32 driverVersion
+//   offset   8..136  char name[128]          ASCII, NUL-terminated
+//   offset 136..264  char errorMessage[128]  ASCII, NUL-terminated
+// This is deliberately not the native ASIODriverInfo memory layout.
+//
 // `asioshim_getClockSources` writes a fixed 48-byte struct per entry:
 //   offset 0..32   char name[32]    ASCII, NUL-terminated
 //   offset 32..36  int32 index
@@ -56,6 +76,8 @@
 #ifndef ASIOSHIM_H_
 #define ASIOSHIM_H_
 
+#include <stdint.h>
+
 #if defined(_WIN32)
 #  if defined(ASIOSHIM_EXPORTS)
 #    define ASIOSHIM_DECL __declspec(dllexport)
@@ -71,6 +93,13 @@
 #else
 #  define ASIOSHIM_API ASIOSHIM_DECL
 #endif
+
+// ── Driver discovery and lifecycle (story 310) ────────────────────
+ASIOSHIM_API int  asioshim_listDrivers(void* outArray, int* outCount);
+ASIOSHIM_API int  asioshim_loadDriver(const char* driverName);
+ASIOSHIM_API int  asioshim_getDriverName(void* outName, int nameCapacity);
+ASIOSHIM_API int  asioshim_getDriverInfo(void* outInfo);
+ASIOSHIM_API void asioshim_unloadDriver(void);
 
 // ── Capability queries (story 130 / 213) ──────────────────────────
 ASIOSHIM_API int  asioshim_getBufferSize(int* min, int* max,
@@ -94,10 +123,14 @@ ASIOSHIM_API int  asioshim_getChannelInfo(int channelIndex, int isInput,
 // ── Format-change host-callback bridge (story 218) ────────────────
 // Signature for the upcall pointer the JVM hands to
 // `installAsioMessageCallback`. Matches Steinberg's `asioMessage`:
+// Keep the native spelling as `long` so this function-pointer type is exactly
+// compatible with Steinberg's ASIOCallbacks::asioMessage declaration. Windows
+// uses LLP64, so `long` remains 32 bits on x64 and maps to JAVA_INT at the Java
+// FFM boundary (enforced by a static_assert in asioshim.cpp).
 //   long asioMessage(long selector, long value,
 //                    void* message, double* opt);
 typedef long (*asio_message_fn)(long selector, long value,
-                                 void* message, double* opt);
+                                void* message, double* opt);
 
 ASIOSHIM_API void installAsioMessageCallback(void* callback);
 ASIOSHIM_API void uninstallAsioMessageCallback(void);
@@ -106,7 +139,7 @@ ASIOSHIM_API void uninstallAsioMessageCallback(void);
 // by the SDK glue when asioshim is built with
 // `-DASIOSHIM_TRAMPOLINE`; loads the callback installed by the JVM and
 // forwards the selector / value / message / opt arguments verbatim.
-ASIOSHIM_API long asioshim_messageTrampoline(long selector, long value,
-                                              void* message, double* opt);
+ASIOSHIM_API long asioshim_messageTrampoline(
+        long selector, long value, void* message, double* opt);
 
 #endif  // ASIOSHIM_H_

--- a/daw-core/pom.xml
+++ b/daw-core/pom.xml
@@ -210,11 +210,11 @@
                          native libraries (must be in argLine, not systemPropertyVariables,
                          because java.library.path is read at JVM bootstrap).
 
-                         daw.core is now a named JPMS module, so native access
-                         is granted to it by module name; ALL-UNNAMED is kept
-                         for any test-only code that still runs on the unnamed
-                         classpath. -->
-                    <argLine>--enable-native-access=daw.core,ALL-UNNAMED -Djava.library.path=${native.libs.dir}</argLine>
+                         daw.core and daw.sdk are named JPMS modules, so native
+                         access is granted to both by module name: daw.core owns
+                         the engine bindings and daw.sdk owns the ASIO bindings.
+                         ALL-UNNAMED is kept for test-only classpath code. -->
+                    <argLine>--enable-native-access=daw.core,daw.sdk,ALL-UNNAMED -Djava.library.path=${native.libs.dir}</argLine>
                 </configuration>
             </plugin>
 

--- a/daw-core/src/main/java/module-info.java
+++ b/daw-core/src/main/java/module-info.java
@@ -28,8 +28,9 @@
  * The PortAudio / FluidSynth / CLAP / codec bindings use the Foreign Function
  * &amp; Memory API. Restricted native access for this <em>named</em> module is
  * granted with {@code --enable-native-access=daw.core} (Surefire argLine and
- * the packaged launcher); the legacy {@code ALL-UNNAMED} grant no longer
- * applies once the module is named.
+ * the packaged launcher). Those launch paths separately grant
+ * {@code daw.sdk} for its ASIO bindings; the legacy {@code ALL-UNNAMED} grant
+ * does not cover either named module.
  */
 module daw.core {
     requires transitive daw.sdk;

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/audio/NativeLibraryDetectorTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/audio/NativeLibraryDetectorTest.java
@@ -134,9 +134,8 @@ class NativeLibraryDetectorTest {
      * Story 224 — when the bundled {@code asioshim.dll} is present on
      * a Windows build, the key symbols required by
      * {@code AsioFormatChangeShim} must be resolvable via FFM so the
-     * shim can install its upcall callback. This test confirms
-     * {@code installAsioMessageCallback} and
-     * {@code uninstallAsioMessageCallback} are exported.
+     * shim can enumerate and own a driver before capability queries begin.
+     * This test confirms both the lifecycle and callback symbol sets.
      */
     @Test
     @EnabledOnOs(OS.WINDOWS)
@@ -150,6 +149,39 @@ class NativeLibraryDetectorTest {
             assertThat(lookup.find("uninstallAsioMessageCallback"))
                     .as("uninstallAsioMessageCallback symbol")
                     .isPresent();
+            for (String symbol : List.of(
+                    "asioshim_listDrivers",
+                    "asioshim_loadDriver",
+                    "asioshim_getDriverName",
+                    "asioshim_getDriverInfo",
+                    "asioshim_unloadDriver")) {
+                assertThat(lookup.find(symbol)).as(symbol).isPresent();
+            }
+
+            var linker = java.lang.foreign.Linker.nativeLinker();
+            var count = arena.allocate(java.lang.foreign.ValueLayout.JAVA_INT);
+            count.set(java.lang.foreign.ValueLayout.JAVA_INT, 0, 0);
+            var listDrivers = linker.downcallHandle(
+                    lookup.find("asioshim_listDrivers").orElseThrow(),
+                    java.lang.foreign.FunctionDescriptor.of(
+                            java.lang.foreign.ValueLayout.JAVA_INT,
+                            java.lang.foreign.ValueLayout.ADDRESS,
+                            java.lang.foreign.ValueLayout.ADDRESS));
+            try {
+                int status = (int) listDrivers.invokeExact(
+                        java.lang.foreign.MemorySegment.NULL, count);
+                assertThat(status).as("zero-capacity list status").isEqualTo(1);
+                assertThat(count.get(java.lang.foreign.ValueLayout.JAVA_INT, 0))
+                        .isZero();
+
+                var unload = linker.downcallHandle(
+                        lookup.find("asioshim_unloadDriver").orElseThrow(),
+                        java.lang.foreign.FunctionDescriptor.ofVoid());
+                unload.invokeExact();
+                unload.invokeExact();
+            } catch (Throwable failure) {
+                throw new AssertionError("asioshim lifecycle smoke call failed", failure);
+            }
         }
     }
 

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
@@ -17,9 +17,10 @@ import java.util.logging.Logger;
  * Windows ASIO backend — Steinberg's low-latency driver model, the de-facto
  * standard for professional audio work on Windows.
  *
- * <p>Bindings are generated with {@code jextract} against the Steinberg
- * ASIO SDK's {@code asio.h} and are loaded from the native shim under
- * {@code daw-core/native/asio/}. The shim must be built opt-in
+ * <p>The backend calls a small, normalized C ABI exposed by the native shim
+ * through the Foreign Function &amp; Memory API (JEP 454, final in Java 22).
+ * The shim is compiled against the Steinberg ASIO SDK headers under
+ * {@code daw-core/native/asio/} and must be built opt-in
  * (the Steinberg licence forbids redistributing the SDK headers) — when
  * it is absent the backend simply reports {@link #isAvailable()} = false
  * and {@link AudioBackendSelector} will fall back to
@@ -54,6 +55,16 @@ public final class AsioBackend implements AudioBackend {
     private static volatile Supplier<AsioCapabilityShim> capabilityShimFactory =
             AsioCapabilityShim::new;
 
+    /** Factory for the optional ASIO enumeration/lifecycle FFM binding. */
+    private static volatile Supplier<AsioDriverShim> driverShimFactory =
+            AsioDriverShim::new;
+
+    /** Serializes the Steinberg SDK's process-wide single-driver lifecycle. */
+    private static final Object DRIVER_LIFECYCLE_LOCK = new Object();
+
+    /** Backend instance that currently owns the single process-wide driver. */
+    private static AsioBackend activeBackend;
+
     /**
      * Whether the "ASIO capability shim is unavailable; using fallback"
      * INFO has already been logged in this JVM. Story 213 explicitly
@@ -61,12 +72,9 @@ public final class AsioBackend implements AudioBackend {
      */
     private static final AtomicBoolean FALLBACK_LOGGED = new AtomicBoolean(false);
 
-    private static final boolean AVAILABLE =
-            "Windows".equalsIgnoreCase(osFamily())
-                    && AudioBackendSupport.nativeLibraryAvailable("asio", "asiosdk");
-
     private final AudioBackendSupport support = new AudioBackendSupport();
     private volatile AsioFormatChangeShim formatChangeShim;
+    private volatile AsioDriverShim driverShim;
 
     /** Creates a new ASIO backend (no native resources allocated until {@link #open}). */
     public AsioBackend() {
@@ -79,31 +87,101 @@ public final class AsioBackend implements AudioBackend {
 
     @Override
     public boolean isAvailable() {
-        return AVAILABLE;
+        try (AsioDriverShim shim = driverShimFactory.get()) {
+            return shim.isEnumerationAvailable() && shim.isLifecycleAvailable();
+        } catch (RuntimeException ignored) {
+            return false;
+        }
     }
 
     @Override
     public List<AudioDeviceInfo> listDevices() {
-        return List.of();
+        try (AsioDriverShim shim = driverShimFactory.get()) {
+            List<AsioDriverShim.DriverDescriptor> drivers = shim.listDrivers();
+            if (drivers.isEmpty()) {
+                return List.of();
+            }
+            List<AudioDeviceInfo> devices = new java.util.ArrayList<>(drivers.size());
+            for (int index = 0; index < drivers.size(); index++) {
+                AsioDriverShim.DriverDescriptor driver = drivers.get(index);
+                devices.add(new AudioDeviceInfo(
+                        index, driver.name(), NAME,
+                        0, 0, 0.0, List.of(), 0.0, 0.0));
+            }
+            return List.copyOf(devices);
+        } catch (RuntimeException ignored) {
+            return List.of();
+        }
     }
 
     @Override
     public void open(DeviceId device, AudioFormat format, int bufferFrames) {
         Objects.requireNonNull(device, "device must not be null");
         Objects.requireNonNull(format, "format must not be null");
-        if (!AVAILABLE) {
-            throw new AudioBackendException(
-                    "ASIO is not available on this host. Install an ASIO driver "
-                            + "(e.g. ASIO4ALL) and rebuild daw-core with the ASIO shim.");
+        if (bufferFrames <= 0) {
+            throw new IllegalArgumentException(
+                    "bufferFrames must be positive: " + bufferFrames);
         }
-        support.markOpen(format, bufferFrames);
-        // Story 218: install the FFM upcall that translates ASIO's
-        // asioMessage host-callback into publishFormatChangeRequested(...).
-        // Construction always succeeds; the actual native registration is
-        // a no-op if the asioshim library is not present on this host.
-        this.formatChangeShim = new AsioFormatChangeShim(this, support, device);
-        // Native ASIO buffer-switch wiring lives in the implementation layer
-        // that ships the Steinberg ASIO SDK shim; see daw-core/native/asio/.
+        synchronized (DRIVER_LIFECYCLE_LOCK) {
+            if (support.isOpen()) {
+                throw new IllegalStateException("backend already has an open stream");
+            }
+            if (activeBackend != null && activeBackend != this) {
+                throw new IllegalStateException(
+                        "another ASIO backend already owns the process-wide driver");
+            }
+
+            AsioDriverShim candidate = driverShimFactory.get();
+            if (!candidate.isLifecycleAvailable()) {
+                candidate.close();
+                throw unavailableException();
+            }
+            String driverName;
+            try {
+                driverName = resolveDriverName(candidate, device);
+            } catch (RuntimeException | Error failure) {
+                candidate.close();
+                throw failure;
+            }
+            if (!candidate.loadDriver(driverName)) {
+                candidate.close();
+                throw new AudioBackendException(
+                        "Could not load and initialize ASIO driver: " + driverName);
+            }
+
+            try {
+                // ASIOInit succeeded before the backend is marked open. This
+                // ordering prevents every capability wrapper from reaching an
+                // uninitialized SDK global.
+                support.markOpen(format, bufferFrames);
+                AsioFormatChangeShim callback =
+                        new AsioFormatChangeShim(this, support, new DeviceId(NAME, driverName));
+                driverShim = candidate;
+                formatChangeShim = callback;
+                activeBackend = this;
+            } catch (RuntimeException | Error failure) {
+                candidate.close();
+                support.markClosed();
+                throw failure;
+            }
+        }
+    }
+
+    private static String resolveDriverName(AsioDriverShim shim, DeviceId device) {
+        if (!device.isDefault()) {
+            return device.name();
+        }
+        return shim.listDrivers().stream()
+                .findFirst()
+                .map(AsioDriverShim.DriverDescriptor::name)
+                .orElseThrow(() -> new AudioBackendException(
+                        "No installed ASIO driver is available for the default device"));
+    }
+
+    private static AudioBackendException unavailableException() {
+        return new AudioBackendException(
+                "ASIO is not available on this host. Install an ASIO driver "
+                        + "(e.g. ASIO4ALL) and bundle daw-core/native/asio/asioshim.dll.");
     }
 
     @Override
@@ -281,12 +359,22 @@ public final class AsioBackend implements AudioBackend {
 
     @Override
     public void close() {
-        AsioFormatChangeShim shim = this.formatChangeShim;
-        this.formatChangeShim = null;
-        if (shim != null) {
-            shim.close();
+        synchronized (DRIVER_LIFECYCLE_LOCK) {
+            AsioFormatChangeShim callback = formatChangeShim;
+            formatChangeShim = null;
+            if (callback != null) {
+                callback.close();
+            }
+            AsioDriverShim lifecycle = driverShim;
+            driverShim = null;
+            if (lifecycle != null) {
+                lifecycle.close();
+            }
+            if (activeBackend == this) {
+                activeBackend = null;
+            }
+            support.close();
         }
-        support.close();
     }
 
     /**
@@ -305,9 +393,8 @@ public final class AsioBackend implements AudioBackend {
      * {@link BufferSizeRange#DEFAULT_RANGE} and logs the absence at
      * {@code INFO} exactly once per process.</p>
      *
-     * <p>The downcall runs on the calling thread (typically the
-     * JavaFX thread when the Audio Settings dialog opens), never on
-     * the audio render thread.</p>
+     * <p>The downcall is serialized on the dedicated
+     * {@link AsioControlThread}, never on the JavaFX or audio render thread.</p>
      */
     @Override
     public BufferSizeRange bufferSizeRange(DeviceId device) {
@@ -406,6 +493,37 @@ public final class AsioBackend implements AudioBackend {
         FALLBACK_LOGGED.set(false);
     }
 
+    /** Test seam for enumeration and lifecycle paths without a native SDK. */
+    static void setDriverShimFactory(Supplier<AsioDriverShim> factory) {
+        driverShimFactory = Objects.requireNonNull(factory, "factory");
+    }
+
+    /** Restores the production ASIO driver shim factory. */
+    static void resetDriverShimFactory() {
+        driverShimFactory = AsioDriverShim::new;
+    }
+
+    /**
+     * Returns display metadata captured from {@code ASIOInit} for the active
+     * driver, or empty while this backend has no initialized driver.
+     */
+    public Optional<AsioDriverInfo> activeDriverInfo() {
+        AsioDriverShim lifecycle = driverShim;
+        if (lifecycle == null) {
+            return Optional.empty();
+        }
+        return lifecycle.getDriverInfo().flatMap(info -> {
+            String name = info.name().isBlank()
+                    ? lifecycle.getDriverName().orElse("") : info.name();
+            if (name.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional.of(new AsioDriverInfo(
+                    name, info.asioVersion(), info.driverVersion(),
+                    info.errorMessage()));
+        });
+    }
+
     /**
      * Reports the hardware clock sources the ASIO driver exposes.
      * Calls {@code ASIOGetClockSources(ASIOClockSource[], int* numSources)}
@@ -423,9 +541,8 @@ public final class AsioBackend implements AudioBackend {
      * disabled combo with a tooltip explaining that the native shim is
      * required.</p>
      *
-     * <p>The downcall runs on the calling thread (typically the JavaFX
-     * thread when the Audio Settings dialog opens), never on the audio
-     * render thread.</p>
+     * <p>The downcall is serialized on the dedicated
+     * {@link AsioControlThread}, never on the JavaFX or audio render thread.</p>
      */
     @Override
     public List<ClockSource> clockSources(DeviceId device) {
@@ -740,10 +857,4 @@ public final class AsioBackend implements AudioBackend {
         };
     }
 
-    private static String osFamily() {
-        String os = System.getProperty("os.name", "").toLowerCase();
-        if (os.contains("win")) return "Windows";
-        if (os.contains("mac") || os.contains("darwin")) return "macOS";
-        return "Other";
-    }
 }

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioCapabilityShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioCapabilityShim.java
@@ -10,7 +10,7 @@ import java.lang.invoke.MethodHandle;
 import java.util.Optional;
 
 /**
- * FFM (JEP 454) shim that bridges the four Steinberg ASIO SDK symbols
+ * FFM (JEP 454) shim that bridges Steinberg ASIO SDK capability symbols
  * needed to populate the Audio Settings dialog with driver-allowed
  * buffer sizes and sample rates (story 130 / story 213). The native
  * counterpart lives under {@code daw-core/native/asio/} and is built
@@ -43,9 +43,10 @@ import java.util.Optional;
  * library lookup itself is platform-conditional; the rest of the class
  * is portable Java.</p>
  *
- * <p>FFM downcalls run on the calling thread (typically the JavaFX
- * thread when the Audio Settings dialog opens), never on the audio
- * render thread. Mid-stream rate changes route through
+ * <p>FFM downcalls are serialized on {@link AsioControlThread}, never on the
+ * JavaFX or audio render thread. Every operation also verifies that
+ * {@link AsioDriverShim} owns an initialized driver before entering native
+ * code. Mid-stream rate changes route through
  * {@link AsioFormatChangeShim}'s reset path, not these capability
  * queries.</p>
  */
@@ -97,12 +98,12 @@ class AsioCapabilityShim implements AutoCloseable {
     private boolean closed;
 
     /**
-     * Loads the {@code asioshim} library and resolves the four entry
+     * Loads the {@code asioshim} library and resolves the core entry
      * points. Any failure is captured silently — the resulting shim is
      * simply {@link #isAvailable() unavailable}.
      */
     AsioCapabilityShim() {
-        this.arena = Arena.ofConfined();
+        this.arena = Arena.ofShared();
         boolean ok = false;
         MethodHandle gbs = null;
         MethodHandle csr = null;
@@ -220,7 +221,7 @@ class AsioCapabilityShim implements AutoCloseable {
         this.getChannelInfo = gci;
     }
 
-    /** Returns {@code true} when all four entry points were resolved. */
+    /** Returns {@code true} when all core capability entry points resolved. */
     boolean isAvailable() {
         return available && !closed;
     }
@@ -233,29 +234,32 @@ class AsioCapabilityShim implements AutoCloseable {
      * any FFM error) returns {@link Optional#empty()}.
      */
     Optional<BufferSizeRange> getBufferSize() {
-        if (!isAvailable()) {
+        if (!isAvailable() || !AsioDriverShim.isDriverLoaded()) {
             return Optional.empty();
         }
-        try (Arena call = Arena.ofConfined()) {
-            MemorySegment min = call.allocate(ValueLayout.JAVA_INT);
-            MemorySegment max = call.allocate(ValueLayout.JAVA_INT);
-            MemorySegment preferred = call.allocate(ValueLayout.JAVA_INT);
-            MemorySegment granularity = call.allocate(ValueLayout.JAVA_INT);
-            int rc = (int) getBufferSize.invokeExact(min, max, preferred, granularity);
-            if (rc != ASE_OK) {
-                return Optional.empty();
-            }
-            int gran = granularity.get(ValueLayout.JAVA_INT, 0);
-            // ASIO uses any negative granularity as a sentinel meaning the
-            // driver accepts power-of-two buffer sizes between min and max.
-            // Normalize to BufferSizeRange.POWER_OF_TWO_GRANULARITY (-1)
-            // so expandedSizes() / accepts() expand the correct ladder.
-            int safeGran = gran < 0 ? BufferSizeRange.POWER_OF_TWO_GRANULARITY : gran;
-            return Optional.of(new BufferSizeRange(
-                    min.get(ValueLayout.JAVA_INT, 0),
-                    max.get(ValueLayout.JAVA_INT, 0),
-                    preferred.get(ValueLayout.JAVA_INT, 0),
-                    safeGran));
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment min = call.allocate(ValueLayout.JAVA_INT);
+                    MemorySegment max = call.allocate(ValueLayout.JAVA_INT);
+                    MemorySegment preferred = call.allocate(ValueLayout.JAVA_INT);
+                    MemorySegment granularity = call.allocate(ValueLayout.JAVA_INT);
+                    int rc = (int) getBufferSize.invokeExact(
+                            min, max, preferred, granularity);
+                    if (rc != ASE_OK) {
+                        return Optional.empty();
+                    }
+                    int gran = granularity.get(ValueLayout.JAVA_INT, 0);
+                    // Any negative value is the SDK's power-of-two sentinel.
+                    int safeGran = gran < 0
+                            ? BufferSizeRange.POWER_OF_TWO_GRANULARITY : gran;
+                    return Optional.of(new BufferSizeRange(
+                            min.get(ValueLayout.JAVA_INT, 0),
+                            max.get(ValueLayout.JAVA_INT, 0),
+                            preferred.get(ValueLayout.JAVA_INT, 0),
+                            safeGran));
+                }
+            });
         } catch (RuntimeException ignored) {
             return Optional.empty();
         } catch (Throwable ignored) {
@@ -269,11 +273,12 @@ class AsioCapabilityShim implements AutoCloseable {
      * the shim is unavailable or any error occurred.
      */
     boolean canSampleRate(double rate) {
-        if (!isAvailable()) {
+        if (!isAvailable() || !AsioDriverShim.isDriverLoaded()) {
             return false;
         }
         try {
-            int rc = (int) canSampleRate.invokeExact(rate);
+            int rc = AsioControlThread.call(
+                    () -> (int) canSampleRate.invokeExact(rate));
             return rc == ASE_OK;
         } catch (Throwable ignored) {
             return false;
@@ -286,16 +291,20 @@ class AsioCapabilityShim implements AutoCloseable {
      * controller after a driver-initiated reset (story 218).
      */
     Optional<Double> getSampleRate() {
-        if (!isAvailable()) {
+        if (!isAvailable() || !AsioDriverShim.isDriverLoaded()) {
             return Optional.empty();
         }
-        try (Arena call = Arena.ofConfined()) {
-            MemorySegment out = call.allocate(ValueLayout.JAVA_DOUBLE);
-            int rc = (int) getSampleRate.invokeExact(out);
-            if (rc != ASE_OK) {
-                return Optional.empty();
-            }
-            return Optional.of(out.get(ValueLayout.JAVA_DOUBLE, 0));
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment out = call.allocate(ValueLayout.JAVA_DOUBLE);
+                    int rc = (int) getSampleRate.invokeExact(out);
+                    if (rc != ASE_OK) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(out.get(ValueLayout.JAVA_DOUBLE, 0));
+                }
+            });
         } catch (Throwable ignored) {
             return Optional.empty();
         }
@@ -306,11 +315,12 @@ class AsioCapabilityShim implements AutoCloseable {
      * {@code true} on {@code ASE_OK}, {@code false} otherwise.
      */
     boolean setSampleRate(double rate) {
-        if (!isAvailable()) {
+        if (!isAvailable() || !AsioDriverShim.isDriverLoaded()) {
             return false;
         }
         try {
-            int rc = (int) setSampleRate.invokeExact(rate);
+            int rc = AsioControlThread.call(
+                    () -> (int) setSampleRate.invokeExact(rate));
             return rc == ASE_OK;
         } catch (Throwable ignored) {
             return false;
@@ -325,7 +335,8 @@ class AsioCapabilityShim implements AutoCloseable {
      * {@code isControlPanelAvailable()} returns {@code false}.
      */
     boolean isControlPanelAvailable() {
-        return isAvailable() && openControlPanel != null;
+        return isAvailable() && AsioDriverShim.isDriverLoaded()
+                && openControlPanel != null;
     }
 
     /**
@@ -338,10 +349,9 @@ class AsioCapabilityShim implements AutoCloseable {
      *   <li>negative — any other {@code ASIOError} (driver-side failure).</li>
      * </ul>
      *
-     * <p>The native call blocks the calling thread until the user
-     * closes the modal panel; callers must therefore invoke this on a
-     * dedicated platform thread, never on the JavaFX thread or the
-     * audio render thread.</p>
+     * <p>The native call blocks the dedicated {@code asio-control} platform
+     * thread until the user closes the modal panel. Callers should still invoke
+     * the supervising action off JavaFX because it waits for that result.</p>
      *
      * <p>If the shim or the {@code openControlPanel} symbol is
      * unavailable, returns a generic failure (negative). FFM-level
@@ -355,7 +365,8 @@ class AsioCapabilityShim implements AutoCloseable {
             return -1;
         }
         try {
-            return (int) openControlPanel.invokeExact();
+            return AsioControlThread.call(
+                    () -> (int) openControlPanel.invokeExact());
         } catch (Throwable ignored) {
             return -1;
         }
@@ -370,7 +381,8 @@ class AsioCapabilityShim implements AutoCloseable {
      * returns {@code false}.
      */
     boolean isClockSourceAvailable() {
-        return isAvailable() && getClockSources != null && setClockSource != null;
+        return isAvailable() && AsioDriverShim.isDriverLoaded()
+                && getClockSources != null && setClockSource != null;
     }
 
     /**
@@ -406,33 +418,33 @@ class AsioCapabilityShim implements AutoCloseable {
         if (!isClockSourceAvailable()) {
             return java.util.List.of();
         }
-        try (Arena call = Arena.ofConfined()) {
-            MemorySegment array = call.allocate((long) CLOCK_SOURCE_STRIDE
-                    * CLOCK_SOURCE_CAPACITY);
-            MemorySegment count = call.allocate(ValueLayout.JAVA_INT);
-            count.set(ValueLayout.JAVA_INT, 0, CLOCK_SOURCE_CAPACITY);
-            int rc = (int) getClockSources.invokeExact(array, count);
-            if (rc != ASE_OK) {
-                return java.util.List.of();
-            }
-            int n = count.get(ValueLayout.JAVA_INT, 0);
-            if (n <= 0) {
-                return java.util.List.of();
-            }
-            if (n > CLOCK_SOURCE_CAPACITY) {
-                n = CLOCK_SOURCE_CAPACITY;
-            }
-            java.util.List<RawClockSource> rows = new java.util.ArrayList<>(n);
-            for (int i = 0; i < n; i++) {
-                long base = (long) i * CLOCK_SOURCE_STRIDE;
-                String name = decodeAsciiName(array, base, 32);
-                int idx       = array.get(ValueLayout.JAVA_INT, base + 32);
-                int chan      = array.get(ValueLayout.JAVA_INT, base + 36);
-                int group     = array.get(ValueLayout.JAVA_INT, base + 40);
-                int isCurrent = array.get(ValueLayout.JAVA_INT, base + 44);
-                rows.add(new RawClockSource(idx, name, chan, group, isCurrent != 0));
-            }
-            return java.util.List.copyOf(rows);
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment array = call.allocate((long) CLOCK_SOURCE_STRIDE
+                            * CLOCK_SOURCE_CAPACITY);
+                    MemorySegment count = call.allocate(ValueLayout.JAVA_INT);
+                    count.set(ValueLayout.JAVA_INT, 0, CLOCK_SOURCE_CAPACITY);
+                    int rc = (int) getClockSources.invokeExact(array, count);
+                    if (rc != ASE_OK) {
+                        return java.util.List.of();
+                    }
+                    int n = Math.clamp(count.get(ValueLayout.JAVA_INT, 0),
+                            0, CLOCK_SOURCE_CAPACITY);
+                    java.util.List<RawClockSource> rows = new java.util.ArrayList<>(n);
+                    for (int i = 0; i < n; i++) {
+                        long base = (long) i * CLOCK_SOURCE_STRIDE;
+                        String name = decodeAsciiName(array, base, 32);
+                        int idx = array.get(ValueLayout.JAVA_INT, base + 32);
+                        int chan = array.get(ValueLayout.JAVA_INT, base + 36);
+                        int group = array.get(ValueLayout.JAVA_INT, base + 40);
+                        int isCurrent = array.get(ValueLayout.JAVA_INT, base + 44);
+                        rows.add(new RawClockSource(
+                                idx, name, chan, group, isCurrent != 0));
+                    }
+                    return java.util.List.copyOf(rows);
+                }
+            });
         } catch (RuntimeException ignored) {
             return java.util.List.of();
         } catch (Throwable ignored) {
@@ -457,7 +469,8 @@ class AsioCapabilityShim implements AutoCloseable {
             return -1000;
         }
         try {
-            return (int) setClockSource.invokeExact(reference);
+            return AsioControlThread.call(
+                    () -> (int) setClockSource.invokeExact(reference));
         } catch (Throwable ignored) {
             return -1000;
         }
@@ -480,7 +493,8 @@ class AsioCapabilityShim implements AutoCloseable {
      * resolved at construction (story 215).
      */
     boolean isChannelInfoAvailable() {
-        return isAvailable() && getChannelCount != null && getChannelInfo != null;
+        return isAvailable() && AsioDriverShim.isDriverLoaded()
+                && getChannelCount != null && getChannelInfo != null;
     }
 
     /**
@@ -493,16 +507,20 @@ class AsioCapabilityShim implements AutoCloseable {
         if (!isChannelInfoAvailable()) {
             return Optional.empty();
         }
-        try (Arena call = Arena.ofConfined()) {
-            MemorySegment ins = call.allocate(ValueLayout.JAVA_INT);
-            MemorySegment outs = call.allocate(ValueLayout.JAVA_INT);
-            int rc = (int) getChannelCount.invokeExact(ins, outs);
-            if (rc != ASE_OK) {
-                return Optional.empty();
-            }
-            return Optional.of(new int[] {
-                    ins.get(ValueLayout.JAVA_INT, 0),
-                    outs.get(ValueLayout.JAVA_INT, 0)
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment ins = call.allocate(ValueLayout.JAVA_INT);
+                    MemorySegment outs = call.allocate(ValueLayout.JAVA_INT);
+                    int rc = (int) getChannelCount.invokeExact(ins, outs);
+                    if (rc != ASE_OK) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(new int[] {
+                            ins.get(ValueLayout.JAVA_INT, 0),
+                            outs.get(ValueLayout.JAVA_INT, 0)
+                    });
+                }
             });
         } catch (RuntimeException ignored) {
             return Optional.empty();
@@ -524,21 +542,25 @@ class AsioCapabilityShim implements AutoCloseable {
         if (channelIndex < 0) {
             return Optional.empty();
         }
-        try (Arena call = Arena.ofConfined()) {
-            MemorySegment row = call.allocate(CHANNEL_INFO_STRIDE);
-            int rc = (int) getChannelInfo.invokeExact(channelIndex,
-                    isInput ? 1 : 0, row);
-            if (rc != ASE_OK) {
-                return Optional.empty();
-            }
-            int idx    = row.get(ValueLayout.JAVA_INT, 0);
-            int isIn   = row.get(ValueLayout.JAVA_INT, 4);
-            int active = row.get(ValueLayout.JAVA_INT, 8);
-            int group  = row.get(ValueLayout.JAVA_INT, 12);
-            int type   = row.get(ValueLayout.JAVA_INT, 16);
-            String name = decodeAsciiName(row, 24, 32);
-            return Optional.of(new RawChannelInfo(idx, isIn != 0, active != 0,
-                    group, type, name));
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment row = call.allocate(CHANNEL_INFO_STRIDE);
+                    int rc = (int) getChannelInfo.invokeExact(
+                            channelIndex, isInput ? 1 : 0, row);
+                    if (rc != ASE_OK) {
+                        return Optional.empty();
+                    }
+                    int idx = row.get(ValueLayout.JAVA_INT, 0);
+                    int isIn = row.get(ValueLayout.JAVA_INT, 4);
+                    int active = row.get(ValueLayout.JAVA_INT, 8);
+                    int group = row.get(ValueLayout.JAVA_INT, 12);
+                    int type = row.get(ValueLayout.JAVA_INT, 16);
+                    String name = decodeAsciiName(row, 24, 32);
+                    return Optional.of(new RawChannelInfo(
+                            idx, isIn != 0, active != 0, group, type, name));
+                }
+            });
         } catch (RuntimeException ignored) {
             return Optional.empty();
         } catch (Throwable ignored) {
@@ -574,7 +596,10 @@ class AsioCapabilityShim implements AutoCloseable {
         }
         closed = true;
         try {
-            arena.close();
+            AsioControlThread.call(() -> {
+                arena.close();
+                return null;
+            });
         } catch (Throwable ignored) {
             // Already closed elsewhere — idempotent.
         }

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioControlThread.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioControlThread.java
@@ -1,0 +1,65 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Single platform thread used for every ASIO host downcall.
+ *
+ * <p>Steinberg's Windows host glue initializes COM and creates an in-process
+ * driver object. Keeping enumeration, init, capability calls, control-panel
+ * dispatch, exit, and COM release on one long-lived platform thread preserves
+ * that apartment affinity and makes it impossible to run these operations on
+ * the real-time render thread.</p>
+ */
+final class AsioControlThread {
+
+    private static volatile Thread controlThread;
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor(task ->
+            Thread.ofPlatform()
+                    .name("asio-control")
+                    .daemon(true)
+                    .unstarted(() -> {
+                        controlThread = Thread.currentThread();
+                        task.run();
+                    }));
+
+    private AsioControlThread() {
+    }
+
+    static <T> T call(Operation<T> operation) throws Throwable {
+        if (Thread.currentThread() == controlThread) {
+            return operation.run();
+        }
+        try {
+            return EXECUTOR.submit(() -> {
+                try {
+                    return operation.run();
+                } catch (Throwable failure) {
+                    throw new OperationFailure(failure);
+                }
+            }).get();
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw interrupted;
+        } catch (ExecutionException execution) {
+            Throwable cause = execution.getCause();
+            if (cause instanceof OperationFailure wrapped) {
+                throw wrapped.getCause();
+            }
+            throw cause;
+        }
+    }
+
+    @FunctionalInterface
+    interface Operation<T> {
+        T run() throws Throwable;
+    }
+
+    private static final class OperationFailure extends Exception {
+        OperationFailure(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverInfo.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverInfo.java
@@ -1,0 +1,27 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import java.util.Objects;
+
+/**
+ * Display-safe metadata returned by the active ASIO driver's
+ * {@code ASIOInit(ASIODriverInfo*)} call.
+ *
+ * @param name          initialized driver name
+ * @param asioVersion   ASIO host API version reported by the driver
+ * @param driverVersion vendor-defined driver version number
+ * @param statusMessage optional driver status/error text; empty when none
+ */
+public record AsioDriverInfo(
+        String name,
+        int asioVersion,
+        int driverVersion,
+        String statusMessage
+) {
+    public AsioDriverInfo {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(statusMessage, "statusMessage must not be null");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverShim.java
@@ -1,0 +1,321 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * FFM (JEP 454, final in Java 22) binding for ASIO driver discovery and
+ * init/exit lifecycle operations exported by {@code asioshim.dll}.
+ *
+ * <p>This class deliberately uses {@link SymbolLookup#libraryLookup(String, Arena)}
+ * directly. The repository's shared native loader lives in {@code daw-core}, while
+ * {@code daw-core} depends on this SDK module. Moving this binding through that
+ * loader would therefore introduce a module cycle. Keeping all ASIO bindings in
+ * the SDK's existing module-safe lookup family is the only legal dependency
+ * direction until native bindings move to a lower-level module.</p>
+ *
+ * <p>The shim is optional. Missing libraries and missing symbols are represented
+ * by unavailable operations and empty results; construction never fails. The
+ * process-global ownership guard mirrors the Steinberg host glue's single-driver
+ * model and prevents an obsolete wrapper from unloading a newer driver's COM
+ * object.</p>
+ */
+class AsioDriverShim implements AutoCloseable {
+
+    static final int DRIVER_NAME_BYTES = 128;
+    static final int DRIVER_CLSID_BYTES = 40;
+    static final int DRIVER_RECORD_STRIDE = DRIVER_NAME_BYTES + DRIVER_CLSID_BYTES;
+    static final int DRIVER_CAPACITY = 64;
+
+    static final int DRIVER_INFO_NAME_OFFSET = 8;
+    static final int DRIVER_INFO_ERROR_OFFSET = DRIVER_INFO_NAME_OFFSET + DRIVER_NAME_BYTES;
+    static final int DRIVER_INFO_STRIDE = DRIVER_INFO_ERROR_OFFSET + DRIVER_NAME_BYTES;
+
+    private static final int SHIM_OK = 1;
+    private static final Object LIFECYCLE_LOCK = new Object();
+    private static AsioDriverShim activeOwner;
+
+    private final Arena arena;
+    private final MethodHandle listDrivers;
+    private final MethodHandle loadDriver;
+    private final MethodHandle getDriverName;
+    private final MethodHandle getDriverInfo;
+    private final MethodHandle unloadDriver;
+    private boolean ownsActiveDriver;
+    private boolean closed;
+
+    AsioDriverShim() {
+        arena = Arena.ofShared();
+        MethodHandle list = null;
+        MethodHandle load = null;
+        MethodHandle name = null;
+        MethodHandle info = null;
+        MethodHandle unload = null;
+        try {
+            SymbolLookup lookup = SymbolLookup.libraryLookup("asioshim", arena);
+            Linker linker = Linker.nativeLinker();
+            list = resolve(linker, lookup, "asioshim_listDrivers",
+                    FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                            ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+            load = resolve(linker, lookup, "asioshim_loadDriver",
+                    FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+            name = resolve(linker, lookup, "asioshim_getDriverName",
+                    FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                            ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+            info = resolve(linker, lookup, "asioshim_getDriverInfo",
+                    FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+            unload = resolve(linker, lookup, "asioshim_unloadDriver",
+                    FunctionDescriptor.ofVoid());
+        } catch (IllegalArgumentException | UnsatisfiedLinkError ignored) {
+            // Optional DLL absent: every operation degrades gracefully.
+        } catch (Throwable ignored) {
+            // Native access disabled or ABI mismatch: keep all handles unavailable.
+        }
+        listDrivers = list;
+        loadDriver = load;
+        getDriverName = name;
+        getDriverInfo = info;
+        unloadDriver = unload;
+    }
+
+    private static MethodHandle resolve(Linker linker, SymbolLookup lookup,
+                                        String symbol, FunctionDescriptor descriptor) {
+        return lookup.find(symbol)
+                .map(address -> linker.downcallHandle(address, descriptor))
+                .orElse(null);
+    }
+
+    boolean isEnumerationAvailable() {
+        return !closed && listDrivers != null;
+    }
+
+    boolean isLifecycleAvailable() {
+        return !closed && loadDriver != null && unloadDriver != null;
+    }
+
+    /** Returns a snapshot of installed x64 ASIO driver registry entries. */
+    List<DriverDescriptor> listDrivers() {
+        if (!isEnumerationAvailable()) {
+            return List.of();
+        }
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment records = call.allocate(
+                            (long) DRIVER_RECORD_STRIDE * DRIVER_CAPACITY);
+                    MemorySegment count = call.allocate(ValueLayout.JAVA_INT);
+                    count.set(ValueLayout.JAVA_INT, 0, DRIVER_CAPACITY);
+                    int status = (int) listDrivers.invokeExact(records, count);
+                    if (status != SHIM_OK) {
+                        return List.of();
+                    }
+                    int actual = Math.clamp(
+                            count.get(ValueLayout.JAVA_INT, 0), 0, DRIVER_CAPACITY);
+                    return decodeDrivers(records, actual);
+                }
+            });
+        } catch (Throwable ignored) {
+            return List.of();
+        }
+    }
+
+    /**
+     * Loads and initializes the named driver. A successful call transfers the
+     * process-global driver ownership to this wrapper.
+     */
+    boolean loadDriver(String driverName) {
+        Objects.requireNonNull(driverName, "driverName must not be null");
+        if (driverName.isBlank() || !isLifecycleAvailable()) {
+            return false;
+        }
+        synchronized (LIFECYCLE_LOCK) {
+            if (activeOwner != null && activeOwner != this) {
+                return false;
+            }
+            try {
+                int status = AsioControlThread.call(() -> {
+                    try (Arena call = Arena.ofConfined()) {
+                        MemorySegment nativeName =
+                                call.allocateFrom(driverName, StandardCharsets.UTF_8);
+                        return (int) loadDriver.invokeExact(nativeName);
+                    }
+                });
+                if (status != SHIM_OK) {
+                    return false;
+                }
+                activeOwner = this;
+                ownsActiveDriver = true;
+                return true;
+            } catch (Throwable ignored) {
+                return false;
+            }
+        }
+    }
+
+    Optional<String> getDriverName() {
+        if (!mayQueryActiveDriver() || getDriverName == null) {
+            return Optional.empty();
+        }
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment name = call.allocate(DRIVER_NAME_BYTES);
+                    int status = (int) getDriverName.invokeExact(name, DRIVER_NAME_BYTES);
+                    if (status != SHIM_OK) {
+                        return Optional.empty();
+                    }
+                    return nonBlank(decodeAscii(name, 0, DRIVER_NAME_BYTES));
+                }
+            });
+        } catch (Throwable ignored) {
+            return Optional.empty();
+        }
+    }
+
+    Optional<DriverInfo> getDriverInfo() {
+        if (!mayQueryActiveDriver() || getDriverInfo == null) {
+            return Optional.empty();
+        }
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment info = call.allocate(DRIVER_INFO_STRIDE);
+                    int status = (int) getDriverInfo.invokeExact(info);
+                    if (status != SHIM_OK) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(decodeDriverInfo(info));
+                }
+            });
+        } catch (Throwable ignored) {
+            return Optional.empty();
+        }
+    }
+
+    /** Calls {@code ASIOExit} and releases the current driver's COM object. */
+    void unloadDriver() {
+        synchronized (LIFECYCLE_LOCK) {
+            if (closed || !ownsActiveDriver || activeOwner != this) {
+                ownsActiveDriver = false;
+                return;
+            }
+            try {
+                if (unloadDriver != null) {
+                    AsioControlThread.call(() -> {
+                        unloadDriver.invokeExact();
+                        return null;
+                    });
+                }
+            } catch (Throwable ignored) {
+                // Native unload is best-effort and the ABI itself is idempotent.
+            } finally {
+                ownsActiveDriver = false;
+                activeOwner = null;
+            }
+        }
+    }
+
+    static boolean isDriverLoaded() {
+        synchronized (LIFECYCLE_LOCK) {
+            return activeOwner != null && activeOwner.ownsActiveDriver && !activeOwner.closed;
+        }
+    }
+
+    private boolean mayQueryActiveDriver() {
+        synchronized (LIFECYCLE_LOCK) {
+            return !closed && ownsActiveDriver && activeOwner == this;
+        }
+    }
+
+    @Override
+    public void close() {
+        synchronized (LIFECYCLE_LOCK) {
+            if (closed) {
+                return;
+            }
+        }
+        unloadDriver();
+        synchronized (LIFECYCLE_LOCK) {
+            if (!closed) {
+                closed = true;
+                try {
+                    AsioControlThread.call(() -> {
+                        arena.close();
+                        return null;
+                    });
+                } catch (Throwable ignored) {
+                    // Best-effort cleanup; close remains idempotent.
+                }
+            }
+        }
+    }
+
+    static List<DriverDescriptor> decodeDrivers(MemorySegment records, int count) {
+        Objects.requireNonNull(records, "records must not be null");
+        int safeCount = Math.max(0, count);
+        List<DriverDescriptor> decoded = new ArrayList<>(safeCount);
+        for (int index = 0; index < safeCount; index++) {
+            long base = (long) index * DRIVER_RECORD_STRIDE;
+            String name = decodeAscii(records, base, DRIVER_NAME_BYTES);
+            if (name.isBlank()) {
+                continue;
+            }
+            String clsid = decodeAscii(records, base + DRIVER_NAME_BYTES, DRIVER_CLSID_BYTES);
+            decoded.add(new DriverDescriptor(name, clsid));
+        }
+        return List.copyOf(decoded);
+    }
+
+    static DriverInfo decodeDriverInfo(MemorySegment info) {
+        Objects.requireNonNull(info, "info must not be null");
+        return new DriverInfo(
+                info.get(ValueLayout.JAVA_INT, 0),
+                info.get(ValueLayout.JAVA_INT, 4),
+                decodeAscii(info, DRIVER_INFO_NAME_OFFSET, DRIVER_NAME_BYTES),
+                decodeAscii(info, DRIVER_INFO_ERROR_OFFSET, DRIVER_NAME_BYTES));
+    }
+
+    private static String decodeAscii(MemorySegment segment, long offset, int length) {
+        byte[] bytes = new byte[length];
+        int used = 0;
+        for (; used < length; used++) {
+            byte value = segment.get(ValueLayout.JAVA_BYTE, offset + used);
+            if (value == 0) {
+                break;
+            }
+            bytes[used] = (value >= 0x20 && value <= 0x7e) ? value : (byte) '?';
+        }
+        return new String(bytes, 0, used, StandardCharsets.US_ASCII);
+    }
+
+    private static Optional<String> nonBlank(String value) {
+        return value.isBlank() ? Optional.empty() : Optional.of(value);
+    }
+
+    record DriverDescriptor(String name, String clsid) {
+        DriverDescriptor {
+            Objects.requireNonNull(name, "name must not be null");
+            Objects.requireNonNull(clsid, "clsid must not be null");
+            if (name.isBlank()) {
+                throw new IllegalArgumentException("name must not be blank");
+            }
+        }
+    }
+
+    record DriverInfo(int asioVersion, int driverVersion, String name, String errorMessage) {
+        DriverInfo {
+            Objects.requireNonNull(name, "name must not be null");
+            Objects.requireNonNull(errorMessage, "errorMessage must not be null");
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverShim.java
@@ -88,6 +88,17 @@ class AsioDriverShim implements AutoCloseable {
         unloadDriver = unload;
     }
 
+    AsioDriverShim(MethodHandle loadDriver, MethodHandle unloadDriver) {
+        arena = Arena.ofShared();
+        listDrivers = null;
+        this.loadDriver = Objects.requireNonNull(loadDriver,
+                "loadDriver must not be null");
+        getDriverName = null;
+        getDriverInfo = null;
+        this.unloadDriver = Objects.requireNonNull(unloadDriver,
+                "unloadDriver must not be null");
+    }
+
     private static MethodHandle resolve(Linker linker, SymbolLookup lookup,
                                         String symbol, FunctionDescriptor descriptor) {
         return lookup.find(symbol)
@@ -151,14 +162,23 @@ class AsioDriverShim implements AutoCloseable {
                     }
                 });
                 if (status != SHIM_OK) {
+                    clearOwnershipAfterFailedLoad();
                     return false;
                 }
                 activeOwner = this;
                 ownsActiveDriver = true;
                 return true;
             } catch (Throwable ignored) {
+                clearOwnershipAfterFailedLoad();
                 return false;
             }
+        }
+    }
+
+    private void clearOwnershipAfterFailedLoad() {
+        ownsActiveDriver = false;
+        if (activeOwner == this) {
+            activeOwner = null;
         }
     }
 

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShim.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 /**
  * FFM (JEP 454) shim that translates the ASIO host-callback's
- * {@code asioMessage(long selector, long value, void* message, double* opt) -> long}
+ * {@code asioMessage(int32 selector, int32 value, void* message, double* opt) -> int32}
  * upcall into {@link AsioBackend#publishFormatChangeRequested(DeviceId,
  * Optional, FormatChangeReason)} invocations (story 218).
  *
@@ -42,15 +42,19 @@ final class AsioFormatChangeShim implements AutoCloseable {
     static final int kAsioBufferSizeChange = 7;
 
     /** ASE_OK — selector handled successfully. */
-    private static final long ASE_OK = 1L;
+    private static final int ASE_OK = 1;
     /** ASE_NotPresent — selector unknown / unhandled. */
-    private static final long ASE_NOT_PRESENT = 0L;
+    private static final int ASE_NOT_PRESENT = 0;
 
-    /** Function descriptor for ASIO's {@code asioMessage(long, long, void*, double*) -> long}. */
+    /**
+     * Windows ASIO callback descriptor. The SDK uses C {@code long}, which is
+     * fixed at 32 bits on Win64 and therefore maps to {@code JAVA_INT}, not
+     * Java's 64-bit {@code long}.
+     */
     private static final FunctionDescriptor ASIO_MESSAGE =
-            FunctionDescriptor.of(ValueLayout.JAVA_LONG,
-                    ValueLayout.JAVA_LONG,
-                    ValueLayout.JAVA_LONG,
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,
                     ValueLayout.ADDRESS,
                     ValueLayout.ADDRESS);
 
@@ -80,7 +84,8 @@ final class AsioFormatChangeShim implements AutoCloseable {
         this.backend = Objects.requireNonNull(backend, "backend must not be null");
         this.support = Objects.requireNonNull(support, "support must not be null");
         this.device = Objects.requireNonNull(device, "device must not be null");
-        this.arena = Arena.ofConfined();
+        // The driver invokes this upcall from its own callback thread.
+        this.arena = Arena.ofShared();
         this.upcallStub = buildUpcallStub();
         this.registered = tryRegister();
     }
@@ -90,8 +95,8 @@ final class AsioFormatChangeShim implements AutoCloseable {
             MethodHandle handle = MethodHandles.lookup().findVirtual(
                     AsioFormatChangeShim.class,
                     "asioMessageUpcall",
-                    MethodType.methodType(long.class,
-                            long.class, long.class,
+                    MethodType.methodType(int.class,
+                            int.class, int.class,
                             MemorySegment.class, MemorySegment.class))
                     .bindTo(this);
             return Linker.nativeLinker().upcallStub(handle, ASIO_MESSAGE, arena);
@@ -114,8 +119,10 @@ final class AsioFormatChangeShim implements AutoCloseable {
                             "installAsioMessageCallback not found"));
             MethodHandle handle = Linker.nativeLinker().downcallHandle(
                     install, FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
-            handle.invoke(upcallStub);
-            return true;
+            return AsioControlThread.call(() -> {
+                handle.invoke(upcallStub);
+                return true;
+            });
         } catch (IllegalArgumentException | UnsatisfiedLinkError ignored) {
             // Library not present on this host — no-op.
             return false;
@@ -132,10 +139,10 @@ final class AsioFormatChangeShim implements AutoCloseable {
      * {@code asioMessage}.
      */
     @SuppressWarnings("unused") // invoked reflectively via the upcall stub
-    private long asioMessageUpcall(long selector, long value,
-                                   MemorySegment message, MemorySegment opt) {
+    private int asioMessageUpcall(int selector, int value,
+                                  MemorySegment message, MemorySegment opt) {
         try {
-            return dispatch(selector, value);
+            return (int) dispatch(selector, value);
         } catch (Throwable t) {
             // Never let an exception propagate back into native code.
             return ASE_NOT_PRESENT;
@@ -242,8 +249,12 @@ final class AsioFormatChangeShim implements AutoCloseable {
                 SymbolLookup lookup = SymbolLookup.libraryLookup("asioshim", arena);
                 lookup.find("uninstallAsioMessageCallback").ifPresent(symbol -> {
                     try {
-                        Linker.nativeLinker().downcallHandle(
-                                symbol, FunctionDescriptor.ofVoid()).invoke();
+                        MethodHandle uninstall = Linker.nativeLinker().downcallHandle(
+                                symbol, FunctionDescriptor.ofVoid());
+                        AsioControlThread.call(() -> {
+                            uninstall.invokeExact();
+                            return null;
+                        });
                     } catch (Throwable ignored) {
                         // Best-effort: never throw from close().
                     }
@@ -253,7 +264,10 @@ final class AsioFormatChangeShim implements AutoCloseable {
             }
         }
         try {
-            arena.close();
+            AsioControlThread.call(() -> {
+                arena.close();
+                return null;
+            });
         } catch (Throwable ignored) {
             // Already closed by something else — idempotent.
         }

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBackendSupport.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBackendSupport.java
@@ -19,19 +19,30 @@ import java.util.concurrent.SubmissionPublisher;
  */
 final class AudioBackendSupport implements AutoCloseable {
 
-    private final SubmissionPublisher<AudioBlock> publisher = new SubmissionPublisher<>();
-    private final SubmissionPublisher<AudioDeviceEvent> devicePublisher = new SubmissionPublisher<>();
+    private volatile SubmissionPublisher<AudioBlock> publisher = new SubmissionPublisher<>();
+    private volatile SubmissionPublisher<AudioDeviceEvent> devicePublisher =
+            new SubmissionPublisher<>();
     private volatile boolean open;
     private volatile AudioFormat format;
     private volatile int bufferFrames;
 
-    void markOpen(AudioFormat format, int bufferFrames) {
+    synchronized void markOpen(AudioFormat format, int bufferFrames) {
         Objects.requireNonNull(format, "format must not be null");
         if (bufferFrames <= 0) {
             throw new IllegalArgumentException("bufferFrames must be positive: " + bufferFrames);
         }
         if (open) {
             throw new IllegalStateException("backend already has an open stream");
+        }
+        // close() completes a stream's publishers, as required by
+        // AudioBackend. A later close-then-open starts a fresh stream and must
+        // therefore expose fresh publishers rather than silently discard ASIO
+        // callbacks on the already-completed instances.
+        if (publisher.isClosed()) {
+            publisher = new SubmissionPublisher<>();
+        }
+        if (devicePublisher.isClosed()) {
+            devicePublisher = new SubmissionPublisher<>();
         }
         this.format = format;
         this.bufferFrames = bufferFrames;
@@ -48,6 +59,13 @@ final class AudioBackendSupport implements AutoCloseable {
 
     int bufferFrames() {
         return bufferFrames;
+    }
+
+    /** Clears stream state after a native open rolled back. */
+    void markClosed() {
+        open = false;
+        format = null;
+        bufferFrames = 0;
     }
 
     Flow.Publisher<AudioBlock> inputBlocks() {
@@ -91,8 +109,8 @@ final class AudioBackendSupport implements AutoCloseable {
     }
 
     @Override
-    public void close() {
-        open = false;
+    public synchronized void close() {
+        markClosed();
         publisher.close();
         devicePublisher.close();
     }

--- a/daw-sdk/src/main/java/module-info.java
+++ b/daw-sdk/src/main/java/module-info.java
@@ -23,6 +23,12 @@
  * {@code META-INF/api-packages.allowlist} on the test classpath. The
  * {@code ModuleExportsAllowlistTest} fails if the two ever drift, so adding
  * or removing an export is always a deliberate, reviewed change.
+ *
+ * <h2>Native access</h2>
+ * The optional ASIO backend uses the Foreign Function &amp; Memory API
+ * (JEP 454, final in Java 22) to call {@code asioshim}. Restricted native
+ * access for this named module must therefore be granted with
+ * {@code --enable-native-access=daw.sdk} in tests and packaged launchers.
  */
 module daw.sdk {
     // java.desktop is required for java.awt.geom.Rectangle2D and javax.sound.sampled

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBackendDriverLifecycleTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBackendDriverLifecycleTest.java
@@ -1,0 +1,303 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Driver enumeration and lifecycle acceptance tests for story 310. */
+class AsioBackendDriverLifecycleTest {
+
+    private static final DeviceId DRIVER_A = new DeviceId("ASIO", "Driver A");
+    private static final DeviceId DRIVER_B = new DeviceId("ASIO", "Driver B");
+
+    private final List<AsioBackend> openedBackends = new ArrayList<>();
+
+    @AfterEach
+    void cleanUp() {
+        openedBackends.forEach(AsioBackend::close);
+        AsioBackend.resetDriverShimFactory();
+        AsioBackend.resetCapabilityShimFactory();
+    }
+
+    @Test
+    void listDevicesReturnsOneEntryPerEnumeratedDriver() {
+        StubDriverShim shim = StubDriverShim.available();
+        AsioBackend.setDriverShimFactory(() -> shim);
+
+        assertThat(new AsioBackend().listDevices())
+                .extracting(AudioDeviceInfo::index, AudioDeviceInfo::name,
+                        AudioDeviceInfo::hostApi)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(0, "Driver A", "ASIO"),
+                        org.assertj.core.groups.Tuple.tuple(1, "Driver B", "ASIO"));
+        assertThat(shim.closeCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void listDevicesReturnsEmptyWhenEnumerationSymbolIsAbsent() {
+        StubDriverShim shim = StubDriverShim.unavailable();
+        AsioBackend.setDriverShimFactory(() -> shim);
+
+        assertThat(new AsioBackend().listDevices()).isEmpty();
+        assertThat(shim.listCalls.get()).isZero();
+    }
+
+    @Test
+    void openLoadsDriverBeforeMarkingBackendOpenAndSurfacesDriverInfo() {
+        AtomicReference<AsioBackend> backendRef = new AtomicReference<>();
+        StubDriverShim shim = StubDriverShim.available();
+        shim.openState = () -> backendRef.get().isOpen();
+        AsioBackend.setDriverShimFactory(() -> shim);
+        AsioBackend backend = track(new AsioBackend());
+        backendRef.set(backend);
+
+        backend.open(DRIVER_A, AudioFormat.CD_QUALITY, 128);
+
+        assertThat(shim.openDuringLoad).isFalse();
+        assertThat(shim.events).containsExactly("load:Driver A");
+        assertThat(backend.isOpen()).isTrue();
+        assertThat(backend.activeDriverInfo()).contains(
+                new AsioDriverInfo("Driver A", 2, 17, "ready"));
+    }
+
+    @Test
+    void activeDriverInfoIsAUsablePublicSdkValue() throws Exception {
+        assertThat(Modifier.isPublic(AsioDriverInfo.class.getModifiers())).isTrue();
+        assertThat(AsioDriverInfo.class.isRecord()).isTrue();
+        assertThat(Modifier.isPublic(AsioBackend.class
+                .getMethod("activeDriverInfo").getModifiers())).isTrue();
+        assertThat(new AsioBackend().activeDriverInfo()).isEmpty();
+    }
+
+    @Test
+    void defaultDeviceResolvesToFirstEnumeratedDriver() {
+        StubDriverShim shim = StubDriverShim.available();
+        AsioBackend.setDriverShimFactory(() -> shim);
+        AsioBackend backend = track(new AsioBackend());
+
+        backend.open(DeviceId.defaultFor("ASIO"), AudioFormat.CD_QUALITY, 128);
+
+        assertThat(shim.events).containsExactly("load:Driver A");
+    }
+
+    @Test
+    void defaultDeviceFailsClearlyWhenNoDriversAreInstalled() {
+        StubDriverShim shim = StubDriverShim.available();
+        shim.drivers = List.of();
+        AsioBackend.setDriverShimFactory(() -> shim);
+        AsioBackend backend = new AsioBackend();
+
+        assertThatThrownBy(() -> backend.open(
+                DeviceId.defaultFor("ASIO"), AudioFormat.CD_QUALITY, 128))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("No installed ASIO driver");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(shim.closeCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void failedLoadRollsBackAndLeavesBackendClosed() {
+        StubDriverShim shim = StubDriverShim.available();
+        shim.loadSucceeds = false;
+        AsioBackend.setDriverShimFactory(() -> shim);
+        AsioBackend backend = new AsioBackend();
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, AudioFormat.CD_QUALITY, 128))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("Could not load and initialize");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(shim.closeCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void validationOccursBeforeCreatingOrLoadingNativeShim() {
+        AtomicInteger factoryCalls = new AtomicInteger();
+        AsioBackend.setDriverShimFactory(() -> {
+            factoryCalls.incrementAndGet();
+            return StubDriverShim.available();
+        });
+        AsioBackend backend = new AsioBackend();
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, AudioFormat.CD_QUALITY, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(factoryCalls.get()).isZero();
+    }
+
+    @Test
+    void secondOpenIsRejectedWithoutReplacingCurrentDriver() {
+        StubDriverShim shim = StubDriverShim.available();
+        AsioBackend.setDriverShimFactory(() -> shim);
+        AsioBackend backend = track(new AsioBackend());
+        backend.open(DRIVER_A, AudioFormat.CD_QUALITY, 128);
+
+        assertThatThrownBy(() -> backend.open(DRIVER_B, AudioFormat.CD_QUALITY, 128))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already has an open stream");
+        assertThat(shim.events).containsExactly("load:Driver A");
+    }
+
+    @Test
+    void closeThenOpenDifferentDriverUnloadsBeforeReloadAndCloseIsIdempotent() {
+        List<String> lifecycle = new ArrayList<>();
+        List<StubDriverShim> shims = new ArrayList<>();
+        AsioBackend.setDriverShimFactory(() -> {
+            StubDriverShim shim = StubDriverShim.available();
+            shim.events = lifecycle;
+            shims.add(shim);
+            return shim;
+        });
+        AsioBackend backend = track(new AsioBackend());
+
+        backend.open(DRIVER_A, AudioFormat.CD_QUALITY, 128);
+        backend.close();
+        backend.open(DRIVER_B, AudioFormat.CD_QUALITY, 256);
+        backend.close();
+        backend.close();
+
+        assertThat(lifecycle).containsExactly(
+                "load:Driver A", "unload", "load:Driver B", "unload");
+        assertThat(shims).hasSize(2);
+        assertThat(backend.isOpen()).isFalse();
+    }
+
+    @Test
+    void closeThenReopenCreatesFreshDeviceEventPublisher() throws Exception {
+        AsioBackend.setDriverShimFactory(StubDriverShim::available);
+        AsioBackend backend = track(new AsioBackend());
+        backend.open(DRIVER_A, AudioFormat.CD_QUALITY, 128);
+        backend.close();
+        backend.open(DRIVER_B, AudioFormat.CD_QUALITY, 256);
+
+        CountDownLatch received = new CountDownLatch(1);
+        AtomicReference<AudioDeviceEvent> event = new AtomicReference<>();
+        backend.deviceEvents().subscribe(new Flow.Subscriber<>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(AudioDeviceEvent item) {
+                event.set(item);
+                received.countDown();
+            }
+
+            @Override public void onError(Throwable throwable) { }
+            @Override public void onComplete() { }
+        });
+        backend.publishFormatChangeRequested(
+                DRIVER_B, Optional.empty(), new FormatChangeReason.DriverReset());
+
+        assertThat(received.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(event.get())
+                .isEqualTo(new AudioDeviceEvent.FormatChangeRequested(
+                        DRIVER_B, Optional.empty(), new FormatChangeReason.DriverReset()));
+    }
+
+    @Test
+    void separateBackendCannotStealProcessWideDriver() {
+        AsioBackend first = track(new AsioBackend());
+        AsioBackend second = track(new AsioBackend());
+        AsioBackend.setDriverShimFactory(StubDriverShim::available);
+        first.open(DRIVER_A, AudioFormat.CD_QUALITY, 128);
+
+        assertThatThrownBy(() -> second.open(DRIVER_B, AudioFormat.CD_QUALITY, 128))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("process-wide driver");
+        assertThat(first.isOpen()).isTrue();
+        assertThat(second.isOpen()).isFalse();
+    }
+
+    private AsioBackend track(AsioBackend backend) {
+        openedBackends.add(backend);
+        return backend;
+    }
+
+    private static final class StubDriverShim extends AsioDriverShim {
+        private List<DriverDescriptor> drivers = List.of(
+                new DriverDescriptor("Driver A", "{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"),
+                new DriverDescriptor("Driver B", "{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}"));
+        private List<String> events = new ArrayList<>();
+        private final AtomicInteger listCalls = new AtomicInteger();
+        private final AtomicInteger closeCalls = new AtomicInteger();
+        private java.util.function.BooleanSupplier openState = () -> false;
+        private boolean enumerationAvailable = true;
+        private boolean lifecycleAvailable = true;
+        private boolean loadSucceeds = true;
+        private boolean closed;
+        private boolean openDuringLoad;
+        private String activeName;
+
+        static StubDriverShim available() {
+            return new StubDriverShim();
+        }
+
+        static StubDriverShim unavailable() {
+            StubDriverShim shim = new StubDriverShim();
+            shim.enumerationAvailable = false;
+            shim.lifecycleAvailable = false;
+            return shim;
+        }
+
+        @Override
+        boolean isEnumerationAvailable() {
+            return enumerationAvailable && !closed;
+        }
+
+        @Override
+        boolean isLifecycleAvailable() {
+            return lifecycleAvailable && !closed;
+        }
+
+        @Override
+        List<DriverDescriptor> listDrivers() {
+            if (!isEnumerationAvailable()) {
+                return List.of();
+            }
+            listCalls.incrementAndGet();
+            return drivers;
+        }
+
+        @Override
+        boolean loadDriver(String driverName) {
+            openDuringLoad = openState.getAsBoolean();
+            events.add("load:" + driverName);
+            if (loadSucceeds) {
+                activeName = driverName;
+            }
+            return loadSucceeds;
+        }
+
+        @Override
+        Optional<DriverInfo> getDriverInfo() {
+            return activeName == null
+                    ? Optional.empty()
+                    : Optional.of(new DriverInfo(2, 17, activeName, "ready"));
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            closeCalls.incrementAndGet();
+            if (activeName != null) {
+                events.add("unload");
+                activeName = null;
+            }
+        }
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverShimTest.java
@@ -1,0 +1,89 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ABI-decoding and graceful-absence tests for {@link AsioDriverShim}. */
+class AsioDriverShimTest {
+
+    @Test
+    void decodesFixedWidthDriverRecordsWithoutNativeLongsOrPointers() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment records = arena.allocate(2L * AsioDriverShim.DRIVER_RECORD_STRIDE);
+            putAscii(records, 0, "Focusrite USB ASIO");
+            putAscii(records, AsioDriverShim.DRIVER_NAME_BYTES,
+                    "{01234567-89AB-CDEF-0123-456789ABCDEF}");
+            long second = AsioDriverShim.DRIVER_RECORD_STRIDE;
+            putAscii(records, second, "RME Fireface USB");
+            putAscii(records, second + AsioDriverShim.DRIVER_NAME_BYTES,
+                    "{FEDCBA98-7654-3210-FEDC-BA9876543210}");
+
+            assertThat(AsioDriverShim.decodeDrivers(records, 2)).containsExactly(
+                    new AsioDriverShim.DriverDescriptor(
+                            "Focusrite USB ASIO",
+                            "{01234567-89AB-CDEF-0123-456789ABCDEF}"),
+                    new AsioDriverShim.DriverDescriptor(
+                            "RME Fireface USB",
+                            "{FEDCBA98-7654-3210-FEDC-BA9876543210}"));
+            assertThat(AsioDriverShim.DRIVER_RECORD_STRIDE).isEqualTo(168);
+        }
+    }
+
+    @Test
+    void decoderSkipsBlankRowsAndSanitizesNonAsciiBytes() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment records = arena.allocate(2L * AsioDriverShim.DRIVER_RECORD_STRIDE);
+            records.set(ValueLayout.JAVA_BYTE, AsioDriverShim.DRIVER_RECORD_STRIDE,
+                    (byte) 0xC3);
+            putAscii(records, AsioDriverShim.DRIVER_RECORD_STRIDE + 1, " Driver");
+
+            assertThat(AsioDriverShim.decodeDrivers(records, 2))
+                    .containsExactly(new AsioDriverShim.DriverDescriptor("? Driver", ""));
+        }
+    }
+
+    @Test
+    void decodesNormalizedDriverInfoRecord() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment info = arena.allocate(AsioDriverShim.DRIVER_INFO_STRIDE);
+            info.set(ValueLayout.JAVA_INT, 0, 2);
+            info.set(ValueLayout.JAVA_INT, 4, 0x01020304);
+            putAscii(info, AsioDriverShim.DRIVER_INFO_NAME_OFFSET, "USB ASIO");
+            putAscii(info, AsioDriverShim.DRIVER_INFO_ERROR_OFFSET, "ready");
+
+            assertThat(AsioDriverShim.decodeDriverInfo(info)).isEqualTo(
+                    new AsioDriverShim.DriverInfo(2, 0x01020304, "USB ASIO", "ready"));
+            assertThat(AsioDriverShim.DRIVER_INFO_STRIDE).isEqualTo(264);
+        }
+    }
+
+    @Test
+    void productionWrapperGracefullyHandlesMissingLibraryOrDriver() {
+        AsioDriverShim shim = new AsioDriverShim();
+        // Every result is safe regardless of whether this workstation happens
+        // to have the optional DLL installed.
+        List<AsioDriverShim.DriverDescriptor> drivers = shim.listDrivers();
+        assertThat(drivers).isNotNull();
+        assertThat(shim.getDriverName()).isEmpty();
+        assertThat(shim.getDriverInfo()).isEmpty();
+        shim.unloadDriver();
+        shim.close();
+        shim.close();
+        assertThat(AsioDriverShim.isDriverLoaded()).isFalse();
+    }
+
+    private static void putAscii(MemorySegment target, long offset, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.US_ASCII);
+        for (int index = 0; index < bytes.length; index++) {
+            target.set(ValueLayout.JAVA_BYTE, offset + index, bytes[index]);
+        }
+        target.set(ValueLayout.JAVA_BYTE, offset + bytes.length, (byte) 0);
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioDriverShimTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -79,11 +82,82 @@ class AsioDriverShimTest {
         assertThat(AsioDriverShim.isDriverLoaded()).isFalse();
     }
 
+    @Test
+    void failedReplacementLoadReleasesStaleOwnership() {
+        LifecycleStub ownerLifecycle = new LifecycleStub();
+        LifecycleStub nextLifecycle = new LifecycleStub();
+        try (AsioDriverShim owner = lifecycleShim(ownerLifecycle);
+             AsioDriverShim next = lifecycleShim(nextLifecycle)) {
+            assertThat(owner.loadDriver("First ASIO Driver")).isTrue();
+
+            ownerLifecycle.loadStatus = 0;
+            assertThat(owner.loadDriver("Missing ASIO Driver")).isFalse();
+
+            assertThat(AsioDriverShim.isDriverLoaded()).isFalse();
+            assertThat(next.loadDriver("Next ASIO Driver")).isTrue();
+        }
+        assertThat(AsioDriverShim.isDriverLoaded()).isFalse();
+    }
+
+    @Test
+    void exceptionalReplacementLoadReleasesStaleOwnership() {
+        LifecycleStub ownerLifecycle = new LifecycleStub();
+        LifecycleStub nextLifecycle = new LifecycleStub();
+        try (AsioDriverShim owner = lifecycleShim(ownerLifecycle);
+             AsioDriverShim next = lifecycleShim(nextLifecycle)) {
+            assertThat(owner.loadDriver("First ASIO Driver")).isTrue();
+
+            ownerLifecycle.throwOnLoad = true;
+            assertThat(owner.loadDriver("Broken ASIO Driver")).isFalse();
+
+            assertThat(AsioDriverShim.isDriverLoaded()).isFalse();
+            assertThat(next.loadDriver("Next ASIO Driver")).isTrue();
+        }
+        assertThat(AsioDriverShim.isDriverLoaded()).isFalse();
+    }
+
     private static void putAscii(MemorySegment target, long offset, String value) {
         byte[] bytes = value.getBytes(StandardCharsets.US_ASCII);
         for (int index = 0; index < bytes.length; index++) {
             target.set(ValueLayout.JAVA_BYTE, offset + index, bytes[index]);
         }
         target.set(ValueLayout.JAVA_BYTE, offset + bytes.length, (byte) 0);
+    }
+
+    private static AsioDriverShim lifecycleShim(LifecycleStub lifecycle) {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MethodHandle loadDriver = lookup.findVirtual(
+                    LifecycleStub.class,
+                    "loadDriver",
+                    MethodType.methodType(int.class, MemorySegment.class))
+                    .bindTo(lifecycle);
+            MethodHandle unloadDriver = lookup.findVirtual(
+                    LifecycleStub.class,
+                    "unloadDriver",
+                    MethodType.methodType(void.class))
+                    .bindTo(lifecycle);
+            return new AsioDriverShim(loadDriver, unloadDriver);
+        } catch (NoSuchMethodException | IllegalAccessException failure) {
+            throw new AssertionError("Could not create ASIO lifecycle test handles", failure);
+        }
+    }
+
+    private static final class LifecycleStub {
+        private volatile int loadStatus = 1;
+        private volatile boolean throwOnLoad;
+
+        @SuppressWarnings("unused")
+        private int loadDriver(MemorySegment ignored) {
+            if (throwOnLoad) {
+                throw new IllegalStateException("simulated native load failure");
+            }
+            return loadStatus;
+        }
+
+        @SuppressWarnings("unused")
+        private void unloadDriver() {
+            // The ownership transition is the behavior under test.
+        }
     }
 }

--- a/docs/native-build-setup.md
+++ b/docs/native-build-setup.md
@@ -111,7 +111,7 @@ The resulting DLL is written to:
 Even on Windows, you can force the asioshim build off:
 
 ```bash
-cmake -S lib -B target/build -DBUILD_ASIOSHIM=OFF
+cmake -S lib -B target/build -DBUILD_ASIO_SHIM=OFF
 ```
 
 This is useful when you have an SDK extract on disk but want to

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,7 +32,17 @@ option(BUILD_LIBVORBIS      "Build libvorbis shared library"      ON)
 # Steinberg licence forbids us from redistributing the SDK source, so
 # the default build path skips this target and the Java layer falls
 # back to BufferSizeRange.DEFAULT_RANGE / the canonical sample-rate set.
-option(BUILD_ASIOSHIM       "Build asioshim FFM bridge (requires ASIO_SDK_DIR)" ON)
+if(DEFINED BUILD_ASIOSHIM)
+    set(_build_asio_shim_default "${BUILD_ASIOSHIM}")
+else()
+    set(_build_asio_shim_default ON)
+endif()
+option(BUILD_ASIO_SHIM     "Build asioshim FFM bridge (requires ASIO_SDK_DIR)"
+                           ${_build_asio_shim_default})
+# Compatibility alias for build scripts written before story 310 normalized
+# the option spelling. BUILD_ASIO_SHIM is the canonical public switch.
+set(BUILD_ASIOSHIM "${BUILD_ASIO_SHIM}" CACHE BOOL
+    "Deprecated alias for BUILD_ASIO_SHIM" FORCE)
 
 # ── 1. PortAudio ───────────────────────────────────────────────────
 if(BUILD_PORTAUDIO)
@@ -254,7 +264,7 @@ endif()
 # subdirectory's own CMakeLists silently returns when ASIO_SDK_DIR is
 # unset or when the host is not Windows, so this add_subdirectory call
 # is safe on every platform / fresh checkout.
-if(BUILD_ASIOSHIM)
+if(BUILD_ASIO_SHIM)
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../daw-core/native/asio"
                      "${CMAKE_CURRENT_BINARY_DIR}/asioshim"
                      EXCLUDE_FROM_ALL)

--- a/pom.xml
+++ b/pom.xml
@@ -169,14 +169,14 @@
 					<configuration>
 						<!-- Native (FFM / JEP 454) access. Every project module
 						     is now a named JPMS module, so ALL-UNNAMED no longer
-						     covers them: grant it to daw.core, which owns the
-						     PortAudio/FluidSynth/CLAP/codec bindings. ALL-UNNAMED
+						     covers them: grant daw.core for its engine bindings and
+						     daw.sdk for its ASIO bindings. ALL-UNNAMED
 						     is kept too for test-only helpers that may still run
 						     on the unnamed classpath (e.g. patched test code
 						     before module resolution). Per-module surefire
 						     <configuration> blocks (daw-core, daw-app) replace
 						     this argLine, so they repeat the flag. -->
-						<argLine>--enable-native-access=daw.core,ALL-UNNAMED</argLine>
+						<argLine>--enable-native-access=daw.core,daw.sdk,ALL-UNNAMED</argLine>
 					</configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
# ASIO Driver Enumeration and Init/Exit Lifecycle (asioshim_listDrivers / loadDriver)

## Motivation

Stories 130 / 212–224 / 256–259 build the entire ASIO capability surface — buffer-size and sample-rate enumeration (213 / 220), the driver control panel (212 / 221), clock-source selection (216 / 222), channel-name enumeration (215 / 223), the format-change host callback (218), and the `asioshim.dll` build/bundle pipeline (224 / 256). Every one of those exports — `asioshim_getBufferSize`, `asioshim_canSampleRate`, `asioshim_getClockSources`, `asioshim_getChannelInfo`, `asioshim_openControlPanel` — calls straight into the Steinberg SDK's `ASIOGetBufferSize` / `ASIOCanSampleRate` / etc. **as though a driver were already loaded and `ASIOInit` already called.** Nothing in the repo ever loads a driver:

- `com.benesquivelmusic.daw.sdk.audio.AsioBackend#listDevices()` returns `List.of()` — an empty list — so the user can never even see, let alone select, an installed ASIO driver.
- `asioshim.cpp` forward-declares only the per-call SDK entry points; it has no `asiodrivers.cpp` / `AsioDrivers` glue to enumerate the registry (`HKEY_LOCAL_MACHINE\SOFTWARE\ASIO`), instantiate a driver's COM object, or call `ASIOInit(ASIODriverInfo*)` / `ASIOExit()`.
- Because no driver is ever bound, every capability export silently hits the SDK's "no driver loaded" path and the Java layer takes its graceful-absence branch — exactly the behaviour the capability stories were written to avoid.

On the project's primary platform (Windows + a multi-channel USB interface), the user's installed ASIO driver (the device's own driver or ASIO4ALL) is invisible to the DAW. This story supplies the missing foundation that all of 212–224 implicitly depend on: enumerate the installed ASIO drivers, load and initialise the selected one, and tear it down cleanly.

## Goals

- Extend the `daw-core/native/asio/` shim with driver enumeration and lifecycle exports, documented in `asioshim.h` alongside the existing ABI notes:
  - `asioshim_listDrivers(void* outArray, int* outCount)` — enumerate installed ASIO drivers from the Windows registry via the SDK's `AsioDrivers` glue, writing a fixed-width record per driver (driver name, CLSID string) using the same normalised int32 / fixed-`char[]` struct convention already established for `asioshim_getClockSources` and `asioshim_getChannelInfo`. `outCount` uses capacity-in/actual-out semantics: on entry it specifies the maximum number of records `outArray` can hold; on return it contains the actual number written (capped at the input capacity).
  - `asioshim_loadDriver(const char* driverName)` — instantiate the named driver's COM object and call `ASIOInit`, returning `1` (`SHIM_OK`) on `ASE_OK` and `0` otherwise, following the existing return-code convention.
  - `asioshim_getDriverName(void* outName, int nameCapacity)` and `asioshim_getDriverInfo(...)` to surface the active driver's name and version for display.
  - `asioshim_unloadDriver(void)` — call `ASIOExit` and release the COM object; idempotent and safe to call when no driver is loaded.
- Link the SDK's `asiodrivers.cpp` / `asiolist.cpp` (the host glue, not the proprietary driver) into the CMake target from story 224, gated by the existing `-DBUILD_ASIO_SHIM=ON` flag. No driver lifecycle export may run on the audio render thread (consistent with the threading note already in `asioshim.cpp`).
- Add a Java capability wrapper (mirroring `AsioCapabilityShim`) that resolves the new symbols via `SymbolLookup.libraryLookup("asioshim", arena)` and exposes typed enumeration / load / unload methods, with a test-injectable factory hook in the same style as `AsioBackend#setCapabilityShimFactory(Supplier)`.
- Make `AsioBackend#listDevices()` return one `AudioDeviceInfo` per enumerated driver (driver name as the device id / display name) instead of an empty list. When the shim or its `asioshim_listDrivers` symbol is absent the method returns an empty list (current behaviour), so non-Windows hosts and shim-less builds degrade gracefully.
- Make `AsioBackend#open(DeviceId, AudioFormat, int)` call `asioshim_loadDriver(device)` before `support.markOpen(...)`, and make `AsioBackend#close()` call `asioshim_unloadDriver()` after releasing the format-change shim, so a driver is loaded for exactly the lifetime of an open stream. Re-opening a different device unloads the previous driver first (one active ASIO driver per process, per the SDK's single-driver model).
- Ordering contract: a driver must be loaded (`asioshim_loadDriver` succeeded) before any capability query (213 / 215 / 216 / 220 / 222 / 223) or `asioshim_openControlPanel` (212 / 221) is meaningful. Document this dependency in `asioshim.h` and have the capability wrappers throw / return graceful-absence when no driver is loaded rather than calling into an uninitialised SDK.

## Non-Goals

- Real-time audio streaming (`ASIOCreateBuffers` / `ASIOStart` / `bufferSwitch`) — owned by the streaming story (311). This story only enumerates, loads, initialises, and exits drivers; it does not move a single audio frame.
- Sample-format conversion — owned by story 312.
- macOS / Linux equivalents — ASIO is Windows-only; CoreAudio / JACK enumerate devices through their own backends.
- ARM64 Windows or x86-32; x64 only, consistent with story 224's non-goals.
- Hot-plug re-enumeration semantics — story 214 owns device-arrival/removal handling; this story only provides the snapshot enumeration it calls.

## Technical Notes

- Files: `daw-core/native/asio/asioshim.cpp` + `asioshim.h` (new lifecycle exports), `daw-core/native/asio/CMakeLists.txt` (link `asiodrivers.cpp` / `asiolist.cpp`), `daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java` (`listDevices` / `open` / `close`), a new `AsioDriverShim` wrapper alongside `AsioCapabilityShim.java`.
- The existing `AsioCapabilityShim` (symbol lookup + struct-decode pattern) and `asioshim_getClockSources` (fixed-width struct array ABI) are the canonical references to copy for `asioshim_listDrivers`.
- This story is a hard prerequisite for stories 311 and 312 and the runtime usefulness of 212 / 213 / 215 / 216 / 220 / 221 / 222 / 223 — none of those capability calls return real data until a driver is actually loaded.
- Research backing: `docs/research/open-source-daw-tools.md` (§ Audio I/O Abstraction — "ASIO: Low-latency audio on Windows") and `docs/research/audio-development-tools.md` (JAsioHost — "Java-based ASIO host for low-latency audio I/O on Windows", relevance High) describe the driver-enumeration-then-init model this story implements.
- Reference original stories: **130 — Audio Backend Selection**, **219 — Instantiate Platform Audio Backends**, and **224 — Build and Bundle asioshim.dll**.
