### PR TITLE
311-asio-realtime-streaming-bufferswitch.md implementation.

### DIFF
--- a/.github/workflows/windows-asioshim.yml
+++ b/.github/workflows/windows-asioshim.yml
@@ -21,11 +21,17 @@ name: Windows asioshim Build & Bundle
 # in this repository's secret-aware context).
 #
 # CI lane contract:
-#   * `DAW_REQUIRE_ASIOSHIM=1` is exported so the env-gated tests
-#     (`NativeLibraryDetectorTest`, `AsioFormatChangeShimTest`) flip
-#     their `Assumptions.assumeTrue(...)` calls to hard `assertTrue(...)`
-#     assertions. Absence of `asioshim.dll` on the FFM library path
+#   * `DAW_REQUIRE_ASIOSHIM=1` is exported so the env-gated tests flip their
+#     `Assumptions.assumeTrue(...)` calls to hard `assertThat(...).isTrue()`
+#     assertions. Two suites read the variable — `NativeLibraryDetectorTest`
+#     and, since story 311, `AsioStreamingIntegrationTest` (both in
+#     `daw-core`, which is the only module whose Surefire sets
+#     `-Djava.library.path=${native.libs.dir}` and which runs after the CMake
+#     native build). Absence of `asioshim.dll` on the FFM library path
 #     therefore fails the job rather than silently skipping the test.
+#     `AsioFormatChangeShimTest` (in `daw-sdk`) deliberately does *not* read
+#     the variable: `daw-sdk` runs before the native build, so its asioshim
+#     assertion can only ever be an unconditional `assumeTrue`.
 #   * The final `Verify bundled distribution` step asserts the
 #     packaged DLL exists under `daw-app/target/dist/native/windows-x64/`.
 
@@ -35,8 +41,11 @@ on:
     paths:
       - 'daw-core/native/asio/**'
       - 'daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/Asio*.java'
+      - 'daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBlockRing.java'
       - 'daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/Asio*.java'
+      - 'daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AudioBlockRingTest.java'
       - 'daw-core/src/test/java/com/benesquivelmusic/daw/core/audio/NativeLibraryDetectorTest.java'
+      - 'daw-core/src/test/java/com/benesquivelmusic/daw/core/audio/AsioStreamingIntegrationTest.java'
       - 'lib/CMakeLists.txt'
       - '.github/workflows/windows-asioshim.yml'
   pull_request:
@@ -44,8 +53,11 @@ on:
     paths:
       - 'daw-core/native/asio/**'
       - 'daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/Asio*.java'
+      - 'daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBlockRing.java'
       - 'daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/Asio*.java'
+      - 'daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AudioBlockRingTest.java'
       - 'daw-core/src/test/java/com/benesquivelmusic/daw/core/audio/NativeLibraryDetectorTest.java'
+      - 'daw-core/src/test/java/com/benesquivelmusic/daw/core/audio/AsioStreamingIntegrationTest.java'
       - 'lib/CMakeLists.txt'
       - '.github/workflows/windows-asioshim.yml'
   workflow_dispatch: {}
@@ -128,8 +140,8 @@ jobs:
         shell: pwsh
         env:
           # Flip the env-gated assertions in NativeLibraryDetectorTest and
-          # AsioFormatChangeShimTest from assumeTrue (skip) to assertTrue
-          # (fail) — see daw-core/native/asio/README.md.
+          # AsioStreamingIntegrationTest from assumeTrue (skip) to a hard
+          # assertion — see daw-core/native/asio/README.md.
           DAW_REQUIRE_ASIOSHIM: '1'
         run: |
           mvn -B -DskipTests=false verify

--- a/daw-core/native/asio/README.md
+++ b/daw-core/native/asio/README.md
@@ -5,7 +5,8 @@ JVM loads via FFM (`SymbolLookup.libraryLookup("asioshim", arena)`) to
 talk to a Steinberg ASIO driver.
 
 The Java side lives in `AsioDriverShim.java`, `AsioCapabilityShim.java`,
-`AsioControlThread.java`, `AsioFormatChangeShim.java`, and the public
+`AsioControlThread.java`, `AsioFormatChangeShim.java`,
+`AsioStreamingShim.java`, `AsioBufferSwitchShim.java`, and the public
 `AsioDriverInfo.java` display value under
 `daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/`.
 
@@ -27,6 +28,15 @@ The Java side lives in `AsioDriverShim.java`, `AsioCapabilityShim.java`,
 | `int asioshim_setClockSource(int reference)` | `ASIOSetClockSource` | `AsioBackend.selectClockSource` (story 216) |
 | `void installAsioMessageCallback(void* callback)` | (host upcall) | `AsioFormatChangeShim` (story 218) |
 | `void uninstallAsioMessageCallback()` | (host upcall) | `AsioFormatChangeShim` close |
+| `long asioshim_messageTrampoline(long selector, long value, void* message, double* opt)` | `ASIOCallbacks::asioMessage` | the vendor driver (story 218; the callbacks table is wired to this exported symbol) |
+| `int asioshim_createBuffers(const int* inputChannels, int numInputs, const int* outputChannels, int numOutputs, int bufferFrames)` | `ASIOCreateBuffers` + `ASIOCallbacks` install | `AsioStreamingShim.createBuffers` (story 311) |
+| `int asioshim_getBufferInfos(void* outArray, int* outCount)` | cached `ASIOBufferInfo[]` + `ASIOGetChannelInfo` types | `AsioStreamingShim.getBufferInfos` (story 311) |
+| `int asioshim_start()` | `ASIOStart` | `AsioStreamingShim.start` (story 311) |
+| `int asioshim_stop()` | `ASIOStop` | `AsioStreamingShim.stop` (story 311) |
+| `int asioshim_disposeBuffers()` | `ASIOStop` + `ASIODisposeBuffers` | `AsioStreamingShim.disposeBuffers` (story 311) |
+| `void installAsioBufferSwitchCallback(void* callback)` | (host upcall) | `AsioStreamingShim.installBufferSwitchCallback` (story 311) |
+| `void uninstallAsioBufferSwitchCallback()` | (host upcall) | `AsioStreamingShim.uninstallBufferSwitchCallback` |
+| `void asioshim_bufferSwitchTrampoline(long index, long directProcess)` | `ASIOCallbacks::bufferSwitch` | the vendor driver (story 311; the callbacks table is wired to this exported symbol) |
 
 Most capability functions return `1` (`SHIM_OK`) for `ASE_OK` and `0`
 (`SHIM_FAIL`) otherwise, with two exceptions:
@@ -38,6 +48,23 @@ Most capability functions return `1` (`SHIM_OK`) for `ASE_OK` and `0`
   `ASE_NotPresent`, `ASE_HWMalfunction`, `ASE_InvalidParameter`,
   `ASE_InvalidMode`, …) so the Java side can translate each into a
   mapped `AudioBackendException` message.
+
+`asioshim_stop` and `asioshim_disposeBuffers` (story 311) follow the normal
+convention with one carve-out: they return `1` when there was **nothing to
+do** — no driver loaded, not started, or no buffers created — because the
+Java `close()` path calls them unconditionally. They still return `0` when
+the SDK call was actually made and the driver **refused** it. That
+distinction is a **diagnostic**, not a stop signal: a driver that answers
+`ASIOStop()` with `ASE_InvalidMode` may keep firing `bufferSwitch`, which is
+worth surfacing, so `AsioBackend#tearDownStreaming` logs the refusal at
+`WARNING` — naming the refused call and the driver — and then deliberately
+carries on to dispose the buffers, uninstall the upcall, and free its arena.
+What makes that free safe is the bounded in-flight callback barrier plus the
+null callback pointer published by `uninstallAsioBufferSwitchCallback` (see
+"Driver-thread entry points" below), not `ASIOStop` having succeeded. Bailing
+out on a refusal would skip the very uninstall that provides the protection,
+and would leak the FFM upcall arena and the `asio-input-drain` thread for the
+life of the process.
 
 `asioshim_getClockSources` writes into a caller-allocated buffer of
 `*outCount` entries (each entry is a fixed 48-byte struct: 32-byte
@@ -95,6 +122,124 @@ graceful-absence/failure value without calling the SDK. Settings screens that
 probe a closed backend therefore see fallback buffer/rate menus and empty
 clock/channel/panel capabilities; they are refreshed against the real driver
 after open.
+
+### The SDK's `asioDrivers` global is ours to manage
+
+The shim loads by **index** (`asioOpenDriver`) instead of calling the SDK's
+`loadAsioDriver(char*)` helper, so that a driver whose registry key differs
+from its display description is still loadable. That has a consequence worth
+spelling out, because getting it wrong is an access violation rather than a
+returned error code:
+
+`loadAsioDriver` is the **only** place the SDK ever assigns its own
+process-global `AsioDrivers* asioDrivers` (defined as
+`AsioDrivers* asioDrivers = 0;` in `host/asiodrivers.cpp`). Steinberg's
+`ASIOExit()` in `common/asio.cpp` then dereferences that global with no null
+check:
+
+```c
+ASIOError ASIOExit(void) {
+    if (theAsioDriver) {
+#if WINDOWS
+        asioDrivers->removeCurrentDriver();
+```
+
+and `AsioDrivers::removeCurrentDriver()` is a non-static member that reads and
+writes `this->curIndex`. Bypassing `loadAsioDriver` would therefore leave the
+global null and turn every `ASIOExit()` — i.e. every `close()` and every
+re-`open()` — into a null-`this` member access. (Some downstream forks, such
+as RtAudio's vendored `asio.cpp`, carry an `if (asioDrivers)` patch; the
+Steinberg SDK this shim builds against does not.)
+
+`asioshim.cpp` therefore owns that global's lifetime explicitly: it publishes
+its own `AsioDrivers` subclass into `asioDrivers` as soon as the instance is
+created — before anything can reach `ASIOInit`/`ASIOExit` — and clears it back
+to `nullptr` immediately before destroying that instance, so the SDK global
+never dangles. The unload path still calls `removeCurrentDriver()` itself for
+the failure paths that never reached `ASIOInit`; when `ASIOExit()` did run,
+that second call is a no-op because `removeCurrentDriver()` leaves
+`curIndex == -1`.
+
+## Real-time streaming (story 311)
+
+Audio only flows once the driver's double buffers exist and the host callback
+table is installed. The ordering contract, all on `asio-control`, is:
+
+```
+asioshim_createBuffers  →  asioshim_getBufferInfos  →  asioshim_start
+        … streaming (driver-thread bufferSwitch callbacks) …
+asioshim_stop  →  asioshim_disposeBuffers  →  asioshim_unloadDriver
+```
+
+`asioshim_createBuffers` requires a loaded driver and no already-created
+buffers. It rejects negative counts, an empty channel set, a non-positive
+`bufferFrames`, negative channel indices, a null channel array with a positive
+matching count, and more than **64 total active channels** — the cap is on
+`numInputs + numOutputs` combined, so a symmetric configuration tops out at 32
+in + 32 out. All of that is checked before entering the SDK. It then builds
+the `ASIOBufferInfo[]` inputs-first-then-outputs, fills the process-global
+`ASIOCallbacks` table, and calls `ASIOCreateBuffers`. On `ASE_OK` it caches
+each channel's `ASIOSampleType` via `ASIOGetChannelInfo`, probes
+`ASIOOutputReady()` once, and publishes the created state.
+
+A failure leaves no partial state — including the partial state the *driver*
+may hold. `ASIOCreateBuffers` can fail part-way through (request 32 in + 32
+out on a 32-in/16-out device and a driver may allocate the inputs, refuse the
+outputs, and return `ASE_InvalidMode` while still holding those inputs and a
+live pointer to the callback table), so the failure path calls
+`ASIODisposeBuffers()` **before** it clears the shim's own "buffers created"
+flag. Clearing first would make every later `asioshim_disposeBuffers` a no-op
+and leave the device unusable — answering each corrected retry with "buffers
+already created" — until the process restarts.
+
+This is also the point at which the story-218
+`asioshim_messageTrampoline` finally becomes reachable: it occupies the
+`ASIOCallbacks::asioMessage` slot, and before this story no `ASIOCallbacks`
+struct was ever constructed, so the driver had nowhere to deliver
+`kAsioResetRequest` / `kAsioBufferSizeChange` / `kAsioResyncRequest`. The
+`sampleRateDidChange` slot forwards to the same trampoline with
+`kAsioResetRequest`, which is what `AsioFormatChangeShim` already documents
+("sample-rate-driven resets … are reported as `DriverReset`").
+
+`asioshim_stop` and `asioshim_disposeBuffers` return `1` when there is nothing
+to do — including when no driver is loaded — so the Java `close()` path can
+call them unconditionally, and `0` when the driver refused the underlying SDK
+call (see the return-code note above). `asioshim_unloadDriver` performs the
+same stop + dispose teardown before `ASIOExit`, so a `close()` that skips the
+explicit teardown still leaves the vendor driver clean.
+
+Each `bufferSwitch` invokes the JVM upcall and then, when the driver
+advertised support at `ASIOCreateBuffers` time, calls `ASIOOutputReady()`
+natively — but **only when the upcall actually ran**. With no upcall installed
+(between `asioshim_start` and `installAsioBufferSwitchCallback`, or after an
+uninstall the driver has not caught up with) nothing filled the output half,
+so signalling output-ready would tell the driver to replay the previous
+cycle's contents: audible looped garbage instead of silence.
+
+`asioshim_getBufferInfos` reports the addresses `ASIOCreateBuffers` handed
+back, one fixed 32-byte record per active channel, in exactly the order passed
+to `asioshim_createBuffers` (all inputs first, then all outputs):
+
+| Offset | Type | Meaning |
+| --- | --- | --- |
+| `0` | `int32` | `channel` — driver channel index |
+| `4` | `int32` | `isInput` — 1 = input, 0 = output |
+| `8` | `int32` | `sampleType` — the driver's `ASIOSampleType`, or `-1` when the driver refused to report one |
+| `12` | `int32` | reserved, always 0 — padding so the two addresses below are 8-byte aligned |
+| `16` | `int64` | `buffer0` — address of `ASIOBufferInfo.buffers[0]` |
+| `24` | `int64` | `buffer1` — address of `ASIOBufferInfo.buffers[1]` |
+
+`*outCount` is capacity-in / actual-written-out, matching
+`asioshim_listDrivers` and `asioshim_getClockSources`. A zero-capacity call is
+a successful no-op; the call fails with `*outCount == 0` when no driver is
+loaded or buffers have not been created.
+
+The raw addresses are deliberate: the sample-format conversion boundary lives
+in Java (story 312 generalises it), so the JVM reads and writes the driver's
+buffers directly through FFM. They are valid only between a successful
+`asioshim_createBuffers` and the matching `asioshim_disposeBuffers` /
+`asioshim_unloadDriver`, and carry no alignment guarantee — the Java side must
+use the `*_UNALIGNED` value layouts.
 
 ## Building
 
@@ -155,10 +300,57 @@ green build.
 
 ## Threading
 
-All enumeration, lifecycle, capability, and control-panel FFM downcalls run on
-the dedicated daemon platform thread named `asio-control`, never the JavaFX or
-audio render thread. This keeps the SDK's COM initialization, driver creation,
-calls, exit, and release in one apartment. `AsioFormatChangeShim` uses a shared
-FFM arena because its upcall is invoked from the vendor driver's callback
-thread. Windows C `long` is 32-bit even on x64, so the callback ABI is
-normalized to `int32_t` / `ValueLayout.JAVA_INT`, not Java `long`.
+All enumeration, lifecycle, capability, control-panel, and streaming-control
+FFM downcalls run on the dedicated daemon platform thread named `asio-control`,
+never the JavaFX or audio render thread. This keeps the SDK's COM
+initialization, driver creation, calls, exit, and release in one apartment.
+`AsioFormatChangeShim` and `AsioBufferSwitchShim` use a shared FFM arena
+because their upcalls are invoked from the vendor driver's callback thread.
+Windows C `long` is 32-bit even on x64, so the callback ABI is normalized to
+`int32_t` / `ValueLayout.JAVA_INT`, not Java `long`.
+
+### Driver-thread entry points
+
+Four functions in `asioshim.cpp` run on the *vendor driver's* real-time audio
+thread rather than on `asio-control`. They are the four `ASIOCallbacks` slots
+`asioshim_createBuffers` installs:
+
+| `ASIOCallbacks` slot | Function | Exported? |
+| --- | --- | --- |
+| `bufferSwitch` | `asioshim_bufferSwitchTrampoline` | yes (story 311) |
+| `asioMessage` | `asioshim_messageTrampoline` | yes (story 218) |
+| `bufferSwitchTimeInfo` | `shimBufferSwitchTimeInfo` | no — `ASIOTime*` has no useful FFM mapping |
+| `sampleRateDidChange` | `shimSampleRateDidChange` | no — forwards to the message trampoline as `kAsioResetRequest` |
+
+**All four are deliberately lock-free.** Every host-called export in
+`asioshim.cpp` takes the shim's `g_driverMutex`; these four must never take
+it, for two reasons:
+
+1. **RT violation.** A mutex acquisition inside the audio callback is an
+   unbounded, priority-inversion-prone blocking operation.
+2. **Deadlock.** A control thread inside `asioshim_stop` holds `g_driverMutex`
+   while `ASIOStop()` waits for the driver's callback thread to quiesce — a
+   callback parked on that same mutex would never return.
+
+The only synchronisation on that path is `std::atomic`, and it takes two
+cooperating mechanisms:
+
+- **State gates.** A null callback pointer (after
+  `uninstallAsioBufferSwitchCallback`) makes the trampoline a cheap no-op, and
+  the "buffers created" flag is published `false` *before* the SDK teardown so
+  a callback that has not started yet returns without touching disposed state.
+- **An in-flight barrier.** Both gates are read once, at callback entry, so
+  neither says anything about a callback that is already past them — and the
+  story-311 driver-reset path really does tear down from a different thread
+  while the driver is still running. Every callback therefore counts itself
+  into an atomic in-flight counter for the duration of its body, and
+  `asioshim_stop`, `asioshim_disposeBuffers` and
+  `uninstallAsioBufferSwitchCallback` each drain that counter to zero before
+  they let the SDK free the driver's buffers or let Java free the upcall
+  stub's arena. The drain spins on `std::this_thread::yield()` and is bounded
+  (~100 ms against a monotonic clock), so a misbehaving driver can delay, but
+  never hang, `asio-control`. Draining while holding `g_driverMutex` is safe
+  precisely because the callback path never takes that mutex.
+
+`ASIOOutputReady()` is likewise called natively from the trampoline rather
+than from Java, keeping the JVM upcall a pure memory copy.

--- a/daw-core/native/asio/asioshim.cpp
+++ b/daw-core/native/asio/asioshim.cpp
@@ -4,11 +4,17 @@
 //
 // Story 130 / 213 — Driver-Reported Buffer Size and Sample-Rate
 // Enumeration. Story 218 — Format-change host-callback bridge.
+// Story 311 — Real-time streaming (ASIOCreateBuffers / ASIOStart /
+// ASIOStop / ASIODisposeBuffers + the bufferSwitch trampolines).
 //
 // Threading: all host downcalls are serialized by the JVM's dedicated
 // `asio-control` platform thread. They must never be called from the audio
-// render thread. The only cross-thread entrypoint is the driver-owned
-// format-change callback trampoline at the bottom of this file.
+// render thread. The cross-thread entrypoints are the four ASIOCallbacks
+// slots the vendor driver invokes on its own real-time thread: the
+// story-218 asioshim_messageTrampoline (asioMessage), the story-311
+// asioshim_bufferSwitchTrampoline (bufferSwitch), and the two file-local
+// slots shimBufferSwitchTimeInfo and shimSampleRateDidChange. All four are
+// deliberately lock-free; see the banner above the story-311 section.
 
 #define ASIOSHIM_EXPORTS
 #include "asioshim.h"
@@ -21,18 +27,46 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 
 #define ASIOSHIM_EXPORT ASIOSHIM_API
 
 // Defined by the SDK's common/asio.cpp; the indexed host-glue open path
 // assigns the single process-wide IASIO instance before ASIOInit.
 extern IASIO* theAsioDriver;
+
+// Defined by the SDK's host/asiodrivers.cpp as `AsioDrivers* asioDrivers = 0;`.
+// asiodrivers.h does not declare it, so we mirror the same extern declaration
+// that Steinberg's own common/asio.cpp carries.
+//
+// story 311 — WHY WE OWN THIS GLOBAL'S LIFETIME. The stock Steinberg
+// ASIOExit() is:
+//
+//     ASIOError ASIOExit(void) {
+//         if (theAsioDriver) {
+//     #if WINDOWS
+//             asioDrivers->removeCurrentDriver();   // no null check
+//     ...
+//
+// and `asioDrivers` is assigned *only* inside loadAsioDriver(char*).
+// ShimAsioDrivers::loadAt deliberately bypasses loadAsioDriver — it calls the
+// protected asioOpenDriver() so a driver whose registry key differs from its
+// description is still loadable by index, and assigns theAsioDriver itself —
+// so the SDK global would stay null for the whole process lifetime and
+// ASIOExit() would perform a null-`this` member access on
+// AsioDrivers::removeCurrentDriver(), which reads and writes this->curIndex.
+// We therefore publish our own instance into it on load and clear it before
+// destroying that instance, so the SDK's own teardown works and the global
+// never dangles. (rtaudio's vendored copy of asio.cpp carries an
+// `if (asioDrivers)` patch; the SDK we build against does not.)
+extern AsioDrivers* asioDrivers;
 
 static_assert(sizeof(long) == 4,
               "asioshim requires the Windows LLP64 32-bit C long ABI");
@@ -93,6 +127,11 @@ namespace {
     ShimAsioDrivers& driverList() {
         if (!g_drivers) {
             g_drivers = std::make_unique<ShimAsioDrivers>();
+            // Keep the SDK's process-global in step with ours the moment the
+            // manager exists — see the extern declaration at the top of this
+            // file (story 311). g_drivers non-null always implies
+            // asioDrivers == g_drivers.get().
+            asioDrivers = g_drivers.get();
         }
         return *g_drivers;
     }
@@ -129,12 +168,167 @@ namespace {
         return clsid;
     }
 
+    // ─── Real-time streaming state (story 311) ──────────────────────
+    //
+    // g_buffersCreated, g_outputReadySupported and g_callbacksInFlight are
+    // std::atomic because the driver's real-time bufferSwitch trampoline
+    // reads and writes them without taking g_driverMutex (see the story-311
+    // banner near the bottom of this file). Everything else here is written
+    // and read only on the `asio-control` thread while g_driverMutex is held.
+    //
+    // MAX_STREAM_CHANNELS caps inputs + outputs *combined*, so a symmetric
+    // configuration tops out at 32 in + 32 out.
+    constexpr int MAX_STREAM_CHANNELS = 64;
+    constexpr int BUFFER_INFO_STRIDE = 32;
+    // Not a valid ASIOSampleType; means "the driver refused to report a
+    // sample type for this channel". The Java side treats anything other
+    // than ASIOSTFloat32LSB as unsupported (story 312 generalises it).
+    constexpr int32_t SAMPLE_TYPE_UNKNOWN = -1;
+    // Upper bound on how long a control-path teardown waits for in-flight
+    // driver callbacks to drain. Best-effort by design: a driver whose
+    // bufferSwitch never returns must not hang the `asio-control` thread.
+    constexpr int DRAIN_TIMEOUT_MS = 100;
+
+    // The driver retains &g_callbacks for the whole lifetime of the
+    // created buffers, so the table must outlive asioshim_createBuffers.
+    ASIOCallbacks g_callbacks{};
+    std::array<ASIOBufferInfo, MAX_STREAM_CHANNELS> g_bufferInfos{};
+    std::array<int32_t, MAX_STREAM_CHANNELS> g_sampleTypes{};
+    int g_bufferInfoCount = 0;
+    std::atomic<bool> g_buffersCreated{false};
+    std::atomic<bool> g_outputReadySupported{false};
+    // Number of driver callbacks currently executing inside
+    // shimBufferSwitchBody. Teardown drains this to zero so it can be sure
+    // no callback is still writing into the driver's buffers or calling the
+    // JVM upcall stub the Java side is about to free.
+    std::atomic<int> g_callbacksInFlight{0};
+    bool g_started = false;
+
+    // RAII counter for shimBufferSwitchBody: increments on construction and
+    // decrements on *every* exit path, including an early return. Lock-free
+    // and allocation-free, so it is safe on the driver's real-time thread.
+    class CallbackInFlightGuard final {
+    public:
+        // seq_cst on the way in: it has to participate in the total order
+        // described on drainInFlightCallbacks(). Plain release is enough on
+        // the way out — the decrement happens after everything the body
+        // touched, and a draining thread only ever needs to not see it too
+        // early.
+        CallbackInFlightGuard() {
+            g_callbacksInFlight.fetch_add(1, std::memory_order_seq_cst);
+        }
+
+        ~CallbackInFlightGuard() {
+            g_callbacksInFlight.fetch_sub(1, std::memory_order_release);
+        }
+
+        CallbackInFlightGuard(const CallbackInFlightGuard&) = delete;
+        CallbackInFlightGuard& operator=(const CallbackInFlightGuard&) = delete;
+    };
+
+    // Waits until no driver callback is inside shimBufferSwitchBody.
+    //
+    // This is the barrier the "buffers created" flag alone cannot provide:
+    // the flag is read once at callback entry, so flipping it does nothing
+    // for a callback that is already past the check.
+    //
+    // Six operations are sequentially consistent so that they share one
+    // total order: the counter increment, the g_buffersCreated load and the
+    // g_bufferSwitchCallback load in the callback; the g_buffersCreated
+    // store in clearBufferStateLocked(); the g_bufferSwitchCallback store in
+    // uninstallAsioBufferSwitchCallback(); and the counter load below. The
+    // consequence is that a callback which still observes the pre-teardown
+    // value of either gate must appear before the corresponding store in
+    // that total order, hence its increment does too, hence this counter
+    // load sees it. A release store followed by an acquire load would leave
+    // the classic store-buffer hole — StoreLoad is the one reordering
+    // acquire/release do not forbid.
+    //
+    // Safe to call while holding g_driverMutex: the callback path never
+    // takes that mutex (see the story-311 real-time banner), so a draining
+    // control thread can never be waiting on a callback parked behind it.
+    // Bounded by DRAIN_TIMEOUT_MS against a monotonic clock, so the loop
+    // always terminates.
+    void drainInFlightCallbacks() {
+        std::chrono::steady_clock::time_point deadline =
+                std::chrono::steady_clock::now()
+                        + std::chrono::milliseconds(DRAIN_TIMEOUT_MS);
+        while (g_callbacksInFlight.load(std::memory_order_seq_cst) != 0) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return;
+            }
+            std::this_thread::yield();
+        }
+    }
+
+    // Zeroes every cached streaming fact. Callers must already hold
+    // g_driverMutex. g_buffersCreated is published false first so a late
+    // driver callback observes "no buffers" before the cache is torn down;
+    // callers that then re-enter the SDK must also drainInFlightCallbacks()
+    // to be sure no callback is still mid-body.
+    void clearBufferStateLocked() {
+        g_buffersCreated.store(false, std::memory_order_seq_cst);
+        g_outputReadySupported.store(false, std::memory_order_release);
+        g_bufferInfos.fill(ASIOBufferInfo{});
+        g_sampleTypes.fill(SAMPLE_TYPE_UNKNOWN);
+        g_bufferInfoCount = 0;
+    }
+
+    // Returns false only when the driver itself refused ASIOStop(). A stop
+    // with nothing running is a successful no-op.
+    bool stopStreamingLocked() {
+        if (!g_started) {
+            return true;
+        }
+        // Clear the flag first so a subsequent failure inside the SDK still
+        // leaves the shim in the "stopped" state (idempotency contract).
+        g_started = false;
+        ASIOError err = ASIOStop();
+        // A conforming driver has already joined its callback thread by the
+        // time ASIOStop returns. Drain anyway: the story-311 driver-reset
+        // path tears down from a different thread while the driver is still
+        // running, so a callback really can be mid-body here.
+        drainInFlightCallbacks();
+        return err == ASE_OK;
+    }
+
+    // Returns false when the driver refused ASIOStop() or
+    // ASIODisposeBuffers(); true when there was simply nothing to dispose.
+    bool disposeBuffersLocked() {
+        bool stopped = stopStreamingLocked();
+        bool hadBuffers = g_buffersCreated.load(std::memory_order_seq_cst);
+        clearBufferStateLocked();
+        if (!hadBuffers) {
+            return stopped;
+        }
+        // No callback may still be inside the body when the driver frees
+        // the very buffers that body writes into.
+        drainInFlightCallbacks();
+        ASIOError err = ASIODisposeBuffers();
+        return stopped && err == ASE_OK;
+    }
+
     void unloadDriverLocked() {
         if (g_driverLoaded) {
+            // story 311: stop and dispose before ASIOExit so a close() that
+            // skips the explicit teardown still leaves the vendor driver
+            // clean rather than exiting with live buffers. The status is
+            // deliberately ignored — unload is unconditional.
+            (void) disposeBuffersLocked();
             ASIOExit();
         }
+        clearBufferStateLocked();
+        g_started = false;
+        g_callbacks = {};
         if (g_drivers) {
+            // When ASIOExit() ran above it already reached this same object
+            // through the SDK's `asioDrivers` global; removeCurrentDriver()
+            // leaves curIndex == -1, so this second call is a no-op. It
+            // still matters for the paths that never got as far as ASIOInit.
             g_drivers->removeCurrentDriver();
+            // Clear the SDK global before destroying the object it points
+            // at — see the extern declaration at the top of this file.
+            asioDrivers = nullptr;
             g_drivers.reset();
         }
         g_driverLoaded = false;
@@ -215,6 +409,11 @@ ASIOSHIM_EXPORT int asioshim_loadDriver(const char* driverName) {
         copyFixedAscii(reinterpret_cast<unsigned char*>(mutableName.data()),
                        mutableName.size(), driverName);
         g_drivers = std::make_unique<ShimAsioDrivers>();
+        // story 311: publish our manager into the SDK's process-global
+        // `asioDrivers` before anything can reach ASIOExit(), which
+        // dereferences it without a null check. See the extern declaration
+        // at the top of this file.
+        asioDrivers = g_drivers.get();
         long matchingIndex = -1;
         long count = std::min(driverList().count(),
                               static_cast<long>(DRIVER_CAPACITY));
@@ -584,10 +783,12 @@ ASIOSHIM_EXPORT void uninstallAsioMessageCallback() {
     g_asioMessageCallback.store(nullptr, std::memory_order_release);
 }
 
-// The SDK's ASIOCallbacks struct contains a slot called asioMessage
-// that the host-side glue (asiodrivers.cpp) routes through this
-// trampoline. The trampoline is referenced from the SDK glue when
-// asioshim is built with -DASIOSHIM_TRAMPOLINE.
+// This IS the ASIOCallbacks::asioMessage slot, not a wrapper around it:
+// asioshim_createBuffers assigns this function into g_callbacks.asioMessage
+// (see `g_callbacks.asioMessage = asioshim_messageTrampoline;` below) and
+// the vendor driver calls it directly, on its own thread. It loads the
+// callback installed by the JVM and forwards selector / value / message /
+// opt verbatim. Like the bufferSwitch trampoline it takes no lock.
 ASIOSHIM_EXPORT long asioshim_messageTrampoline(
         long selector, long value, void* message, double* opt) {
     asio_message_fn cb = g_asioMessageCallback.load(std::memory_order_acquire);
@@ -595,4 +796,395 @@ ASIOSHIM_EXPORT long asioshim_messageTrampoline(
         return 0;
     }
     return cb(selector, value, message, opt);
+}
+
+// ─── Real-time streaming (story 311) ────────────────────────────────
+//
+// asioshim_createBuffers is where the process-global ASIOCallbacks table is
+// finally populated. That makes the story-218 asioshim_messageTrampoline
+// reachable for the first time: before this story no ASIOCallbacks struct was
+// ever constructed, so the driver had nowhere to deliver kAsioResetRequest /
+// kAsioBufferSizeChange / kAsioResyncRequest.
+//
+// Lifecycle contract:
+//   asioshim_createBuffers → asioshim_getBufferInfos → asioshim_start
+//     … streaming … → asioshim_stop → asioshim_disposeBuffers
+// asioshim_stop and asioshim_disposeBuffers are idempotent so the Java
+// close() path can call them unconditionally: "nothing to do" is SHIM_OK.
+// "The driver refused" is not — a non-ASE_OK ASIOStop / ASIODisposeBuffers
+// returns SHIM_FAIL. That status is a *diagnostic*, not a stop signal:
+// AsioBackend#tearDownStreaming logs it at WARNING and deliberately carries
+// on through the rest of the teardown. What protects the JVM upcall stub
+// from a driver that ignored ASIOStop is the in-flight barrier plus the null
+// callback pointer published by uninstallAsioBufferSwitchCallback (see the
+// REAL-TIME DISCIPLINE banner below) — not ASIOStop having succeeded. Bailing
+// out on a refusal would skip the very uninstall that makes the arena free
+// safe. unloadDriverLocked() runs the same teardown before ASIOExit.
+//
+// ── REAL-TIME DISCIPLINE — read before touching shimBufferSwitchBody ──
+//
+// The bufferSwitch callbacks run on the *vendor driver's* real-time audio
+// thread, not on `asio-control`. They MUST NEVER take g_driverMutex. Every
+// other export in this file locks it, so a lock here would be both:
+//
+//   (a) an RT violation — an unbounded, priority-inversion-prone blocking
+//       operation inside the audio callback; and
+//   (b) a deadlock hazard — a control thread inside asioshim_stop() holds
+//       g_driverMutex while ASIOStop() waits for the driver's callback
+//       thread to quiesce, and that callback would be parked on the very
+//       mutex ASIOStop is waiting behind.
+//
+// The only synchronisation permitted here is std::atomic, and it is two
+// mechanisms working together:
+//
+//   1. State gates. A null g_bufferSwitchCallback (after uninstall) makes
+//      the callback a cheap no-op, and g_buffersCreated is published false
+//      *before* the SDK teardown so a callback that has not started yet
+//      returns without touching disposed state.
+//   2. An in-flight barrier. Both gates are read once, at entry — they say
+//      nothing about a callback that is already past them. Every callback
+//      therefore counts itself into g_callbacksInFlight via
+//      CallbackInFlightGuard, and every teardown step calls
+//      drainInFlightCallbacks() before it lets the SDK (or the JVM) free
+//      anything the body touches. Because the callback never takes
+//      g_driverMutex, a control thread may hold that mutex while draining
+//      without any risk of deadlock.
+
+namespace {
+    std::atomic<asio_buffer_switch_fn> g_bufferSwitchCallback{nullptr};
+
+    // Shared body of both Steinberg bufferSwitch entry points.
+    // Lock-free and allocation-free by contract — see the banner above.
+    void shimBufferSwitchBody(long bufferIndex, ASIOBool directProcess) {
+        // Count in first, then re-read the gate: that ordering is what lets
+        // drainInFlightCallbacks() conclude that a zero counter means no
+        // callback is inside this body. The guard decrements on every exit
+        // path, including the two early returns below.
+        CallbackInFlightGuard inFlight;
+        if (!g_buffersCreated.load(std::memory_order_seq_cst)) {
+            return;
+        }
+        // seq_cst, not merely acquire: this load has to join the total order
+        // described on drainInFlightCallbacks() so that a callback which
+        // still sees the pre-uninstall pointer is guaranteed to be counted.
+        asio_buffer_switch_fn cb =
+                g_bufferSwitchCallback.load(std::memory_order_seq_cst);
+        if (cb == nullptr) {
+            // No upcall installed — between asioshim_start and
+            // installAsioBufferSwitchCallback, or after an uninstall that
+            // ASIOStop has not yet caught up with. Nothing filled the output
+            // half this cycle, so signalling ASIOOutputReady() here would
+            // tell the driver to play back whatever the previous cycle left
+            // behind: audible looped garbage instead of silence. Stay quiet.
+            return;
+        }
+        // directProcess is forwarded verbatim; the shim always processes
+        // inline, so it is informational for the JVM upcall.
+        cb(bufferIndex, static_cast<long>(directProcess));
+        // Called natively rather than from Java so the JVM upcall stays a
+        // pure memory copy. Only meaningful when the driver advertised
+        // support at ASIOCreateBuffers time (probed once, cached), and only
+        // reached once the upcall above has actually filled the output half.
+        if (g_outputReadySupported.load(std::memory_order_acquire)) {
+            ASIOOutputReady();
+        }
+    }
+
+    // ASIOCallbacks::bufferSwitchTimeInfo slot (ASIO 2.0 entry point).
+    // `params` is unused: the shim does not consume the driver's time
+    // stamps (round-trip latency reporting is story 217). The driver
+    // ignores the return value; Steinberg's own hostsample returns 0L.
+    ASIOTime* shimBufferSwitchTimeInfo(ASIOTime* params,
+                                       long doubleBufferIndex,
+                                       ASIOBool directProcess) {
+        (void) params;
+        shimBufferSwitchBody(doubleBufferIndex, directProcess);
+        return nullptr;
+    }
+
+    // ASIOCallbacks::sampleRateDidChange slot. The hardware clock changed
+    // rate underneath us, which invalidates the negotiated format. Report it
+    // as a driver reset through the story-218 message trampoline rather than
+    // inventing a second upcall — AsioFormatChangeShim's Javadoc already
+    // anticipates exactly this: "Sample-rate-driven resets … are reported as
+    // DriverReset and the controller re-queries device capabilities on
+    // reopen." Also lock-free: this too arrives on the driver's thread.
+    void shimSampleRateDidChange(ASIOSampleRate sampleRate) {
+        (void) sampleRate;
+        asioshim_messageTrampoline(static_cast<long>(kAsioResetRequest),
+                                   0, nullptr, nullptr);
+    }
+}
+
+// Creates the driver's double-buffered I/O buffers for the requested active
+// channels and installs the host callback table.
+//
+// inputChannels[0..numInputs) and outputChannels[0..numOutputs) are driver
+// channel indices. The resulting ASIOBufferInfo records — and therefore the
+// records asioshim_getBufferInfos reports — are ordered inputs first (in
+// inputChannels order) then outputs (in outputChannels order).
+//
+// numInputs + numOutputs is capped at MAX_STREAM_CHANNELS (64) *combined*,
+// so a symmetric configuration tops out at 32 in + 32 out.
+//
+// Requires a loaded driver and no already-created buffers. Returns SHIM_OK
+// (1) on ASE_OK, SHIM_FAIL (0) otherwise; a failure leaves no partial state.
+//
+// There is no try/catch here (nor in the other story-311 exports): nothing
+// in the body can throw — std::array::fill over PODs, plain assignment, and
+// C calls into the SDK — and MSVC's default /EHsc does not turn an access
+// violation inside a vendor driver into a C++ exception, so a handler would
+// be unreachable. The genuinely reachable handlers are the ones in
+// asioshim_listDrivers / asioshim_loadDriver, where std::make_unique can
+// throw std::bad_alloc.
+ASIOSHIM_EXPORT int asioshim_createBuffers(const int* inputChannels,
+                                           int numInputs,
+                                           const int* outputChannels,
+                                           int numOutputs,
+                                           int bufferFrames) {
+    if (numInputs < 0 || numOutputs < 0 || bufferFrames <= 0) {
+        return SHIM_FAIL;
+    }
+    if ((numInputs > 0 && !inputChannels)
+            || (numOutputs > 0 && !outputChannels)) {
+        return SHIM_FAIL;
+    }
+    int total = numInputs + numOutputs;
+    if (total <= 0 || total > MAX_STREAM_CHANNELS) {
+        return SHIM_FAIL;
+    }
+    // Validate every channel index before entering the SDK — a negative
+    // index would be forwarded straight into the vendor driver.
+    for (int index = 0; index < numInputs; ++index) {
+        if (inputChannels[index] < 0) {
+            return SHIM_FAIL;
+        }
+    }
+    for (int index = 0; index < numOutputs; ++index) {
+        if (outputChannels[index] < 0) {
+            return SHIM_FAIL;
+        }
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded || g_buffersCreated.load(std::memory_order_acquire)) {
+        return SHIM_FAIL;
+    }
+    clearBufferStateLocked();
+    for (int index = 0; index < numInputs; ++index) {
+        ASIOBufferInfo& info = g_bufferInfos[index];
+        info.isInput = ASIOTrue;
+        info.channelNum = static_cast<long>(inputChannels[index]);
+        info.buffers[0] = nullptr;
+        info.buffers[1] = nullptr;
+    }
+    for (int index = 0; index < numOutputs; ++index) {
+        ASIOBufferInfo& info = g_bufferInfos[numInputs + index];
+        info.isInput = ASIOFalse;
+        info.channelNum = static_cast<long>(outputChannels[index]);
+        info.buffers[0] = nullptr;
+        info.buffers[1] = nullptr;
+    }
+
+    // Both trampolines the driver calls are the exported symbols themselves,
+    // so the DLL's public surface is exactly what the driver invokes.
+    g_callbacks.bufferSwitch = asioshim_bufferSwitchTrampoline;
+    g_callbacks.sampleRateDidChange = &shimSampleRateDidChange;
+    // story 218: the JVM-installed asioMessage upcall finally gets a
+    // slot in a real ASIOCallbacks table.
+    g_callbacks.asioMessage = asioshim_messageTrampoline;
+    // bufferSwitchTimeInfo keeps the file-local function: its signature
+    // (ASIOTime*) has no useful FFM mapping, so exporting it would only add
+    // a symbol nothing calls.
+    g_callbacks.bufferSwitchTimeInfo = &shimBufferSwitchTimeInfo;
+
+    ASIOError err = ASIOCreateBuffers(g_bufferInfos.data(),
+                                      static_cast<long>(total),
+                                      static_cast<long>(bufferFrames),
+                                      &g_callbacks);
+    if (err != ASE_OK) {
+        // ASIOCreateBuffers can fail part-way through — e.g. 32 in + 32 out
+        // requested on a 32-in/16-out device allocates the inputs and then
+        // refuses the outputs — leaving the driver holding buffers and a
+        // live pointer to &g_callbacks. Dispose *before* clearing our state:
+        // clearBufferStateLocked() publishes g_buffersCreated = false, after
+        // which disposeBuffersLocked() would skip ASIODisposeBuffers()
+        // forever and the device would stay unusable (every retry answered
+        // with "buffers already created") until the process restarts.
+        //
+        // Harmless when the driver allocated nothing: g_driverLoaded is
+        // checked above so the SDK always has a driver to forward to, and a
+        // driver with no buffers simply answers with an error we ignore.
+        ASIODisposeBuffers();
+        clearBufferStateLocked();
+        return SHIM_FAIL;
+    }
+    // Cache each channel's ASIOSampleType now so the real-time path
+    // never has to re-enter the SDK to learn the driver's format.
+    for (int index = 0; index < total; ++index) {
+        ASIOChannelInfo channelInfo{};
+        channelInfo.channel = g_bufferInfos[index].channelNum;
+        channelInfo.isInput = g_bufferInfos[index].isInput;
+        g_sampleTypes[index] =
+                (ASIOGetChannelInfo(&channelInfo) == ASE_OK)
+                        ? static_cast<int32_t>(channelInfo.type)
+                        : SAMPLE_TYPE_UNKNOWN;
+    }
+    g_bufferInfoCount = total;
+    g_outputReadySupported.store(ASIOOutputReady() == ASE_OK,
+                                 std::memory_order_release);
+    g_buffersCreated.store(true, std::memory_order_release);
+    return SHIM_OK;
+}
+
+// Reports the buffer addresses ASIOCreateBuffers handed back, so the JVM
+// can read and write the driver's buffers directly (the sample-format
+// conversion boundary lives in Java — story 312 generalises it).
+//
+// Writes a fixed 32-byte record per active channel, in exactly the order
+// passed to asioshim_createBuffers:
+//   [0..4)   int32 channel      driver channel index
+//   [4..8)   int32 isInput      1 = input, 0 = output
+//   [8..12)  int32 sampleType   driver ASIOSampleType (-1 = unknown)
+//   [12..16) int32 reserved     always 0 (keeps the pointers 8-byte aligned)
+//   [16..24) int64 buffer0      address of ASIOBufferInfo.buffers[0]
+//   [24..32) int64 buffer1      address of ASIOBufferInfo.buffers[1]
+//
+// *outCount is capacity-in / actual-written-out. A zero-capacity call is a
+// successful no-op. Fails with *outCount = 0 when no driver is loaded or
+// buffers have not been created.
+ASIOSHIM_EXPORT int asioshim_getBufferInfos(void* outArray, int* outCount) {
+    if (!outCount) {
+        return SHIM_FAIL;
+    }
+    int capacity = *outCount;
+    *outCount = 0;
+    if (capacity < 0) {
+        return SHIM_FAIL;
+    }
+    if (capacity > 0 && !outArray) {
+        return SHIM_FAIL;
+    }
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded || !g_buffersCreated.load(std::memory_order_acquire)) {
+        return SHIM_FAIL;
+    }
+    if (capacity == 0) {
+        return SHIM_OK;
+    }
+    int written = std::min(capacity, g_bufferInfoCount);
+    auto* bytes = static_cast<unsigned char*>(outArray);
+    for (int index = 0; index < written; ++index) {
+        const ASIOBufferInfo& info = g_bufferInfos[index];
+        unsigned char* row = bytes + (index * BUFFER_INFO_STRIDE);
+        // Pack little-endian via memcpy (ASIO is Windows-only — x64 /
+        // x86 / ARM64, all little-endian — so this matches the Java
+        // ValueLayout.JAVA_INT / JAVA_LONG host-endian contract).
+        int32_t channel    = static_cast<int32_t>(info.channelNum);
+        int32_t isInput    = (info.isInput != ASIOFalse) ? 1 : 0;
+        int32_t sampleType = g_sampleTypes[index];
+        int32_t reserved   = 0;
+        int64_t buffer0    = static_cast<int64_t>(
+                reinterpret_cast<std::uintptr_t>(info.buffers[0]));
+        int64_t buffer1    = static_cast<int64_t>(
+                reinterpret_cast<std::uintptr_t>(info.buffers[1]));
+        std::memcpy(row + 0,  &channel,    4);
+        std::memcpy(row + 4,  &isInput,    4);
+        std::memcpy(row + 8,  &sampleType, 4);
+        std::memcpy(row + 12, &reserved,   4);
+        std::memcpy(row + 16, &buffer0,    8);
+        std::memcpy(row + 24, &buffer1,    8);
+    }
+    *outCount = written;
+    return SHIM_OK;
+}
+
+// Wraps ASIOStart(). Requires created buffers. Returns SHIM_OK (1) when the
+// driver is already streaming, so the call is safe to repeat.
+ASIOSHIM_EXPORT int asioshim_start(void) {
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    if (!g_driverLoaded || !g_buffersCreated.load(std::memory_order_acquire)) {
+        return SHIM_FAIL;
+    }
+    if (g_started) {
+        return SHIM_OK;
+    }
+    if (ASIOStart() != ASE_OK) {
+        return SHIM_FAIL;
+    }
+    g_started = true;
+    return SHIM_OK;
+}
+
+// Wraps ASIOStop(). Idempotent in the "nothing to do" sense: returns
+// SHIM_OK (1) when nothing is streaming — including when no driver is
+// loaded at all — so the Java close() path can call it unconditionally
+// without branching on state.
+//
+// It does NOT paper over a refusal: when ASIOStop() itself returns anything
+// other than ASE_OK the driver may still be firing bufferSwitch, so this
+// returns SHIM_FAIL. The Java side consumes that as a diagnostic rather than
+// as a stop signal — AsioBackend#tearDownStreaming logs it at WARNING, naming
+// the refused call and the driver, and then continues the teardown.
+//
+// Continuing is the safe response. asioshim_disposeBuffers publishes
+// g_buffersCreated = false before it re-enters the SDK and then drains the
+// in-flight barrier, so a later callback short-circuits at the top of
+// shimBufferSwitchBody without ever loading the callback pointer; then
+// uninstallAsioBufferSwitchCallback stores a null pointer and drains again,
+// after which the trampoline loads null and returns without touching the
+// upcall stub. Only then does Java free the arena, so the free is guarded by
+// those two steps — not by ASIOStop. Aborting here would skip the uninstall
+// that is the actual protection and would leak the upcall arena and the
+// asio-input-drain thread for the life of the process.
+ASIOSHIM_EXPORT int asioshim_stop(void) {
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    return stopStreamingLocked() ? SHIM_OK : SHIM_FAIL;
+}
+
+// Wraps ASIODisposeBuffers(), stopping the driver first when it is still
+// streaming. Clears the cached buffer records and the output-ready probe.
+//
+// Same distinction as asioshim_stop: SHIM_OK (1) when there was nothing to
+// dispose, SHIM_FAIL (0) when the driver refused ASIOStop() or
+// ASIODisposeBuffers().
+ASIOSHIM_EXPORT int asioshim_disposeBuffers(void) {
+    std::lock_guard<std::mutex> lock(g_driverMutex);
+    return disposeBuffersLocked() ? SHIM_OK : SHIM_FAIL;
+}
+
+// Registers the JVM FFM upcall invoked from every bufferSwitch. Mirrors
+// installAsioMessageCallback (a single atomic store) so the real-time
+// trampoline never needs a lock to observe the swap.
+ASIOSHIM_EXPORT void installAsioBufferSwitchCallback(void* callback) {
+    g_bufferSwitchCallback.store(
+            reinterpret_cast<asio_buffer_switch_fn>(callback),
+            std::memory_order_release);
+}
+
+// Nulling the pointer only stops callbacks that have not read it yet, so
+// wait for the ones that already have. The Java side frees the upcall
+// stub's arena right after this returns; a callback still inside
+// shimBufferSwitchBody would otherwise jump into released memory.
+//
+// The store is seq_cst so that it joins the total order described on
+// drainInFlightCallbacks() together with the callback's seq_cst increment
+// and matching seq_cst load of the same pointer: a callback that still
+// observes the old, non-null pointer is therefore guaranteed to be visible
+// in the counter this drain reads.
+ASIOSHIM_EXPORT void uninstallAsioBufferSwitchCallback() {
+    g_bufferSwitchCallback.store(nullptr, std::memory_order_seq_cst);
+    drainInFlightCallbacks();
+}
+
+// The ASIOCallbacks::bufferSwitch slot itself (the ASIO 1.0 entry point),
+// wired in asioshim_createBuffers exactly the way asioshim_messageTrampoline
+// is wired into the asioMessage slot. It is exported rather than file-local
+// so both driver-invoked trampolines are visible in the DLL's symbol table
+// for diagnostics.
+//
+// Runs on the vendor driver's real-time thread and takes no lock — see the
+// REAL-TIME DISCIPLINE banner above.
+ASIOSHIM_EXPORT void asioshim_bufferSwitchTrampoline(long bufferIndex,
+                                                     long directProcess) {
+    shimBufferSwitchBody(bufferIndex, static_cast<ASIOBool>(directProcess));
 }

--- a/daw-core/native/asio/asioshim.h
+++ b/daw-core/native/asio/asioshim.h
@@ -30,13 +30,48 @@
 //   - `asioshim_setClockSource` returns the raw `ASIOError` directly
 //     (0 on `ASE_OK`, negative on the SDK's standard error codes).
 //
+// `asioshim_stop` and `asioshim_disposeBuffers` (story 311) are idempotent
+// teardown steps the Java `close()` path calls unconditionally, so they
+// return `1` when there is *nothing to do*: no driver loaded, not started,
+// or no buffers created.
+//
+// They do **not** report `1` when the driver refuses. If `ASIOStop()` or
+// `ASIODisposeBuffers()` returns anything other than `ASE_OK` these return
+// `0`, because a driver that may still be firing `bufferSwitch` is worth
+// surfacing. "Nothing to do" is a success; "the driver said no" is a failure.
+//
+// That failure is a diagnostic, not a stop signal. The Java caller
+// (`AsioBackend#tearDownStreaming`) logs it at WARNING and continues the
+// teardown: the upcall stub is protected by the bounded in-flight callback
+// barrier and by the null callback pointer `uninstallAsioBufferSwitchCallback`
+// publishes, not by `ASIOStop` having succeeded — so aborting on a refusal
+// would skip the uninstall that makes the caller's arena free safe.
+//
+// ──────────────────────────────────────────────────────────────────
+// Thread affinity
+// ──────────────────────────────────────────────────────────────────
+// All capability, control-panel, and streaming-control exports require a
+// successfully loaded driver. Callers must use asioshim_loadDriver first;
+// unloaded calls fail without entering the Steinberg SDK. None of these
+// lifecycle/capability/streaming-control exports may be invoked on the
+// audio render thread — or on the driver's own callback thread, which the
+// ASIO contract forbids.
+//
+// Two exports are never called by the host at all. They *are* driver
+// callbacks: `asioshim_createBuffers` installs them into the process-global
+// `ASIOCallbacks` table and the vendor driver invokes them on its own
+// real-time audio thread —
+//   - `asioshim_bufferSwitchTrampoline` → `ASIOCallbacks::bufferSwitch`
+//   - `asioshim_messageTrampoline`      → `ASIOCallbacks::asioMessage`
+// Two further driver-thread entry points are file-local to `asioshim.cpp`
+// and deliberately not exported, because their signatures have no useful
+// FFM mapping: the `ASIOCallbacks::bufferSwitchTimeInfo` and
+// `ASIOCallbacks::sampleRateDidChange` slots. All four are lock-free; see
+// the REAL-TIME DISCIPLINE banner in `asioshim.cpp`.
+//
 // ──────────────────────────────────────────────────────────────────
 // Pointer ABIs
 // ──────────────────────────────────────────────────────────────────
-// All capability and control-panel exports require a successfully loaded
-// driver. Callers must use asioshim_loadDriver first; unloaded calls fail
-// without entering the Steinberg SDK. None of these lifecycle/capability
-// exports may be invoked on the audio render thread.
 //
 // `asioshim_listDrivers` writes a fixed 168-byte struct per entry:
 //   offset   0..128  char name[128]   ASCII, NUL-terminated
@@ -69,9 +104,28 @@
 //   offset 20..24  int32 reserved (padding so name starts at byte 24)
 //   offset 24..56  char  name[32]  ASCII, NUL-terminated
 //
-// Both struct layouts are normalised to 32-bit integer fields so the
-// Java FFM layer can use `ValueLayout.JAVA_INT` without tracking the
-// SDK's platform-dependent `long` width.
+// `asioshim_getBufferInfos` writes a fixed 32-byte struct per active
+// channel (story 311). Records appear in exactly the order passed to
+// `asioshim_createBuffers`: all inputs first (in `inputChannels` order),
+// then all outputs (in `outputChannels` order):
+//   offset  0..4   int32 channel     driver channel index
+//   offset  4..8   int32 isInput     (1 = input, 0 = output)
+//   offset  8..12  int32 sampleType  driver `ASIOSampleType`, -1 if the
+//                                    driver refused to report one
+//   offset 12..16  int32 reserved    always 0 — padding so the two
+//                                    addresses below are 8-byte aligned
+//   offset 16..24  int64 buffer0     address of `ASIOBufferInfo.buffers[0]`
+//   offset 24..32  int64 buffer1     address of `ASIOBufferInfo.buffers[1]`
+// The two addresses are the driver's own double-buffer halves; the JVM
+// reads and writes them directly because the sample-format conversion
+// boundary lives in Java (story 312 generalises it). They are valid only
+// between a successful `asioshim_createBuffers` and the matching
+// `asioshim_disposeBuffers` / `asioshim_unloadDriver`.
+//
+// All struct layouts are normalised to 32-bit integer fields (plus the
+// two 64-bit addresses above) so the Java FFM layer can use
+// `ValueLayout.JAVA_INT` / `JAVA_LONG` without tracking the SDK's
+// platform-dependent `long` width.
 
 #ifndef ASIOSHIM_H_
 #define ASIOSHIM_H_
@@ -92,6 +146,24 @@
 #  define ASIOSHIM_API extern "C" ASIOSHIM_DECL
 #else
 #  define ASIOSHIM_API ASIOSHIM_DECL
+#endif
+
+// ── Windows-only `long` precondition ──────────────────────────────
+// The two callback typedefs below spell Steinberg's native `long` so they
+// stay ABI-exact against `ASIOCallbacks`. asioshim is a Windows-x64-only
+// artefact (story 224 non-goals) and Windows is LLP64, so `long` is 32 bits
+// and maps to `ValueLayout.JAVA_INT` on the Java FFM side — never Java
+// `long`. On an LP64 host `long` would be 64 bits and that mapping would
+// silently become false, so the precondition is asserted here for anyone who
+// includes this header, as well as in `asioshim.cpp`.
+#if defined(_WIN32)
+#  if defined(__cplusplus)
+static_assert(sizeof(long) == 4,
+              "asioshim requires the Windows LLP64 32-bit C long ABI");
+#  elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(sizeof(long) == 4,
+               "asioshim requires the Windows LLP64 32-bit C long ABI");
+#  endif
 #endif
 
 // ── Driver discovery and lifecycle (story 310) ────────────────────
@@ -126,7 +198,7 @@ ASIOSHIM_API int  asioshim_getChannelInfo(int channelIndex, int isInput,
 // Keep the native spelling as `long` so this function-pointer type is exactly
 // compatible with Steinberg's ASIOCallbacks::asioMessage declaration. Windows
 // uses LLP64, so `long` remains 32 bits on x64 and maps to JAVA_INT at the Java
-// FFM boundary (enforced by a static_assert in asioshim.cpp).
+// FFM boundary (see the static_assert above, and its twin in asioshim.cpp).
 //   long asioMessage(long selector, long value,
 //                    void* message, double* opt);
 typedef long (*asio_message_fn)(long selector, long value,
@@ -135,11 +207,74 @@ typedef long (*asio_message_fn)(long selector, long value,
 ASIOSHIM_API void installAsioMessageCallback(void* callback);
 ASIOSHIM_API void uninstallAsioMessageCallback(void);
 
-// Trampoline routed into Steinberg's `ASIOCallbacks::asioMessage` slot
-// by the SDK glue when asioshim is built with
-// `-DASIOSHIM_TRAMPOLINE`; loads the callback installed by the JVM and
-// forwards the selector / value / message / opt arguments verbatim.
+// This function *is* Steinberg's `ASIOCallbacks::asioMessage` slot, not a
+// wrapper around it: `asioshim_createBuffers` (story 311) assigns it into
+// the process-global callback table, and the vendor driver calls it directly
+// on its own thread. It loads the callback installed by the JVM and forwards
+// the selector / value / message / opt arguments verbatim, returning 0 when
+// no callback is installed.
 ASIOSHIM_API long asioshim_messageTrampoline(
         long selector, long value, void* message, double* opt);
+
+// ── Real-time streaming (story 311) ───────────────────────────────
+// Lifecycle contract, all on the `asio-control` thread:
+//   asioshim_createBuffers → asioshim_getBufferInfos → asioshim_start
+//     … streaming … → asioshim_stop → asioshim_disposeBuffers
+// `asioshim_createBuffers` requires a loaded driver and no already-created
+// buffers; it also populates the process-global `ASIOCallbacks` table, which
+// is what finally makes `asioshim_messageTrampoline` above reachable.
+// `numInputs + numOutputs` is capped at 64 **total active channels** — the
+// cap is on the two directions combined, so a symmetric configuration tops
+// out at 32 in + 32 out.
+// `asioshim_stop` and `asioshim_disposeBuffers` return `1` when there is
+// nothing to do, so `close()` can call them unconditionally, and `0` when
+// the driver refused the SDK call (see "Return-code conventions" above).
+// `asioshim_unloadDriver` runs the same stop + dispose teardown before
+// `ASIOExit`.
+//
+// Every teardown step waits (bounded, best-effort) for any `bufferSwitch`
+// already executing on the driver's thread to return before it lets the SDK
+// or the JVM free anything that callback touches.
+ASIOSHIM_API int  asioshim_createBuffers(const int* inputChannels,
+                                          int numInputs,
+                                          const int* outputChannels,
+                                          int numOutputs,
+                                          int bufferFrames);
+ASIOSHIM_API int  asioshim_getBufferInfos(void* outArray, int* outCount);
+ASIOSHIM_API int  asioshim_start(void);
+ASIOSHIM_API int  asioshim_stop(void);
+ASIOSHIM_API int  asioshim_disposeBuffers(void);
+
+// Signature of the JVM upcall the shim invokes from each bufferSwitch.
+// The native `long` spelling is retained so the trampoline below is ABI-exact
+// against Steinberg's `ASIOCallbacks::bufferSwitch` (`ASIOBool` is itself a
+// `long`); Windows is LLP64, so `long` is 32 bits on x64 and maps to
+// `ValueLayout.JAVA_INT` at the Java FFM boundary — see the static_assert
+// above, and its twin in asioshim.cpp.
+//   void bufferSwitch(long doubleBufferIndex, ASIOBool directProcess);
+typedef void (*asio_buffer_switch_fn)(long bufferIndex, long directProcess);
+
+ASIOSHIM_API void installAsioBufferSwitchCallback(void* callback);
+
+// Clears the installed upcall and then waits (bounded) for any callback
+// already inside the shim to return, so the caller can safely free the
+// upcall stub's arena as soon as this returns.
+ASIOSHIM_API void uninstallAsioBufferSwitchCallback(void);
+
+// This function *is* Steinberg's `ASIOCallbacks::bufferSwitch` slot, exactly
+// as `asioshim_messageTrampoline` is the `asioMessage` slot:
+// `asioshim_createBuffers` assigns it into the callback table and the vendor
+// driver invokes it on its real-time audio thread. It is exported rather than
+// file-local so both driver-invoked trampolines are visible in the DLL's
+// symbol table for diagnostics.
+//
+// Together with `asioshim_messageTrampoline` (and the two non-exported slots
+// listed under "Thread affinity" above) it runs on the driver's thread and
+// deliberately takes no lock, while every host-called export locks the shim's
+// driver mutex: a lock here would be an RT violation and would deadlock
+// against a concurrent `asioshim_stop`. See the story-311 banner in
+// asioshim.cpp.
+ASIOSHIM_API void asioshim_bufferSwitchTrampoline(long bufferIndex,
+                                                   long directProcess);
 
 #endif  // ASIOSHIM_H_

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/annotation/RealTimeSafeContractTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/annotation/RealTimeSafeContractTest.java
@@ -12,6 +12,7 @@ import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.attribute.CodeAttribute;
+import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.classfile.instruction.MonitorInstruction;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -60,6 +61,19 @@ class RealTimeSafeContractTest {
     private static final Set<Class<?>> BOXED_TYPES = Set.of(
             Boolean.class, Byte.class, Character.class, Short.class,
             Integer.class, Long.class, Float.class, Double.class);
+
+    /** Story 311 — the ASIO real-time bridge scanned by the sentinels below. */
+    private static final String ASIO_BRIDGE_CLASS =
+            "com.benesquivelmusic.daw.sdk.audio.AsioBufferSwitchShim";
+
+    /**
+     * Story 311 — the method on {@link #ASIO_BRIDGE_CLASS} that the driver's
+     * real-time thread enters. The bytecode sentinel below matches on this
+     * name, so renaming the bridge method without updating this constant would
+     * silently stop the scan; that is exactly what the sentinel's non-empty
+     * guard fails on.
+     */
+    private static final String ASIO_BRIDGE_METHOD = "bufferSwitch";
 
     // ------------------------------------------------------------------
     // Discovery
@@ -134,6 +148,99 @@ class RealTimeSafeContractTest {
         assertThat(isRealTimeSafe(processBlock))
                 .as("AudioEngine.processBlock must be annotated @RealTimeSafe")
                 .isTrue();
+    }
+
+    /**
+     * Story 311 — the ASIO buffer-switch bridge runs on the driver's own
+     * real-time thread, so it is a critical path in exactly the same sense as
+     * {@code AudioEngine.processBlock}. The generic bytecode / varargs /
+     * boxing checks below already sweep {@code daw.sdk}; this asserts the
+     * bridge method carries the annotation in the first place.
+     */
+    @Test
+    void asioBufferSwitchBridgeShouldBeRealTimeSafe() throws Exception {
+        Class<?> bridge = Class.forName(ASIO_BRIDGE_CLASS);
+        // getDeclaredMethod throws NoSuchMethodException when either method is
+        // renamed away, so this sentinel already fails loudly rather than
+        // silently asserting nothing.
+        Method bufferSwitch = bridge.getDeclaredMethod(
+                ASIO_BRIDGE_METHOD, int.class, int.class);
+        assertThat(isRealTimeSafe(bufferSwitch))
+                .as("AsioBufferSwitchShim.bufferSwitch must be annotated @RealTimeSafe")
+                .isTrue();
+        Method write = bridge.getDeclaredMethod(
+                "write", Class.forName("com.benesquivelmusic.daw.sdk.audio.AudioBlock"));
+        assertThat(isRealTimeSafe(write))
+                .as("AsioBufferSwitchShim.write must be annotated @RealTimeSafe")
+                .isTrue();
+    }
+
+    /**
+     * Story 311 — structural guard for the off-thread input marshalling.
+     *
+     * <p>{@code SubmissionPublisher.doOffer} acquires a
+     * {@link java.util.concurrent.locks.ReentrantLock} (even with zero
+     * subscribers, and held across the whole subscriber fan-out),
+     * {@code BufferedSubscription.offer} grows an {@code Object[]}, and the
+     * delivery {@code Executor} allocates a task. {@link RealTimeSafe} forbids
+     * all three verbatim. The bridge therefore de-interleaves into a lock-free
+     * ring and lets the {@code asio-input-drain} thread do the publishing —
+     * a property no behavioural test can pin down, so it is asserted directly
+     * against the callback's bytecode.</p>
+     *
+     * <p>The scan is by method <em>name</em>, so it would pass vacuously if the
+     * bridge method were renamed or compiled without a {@code Code} attribute:
+     * the loop body would never run and {@code offenders} would be empty. The
+     * scanned-method count is therefore asserted non-empty first, per this
+     * repo's conformance-sentinel convention.</p>
+     */
+    @Test
+    void asioBufferSwitchMustNotPublishFromTheCallbackThread() throws Exception {
+        Class<?> bridge = Class.forName(ASIO_BRIDGE_CLASS);
+        byte[] bytes = readClassBytes(bridge);
+        assertThat(bytes).as("AsioBufferSwitchShim class file must be readable").isNotNull();
+        ClassModel model = ClassFile.of().parse(bytes);
+
+        List<String> offenders = new ArrayList<>();
+        int scannedBridgeMethods = 0;
+        for (MethodModel mm : model.methods()) {
+            if (!mm.methodName().stringValue().equals(ASIO_BRIDGE_METHOD)) {
+                continue;
+            }
+            CodeAttribute code = mm
+                    .findAttribute(java.lang.classfile.Attributes.code())
+                    .map(CodeAttribute.class::cast)
+                    .orElse(null);
+            if (code == null) {
+                continue;
+            }
+            scannedBridgeMethods++;
+            for (var element : code) {
+                if (!(element instanceof InvokeInstruction invoke)) {
+                    continue;
+                }
+                String owner = invoke.owner().asInternalName();
+                String name = invoke.name().stringValue();
+                if (owner.contains("SubmissionPublisher")
+                        || name.equals("publishInput")
+                        || name.equals("submit")
+                        || name.equals("offer")) {
+                    offenders.add("bufferSwitch invokes " + owner + "#" + name);
+                }
+            }
+        }
+
+        assertThat(scannedBridgeMethods)
+                .as("this sentinel only asserts anything if it actually scanned the "
+                        + "bytecode of AsioBufferSwitchShim#%s, and no such method "
+                        + "with a Code attribute was found, so the check below would "
+                        + "pass vacuously. If the ASIO bridge method was renamed, "
+                        + "update ASIO_BRIDGE_METHOD here.", ASIO_BRIDGE_METHOD)
+                .isGreaterThanOrEqualTo(1);
+        assertThat(offenders)
+                .as("AsioBufferSwitchShim.bufferSwitch must hand captured audio to the "
+                        + "asio-input-drain thread instead of publishing inline")
+                .isEmpty();
     }
 
     // ------------------------------------------------------------------

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/audio/AsioStreamingIntegrationTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/audio/AsioStreamingIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.benesquivelmusic.daw.core.audio;
+
+import com.benesquivelmusic.daw.sdk.audio.AsioBackend;
+import com.benesquivelmusic.daw.sdk.audio.AudioBackendException;
+import com.benesquivelmusic.daw.sdk.audio.AudioBlock;
+import com.benesquivelmusic.daw.sdk.audio.AudioFormat;
+import com.benesquivelmusic.daw.sdk.audio.BufferSizeRange;
+import com.benesquivelmusic.daw.sdk.audio.DeviceId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Story 311 — end-to-end streaming smoke test against a real, installed ASIO
+ * driver: open the default device, confirm at least one genuine
+ * {@code bufferSwitch} reaches {@link AsioBackend#inputBlocks()}, then close
+ * cleanly with no leaked driver state.
+ *
+ * <p>The test lives in {@code daw-core} rather than next to
+ * {@code AsioBackend} in {@code daw-sdk} for two reasons, both of which also
+ * put {@code NativeLibraryDetectorTest}'s asioshim assertions here:</p>
+ * <ol>
+ *   <li>{@link NativeLibraryDetector} is a {@code daw-core} class, and
+ *       {@code daw-sdk} is the API floor — it must not depend on
+ *       {@code daw-core}.</li>
+ *   <li>Only {@code daw-core}'s Surefire sets
+ *       {@code -Djava.library.path=${native.libs.dir}}, and only
+ *       {@code daw-core} runs <em>after</em> the CMake native build that
+ *       produces {@code asioshim.dll}. A {@code daw-sdk} test could never see
+ *       the library.</li>
+ * </ol>
+ *
+ * <p>Gating, in order: Windows only (the story's stated target), then the
+ * {@code requireOrAssumeAsioshim()} pattern copied from
+ * {@code NativeLibraryDetectorTest} (hard failure when
+ * {@code DAW_REQUIRE_ASIOSHIM=1}, a clean skip otherwise), then a skip when
+ * no ASIO driver is installed on the machine.</p>
+ */
+@EnabledOnOs(OS.WINDOWS)
+class AsioStreamingIntegrationTest {
+
+    private static final AudioFormat FORMAT = new AudioFormat(48_000.0, 2, 32);
+
+    @Test
+    void openStreamsRealBufferSwitchCallbacksAndClosesCleanly() throws Exception {
+        requireOrAssumeAsioshim();
+        AsioBackend backend = new AsioBackend();
+        assumeTrue(!backend.listDevices().isEmpty(), "no ASIO driver installed");
+
+        DeviceId device = DeviceId.defaultFor("ASIO");
+        // bufferSizeRange() can only reach ASIOGetBufferSize once a driver is
+        // loaded, which open() is what does — so the first attempt uses the
+        // portable DEFAULT_RANGE preferred value.
+        BufferSizeRange range = backend.bufferSizeRange(device);
+        int bufferFrames = range.preferred();
+
+        CountDownLatch firstBlock = new CountDownLatch(1);
+        AtomicReference<AudioBlock> captured = new AtomicReference<>();
+        AtomicInteger blockCount = new AtomicInteger();
+        backend.inputBlocks().subscribe(new Flow.Subscriber<AudioBlock>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(AudioBlock item) {
+                blockCount.incrementAndGet();
+                // Story 311 marshals capture off the driver's real-time thread
+                // via asio-input-drain, which allocates a fresh AudioBlock per
+                // callback — the block is immutable and safe to retain.
+                captured.compareAndSet(null, item);
+                firstBlock.countDown();
+            }
+
+            @Override public void onError(Throwable throwable) { }
+
+            @Override public void onComplete() { }
+        });
+
+        try {
+            backend.open(device, FORMAT, bufferFrames);
+        } catch (AudioBackendException rejected) {
+            // An exotic driver may reject the portable default size outright.
+            // Skipping keeps the lane honest instead of failing on hardware
+            // the story does not control.
+            assumeTrue(false, "ASIO driver rejected the requested buffer size: "
+                    + rejected.getMessage());
+            return;
+        }
+
+        try {
+            assertThat(backend.isOpen()).isTrue();
+            assertThat(firstBlock.await(5, TimeUnit.SECONDS))
+                    .as("at least one real ASIO bufferSwitch must reach inputBlocks() "
+                            + "within 5 s of ASIOStart")
+                    .isTrue();
+            AudioBlock block = captured.get();
+            assertThat(block).isNotNull();
+            assertThat(block.channels()).isEqualTo(FORMAT.channels());
+            assertThat(block.frames()).isEqualTo(bufferFrames);
+            assertThat(blockCount.get()).isPositive();
+        } finally {
+            backend.close();
+        }
+
+        assertThat(backend.isOpen()).isFalse();
+        assertThatCode(backend::close)
+                .as("a second close() must be a safe no-op")
+                .doesNotThrowAnyException();
+    }
+
+    /**
+     * Story 224 — gates the dedicated Windows-with-shim CI lane (the
+     * {@code windows-asioshim.yml} workflow exports
+     * {@code DAW_REQUIRE_ASIOSHIM=1}). Copied verbatim from
+     * {@code NativeLibraryDetectorTest} so both suites gate identically.
+     */
+    private static void requireOrAssumeAsioshim() {
+        boolean available = NativeLibraryDetector.isAvailable("asioshim");
+        if ("1".equals(System.getenv("DAW_REQUIRE_ASIOSHIM"))) {
+            assertThat(available)
+                    .as("DAW_REQUIRE_ASIOSHIM=1 — asioshim.dll must be on the "
+                            + "FFM library path. Ensure the native build ran "
+                            + "with -DASIO_SDK_DIR=... before mvn verify.")
+                    .isTrue();
+        } else {
+            assumeTrue(available,
+                    "asioshim.dll not on java.library.path — skip "
+                            + "(build the native libs with -DASIO_SDK_DIR=...; "
+                            + "set DAW_REQUIRE_ASIOSHIM=1 to fail instead of skip)");
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
@@ -99,6 +100,7 @@ public final class AsioBackend implements AudioBackend {
      */
     private static final AtomicBoolean FALLBACK_LOGGED = new AtomicBoolean(false);
 
+    private final Executor resetTeardownExecutor;
     private final AudioBackendSupport support = new AudioBackendSupport();
     private volatile AsioFormatChangeShim formatChangeShim;
     private volatile AsioDriverShim driverShim;
@@ -124,6 +126,13 @@ public final class AsioBackend implements AudioBackend {
 
     /** Creates a new ASIO backend (no native resources allocated until {@link #open}). */
     public AsioBackend() {
+        this(RESET_TEARDOWN_EXECUTOR);
+    }
+
+    /** Test seam for controlling when an asynchronous reset teardown runs. */
+    AsioBackend(Executor resetTeardownExecutor) {
+        this.resetTeardownExecutor = Objects.requireNonNull(
+                resetTeardownExecutor, "resetTeardownExecutor");
     }
 
     @Override
@@ -857,6 +866,13 @@ public final class AsioBackend implements AudioBackend {
      * frees nothing — the upcall stays installed and the bridge alive — so the
      * refusal is a diagnostic rather than a hazard.</p>
      *
+     * <p>The queued task rechecks that its captured streaming shim is still
+     * current while holding the lifecycle lock. If {@link #close()} and a
+     * subsequent {@link #open(DeviceId, AudioFormat, int)} have already moved
+     * the backend to another stream, the stale task makes no native calls and
+     * logs no refusal. The driver callback itself only quiesces the bridge and
+     * enqueues this work; it never acquires that lock or waits.</p>
+     *
      * <p><strong>The backend stays open.</strong> This does not call
      * {@code markClosed()} — the driver is still loaded, and short-circuiting
      * {@link #close()} would leak the driver shim. {@link #isOpen()} therefore
@@ -883,10 +899,19 @@ public final class AsioBackend implements AudioBackend {
         if (streaming == null) {
             return;
         }
-        RESET_TEARDOWN_EXECUTOR.execute(() -> {
-            boolean stopped = streaming.stop();
-            boolean disposed = streaming.disposeBuffers();
-            warnIfDriverRefusedTeardown(stopped, disposed);
+        resetTeardownExecutor.execute(() -> {
+            synchronized (DRIVER_LIFECYCLE_LOCK) {
+                // close() may have already disposed this shim and open() may
+                // have published its replacement while this task was queued.
+                // Keep the identity check and downcalls in the same lifecycle
+                // critical section so the stream cannot move on between them.
+                if (streamingShim != streaming) {
+                    return;
+                }
+                boolean stopped = streaming.stop();
+                boolean disposed = streaming.disposeBuffers();
+                warnIfDriverRefusedTeardown(stopped, disposed);
+            }
         });
     }
 

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -59,8 +61,33 @@ public final class AsioBackend implements AudioBackend {
     private static volatile Supplier<AsioDriverShim> driverShimFactory =
             AsioDriverShim::new;
 
+    /**
+     * Factory for the optional real-time streaming FFM binding (story 311).
+     * Defaults to loading {@code asioshim} via {@link AsioStreamingShim};
+     * tests inject a stub via {@link #setStreamingShimFactory(Supplier)} to
+     * exercise the {@code createBuffers} / {@code start} / {@code stop} /
+     * {@code disposeBuffers} ordering without a Windows host.
+     */
+    private static volatile Supplier<AsioStreamingShim> streamingShimFactory =
+            AsioStreamingShim::new;
+
     /** Serializes the Steinberg SDK's process-wide single-driver lifecycle. */
     private static final Object DRIVER_LIFECYCLE_LOCK = new Object();
+
+    /**
+     * Runs {@code ASIOStop} / {@code ASIODisposeBuffers} after a
+     * driver-initiated reset (story 218 &times; 311). A pre-created
+     * single-thread daemon executor rather than a thread per reset: the caller
+     * is the driver's own host-callback thread, which must not pay for an OS
+     * thread creation, and serializing the teardowns keeps a reset storm from
+     * spawning an unbounded number of threads. Mirrors the house
+     * {@link AsioControlThread} idiom.
+     */
+    private static final ExecutorService RESET_TEARDOWN_EXECUTOR =
+            Executors.newSingleThreadExecutor(task -> Thread.ofPlatform()
+                    .name("asio-reset-teardown")
+                    .daemon(true)
+                    .unstarted(task));
 
     /** Backend instance that currently owns the single process-wide driver. */
     private static AsioBackend activeBackend;
@@ -75,6 +102,25 @@ public final class AsioBackend implements AudioBackend {
     private final AudioBackendSupport support = new AudioBackendSupport();
     private volatile AsioFormatChangeShim formatChangeShim;
     private volatile AsioDriverShim driverShim;
+    private volatile AsioStreamingShim streamingShim;
+    private volatile AsioBufferSwitchShim bufferSwitchShim;
+
+    /**
+     * Name of the driver {@code ASIOInit} succeeded for, or {@code null} while
+     * no driver is loaded. Held so a teardown the driver refuses can name it in
+     * the diagnostic without issuing a downcall from the teardown path.
+     */
+    private volatile String activeDriverName;
+
+    /**
+     * Latched by every {@link #stopStreamingForDriverReset()}, cleared on entry
+     * to {@link #open(DeviceId, AudioFormat, int)} and re-checked once the
+     * stream is running. A driver may issue {@code kAsioResetRequest} from
+     * inside {@code ASIOCreateBuffers} — before either streaming shim is
+     * published — in which case the reset would otherwise silently no-op while
+     * {@code open()} went on to start a driver that just asked to be reset.
+     */
+    private volatile boolean driverResetRequested;
 
     /** Creates a new ASIO backend (no native resources allocated until {@link #open}). */
     public AsioBackend() {
@@ -114,6 +160,37 @@ public final class AsioBackend implements AudioBackend {
         }
     }
 
+    /**
+     * Opens the driver and, when the native streaming shim is present, starts
+     * the ASIO buffer-switch loop (story 311).
+     *
+     * <p>Sequence, all under the process-wide driver lifecycle lock:</p>
+     * <ol>
+     *   <li>{@code asioshim_loadDriver} + {@code ASIOInit} (story 310).</li>
+     *   <li>Buffer-size negotiation against the driver-reported
+     *       {@code ASIOGetBufferSize} four-tuple (stories 213 / 220). A
+     *       request outside the reported range or off its granularity ladder
+     *       raises {@link AudioBackendException}; the size is never silently
+     *       resized.</li>
+     *   <li>Install the story-218 {@code asioMessage} shim — <em>before</em>
+     *       {@code ASIOCreateBuffers}, because drivers issue the ASIO handshake
+     *       selectors synchronously from inside that call.</li>
+     *   <li>{@code ASIOCreateBuffers} for the opened channel set, clamped in
+     *       each direction against the driver's reported input / output counts,
+     *       then a read-back of the driver's buffer descriptors.</li>
+     *   <li>{@link AudioBackendSupport#markOpen(AudioFormat, int)} —
+     *       <em>before</em> the upcall is installed, because
+     *       {@code publishInput} drops while the backend is not open and the
+     *       first callback must not race the flag.</li>
+     *   <li>Install the buffer-switch upcall, publish the streaming fields, then
+     *       {@code ASIOStart} and take ownership of the process-wide driver.</li>
+     * </ol>
+     *
+     * <p>When {@code asioshim} is absent — every non-Windows host, and every
+     * Windows build made without the Steinberg SDK — steps 4 and 6 are
+     * skipped and the method behaves exactly as it did in story 310: the
+     * backend opens, publishes device events, and simply streams no audio.</p>
+     */
     @Override
     public void open(DeviceId device, AudioFormat format, int bufferFrames) {
         Objects.requireNonNull(device, "device must not be null");
@@ -130,6 +207,7 @@ public final class AsioBackend implements AudioBackend {
                 throw new IllegalStateException(
                         "another ASIO backend already owns the process-wide driver");
             }
+            driverResetRequested = false;
 
             AsioDriverShim candidate = driverShimFactory.get();
             if (!candidate.isLifecycleAvailable()) {
@@ -148,23 +226,310 @@ public final class AsioBackend implements AudioBackend {
                 throw new AudioBackendException(
                         "Could not load and initialize ASIO driver: " + driverName);
             }
+            activeDriverName = driverName;
 
+            AsioStreamingShim streaming = null;
+            AsioBufferSwitchShim bridge = null;
+            AsioFormatChangeShim callback = null;
+            boolean marked = false;
             try {
+                // ASIOGetBufferSize only answers once the driver is
+                // initialized, so negotiation happens after loadDriver and
+                // before any buffer is created.
+                requireAcceptedBufferSize(bufferFrames);
+
+                // The asioMessage upcall must be live BEFORE ASIOCreateBuffers.
+                // Story 311 is the first story that ever builds an ASIOCallbacks
+                // table, and real drivers issue kAsioEngineVersion /
+                // kAsioSelectorSupported / kAsioSupportsTimeInfo synchronously
+                // from inside ASIOCreateBuffers. With the slot still empty the
+                // trampoline answers 0 and the driver falls back to ASIO 1.0.
+                // support.format() is deliberately still null here, so a
+                // kAsioBufferSizeChange arriving during ASIOCreateBuffers yields
+                // Optional.empty() for the proposed format — which
+                // AsioFormatChangeShim#dispatch already handles correctly.
+                callback = new AsioFormatChangeShim(
+                        this, support, new DeviceId(NAME, driverName));
+                formatChangeShim = callback;
+
+                streaming = acquireStreamingShim();
+                List<AsioStreamingShim.BufferInfo> bufferInfos = List.of();
+                if (streaming != null) {
+                    int[] counts = negotiateChannelCounts(format.channels(), driverName);
+                    if (!streaming.createBuffers(channelIndices(counts[0]),
+                            channelIndices(counts[1]), bufferFrames)) {
+                        throw new AudioBackendException(
+                                "ASIO driver rejected ASIOCreateBuffers for "
+                                        + counts[0] + " input(s) / " + counts[1]
+                                        + " output(s) at " + bufferFrames
+                                        + " frames: " + driverName);
+                    }
+                    bufferInfos = streaming.getBufferInfos();
+                    if (bufferInfos.isEmpty()) {
+                        throw new AudioBackendException(
+                                "ASIO driver reported no buffer descriptors after "
+                                        + "ASIOCreateBuffers: " + driverName);
+                    }
+                }
+
                 // ASIOInit succeeded before the backend is marked open. This
                 // ordering prevents every capability wrapper from reaching an
                 // uninitialized SDK global.
                 support.markOpen(format, bufferFrames);
-                AsioFormatChangeShim callback =
-                        new AsioFormatChangeShim(this, support, new DeviceId(NAME, driverName));
+                marked = true;
+
+                if (streaming != null) {
+                    bridge = new AsioBufferSwitchShim(
+                            support, format, bufferFrames, bufferInfos);
+                    if (!streaming.installBufferSwitchCallback(bridge.upcallStub())) {
+                        throw new AudioBackendException(
+                                "Could not install the ASIO buffer-switch callback for "
+                                        + driverName);
+                    }
+                    // Publish both shims BEFORE ASIOStart: a block sunk in the
+                    // window between start and the field assignment would
+                    // otherwise be silently dropped, and a reset arriving in
+                    // that window would find nothing to tear down.
+                    streamingShim = streaming;
+                    bufferSwitchShim = bridge;
+                    if (!streaming.start()) {
+                        throw new AudioBackendException(
+                                "ASIOStart failed for driver: " + driverName);
+                    }
+                }
+
                 driverShim = candidate;
-                formatChangeShim = callback;
                 activeBackend = this;
             } catch (RuntimeException | Error failure) {
-                candidate.close();
-                support.markClosed();
+                rollbackOpen(candidate, streaming, bridge, callback, marked);
                 throw failure;
             }
+
+            if (driverResetRequested) {
+                // A reset arrived while open() was still wiring the stream up
+                // (drivers legitimately send one from inside ASIOCreateBuffers).
+                // The earlier call could only latch the request because neither
+                // shim was published yet; both are live now, so run the real
+                // teardown before handing a "running" stream back to the caller.
+                stopStreamingForDriverReset();
+            }
         }
+    }
+
+    /**
+     * Resolves how many input and output channels {@code ASIOCreateBuffers}
+     * should be asked for (story 311, S1).
+     *
+     * <p>Story 310's behaviour of requesting the opened format's channel set in
+     * <em>both</em> directions breaks on a playback-only device — or on
+     * ASIO4ALL with only speakers enabled — because {@code ASIOCreateBuffers}
+     * fails for the phantom inputs and {@code open()} would throw where it used
+     * to succeed. Asymmetric input / output counts are the norm on
+     * multi-channel USB interfaces, this project's primary target, so each
+     * direction is clamped against the driver's reported count. Channels the
+     * driver does not have simply get no buffer;
+     * {@link AsioBufferSwitchShim} captures silence for them and leaves their
+     * (non-existent) output buffers alone.</p>
+     *
+     * <p>When no count is available — no capability shim, or
+     * {@code ASIOGetChannels} failed — the request keeps the previous
+     * behaviour.</p>
+     *
+     * @return {@code {inputs, outputs}}
+     * @throws AudioBackendException when the combined request exceeds the
+     *                               native shim's {@code MAX_STREAM_CHANNELS}
+     *                               cap, rather than letting
+     *                               {@code ASIOCreateBuffers} fail opaquely
+     */
+    private static int[] negotiateChannelCounts(int formatChannels, String driverName) {
+        int inputs = formatChannels;
+        int outputs = formatChannels;
+        Optional<int[]> reported = driverChannelCounts();
+        if (reported.isPresent()) {
+            inputs = Math.clamp(reported.get()[0], 0, formatChannels);
+            outputs = Math.clamp(reported.get()[1], 0, formatChannels);
+        }
+        if (inputs + outputs > AsioStreamingShim.MAX_STREAM_CHANNELS) {
+            throw new AudioBackendException(
+                    "ASIO driver rejected channel request " + inputs + " input(s) + "
+                            + outputs + " output(s): the native shim activates at most "
+                            + AsioStreamingShim.MAX_STREAM_CHANNELS
+                            + " channels in total (inputs + outputs), so a symmetric "
+                            + "request tops out at "
+                            + (AsioStreamingShim.MAX_STREAM_CHANNELS / 2)
+                            + " channels: " + driverName);
+        }
+        return new int[] {inputs, outputs};
+    }
+
+    /**
+     * Reads {@code ASIOGetChannels(numInputChannels, numOutputChannels)} via
+     * the capability shim, or {@link Optional#empty()} when the shim, the
+     * symbol, or the driver cannot answer.
+     */
+    private static Optional<int[]> driverChannelCounts() {
+        try (AsioCapabilityShim shim = capabilityShimFactory.get()) {
+            return shim.getChannelCount();
+        }
+    }
+
+    /**
+     * Returns a streaming shim when the native library exports the story-311
+     * symbols, or {@code null} when it does not — in which case the caller
+     * keeps the story-310 no-streaming path. An unusable shim is closed
+     * immediately so its FFM arena is not leaked.
+     */
+    private static AsioStreamingShim acquireStreamingShim() {
+        AsioStreamingShim candidate = streamingShimFactory.get();
+        if (candidate.isStreamingAvailable()) {
+            return candidate;
+        }
+        candidate.close();
+        return null;
+    }
+
+    /** The opened format's channel set: {@code {0, 1, …, channels - 1}}. */
+    private static int[] channelIndices(int channels) {
+        int[] indices = new int[channels];
+        for (int i = 0; i < channels; i++) {
+            indices[i] = i;
+        }
+        return indices;
+    }
+
+    /**
+     * Rejects a buffer size the driver does not accept (stories 213 / 220
+     * &times; 311). When no driver-reported range is available — the {@code asioshim}
+     * library is missing, or {@code ASIOGetBufferSize} failed — the requested
+     * size is accepted unchanged, exactly as before story 311.
+     */
+    private static void requireAcceptedBufferSize(int bufferFrames) {
+        Optional<BufferSizeRange> reported;
+        try (AsioCapabilityShim shim = capabilityShimFactory.get()) {
+            reported = shim.isAvailable() ? shim.getBufferSize() : Optional.empty();
+        }
+        if (reported.isEmpty()) {
+            return;
+        }
+        BufferSizeRange range = reported.get();
+        if (range.accepts(bufferFrames)) {
+            return;
+        }
+        throw new AudioBackendException(
+                "ASIO driver rejected buffer size " + bufferFrames
+                        + " frames: driver reports min=" + range.min()
+                        + " max=" + range.max()
+                        + " preferred=" + range.preferred()
+                        + " granularity=" + range.granularity());
+    }
+
+    /**
+     * Undoes a partially completed {@link #open(DeviceId, AudioFormat, int)}.
+     * The teardown order matches {@link #close()}: stop and dispose the
+     * driver's buffers, uninstall the upcall, and only then free the stub's
+     * arena — a late callback must never jump into released memory. The
+     * {@code asioMessage} shim is closed too, so a failed open never leaves a
+     * registered upcall behind (it is now installed before
+     * {@code ASIOCreateBuffers}).
+     */
+    private void rollbackOpen(AsioDriverShim candidate, AsioStreamingShim streaming,
+                              AsioBufferSwitchShim bridge, AsioFormatChangeShim callback,
+                              boolean marked) {
+        bufferSwitchShim = null;
+        streamingShim = null;
+        formatChangeShim = null;
+        if (bridge != null) {
+            bridge.stopStreaming();
+        }
+        if (streaming != null) {
+            tearDownStreaming(streaming);
+        }
+        if (bridge != null) {
+            bridge.close();
+        }
+        if (streaming != null) {
+            streaming.close();
+        }
+        if (callback != null) {
+            callback.close();
+        }
+        if (marked) {
+            support.markClosed();
+        }
+        activeDriverName = null;
+        candidate.close();
+    }
+
+    /**
+     * Runs the driver-side half of the story-311 teardown — {@code ASIOStop},
+     * {@code ASIODisposeBuffers}, then uninstalling the buffer-switch upcall —
+     * and reports a driver that refused either of the first two.
+     *
+     * <p>The native shim propagates the driver's own status rather than always
+     * answering "OK": {@code asioshim_stop} and {@code asioshim_disposeBuffers}
+     * return success only for the genuine "nothing to do" cases (not started, no
+     * buffers, no driver loaded) and failure when the SDK call was actually made
+     * and the driver refused it. A driver that ignores {@code ASIOStop} and
+     * keeps firing {@code bufferSwitch} is therefore detectable here, and is
+     * logged at {@link Level#WARNING} naming the refused call and the driver.</p>
+     *
+     * <p><strong>Why the teardown then continues instead of bailing out.</strong>
+     * The caller frees the upcall stub's arena immediately after this returns, so
+     * the question a refusal raises is whether a still-running driver can reach
+     * that stub. It cannot, because the native shim closes both windows:</p>
+     * <ul>
+     *   <li>{@code asioshim_disposeBuffers} publishes "no buffers created"
+     *       before it re-enters the SDK and then waits on a bounded in-flight
+     *       barrier, so no callback is inside the native {@code bufferSwitch}
+     *       body when {@code ASIODisposeBuffers} frees the buffers that body
+     *       writes into; and</li>
+     *   <li>{@code uninstallAsioBufferSwitchCallback} stores a null callback
+     *       pointer and drains that same barrier again. Every callback that
+     *       arrives afterwards loads null and returns without ever touching the
+     *       upcall stub.</li>
+     * </ul>
+     *
+     * <p>Aborting on a refused {@code ASIOStop} would therefore make nothing
+     * safer — it would skip the uninstall that is the actual protection, leak
+     * the upcall arena and the {@code asio-input-drain} thread for the life of
+     * the process, and leave the driver streaming into buffers nobody disposes.
+     * The native {@code asioshim_unloadDriver} repeats this same teardown before
+     * {@code ASIOExit}, which is the last chance to quiesce such a driver.</p>
+     */
+    private void tearDownStreaming(AsioStreamingShim streaming) {
+        boolean stopped = streaming.stop();
+        boolean disposed = streaming.disposeBuffers();
+        warnIfDriverRefusedTeardown(stopped, disposed);
+        streaming.uninstallBufferSwitchCallback();
+    }
+
+    /**
+     * Logs a driver that refused {@code ASIOStop} and/or
+     * {@code ASIODisposeBuffers}. Shared by {@link #close()} /
+     * {@code rollbackOpen(...)} — via {@link #tearDownStreaming} — and by the
+     * asynchronous {@link #stopStreamingForDriverReset()} teardown, which runs
+     * the same two calls and would otherwise discard the same information.
+     */
+    private void warnIfDriverRefusedTeardown(boolean stopped, boolean disposed) {
+        if (stopped && disposed) {
+            return;
+        }
+        String refused;
+        if (!stopped && !disposed) {
+            refused = "ASIOStop and ASIODisposeBuffers";
+        } else if (!stopped) {
+            refused = "ASIOStop";
+        } else {
+            refused = "ASIODisposeBuffers";
+        }
+        String driver = activeDriverName;
+        LOG.log(Level.WARNING,
+                "ASIO driver refused " + refused + " during teardown: "
+                        + (driver == null ? "<no driver loaded>" : driver)
+                        + ". The driver may still be firing bufferSwitch. The "
+                        + "teardown continues: the native shim closes its buffer "
+                        + "gate and waits on a bounded in-flight callback barrier "
+                        + "before anything a callback touches is released.");
     }
 
     private static String resolveDriverName(AsioDriverShim shim, DeviceId device) {
@@ -184,6 +549,21 @@ public final class AsioBackend implements AudioBackend {
                         + "(e.g. ASIO4ALL) and bundle daw-core/native/asio/asioshim.dll.");
     }
 
+    /**
+     * Live capture stream fed by the ASIO buffer-switch callback (story 311).
+     *
+     * <p>Each callback de-interleaves the driver's input half into a lock-free
+     * ring; the dedicated {@code asio-input-drain} daemon thread then allocates
+     * one {@link AudioBlock} per captured block, in order, and publishes it
+     * here. Marshalling the publish off the driver's real-time thread is what
+     * keeps the callback allocation- and lock-free, and it means every
+     * published block owns a private sample array — {@link AudioBlock}'s
+     * documented immutability holds and subscribers need not copy.</p>
+     *
+     * <p>Delivery is non-blocking in both stages: a subscriber that cannot keep
+     * up loses blocks rather than stalling the audio device, and a drain thread
+     * that cannot keep up loses blocks rather than stalling the driver.</p>
+     */
     @Override
     public Flow.Publisher<AudioBlock> inputBlocks() {
         return support.inputBlocks();
@@ -205,6 +585,17 @@ public final class AsioBackend implements AudioBackend {
      * ASIO host-callback thread; see that method's Javadoc for the
      * exact mapping from each ASIO callback to a
      * {@link FormatChangeReason}.</p>
+     *
+     * <p><strong>Reopen contract (stories 218 &times; 311).</strong> A
+     * {@code kAsioResetRequest} / {@code kAsioBufferSizeChange} quiesces the
+     * streaming bridge and disposes the driver's buffers, but it deliberately
+     * does <em>not</em> mark the backend closed — the driver is still loaded.
+     * {@link #isOpen()} therefore keeps reporting {@code true} and a second
+     * {@link #open(DeviceId, AudioFormat, int)} throws
+     * {@link IllegalStateException}. The consumer of a
+     * {@link AudioDeviceEvent.FormatChangeRequested} must
+     * {@link #close()} this backend and then {@code open(...)} it again with
+     * the new format / buffer size.</p>
      */
     @Override
     public Flow.Publisher<AudioDeviceEvent> deviceEvents() {
@@ -263,9 +654,46 @@ public final class AsioBackend implements AudioBackend {
                 new AudioDeviceEvent.FormatChangeRequested(device, proposedFormat, reason));
     }
 
+    /**
+     * Hands a rendered block to the ASIO buffer-switch bridge (story 311).
+     * The block is copied into a lock-free single-producer / single-consumer
+     * ring; the next {@code bufferSwitch} pulls the most recent one and
+     * interleaves it into the driver's output buffers. The call never blocks:
+     * a full ring drops the block.
+     *
+     * <p>Before {@link #open(DeviceId, AudioFormat, int)} — or on a build
+     * without the native streaming shim — the block is validated and
+     * discarded, exactly as in story 310.</p>
+     *
+     * @throws AudioBackendException when the block's frame count does not match
+     *                               the size the stream was opened at. An
+     *                               engine rendering 64-frame blocks into a
+     *                               128-frame ASIO stream would otherwise
+     *                               produce half-audio / half-silence buffers
+     *                               with no diagnostic; the story requires a
+     *                               buffer-size mismatch to surface "rather
+     *                               than silently resizing"
+     */
     @Override
     public void sink(AudioBlock block) {
         support.validateOutgoing(block);
+        // Capture the swappable reference exactly once: close() may null the
+        // field concurrently with a render-thread sink(...).
+        AsioBufferSwitchShim bridge = bufferSwitchShim;
+        if (bridge == null) {
+            return;
+        }
+        // The bridge is the authority on the negotiated size — it is what
+        // actually indexes the driver's buffers.
+        int streamFrames = bridge.bufferFrames();
+        if (block.frames() != streamFrames) {
+            throw new AudioBackendException(
+                    "ASIO driver rejected block size " + block.frames()
+                            + " frames: the open stream runs at " + streamFrames
+                            + " frames per buffer. Re-open the backend for the "
+                            + "new size rather than resizing silently.");
+        }
+        bridge.write(block);
     }
 
     @Override
@@ -357,9 +785,42 @@ public final class AsioBackend implements AudioBackend {
         }
     }
 
+    /**
+     * Tears the stream down in the order story 311 mandates:
+     * {@code ASIOStop} &rarr; {@code ASIODisposeBuffers} &rarr; uninstall the
+     * buffer-switch upcall &rarr; free the upcall arena &rarr; the existing
+     * story-310 {@code asioMessage} uninstall and {@code ASIOExit}.
+     *
+     * <p>Freeing the upcall arena strictly after the uninstall is the load-
+     * bearing part: a callback that arrives between the two would otherwise
+     * jump into released memory. Closing the buffer-switch shim also flushes
+     * and joins the {@code asio-input-drain} thread, so no captured block is
+     * published after this method returns. Idempotent.</p>
+     *
+     * <p>A driver that refuses {@code ASIOStop} or {@code ASIODisposeBuffers} is
+     * logged and the teardown carries on; see
+     * {@link #tearDownStreaming(AsioStreamingShim)} for why continuing is the
+     * safe response and aborting is not.</p>
+     */
     @Override
     public void close() {
         synchronized (DRIVER_LIFECYCLE_LOCK) {
+            AsioStreamingShim streaming = streamingShim;
+            streamingShim = null;
+            AsioBufferSwitchShim bridge = bufferSwitchShim;
+            bufferSwitchShim = null;
+            if (bridge != null) {
+                bridge.stopStreaming();
+            }
+            if (streaming != null) {
+                tearDownStreaming(streaming);
+            }
+            if (bridge != null) {
+                bridge.close();
+            }
+            if (streaming != null) {
+                streaming.close();
+            }
             AsioFormatChangeShim callback = formatChangeShim;
             formatChangeShim = null;
             if (callback != null) {
@@ -367,6 +828,7 @@ public final class AsioBackend implements AudioBackend {
             }
             AsioDriverShim lifecycle = driverShim;
             driverShim = null;
+            activeDriverName = null;
             if (lifecycle != null) {
                 lifecycle.close();
             }
@@ -375,6 +837,76 @@ public final class AsioBackend implements AudioBackend {
             }
             support.close();
         }
+    }
+
+    /**
+     * Quiesces the streaming bridge and tears the driver's buffers down after
+     * a driver-initiated reset (story 218 &times; 311).
+     *
+     * <p>Called from {@link AsioFormatChangeShim#dispatch(long, long)} — i.e.
+     * from the driver's own host-callback thread — for
+     * {@code kAsioResetRequest} and {@code kAsioBufferSizeChange}. The bridge
+     * is quiesced inline with a plain volatile write so no further callback
+     * touches the driver's buffers, but {@code ASIOStop} /
+     * {@code ASIODisposeBuffers} are dispatched to the shared
+     * {@code asio-reset-teardown} daemon executor: the ASIO contract forbids
+     * calling driver functions from inside a host callback, and doing so would
+     * deadlock against the shim's driver mutex. A driver that refuses either
+     * call is logged at {@link Level#WARNING} exactly as in
+     * {@link #tearDownStreaming(AsioStreamingShim)}; unlike that path this one
+     * frees nothing — the upcall stays installed and the bridge alive — so the
+     * refusal is a diagnostic rather than a hazard.</p>
+     *
+     * <p><strong>The backend stays open.</strong> This does not call
+     * {@code markClosed()} — the driver is still loaded, and short-circuiting
+     * {@link #close()} would leak the driver shim. {@link #isOpen()} therefore
+     * still reports {@code true} afterwards and a second
+     * {@link #open(DeviceId, AudioFormat, int)} throws
+     * {@link IllegalStateException}{@code ("backend already has an open
+     * stream")}. That is the intended story-218 contract: the consumer of the
+     * {@link AudioDeviceEvent.FormatChangeRequested} event must
+     * {@link #close()} and then {@code open(...)} again, which re-creates the
+     * driver's buffers at the new size.</p>
+     *
+     * <p>Idempotent, and a no-op when nothing is streaming. The request is
+     * latched unconditionally so a reset arriving from inside
+     * {@code ASIOCreateBuffers} — before either shim is published — is re-run
+     * by {@code open(...)} once the fields are live.</p>
+     */
+    void stopStreamingForDriverReset() {
+        driverResetRequested = true;
+        AsioBufferSwitchShim bridge = bufferSwitchShim;
+        if (bridge != null) {
+            bridge.stopStreaming();
+        }
+        AsioStreamingShim streaming = streamingShim;
+        if (streaming == null) {
+            return;
+        }
+        RESET_TEARDOWN_EXECUTOR.execute(() -> {
+            boolean stopped = streaming.stop();
+            boolean disposed = streaming.disposeBuffers();
+            warnIfDriverRefusedTeardown(stopped, disposed);
+        });
+    }
+
+    /**
+     * Test seam: the buffer-switch bridge currently installed by
+     * {@link #open(DeviceId, AudioFormat, int)}, or {@code null} when the
+     * backend is closed or the native streaming shim was unavailable.
+     */
+    AsioBufferSwitchShim activeBufferSwitchShim() {
+        return bufferSwitchShim;
+    }
+
+    /**
+     * Test seam: the story-218 {@code asioMessage} shim currently installed by
+     * {@link #open(DeviceId, AudioFormat, int)}, or {@code null} when the
+     * backend is closed. Non-null from before {@code ASIOCreateBuffers} runs,
+     * which is the ordering story 311 depends on.
+     */
+    AsioFormatChangeShim activeFormatChangeShim() {
+        return formatChangeShim;
     }
 
     /**
@@ -501,6 +1033,24 @@ public final class AsioBackend implements AudioBackend {
     /** Restores the production ASIO driver shim factory. */
     static void resetDriverShimFactory() {
         driverShimFactory = AsioDriverShim::new;
+    }
+
+    /**
+     * Test seam for the story-311 streaming path: replaces the factory the
+     * backend uses to obtain its {@link AsioStreamingShim}, so the
+     * {@code createBuffers} / {@code start} / {@code stop} /
+     * {@code disposeBuffers} ordering can be asserted without a Windows host
+     * or the Steinberg SDK.
+     *
+     * @param factory non-null supplier of a shim instance per open
+     */
+    static void setStreamingShimFactory(Supplier<AsioStreamingShim> factory) {
+        streamingShimFactory = Objects.requireNonNull(factory, "factory");
+    }
+
+    /** Restores the production ASIO streaming shim factory. */
+    static void resetStreamingShimFactory() {
+        streamingShimFactory = AsioStreamingShim::new;
     }
 
     /**

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBufferSwitchShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBufferSwitchShim.java
@@ -1,0 +1,584 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.locks.LockSupport;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * FFM (JEP 454) upcall that bridges the ASIO driver's
+ * {@code bufferSwitch(long bufferIndex, long directProcess)} host callback
+ * into the engine (story 311): driver input buffers are de-interleaved into a
+ * lock-free ring and republished on {@link AsioBackend#inputBlocks()} by a
+ * dedicated drain thread, and the most recent block handed to
+ * {@link AsioBackend#sink(AudioBlock)} is interleaved back out into the
+ * driver's output buffers.
+ *
+ * <p>{@link AsioFormatChangeShim} is the canonical reference for the upcall
+ * stub construction, the {@link Arena#ofShared()} rationale (the driver calls
+ * back from its own thread, so a confined arena would be illegal), and the
+ * "never let an exception propagate back into native code" wrapper.</p>
+ *
+ * <h2>Real-time discipline</h2>
+ * <p>Everything {@link #bufferSwitch(int, int)} touches — the reinterpreted
+ * {@link MemorySegment} views of the driver's double buffers, the per-channel
+ * and interleaved scratch arrays, and both {@link AudioBlockRing}s — is
+ * allocated in the constructor, on the calling (control) thread. The callback
+ * body therefore performs only {@code MemorySegment} bulk copies,
+ * {@code float[]} writes and {@link java.util.concurrent.atomic.AtomicLong}
+ * {@code lazySet} release stores: no allocation, no lock, no blocking call, no
+ * logging.</p>
+ *
+ * <h2>Off-thread input marshalling</h2>
+ * <p>{@code SubmissionPublisher.offer(...)} acquires a
+ * {@link java.util.concurrent.locks.ReentrantLock} and may allocate, which the
+ * {@link RealTimeSafe} contract forbids outright. The callback therefore never
+ * publishes: it de-interleaves into {@code inputRing} and hands off to the
+ * dedicated {@code asio-input-drain} daemon platform thread, which allocates a
+ * fresh {@link AudioBlock} per drained slot and calls
+ * {@link AudioBackendSupport#publishInput(AudioBlock)}. Because each published
+ * block owns a private sample array, {@link AudioBlock}'s documented
+ * immutability holds and subscribers need not copy.</p>
+ *
+ * <p>The hand-off signal is {@link LockSupport#unpark(Thread)} — the only
+ * cross-thread call the callback makes. It allocates nothing and returns
+ * whether or not the target is parked; a permit issued before the drain thread
+ * parks simply makes the next park return at once, so a wake-up can never be
+ * lost. Precisely stated, {@code unpark} is a <em>bounded</em> OS signalling
+ * primitive rather than a strictly lock-free one: on HotSpot/Windows — this
+ * project's target — {@code Parker::unpark} is a {@code SetEvent} on an event
+ * handle, while on some other platforms it briefly takes an internal OS mutex
+ * shared only with the target thread's own park. It is nevertheless the right
+ * primitive here, because unlike {@code SubmissionPublisher}'s
+ * {@link java.util.concurrent.locks.ReentrantLock} it holds nothing across user
+ * code and so can never be blocked by a slow subscriber. The drain thread
+ * parks with a bounded timeout so it neither busy-spins at 100&nbsp;% CPU nor
+ * can stall if an unpark is ever missed. It consumes the ring strictly
+ * <em>in order</em> ({@link AudioBlockRing#readInto(float[])}), because
+ * recorded audio must stay contiguous.</p>
+ *
+ * <h2>Sample format</h2>
+ * <p>Story 311 implements {@code ASIOSTFloat32LSB} ({@value #ASIOST_FLOAT32_LSB})
+ * only; generalising the conversion is story 312's job. Channels whose driver
+ * reported any other {@code ASIOSampleType} are zero-filled on input
+ * <em>and</em> on output — leaving the driver's own output bytes in place would
+ * replay them every block as a fixed-pitch buzz. The unsupported types are
+ * logged once at construction time, never from the callback thread.</p>
+ */
+final class AsioBufferSwitchShim implements AutoCloseable {
+
+    private static final Logger LOG =
+            Logger.getLogger(AsioBufferSwitchShim.class.getName());
+
+    /** {@code ASIOSTFloat32LSB} — the only sample type story 311 converts. */
+    static final int ASIOST_FLOAT32_LSB = 19;
+
+    /** Bytes per {@code ASIOSTFloat32LSB} sample. */
+    private static final int BYTES_PER_SAMPLE = 4;
+
+    /** Name of the daemon thread that marshals captured blocks off the RT thread. */
+    static final String DRAIN_THREAD_NAME = "asio-input-drain";
+
+    /**
+     * Slots in the callback &rarr; {@code asio-input-drain} hand-off ring.
+     * Sized generously: the drain thread only has to keep up on average, and
+     * a deeper ring absorbs a scheduling hiccup without losing captured audio.
+     */
+    private static final int INPUT_RING_SLOTS = 32;
+
+    /** Slots in the {@code sink(...)} &rarr; callback hand-off ring. */
+    private static final int OUTPUT_RING_SLOTS = 4;
+
+    /** Backstop park interval for the drain thread when the ring runs dry. */
+    private static final long DRAIN_PARK_NANOS = 20_000_000L; // 20 ms
+
+    /** How long {@link #close()} waits for the drain thread to finish. */
+    private static final long DRAIN_SHUTDOWN_TIMEOUT_MILLIS = 2_000L;
+
+    /** ASIO's double-buffer index is always 0 or 1. */
+    private static final int HALVES = 2;
+
+    /**
+     * Windows ASIO callback descriptor. The SDK uses C {@code long}, which is
+     * fixed at 32 bits on Win64 and therefore maps to {@code JAVA_INT}, not
+     * Java's 64-bit {@code long}.
+     */
+    private static final FunctionDescriptor ASIO_BUFFER_SWITCH =
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT);
+
+    private final AudioBackendSupport support;
+    private final double sampleRate;
+    private final int channels;
+    private final int bufferFrames;
+
+    /** Driver input buffers indexed {@code [half][channel]}. */
+    private final MemorySegment[][] inputBuffers;
+    /** Driver output buffers indexed {@code [half][channel]}. */
+    private final MemorySegment[][] outputBuffers;
+    /** Whether channel {@code c} has a usable float32 input buffer. */
+    private final boolean[] inputReady;
+    /** Whether the driver exposed any output buffer at all for channel {@code c}. */
+    private final boolean[] outputBound;
+    /** Whether channel {@code c} has a usable float32 output buffer. */
+    private final boolean[] outputReady;
+
+    /** Interleaved capture staging buffer; callback thread only. */
+    private final float[] inputScratch;
+    /** Per-channel capture staging buffer; callback thread only. */
+    private final float[] inputChannelScratch;
+    /** Interleaved playback staging buffer; callback thread only. */
+    private final float[] outputScratch;
+    /** Per-channel playback staging buffer; callback thread only. */
+    private final float[] outputChannelScratch;
+    /** Interleaved staging buffer; {@code asio-input-drain} thread only. */
+    private final float[] drainScratch;
+
+    private final AudioBlockRing inputRing;
+    private final AudioBlockRing outputRing;
+    private final Thread drainThread;
+
+    private final Arena arena;
+    private final MemorySegment upcallStub;
+
+    private volatile boolean streaming = true;
+    private volatile boolean draining = true;
+    private volatile boolean closed;
+
+    /**
+     * Pre-allocates every buffer, view and staging array the callback needs,
+     * builds the FFM upcall stub, and starts the {@code asio-input-drain}
+     * thread. Runs on the calling (control) thread — never on the driver's
+     * real-time thread.
+     *
+     * @param support      the backend support that owns the input publisher
+     *                     and the open flag; must not be null
+     * @param format       the opened format; its channel count defines the
+     *                     active channel set; must not be null
+     * @param bufferFrames the negotiated buffer size in sample frames; must be positive
+     * @param bufferInfos  the descriptors returned by
+     *                     {@link AsioStreamingShim#getBufferInfos()}; must not be null
+     */
+    AsioBufferSwitchShim(AudioBackendSupport support, AudioFormat format,
+                         int bufferFrames, List<AsioStreamingShim.BufferInfo> bufferInfos) {
+        this.support = Objects.requireNonNull(support, "support must not be null");
+        Objects.requireNonNull(format, "format must not be null");
+        Objects.requireNonNull(bufferInfos, "bufferInfos must not be null");
+        if (bufferFrames <= 0) {
+            throw new IllegalArgumentException(
+                    "bufferFrames must be positive: " + bufferFrames);
+        }
+        this.sampleRate = format.sampleRate();
+        this.channels = format.channels();
+        this.bufferFrames = bufferFrames;
+        this.inputBuffers = new MemorySegment[HALVES][channels];
+        this.outputBuffers = new MemorySegment[HALVES][channels];
+        this.inputReady = new boolean[channels];
+        this.outputBound = new boolean[channels];
+        this.outputReady = new boolean[channels];
+        for (int half = 0; half < HALVES; half++) {
+            Arrays.fill(inputBuffers[half], MemorySegment.NULL);
+            Arrays.fill(outputBuffers[half], MemorySegment.NULL);
+        }
+        long byteSize = (long) bufferFrames * BYTES_PER_SAMPLE;
+        String unsupportedTypes = bindDriverBuffers(bufferInfos, byteSize);
+        warnAboutUnsupportedSampleTypes(unsupportedTypes);
+
+        int samplesPerBlock = channels * bufferFrames;
+        this.inputScratch = new float[samplesPerBlock];
+        this.inputChannelScratch = new float[bufferFrames];
+        this.outputScratch = new float[samplesPerBlock];
+        this.outputChannelScratch = new float[bufferFrames];
+        this.drainScratch = new float[samplesPerBlock];
+        this.inputRing = new AudioBlockRing(INPUT_RING_SLOTS, samplesPerBlock);
+        this.outputRing = new AudioBlockRing(OUTPUT_RING_SLOTS, samplesPerBlock);
+
+        // The driver invokes this upcall from its own callback thread, so the
+        // stub's arena must be shared rather than confined.
+        this.arena = Arena.ofShared();
+        this.upcallStub = buildUpcallStub();
+
+        this.drainThread = Thread.ofPlatform()
+                .name(DRAIN_THREAD_NAME)
+                .daemon(true)
+                .unstarted(this::drainLoop);
+        // Started last: Thread.start() publishes every field written above.
+        drainThread.start();
+    }
+
+    /**
+     * Reinterprets each descriptor's raw {@code buffers[0]} / {@code buffers[1]}
+     * addresses into bounded {@link MemorySegment} views.
+     *
+     * <p>Descriptors for channels the opened format does not cover are ignored,
+     * and channels the driver never reported keep their
+     * {@link MemorySegment#NULL} placeholder — a playback-only device simply
+     * captures silence, and an interface with fewer outputs than the format
+     * asks for leaves the extra channels unwritten (story 311, S1).</p>
+     *
+     * @return a comma-separated list of the {@code ASIOSampleType}s story 311
+     *         cannot convert, or an empty string when every channel is float32
+     */
+    private String bindDriverBuffers(List<AsioStreamingShim.BufferInfo> bufferInfos,
+                                     long byteSize) {
+        StringBuilder unsupported = new StringBuilder();
+        for (AsioStreamingShim.BufferInfo info : bufferInfos) {
+            int channel = info.channel();
+            if (channel < 0 || channel >= channels) {
+                continue;
+            }
+            boolean supported = info.sampleType() == ASIOST_FLOAT32_LSB;
+            if (!supported) {
+                if (!unsupported.isEmpty()) {
+                    unsupported.append(", ");
+                }
+                unsupported.append(info.input() ? "input " : "output ")
+                        .append(channel).append('=').append(info.sampleType());
+            }
+            MemorySegment half0 = viewOf(info.buffer0(), byteSize);
+            MemorySegment half1 = viewOf(info.buffer1(), byteSize);
+            boolean bound = !half0.equals(MemorySegment.NULL)
+                    && !half1.equals(MemorySegment.NULL);
+            if (info.input()) {
+                inputBuffers[0][channel] = half0;
+                inputBuffers[1][channel] = half1;
+                inputReady[channel] = bound && supported;
+            } else {
+                outputBuffers[0][channel] = half0;
+                outputBuffers[1][channel] = half1;
+                outputBound[channel] = bound;
+                outputReady[channel] = bound && supported;
+            }
+        }
+        return unsupported.toString();
+    }
+
+    /**
+     * Builds a bounded view over a raw driver buffer address. The resulting
+     * segment carries <em>no</em> alignment guarantee, which is why every
+     * access uses {@code JAVA_FLOAT_UNALIGNED}.
+     */
+    private static MemorySegment viewOf(long address, long byteSize) {
+        if (address == 0L) {
+            return MemorySegment.NULL;
+        }
+        try {
+            return MemorySegment.ofAddress(address).reinterpret(byteSize);
+        } catch (Throwable ignored) {
+            // Restricted-method access denied (no --enable-native-access) or a
+            // bogus address: treat the channel as absent rather than fail open.
+            return MemorySegment.NULL;
+        }
+    }
+
+    /**
+     * Logs the unsupported {@code ASIOSampleType}s exactly once, here at
+     * construction time. The callback thread must never log.
+     */
+    private static void warnAboutUnsupportedSampleTypes(String unsupportedTypes) {
+        if (unsupportedTypes.isEmpty()) {
+            return;
+        }
+        LOG.log(Level.WARNING,
+                "ASIO driver reported unsupported ASIOSampleType(s) [" + unsupportedTypes
+                        + "]; story 311 converts ASIOSTFloat32LSB (" + ASIOST_FLOAT32_LSB
+                        + ") only, so those channels are silenced until story 312 "
+                        + "(ASIO sample-format conversion) generalises the copy boundary.");
+    }
+
+    private MemorySegment buildUpcallStub() {
+        try {
+            MethodHandle handle = MethodHandles.lookup().findVirtual(
+                    AsioBufferSwitchShim.class,
+                    "bufferSwitchUpcall",
+                    MethodType.methodType(void.class, int.class, int.class))
+                    .bindTo(this);
+            return Linker.nativeLinker().upcallStub(handle, ASIO_BUFFER_SWITCH, arena);
+        } catch (Throwable t) {
+            // Linker/method-handle wiring should never fail on a supported
+            // JVM, but if it does we degrade to a null stub rather than break
+            // open() — story 311 requires graceful degradation everywhere.
+            return MemorySegment.NULL;
+        }
+    }
+
+    /**
+     * Method-handle target bound into the FFM upcall stub. The JVM calls it
+     * from the driver's real-time callback thread.
+     */
+    @SuppressWarnings("unused") // invoked reflectively via the upcall stub
+    private void bufferSwitchUpcall(int bufferIndex, int directProcess) {
+        try {
+            bufferSwitch(bufferIndex, directProcess);
+        } catch (Throwable ignored) {
+            // Never let an exception propagate back into native code — the
+            // ASIO driver has no way to recover from a Java stack unwind.
+        }
+    }
+
+    /**
+     * The story's real-time bridge: de-interleave the driver's input half into
+     * the capture ring and wake the drain thread, then interleave the most
+     * recent {@code sink(...)} block into the driver's output half.
+     *
+     * <p>Package-private so unit tests can drive synthetic callbacks directly,
+     * exactly the way {@link AsioFormatChangeShim#dispatch(long, long)} is
+     * tested. Allocation-free, lock-free, blocking-free and log-free — see the
+     * "Real-time discipline" and "Off-thread input marshalling" notes on the
+     * class.</p>
+     *
+     * <p>{@code ASIOOutputReady()} is deliberately <em>not</em> called from
+     * here: the native trampoline calls it after this upcall returns, which
+     * keeps the downcall out of the JVM upcall.</p>
+     *
+     * @param bufferIndex  ASIO's double-buffer half, 0 or 1
+     * @param directProcess ASIO's {@code directProcess} hint; unused — the
+     *                      bridge always processes inline
+     */
+    @RealTimeSafe
+    void bufferSwitch(int bufferIndex, int directProcess) {
+        if (!streaming) {
+            return;
+        }
+        if (bufferIndex < 0 || bufferIndex >= HALVES) {
+            return;
+        }
+        int channelCount = channels;
+        int frames = bufferFrames;
+
+        float[] incoming = inputScratch;
+        MemorySegment[] inputs = inputBuffers[bufferIndex];
+        for (int channel = 0; channel < channelCount; channel++) {
+            copyInputChannel(inputs[channel], inputReady[channel],
+                    incoming, channel, channelCount, frames);
+        }
+        // Drop-on-full rather than block: a stalled drain thread must never
+        // hold up the driver. The unpark is non-blocking and allocation-free.
+        inputRing.write(incoming, incoming.length);
+        LockSupport.unpark(drainThread);
+
+        if (!outputRing.drainLatestInto(outputScratch)) {
+            // Nothing rendered yet this cycle — emit silence rather than
+            // repeating the previous block.
+            Arrays.fill(outputScratch, 0f);
+        }
+        MemorySegment[] outputs = outputBuffers[bufferIndex];
+        for (int channel = 0; channel < channelCount; channel++) {
+            copyOutputChannel(outputs[channel], outputBound[channel],
+                    outputReady[channel], outputScratch, channel, channelCount, frames);
+        }
+    }
+
+    /**
+     * Driver &rarr; engine copy for one channel: bulk-reads the per-channel
+     * driver buffer into a scratch array, then de-interleaves it into the
+     * interleaved {@link AudioBlock} layout.
+     *
+     * <p>One {@link MemorySegment#copy} per channel replaces {@code frames}
+     * individually bounds-checked {@code get} calls (8192 of them at
+     * 32&nbsp;channels &times; 128&nbsp;frames) and is still allocation-free.</p>
+     *
+     * <p>story 312: this is one of the two sample-format conversion seams.
+     * Story 311 only decodes {@code ASIOSTFloat32LSB}; every other
+     * {@code ASIOSampleType} — and every channel the driver did not expose —
+     * arrives here with {@code ready == false} and is silenced. Story 312
+     * generalises the decode based on the per-channel {@code ASIOSampleType}
+     * captured at construction.</p>
+     */
+    @RealTimeSafe
+    private void copyInputChannel(MemorySegment source, boolean ready,
+                                  float[] destination, int channel,
+                                  int channelCount, int frames) {
+        if (!ready) {
+            for (int frame = 0; frame < frames; frame++) {
+                destination[frame * channelCount + channel] = 0f;
+            }
+            return;
+        }
+        float[] scratch = inputChannelScratch;
+        // JAVA_FLOAT_UNALIGNED: a reinterpreted native segment carries no
+        // alignment guarantee, and the aligned layout would throw
+        // IllegalArgumentException on a misaligned driver buffer.
+        MemorySegment.copy(source, ValueLayout.JAVA_FLOAT_UNALIGNED, 0L,
+                scratch, 0, frames);
+        for (int frame = 0; frame < frames; frame++) {
+            destination[frame * channelCount + channel] = scratch[frame];
+        }
+    }
+
+    /**
+     * Engine &rarr; driver copy for one channel: interleaved scratch into a
+     * per-channel scratch array, then one bulk {@link MemorySegment#copy} into
+     * the driver's buffer.
+     *
+     * <p>story 312: the encode counterpart of {@link #copyInputChannel}. Story
+     * 311 only encodes {@code ASIOSTFloat32LSB}; a channel of any other
+     * {@code ASIOSampleType} has its driver buffer <strong>zero-filled</strong>
+     * rather than skipped. A zero byte pattern is silence for every integer PCM
+     * and float {@code ASIOSampleType}, whereas leaving the driver's bytes
+     * alone would replay them every block as a fixed-pitch buzz. Story 312
+     * generalises the encode.</p>
+     */
+    @RealTimeSafe
+    private void copyOutputChannel(MemorySegment destination, boolean bound,
+                                   boolean ready, float[] source, int channel,
+                                   int channelCount, int frames) {
+        if (!bound) {
+            // The driver exposes no output buffer for this channel (fewer
+            // hardware outputs than the opened format asks for).
+            return;
+        }
+        if (!ready) {
+            destination.fill((byte) 0);
+            return;
+        }
+        float[] scratch = outputChannelScratch;
+        for (int frame = 0; frame < frames; frame++) {
+            scratch[frame] = source[frame * channelCount + channel];
+        }
+        MemorySegment.copy(scratch, 0, destination,
+                ValueLayout.JAVA_FLOAT_UNALIGNED, 0L, frames);
+    }
+
+    /**
+     * Body of the {@code asio-input-drain} daemon thread: consumes the capture
+     * ring in order, allocates one {@link AudioBlock} per drained slot and
+     * publishes it. Allocation here is deliberate and safe — this is not the
+     * driver's real-time thread.
+     */
+    private void drainLoop() {
+        float[] scratch = drainScratch;
+        while (draining) {
+            boolean progressed = false;
+            while (inputRing.readInto(scratch)) {
+                progressed = true;
+                publishDrained(scratch);
+            }
+            if (!progressed) {
+                // Bounded park: the callback's unpark normally wakes us
+                // immediately, and the timeout is a backstop that also keeps
+                // close() responsive without a busy-spin.
+                LockSupport.parkNanos(this, DRAIN_PARK_NANOS);
+            }
+        }
+        // Final sweep so blocks captured just before close() still reach
+        // subscribers that are still attached.
+        while (inputRing.readInto(scratch)) {
+            publishDrained(scratch);
+        }
+    }
+
+    private void publishDrained(float[] scratch) {
+        try {
+            support.publishInput(new AudioBlock(
+                    sampleRate, channels, bufferFrames, scratch.clone()));
+        } catch (Throwable ignored) {
+            // A publisher closed concurrently with this drain, or a
+            // misbehaving drop handler, must never kill the drain thread —
+            // the next callback still has to be delivered.
+        }
+    }
+
+    /**
+     * Hands the engine's rendered block to the callback thread. Called from
+     * {@link AsioBackend#sink(AudioBlock)} on the render thread; drops the
+     * block (rather than blocking) when the ring is full.
+     *
+     * @param block the rendered output block; must not be null
+     */
+    @RealTimeSafe
+    void write(AudioBlock block) {
+        Objects.requireNonNull(block, "block must not be null");
+        if (!streaming) {
+            return;
+        }
+        float[] samples = block.samples();
+        // A frame-count mismatch is rejected by AsioBackend#sink before it
+        // reaches here; the ring's own clamp is the last-resort guard so the
+        // render thread never takes an exception.
+        outputRing.write(samples, samples.length);
+    }
+
+    /**
+     * Quiesces the bridge: no further callback touches the driver's buffers.
+     * A plain volatile write, so it is safe to call from the driver's own
+     * callback thread during a reset request (story 218 &times; 311).
+     * Idempotent.
+     *
+     * <p>The drain thread keeps running so already-captured blocks still reach
+     * subscribers; it is stopped by {@link #close()}.</p>
+     */
+    void stopStreaming() {
+        streaming = false;
+    }
+
+    /** Returns {@code true} while callbacks are still bridged into the engine. */
+    boolean isStreaming() {
+        return streaming;
+    }
+
+    /**
+     * Returns the address of the upcall stub bound to ASIO's
+     * {@code bufferSwitch} entrypoint. Exposed for
+     * {@link AsioStreamingShim#installBufferSwitchCallback(MemorySegment)}
+     * and for testing.
+     *
+     * @return the stub's address (never null; {@link MemorySegment#NULL} if
+     *         construction failed)
+     */
+    MemorySegment upcallStub() {
+        return upcallStub;
+    }
+
+    /** Returns the negotiated buffer size in sample frames. */
+    int bufferFrames() {
+        return bufferFrames;
+    }
+
+    /**
+     * Test seam: the {@code asio-input-drain} daemon thread that marshals
+     * captured blocks off the driver's real-time thread. Never null.
+     */
+    Thread drainThread() {
+        return drainThread;
+    }
+
+    /**
+     * Quiesces the bridge, stops the {@code asio-input-drain} thread and frees
+     * the upcall stub's arena. The caller must have uninstalled the callback
+     * first, or a late driver callback would jump into released memory.
+     * Idempotent.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        streaming = false;
+        draining = false;
+        LockSupport.unpark(drainThread);
+        try {
+            drainThread.join(DRAIN_SHUTDOWN_TIMEOUT_MILLIS);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        try {
+            arena.close();
+        } catch (Throwable ignored) {
+            // Arena already closed, or closed from another thread — close()
+            // stays idempotent and must never throw from a teardown path.
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShim.java
@@ -34,10 +34,21 @@ import java.util.Optional;
  */
 final class AsioFormatChangeShim implements AutoCloseable {
 
+    /**
+     * ASIO selector: "do you handle selector {@code value}?" — the driver's
+     * capability handshake, answered from {@link #handlesSelector(int)}.
+     */
+    static final int kAsioSelectorSupported = 1;
+    /** ASIO selector: which ASIO engine version the host implements. */
+    static final int kAsioEngineVersion = 2;
     /** ASIO selector: a generic reset request from the driver. */
     static final int kAsioResetRequest = 3;
     /** ASIO selector: the driver wants the host to resync the device clock. */
     static final int kAsioResyncRequest = 4;
+    /** ASIO selector: does the host implement {@code bufferSwitchTimeInfo}? */
+    static final int kAsioSupportsTimeInfo = 5;
+    /** ASIO selector: the driver's reported latencies changed. */
+    static final int kAsioLatenciesChanged = 6;
     /** ASIO selector: the driver renegotiated the buffer size to {@code value} frames. */
     static final int kAsioBufferSizeChange = 7;
 
@@ -45,6 +56,13 @@ final class AsioFormatChangeShim implements AutoCloseable {
     private static final int ASE_OK = 1;
     /** ASE_NotPresent — selector unknown / unhandled. */
     private static final int ASE_NOT_PRESENT = 0;
+
+    /**
+     * ASIO 2.0. Answering {@code kAsioEngineVersion} with 0 makes drivers fall
+     * back to ASIO 1.0 behaviour (no {@code bufferSwitchTimeInfo}, no sample
+     * position), so the host must report 2.
+     */
+    private static final int ASIO_ENGINE_VERSION = 2;
 
     /**
      * Windows ASIO callback descriptor. The SDK uses C {@code long}, which is
@@ -174,6 +192,35 @@ final class AsioFormatChangeShim implements AutoCloseable {
      *       controller re-queries device capabilities on reopen.</li>
      * </ul>
      *
+     * <p>Story 311 makes this shim reachable for the first time: the
+     * {@code ASIOCallbacks} struct is only built by
+     * {@code asioshim_createBuffers}, so drivers now also send the ASIO
+     * handshake selectors this method answers:</p>
+     * <ul>
+     *   <li>{@link #kAsioSelectorSupported} &rarr; 1 when {@code value} names
+     *       a selector this shim handles, 0 otherwise.</li>
+     *   <li>{@link #kAsioEngineVersion} &rarr; {@value #ASIO_ENGINE_VERSION}.</li>
+     *   <li>{@link #kAsioSupportsTimeInfo} &rarr; 1; the native shim
+     *       implements {@code bufferSwitchTimeInfo}.</li>
+     *   <li>{@link #kAsioLatenciesChanged} &rarr; 1 (accepted). Latency
+     *       <em>reporting</em> belongs to story 217, so nothing is published.</li>
+     * </ul>
+     *
+     * <p>{@link #kAsioBufferSizeChange} and {@link #kAsioResetRequest}
+     * invalidate the driver's buffers, so they quiesce the streaming bridge
+     * via {@link AsioBackend#stopStreamingForDriverReset()} <em>before</em>
+     * announcing the event (story 311). {@link #kAsioResyncRequest} does not
+     * invalidate the buffers and is left alone.</p>
+     *
+     * <p>Because story 311 installs this shim <em>before</em>
+     * {@code ASIOCreateBuffers} — drivers issue the handshake selectors
+     * synchronously from inside that call — a
+     * {@link #kAsioBufferSizeChange} can legitimately arrive while
+     * {@link AudioBackendSupport#format()} is still {@code null}. The proposed
+     * format is then {@link Optional#empty()}, which is exactly the
+     * "format unknown" case the {@link AudioDeviceEvent.FormatChangeRequested}
+     * contract already defines.</p>
+     *
      * <p>Package-private so that unit tests can drive each selector
      * without needing a real ASIO driver loaded.</p>
      *
@@ -184,7 +231,16 @@ final class AsioFormatChangeShim implements AutoCloseable {
      */
     long dispatch(long selector, long value) {
         switch ((int) selector) {
+            case kAsioSelectorSupported:
+                return handlesSelector((int) value) ? ASE_OK : ASE_NOT_PRESENT;
+            case kAsioEngineVersion:
+                return ASIO_ENGINE_VERSION;
+            case kAsioSupportsTimeInfo:
+                return ASE_OK;
+            case kAsioLatenciesChanged:
+                return ASE_OK;
             case kAsioBufferSizeChange: {
+                backend.stopStreamingForDriverReset();
                 AudioFormat current = support.format();
                 Optional<AudioFormat> proposed = current == null
                         ? Optional.empty()
@@ -203,6 +259,7 @@ final class AsioFormatChangeShim implements AutoCloseable {
                         new FormatChangeReason.ClockSourceChange());
                 return ASE_OK;
             case kAsioResetRequest:
+                backend.stopStreamingForDriverReset();
                 backend.publishFormatChangeRequested(
                         device, Optional.empty(),
                         new FormatChangeReason.DriverReset());
@@ -210,6 +267,19 @@ final class AsioFormatChangeShim implements AutoCloseable {
             default:
                 return ASE_NOT_PRESENT;
         }
+    }
+
+    /**
+     * Answers ASIO's {@code kAsioSelectorSupported} handshake: the set of
+     * selectors {@link #dispatch(long, long)} implements.
+     */
+    private static boolean handlesSelector(int selector) {
+        return switch (selector) {
+            case kAsioSelectorSupported, kAsioEngineVersion, kAsioResetRequest,
+                 kAsioResyncRequest, kAsioSupportsTimeInfo,
+                 kAsioLatenciesChanged, kAsioBufferSizeChange -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioStreamingShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioStreamingShim.java
@@ -1,0 +1,425 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * FFM (JEP 454, final in Java 22) binding for the real-time streaming
+ * entrypoints exported by {@code asioshim.dll} (story 311):
+ * {@code asioshim_createBuffers} / {@code asioshim_getBufferInfos} /
+ * {@code asioshim_start} / {@code asioshim_stop} /
+ * {@code asioshim_disposeBuffers}, plus the
+ * {@code installAsioBufferSwitchCallback} /
+ * {@code uninstallAsioBufferSwitchCallback} pair that registers the JVM
+ * upcall built by {@link AsioBufferSwitchShim}.
+ *
+ * <p>Shape and degradation semantics are identical to {@link AsioDriverShim}
+ * and {@link AsioCapabilityShim}: construction never throws, a missing
+ * library or symbol leaves the corresponding {@link MethodHandle} null, and
+ * every operation then reports "unavailable" instead of failing. On a normal
+ * checkout the Steinberg SDK is absent, {@code asioshim.dll} is not built, and
+ * {@link #isStreamingAvailable()} is {@code false} — in which case
+ * {@link AsioBackend#open(DeviceId, AudioFormat, int)} keeps exactly the
+ * story-310 behaviour and no audio streams.</p>
+ *
+ * <p>Every call here is a <em>downcall</em> and is therefore serialized on the
+ * dedicated {@link AsioControlThread}, preserving the COM apartment affinity
+ * the Steinberg host glue requires. The buffer-switch <em>upcall</em> arrives
+ * on the driver's own real-time thread and must never touch this class.</p>
+ *
+ * <p>Non-final, with package-private methods, so unit tests can subclass it —
+ * the same seam {@link AsioDriverShim} and {@link AsioCapabilityShim} provide.</p>
+ */
+class AsioStreamingShim implements AutoCloseable {
+
+    /** Shim success convention shared by every {@code asioshim_*} export. */
+    private static final int SHIM_OK = 1;
+
+    /**
+     * Bytes per {@code asioshim_getBufferInfos} record:
+     * {@code int32 channel}, {@code int32 isInput}, {@code int32 sampleType},
+     * {@code int32 reserved}, {@code int64 buffer0}, {@code int64 buffer1}.
+     */
+    static final int BUFFER_INFO_STRIDE = 32;
+
+    /**
+     * Byte alignment {@code asioshim_getBufferInfos} records require. The two
+     * pointer fields are read as {@code int64} at {@code base + 16} /
+     * {@code base + 24}, so the array's base address must be 8-byte aligned.
+     */
+    static final int BUFFER_INFO_ALIGNMENT = 8;
+
+    /**
+     * Maximum number of active channels the native side accepts:
+     * {@code asioshim_createBuffers} rejects
+     * {@code numInputs + numOutputs > 64} ({@code MAX_STREAM_CHANNELS} in
+     * {@code asioshim.cpp}). The cap is on the <em>combined</em> count, so a
+     * symmetric request tops out at 32 in + 32 out.
+     */
+    static final int MAX_STREAM_CHANNELS = 64;
+
+    /**
+     * Capacity this shim hands to {@code asioshim_getBufferInfos} — one record
+     * per activatable channel.
+     */
+    static final int BUFFER_INFO_CAPACITY = MAX_STREAM_CHANNELS;
+
+    // ── ABI contract ──────────────────────────────────────────────────
+    // One constant per exported symbol. The production bindings below and
+    // AsioStreamingShimTest's pure-Java upcall/downcall round trip both read
+    // these, so an argument-count or carrier-type drift fails in CI without
+    // any native library present (story 311).
+
+    /**
+     * {@code int asioshim_createBuffers(const int* inputChannels, int numInputs,
+     * const int* outputChannels, int numOutputs, int bufferFrames)}.
+     */
+    static final FunctionDescriptor CREATE_BUFFERS =
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS, ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS, ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT);
+
+    /** {@code int asioshim_getBufferInfos(void* outArray, int* outCount)}. */
+    static final FunctionDescriptor GET_BUFFER_INFOS =
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS, ValueLayout.ADDRESS);
+
+    /** {@code int asioshim_start(void)}. */
+    static final FunctionDescriptor START =
+            FunctionDescriptor.of(ValueLayout.JAVA_INT);
+
+    /** {@code int asioshim_stop(void)}. */
+    static final FunctionDescriptor STOP =
+            FunctionDescriptor.of(ValueLayout.JAVA_INT);
+
+    /** {@code int asioshim_disposeBuffers(void)}. */
+    static final FunctionDescriptor DISPOSE_BUFFERS =
+            FunctionDescriptor.of(ValueLayout.JAVA_INT);
+
+    /** {@code void installAsioBufferSwitchCallback(void* callback)}. */
+    static final FunctionDescriptor INSTALL_BUFFER_SWITCH_CALLBACK =
+            FunctionDescriptor.ofVoid(ValueLayout.ADDRESS);
+
+    /** {@code void uninstallAsioBufferSwitchCallback(void)}. */
+    static final FunctionDescriptor UNINSTALL_BUFFER_SWITCH_CALLBACK =
+            FunctionDescriptor.ofVoid();
+
+    private final Arena arena;
+    private final MethodHandle createBuffers;
+    private final MethodHandle getBufferInfos;
+    private final MethodHandle start;
+    private final MethodHandle stop;
+    private final MethodHandle disposeBuffers;
+    private final MethodHandle installCallback;
+    private final MethodHandle uninstallCallback;
+    private volatile boolean closed;
+
+    /**
+     * Loads {@code asioshim} and resolves the seven streaming symbols. Any
+     * failure is captured silently; the resulting shim simply reports
+     * {@link #isStreamingAvailable()} = {@code false}.
+     */
+    AsioStreamingShim() {
+        arena = Arena.ofShared();
+        MethodHandle create = null;
+        MethodHandle infos = null;
+        MethodHandle begin = null;
+        MethodHandle end = null;
+        MethodHandle dispose = null;
+        MethodHandle install = null;
+        MethodHandle uninstall = null;
+        try {
+            SymbolLookup lookup = SymbolLookup.libraryLookup("asioshim", arena);
+            Linker linker = Linker.nativeLinker();
+            create = resolve(linker, lookup, "asioshim_createBuffers", CREATE_BUFFERS);
+            infos = resolve(linker, lookup, "asioshim_getBufferInfos", GET_BUFFER_INFOS);
+            begin = resolve(linker, lookup, "asioshim_start", START);
+            end = resolve(linker, lookup, "asioshim_stop", STOP);
+            dispose = resolve(linker, lookup, "asioshim_disposeBuffers", DISPOSE_BUFFERS);
+            install = resolve(linker, lookup, "installAsioBufferSwitchCallback",
+                    INSTALL_BUFFER_SWITCH_CALLBACK);
+            uninstall = resolve(linker, lookup, "uninstallAsioBufferSwitchCallback",
+                    UNINSTALL_BUFFER_SWITCH_CALLBACK);
+        } catch (IllegalArgumentException | UnsatisfiedLinkError ignored) {
+            // Optional DLL absent (every non-Windows host, and every Windows
+            // build made without -DASIO_SDK_DIR): degrade to a no-op shim.
+        } catch (Throwable ignored) {
+            // Native access disabled or ABI mismatch: keep all handles null so
+            // isStreamingAvailable() reports false rather than exploding later.
+        }
+        createBuffers = create;
+        getBufferInfos = infos;
+        start = begin;
+        stop = end;
+        disposeBuffers = dispose;
+        installCallback = install;
+        uninstallCallback = uninstall;
+    }
+
+    private static MethodHandle resolve(Linker linker, SymbolLookup lookup,
+                                        String symbol, FunctionDescriptor descriptor) {
+        return lookup.find(symbol)
+                .map(address -> linker.downcallHandle(address, descriptor))
+                .orElse(null);
+    }
+
+    /**
+     * Returns {@code true} only when this shim is open and every streaming
+     * symbol resolved. A partially-resolved shim (an older {@code asioshim}
+     * build) is treated as unavailable so {@code open(...)} keeps the
+     * story-310 no-streaming path rather than half-starting a driver.
+     */
+    boolean isStreamingAvailable() {
+        return !closed
+                && createBuffers != null
+                && getBufferInfos != null
+                && start != null
+                && stop != null
+                && disposeBuffers != null
+                && installCallback != null
+                && uninstallCallback != null;
+    }
+
+    /**
+     * Calls {@code ASIOCreateBuffers} for the requested active channels with
+     * the shim's host-callback set installed.
+     *
+     * @param inputChannels  driver input channel indices to activate; must not be null
+     * @param outputChannels driver output channel indices to activate; must not be null
+     * @param bufferFrames   negotiated buffer size in sample frames; must be positive
+     * @return {@code true} on {@code ASE_OK}
+     */
+    boolean createBuffers(int[] inputChannels, int[] outputChannels, int bufferFrames) {
+        Objects.requireNonNull(inputChannels, "inputChannels must not be null");
+        Objects.requireNonNull(outputChannels, "outputChannels must not be null");
+        if (!isStreamingAvailable() || bufferFrames <= 0) {
+            return false;
+        }
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    MemorySegment ins = allocateChannels(call, inputChannels);
+                    MemorySegment outs = allocateChannels(call, outputChannels);
+                    int status = (int) createBuffers.invokeExact(
+                            ins, inputChannels.length,
+                            outs, outputChannels.length,
+                            bufferFrames);
+                    return status == SHIM_OK;
+                }
+            });
+        } catch (Throwable ignored) {
+            // Native call failed or the ABI mismatched — report rejection so
+            // AsioBackend#open rolls back and surfaces AudioBackendException.
+            return false;
+        }
+    }
+
+    private static MemorySegment allocateChannels(Arena arena, int[] channels) {
+        if (channels.length == 0) {
+            return MemorySegment.NULL;
+        }
+        return arena.allocateFrom(ValueLayout.JAVA_INT, channels);
+    }
+
+    /**
+     * Reads back the driver buffer descriptors created by
+     * {@link #createBuffers(int[], int[], int)}. Records appear in exactly the
+     * order the channels were passed: all inputs first, then all outputs.
+     *
+     * @return one {@link BufferInfo} per active channel, or an empty list when
+     *         the shim is unavailable or the native call failed
+     */
+    List<BufferInfo> getBufferInfos() {
+        if (!isStreamingAvailable()) {
+            return List.of();
+        }
+        try {
+            return AsioControlThread.call(() -> {
+                try (Arena call = Arena.ofConfined()) {
+                    // Explicit 8-byte alignment: the single-argument
+                    // allocate(byteSize) is specified as byte-alignment 1, and
+                    // the record's two pointer fields are 64-bit.
+                    MemorySegment records = call.allocate(
+                            (long) BUFFER_INFO_STRIDE * BUFFER_INFO_CAPACITY,
+                            BUFFER_INFO_ALIGNMENT);
+                    MemorySegment count = call.allocate(ValueLayout.JAVA_INT);
+                    count.set(ValueLayout.JAVA_INT, 0, BUFFER_INFO_CAPACITY);
+                    int status = (int) getBufferInfos.invokeExact(records, count);
+                    if (status != SHIM_OK) {
+                        return List.of();
+                    }
+                    int actual = Math.clamp(
+                            count.get(ValueLayout.JAVA_INT, 0), 0, BUFFER_INFO_CAPACITY);
+                    return decodeBufferInfos(records, actual);
+                }
+            });
+        } catch (Throwable ignored) {
+            // Missing driver state or FFM failure — an empty list makes
+            // AsioBackend#open roll back cleanly.
+            return List.of();
+        }
+    }
+
+    /**
+     * Decodes {@code count} 32-byte buffer-info records from {@code records}.
+     * Package-private so the layout can be unit-tested without a driver.
+     *
+     * <p>The {@code _UNALIGNED} layout variants are deliberate. The aligned
+     * {@code JAVA_LONG} enforces 8-byte alignment of the <em>absolute</em>
+     * address, which would make this method untestable against a heap segment
+     * ({@link MemorySegment#ofArray(byte[])} has maximum alignment 1) and would
+     * throw {@link IllegalArgumentException} rather than decode. The caller
+     * still allocates with {@link #BUFFER_INFO_ALIGNMENT} so the native writes
+     * are properly aligned; this is purely about not letting the read path
+     * impose an alignment the segment cannot advertise.</p>
+     */
+    static List<BufferInfo> decodeBufferInfos(MemorySegment records, int count) {
+        Objects.requireNonNull(records, "records must not be null");
+        int safeCount = Math.max(0, count);
+        List<BufferInfo> decoded = new ArrayList<>(safeCount);
+        for (int index = 0; index < safeCount; index++) {
+            long base = (long) index * BUFFER_INFO_STRIDE;
+            decoded.add(new BufferInfo(
+                    records.get(ValueLayout.JAVA_INT_UNALIGNED, base),
+                    records.get(ValueLayout.JAVA_INT_UNALIGNED, base + 4) != 0,
+                    records.get(ValueLayout.JAVA_INT_UNALIGNED, base + 8),
+                    records.get(ValueLayout.JAVA_LONG_UNALIGNED, base + 16),
+                    records.get(ValueLayout.JAVA_LONG_UNALIGNED, base + 24)));
+        }
+        return List.copyOf(decoded);
+    }
+
+    /** Calls {@code ASIOStart}. Returns {@code true} on {@code ASE_OK}. */
+    boolean start() {
+        return invokeStatus(start);
+    }
+
+    /** Calls {@code ASIOStop}. Idempotent; {@code true} when not started. */
+    boolean stop() {
+        return invokeStatus(stop);
+    }
+
+    /** Calls {@code ASIODisposeBuffers} (stopping first if needed). Idempotent. */
+    boolean disposeBuffers() {
+        return invokeStatus(disposeBuffers);
+    }
+
+    private boolean invokeStatus(MethodHandle handle) {
+        if (handle == null || closed) {
+            return false;
+        }
+        try {
+            int status = AsioControlThread.call(() -> (int) handle.invokeExact());
+            return status == SHIM_OK;
+        } catch (Throwable ignored) {
+            // Best-effort: a failed teardown must never break close().
+            return false;
+        }
+    }
+
+    /**
+     * Registers the FFM upcall stub the shim invokes from every
+     * {@code bufferSwitch}.
+     *
+     * @param upcallStub the stub produced by {@link AsioBufferSwitchShim#upcallStub()};
+     *                   must not be null
+     * @return {@code true} when the callback was installed
+     */
+    boolean installBufferSwitchCallback(MemorySegment upcallStub) {
+        Objects.requireNonNull(upcallStub, "upcallStub must not be null");
+        if (!isStreamingAvailable() || upcallStub.equals(MemorySegment.NULL)) {
+            return false;
+        }
+        try {
+            return AsioControlThread.call(() -> {
+                installCallback.invokeExact(upcallStub);
+                return true;
+            });
+        } catch (Throwable ignored) {
+            // Install failed — the caller rolls the open back.
+            return false;
+        }
+    }
+
+    /**
+     * Clears the registered buffer-switch upcall. Must be called before the
+     * {@link AsioBufferSwitchShim}'s arena is freed, or a late callback would
+     * jump into a released stub. Best-effort and idempotent.
+     */
+    void uninstallBufferSwitchCallback() {
+        if (uninstallCallback == null || closed) {
+            return;
+        }
+        try {
+            AsioControlThread.call(() -> {
+                uninstallCallback.invokeExact();
+                return null;
+            });
+        } catch (Throwable ignored) {
+            // Best-effort: never throw from the teardown path.
+        }
+    }
+
+    /**
+     * Releases the FFM arena that owns this shim's method handles. Idempotent.
+     *
+     * <p>This deliberately performs <em>no</em> driver teardown. The caller
+     * owns the story-mandated ordering — {@code stop()} &rarr;
+     * {@code disposeBuffers()} &rarr;
+     * {@link #uninstallBufferSwitchCallback()} &rarr; close the
+     * {@link AsioBufferSwitchShim} (freeing its upcall arena strictly after the
+     * uninstall) &rarr; {@code close()} — and
+     * {@link AsioBackend#close()} and {@code rollbackOpen(...)} both do exactly
+     * that. Repeating the teardown here would make the headline ordering test
+     * assert a call sequence production does not have.</p>
+     *
+     * <p>For a caller that skips the explicit teardown, the native
+     * {@code asioshim_unloadDriver} is the backstop: it stops and disposes the
+     * driver's buffers before {@code ASIOExit}, so the driver is never left
+     * streaming.</p>
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            AsioControlThread.call(() -> {
+                arena.close();
+                return null;
+            });
+        } catch (Throwable ignored) {
+            // Already closed elsewhere — close() stays idempotent.
+        }
+    }
+
+    /**
+     * One active channel's driver buffer descriptor, decoded from the
+     * 32-byte {@code asioshim_getBufferInfos} record.
+     *
+     * @param channel    driver channel index
+     * @param input      {@code true} for an input channel, {@code false} for output
+     * @param sampleType the driver's {@code ASIOSampleType} for this channel
+     * @param buffer0    address of {@code ASIOBufferInfo.buffers[0]}
+     * @param buffer1    address of {@code ASIOBufferInfo.buffers[1]}
+     */
+    record BufferInfo(int channel, boolean input, int sampleType,
+                      long buffer0, long buffer1) {
+        BufferInfo {
+            if (channel < 0) {
+                throw new IllegalArgumentException(
+                        "channel must not be negative: " + channel);
+            }
+        }
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBackendSupport.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBackendSupport.java
@@ -37,12 +37,23 @@ final class AudioBackendSupport implements AutoCloseable {
     private static final BiPredicate<Flow.Subscriber<? super AudioDeviceEvent>, AudioDeviceEvent>
             DROP_DEVICE_EVENT = (subscriber, droppedEvent) -> false;
 
-    private volatile SubmissionPublisher<AudioBlock> publisher = new SubmissionPublisher<>();
-    private volatile SubmissionPublisher<AudioDeviceEvent> devicePublisher =
-            new SubmissionPublisher<>();
+    private volatile SubmissionPublisher<AudioBlock> publisher;
+    private volatile SubmissionPublisher<AudioDeviceEvent> devicePublisher;
     private volatile boolean open;
     private volatile AudioFormat format;
     private volatile int bufferFrames;
+
+    AudioBackendSupport() {
+        this(new SubmissionPublisher<>(), new SubmissionPublisher<>());
+    }
+
+    /** Test seam for deterministically exercising publisher-close races. */
+    AudioBackendSupport(SubmissionPublisher<AudioBlock> publisher,
+                        SubmissionPublisher<AudioDeviceEvent> devicePublisher) {
+        this.publisher = Objects.requireNonNull(publisher, "publisher must not be null");
+        this.devicePublisher = Objects.requireNonNull(
+                devicePublisher, "devicePublisher must not be null");
+    }
 
     synchronized void markOpen(AudioFormat format, int bufferFrames) {
         Objects.requireNonNull(format, "format must not be null");
@@ -113,7 +124,7 @@ final class AudioBackendSupport implements AutoCloseable {
         // Use offer() with a drop handler instead of submit() to avoid
         // blocking under backpressure — this may be called from a native
         // callback thread (e.g. ASIO's asioMessage) that must not stall.
-        current.offer(event, DROP_DEVICE_EVENT);
+        offerUnlessClosed(current, event, DROP_DEVICE_EVENT);
     }
 
     /**
@@ -130,10 +141,10 @@ final class AudioBackendSupport implements AutoCloseable {
      * a block instead of stalling capture.</p>
      *
      * <p>The guard checks both the open flag <em>and</em> the publisher's
-     * closed state: {@link SubmissionPublisher#offer} throws
-     * {@code IllegalStateException("Closed")} on a closed publisher with no
-     * subscribers, so a publish racing {@link #close()} must be filtered out
-     * here rather than construct an exception.</p>
+     * closed state as a cheap fast path. Because {@link #close()} can still win
+     * between that check and {@link SubmissionPublisher#offer},
+     * {@link #offerUnlessClosed(SubmissionPublisher, Object, BiPredicate)}
+     * handles the documented close exception at the operation itself.</p>
      *
      * @param block the captured block; must not be null
      */
@@ -145,7 +156,31 @@ final class AudioBackendSupport implements AutoCloseable {
         if (!open || current.isClosed()) {
             return;
         }
-        current.offer(block, DROP_INPUT_BLOCK);
+        offerUnlessClosed(current, block, DROP_INPUT_BLOCK);
+    }
+
+    /**
+     * Offers an item without allowing a concurrent {@link #close()} to leak
+     * {@link IllegalStateException} onto a backend callback thread.
+     *
+     * <p>The earlier {@link SubmissionPublisher#isClosed()} checks remain a
+     * cheap fast path, but they cannot make the subsequent offer atomic with
+     * close. Serializing the operations would block the real-time caller, so
+     * the close race is handled at the non-blocking operation itself. An
+     * {@code IllegalStateException} from an open publisher is rethrown rather
+     * than hidden.</p>
+     */
+    private static <T> void offerUnlessClosed(
+            SubmissionPublisher<T> publisher,
+            T item,
+            BiPredicate<Flow.Subscriber<? super T>, T> dropHandler) {
+        try {
+            publisher.offer(item, dropHandler);
+        } catch (IllegalStateException closedRace) {
+            if (!publisher.isClosed()) {
+                throw closedRace;
+            }
+        }
     }
 
     void validateOutgoing(AudioBlock block) {

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBackendSupport.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBackendSupport.java
@@ -5,6 +5,7 @@ import java.lang.foreign.SymbolLookup;
 import java.util.Objects;
 import java.util.concurrent.Flow;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.function.BiPredicate;
 
 /**
  * Internal helper that holds the mutable state every {@link AudioBackend}
@@ -18,6 +19,23 @@ import java.util.concurrent.SubmissionPublisher;
  * sealed {@link AudioBackend} hierarchy is the public surface.</p>
  */
 final class AudioBackendSupport implements AutoCloseable {
+
+    /**
+     * Drop handler shared by every {@link #publishInput(AudioBlock)} call.
+     * Hoisted into a constant so no lambda is allocated per published block
+     * (story 311). Returning {@code false} tells
+     * {@link SubmissionPublisher#offer(Object, java.util.function.BiPredicate)}
+     * to drop the item rather than retry.
+     */
+    private static final BiPredicate<Flow.Subscriber<? super AudioBlock>, AudioBlock>
+            DROP_INPUT_BLOCK = (subscriber, droppedBlock) -> false;
+
+    /**
+     * Drop handler shared by every {@link #publishDeviceEvent(AudioDeviceEvent)}
+     * call; hoisted for the same reason as {@link #DROP_INPUT_BLOCK}.
+     */
+    private static final BiPredicate<Flow.Subscriber<? super AudioDeviceEvent>, AudioDeviceEvent>
+            DROP_DEVICE_EVENT = (subscriber, droppedEvent) -> false;
 
     private volatile SubmissionPublisher<AudioBlock> publisher = new SubmissionPublisher<>();
     private volatile SubmissionPublisher<AudioDeviceEvent> devicePublisher =
@@ -76,25 +94,58 @@ final class AudioBackendSupport implements AutoCloseable {
         return devicePublisher;
     }
 
+    /**
+     * Publishes a device event without ever blocking the caller.
+     *
+     * <p>Deliberately <em>not</em> gated on the open flag: story 218's
+     * driver-initiated reset and format-change notifications must still reach
+     * subscribers while the backend is opening or tearing down, which is
+     * exactly when a driver sends them.</p>
+     */
     void publishDeviceEvent(AudioDeviceEvent event) {
         Objects.requireNonNull(event, "event must not be null");
-        if (devicePublisher.isClosed()) {
+        // Capture the swappable publisher reference exactly once: markOpen()
+        // may replace it concurrently after a close-then-open cycle.
+        SubmissionPublisher<AudioDeviceEvent> current = devicePublisher;
+        if (current.isClosed()) {
             return;
         }
         // Use offer() with a drop handler instead of submit() to avoid
         // blocking under backpressure — this may be called from a native
-        // callback thread (e.g. ASIO buffer-switch) that must not stall.
-        devicePublisher.offer(event, (subscriber, droppedEvent) -> {
-            // Drop the event rather than block; log for diagnostics.
-            return false;
-        });
+        // callback thread (e.g. ASIO's asioMessage) that must not stall.
+        current.offer(event, DROP_DEVICE_EVENT);
     }
 
+    /**
+     * Publishes a captured input block without ever blocking the caller.
+     *
+     * <p>Story 311: for the ASIO backend this runs on the dedicated
+     * {@code asio-input-drain} thread rather than the driver's real-time
+     * thread, but it must still never stall — a stalled drain thread backs up
+     * into the callback's capture ring. The previous
+     * {@code publisher.submit(...)} blocks under back-pressure and was
+     * therefore unusable. {@code offer(...)} with a drop handler applies
+     * exactly the rationale already documented on
+     * {@link #publishDeviceEvent(AudioDeviceEvent)}: a slow subscriber loses
+     * a block instead of stalling capture.</p>
+     *
+     * <p>The guard checks both the open flag <em>and</em> the publisher's
+     * closed state: {@link SubmissionPublisher#offer} throws
+     * {@code IllegalStateException("Closed")} on a closed publisher with no
+     * subscribers, so a publish racing {@link #close()} must be filtered out
+     * here rather than construct an exception.</p>
+     *
+     * @param block the captured block; must not be null
+     */
     void publishInput(AudioBlock block) {
         Objects.requireNonNull(block, "block must not be null");
-        if (open) {
-            publisher.submit(block);
+        // Capture the swappable publisher reference exactly once: markOpen()
+        // may replace it concurrently after a close-then-open cycle.
+        SubmissionPublisher<AudioBlock> current = publisher;
+        if (!open || current.isClosed()) {
+            return;
         }
+        current.offer(block, DROP_INPUT_BLOCK);
     }
 
     void validateOutgoing(AudioBlock block) {

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBlockRing.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AudioBlockRing.java
@@ -1,0 +1,223 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Allocation-free, single-producer / single-consumer ring of fixed-size
+ * interleaved sample buffers used by the ASIO streaming bridge (story 311).
+ *
+ * <p>Two instances are in play, one per direction:</p>
+ * <ul>
+ *   <li><strong>Output.</strong> Producer is the engine render thread
+ *       ({@link AsioBackend#sink(AudioBlock)} &rarr; {@link #write(float[], int)});
+ *       consumer is the driver's real-time callback thread
+ *       ({@link #drainLatestInto(float[])}), which deliberately discards
+ *       everything but the newest queued block — playback must not fall
+ *       behind.</li>
+ *   <li><strong>Input.</strong> Producer is the driver's real-time callback
+ *       thread ({@link #write(float[], int)}); consumer is the
+ *       {@code asio-input-drain} thread ({@link #readInto(float[])}), which
+ *       consumes strictly <em>in order</em>, one slot per call — recording must
+ *       not skip blocks.</li>
+ * </ul>
+ *
+ * <p>This is a deliberate in-module sibling of
+ * {@code com.benesquivelmusic.daw.core.audio.performance.XrunEventRingBuffer},
+ * which is the house lock-free SPSC idiom (pre-allocated mutable slots,
+ * {@link AtomicLong} head/tail, {@code lazySet} release stores, drop-on-full
+ * rather than block). {@code daw-sdk} is the API floor and must not depend on
+ * {@code daw-core}, so the idiom is re-implemented here rather than reused.</p>
+ *
+ * <p>A single ring must use exactly one of {@link #drainLatestInto(float[])} or
+ * {@link #readInto(float[])}: they are alternative consumer disciplines over
+ * the same single consumer index, not composable operations.</p>
+ */
+final class AudioBlockRing {
+
+    private final float[][] slots;
+    private final int mask;
+    private final int capacity;
+    private final int samplesPerBlock;
+    private final AtomicLong head = new AtomicLong(0); // consumer
+    private final AtomicLong tail = new AtomicLong(0); // producer
+
+    /**
+     * Creates a ring with at least {@code requestedCapacity} slots, each
+     * holding {@code samplesPerBlock} interleaved float samples. Capacity is
+     * rounded up to the next power of two so the index wrap is a mask.
+     *
+     * @param requestedCapacity minimum number of slots; must be positive
+     * @param samplesPerBlock   interleaved samples per slot
+     *                          ({@code channels * frames}); must be positive
+     */
+    AudioBlockRing(int requestedCapacity, int samplesPerBlock) {
+        if (requestedCapacity <= 0) {
+            throw new IllegalArgumentException(
+                    "capacity must be positive: " + requestedCapacity);
+        }
+        if (samplesPerBlock <= 0) {
+            throw new IllegalArgumentException(
+                    "samplesPerBlock must be positive: " + samplesPerBlock);
+        }
+        int cap = 1;
+        while (cap < requestedCapacity) {
+            cap <<= 1;
+        }
+        this.capacity = cap;
+        this.mask = cap - 1;
+        this.samplesPerBlock = samplesPerBlock;
+        this.slots = new float[cap][samplesPerBlock];
+    }
+
+    /**
+     * Copies up to {@link #samplesPerBlock()} samples from {@code source}
+     * into the next free slot and publishes it.
+     *
+     * <p>Length mismatches are tolerated rather than rejected: a shorter
+     * source is zero-padded and a longer one is truncated, so a caller that
+     * momentarily hands over a differently-shaped block never throws on the
+     * render or callback thread.</p>
+     *
+     * <p>When the ring is full the <em>incoming</em> block is dropped and the
+     * queued ones are kept. Overwriting the oldest slot instead would not be
+     * single-producer safe: the consumer may be copying out of that very slot
+     * at the time.</p>
+     *
+     * @param source interleaved samples to publish; must not be null
+     * @param length number of samples to take from {@code source}
+     * @return {@code true} when the block was queued, {@code false} when the
+     *         ring was full and the block was dropped
+     */
+    @RealTimeSafe
+    boolean write(float[] source, int length) {
+        if (source == null || length < 0) {
+            return false;
+        }
+        long t = tail.get();
+        long h = head.get();
+        if (t - h >= capacity) {
+            return false; // full — drop the newest rather than block
+        }
+        float[] slot = slots[(int) (t & mask)];
+        int copied = Math.min(Math.min(length, source.length), slot.length);
+        System.arraycopy(source, 0, slot, 0, copied);
+        if (copied < slot.length) {
+            Arrays.fill(slot, copied, slot.length, 0f);
+        }
+        // lazySet (release store) is sufficient for SPSC and avoids the
+        // StoreLoad fence a plain volatile set would impose on the render
+        // thread. The slot write above happens-before this store, so the
+        // consumer's acquire-load of tail establishes the needed ordering.
+        tail.lazySet(t + 1);
+        return true;
+    }
+
+    /**
+     * Consumes every queued slot and copies the most recent one into
+     * {@code destination} — the output-direction consumer discipline.
+     *
+     * <p>Draining all pending slots (instead of one per call) keeps the
+     * callback thread from replaying stale audio when the render thread
+     * momentarily runs ahead: everything older than the newest queued block is
+     * discarded unheard. Note that this is only true of blocks the producer
+     * managed to queue — {@link #write(float[], int)} drops incoming blocks
+     * while the ring is full, so a stalled consumer loses the newest audio, not
+     * the oldest.</p>
+     *
+     * @param destination interleaved buffer to fill; must not be null.
+     *                    Trailing elements beyond the slot size are zeroed
+     * @return {@code true} when a block was copied, {@code false} when the
+     *         ring was empty (in which case {@code destination} is untouched)
+     */
+    @RealTimeSafe
+    boolean drainLatestInto(float[] destination) {
+        if (destination == null) {
+            return false;
+        }
+        long h = head.get();
+        long t = tail.get();
+        if (h >= t) {
+            return false; // empty
+        }
+        float[] latest = slots[(int) ((t - 1) & mask)];
+        int copied = Math.min(destination.length, latest.length);
+        System.arraycopy(latest, 0, destination, 0, copied);
+        if (copied < destination.length) {
+            Arrays.fill(destination, copied, destination.length, 0f);
+        }
+        // Release store after the copy: the producer may only reuse the
+        // slots once it observes the advanced head.
+        head.lazySet(t);
+        return true;
+    }
+
+    /**
+     * Consumes exactly one queued slot, oldest first, into
+     * {@code destination} — the input-direction consumer discipline
+     * (story 311).
+     *
+     * <p>Unlike {@link #drainLatestInto(float[])} this never skips a block:
+     * captured audio handed to {@link AsioBackend#inputBlocks()} subscribers
+     * must stay contiguous, so the {@code asio-input-drain} thread calls this
+     * in a loop until it returns {@code false}.</p>
+     *
+     * @param destination interleaved buffer to fill; must not be null.
+     *                    Trailing elements beyond the slot size are zeroed
+     * @return {@code true} when a block was copied, {@code false} when the
+     *         ring was empty (in which case {@code destination} is untouched)
+     */
+    @RealTimeSafe
+    boolean readInto(float[] destination) {
+        if (destination == null) {
+            return false;
+        }
+        long h = head.get();
+        long t = tail.get();
+        if (h >= t) {
+            return false; // empty
+        }
+        float[] slot = slots[(int) (h & mask)];
+        int copied = Math.min(destination.length, slot.length);
+        System.arraycopy(slot, 0, destination, 0, copied);
+        if (copied < destination.length) {
+            Arrays.fill(destination, copied, destination.length, 0f);
+        }
+        // Release store after the copy: the producer may only reuse this slot
+        // once it observes the advanced head.
+        head.lazySet(h + 1);
+        return true;
+    }
+
+    /** Returns the slot count (the requested capacity rounded up to a power of two). */
+    int capacity() {
+        return capacity;
+    }
+
+    /** Returns the interleaved sample count each slot holds. */
+    int samplesPerBlock() {
+        return samplesPerBlock;
+    }
+
+    /** Returns {@code true} when no published slot is pending. */
+    @RealTimeSafe
+    boolean isEmpty() {
+        return head.get() >= tail.get();
+    }
+
+    /** Returns the number of published-but-unconsumed slots. */
+    @RealTimeSafe
+    int size() {
+        long h = head.get();
+        long t = tail.get();
+        return (int) Math.max(0, t - h);
+    }
+
+    @Override
+    public String toString() {
+        return "AudioBlockRing[capacity=" + capacity
+                + ", samplesPerBlock=" + samplesPerBlock + "]";
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBackendStreamingTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBackendStreamingTest.java
@@ -1,0 +1,886 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * Story 311 lifecycle tests for the streaming path wired into
+ * {@link AsioBackend}: {@code open} &rarr; install the story-218
+ * {@code asioMessage} upcall / {@code createBuffers} /
+ * {@code installBufferSwitchCallback} / {@code start}, and {@code close}
+ * &rarr; {@code stop} / {@code disposeBuffers} /
+ * {@code uninstallBufferSwitchCallback}, in that order.
+ *
+ * <p>Uses the established stubbing idiom — a
+ * {@code private final class Stub… extends Asio…Shim} injected through
+ * the backend's static factory seams and reset in {@code @AfterEach} (see
+ * {@code AsioBackendDriverLifecycleTest} / {@code AsioBackendCapabilityTest}).
+ * Every stub calls {@code super.close()} so the real superclass's
+ * {@code Arena.ofShared()} is released and the asserted call sequence is the
+ * shape production actually has.</p>
+ */
+class AsioBackendStreamingTest {
+
+    private static final DeviceId DRIVER_A = new DeviceId("ASIO", "Driver A");
+    private static final AudioFormat FORMAT = new AudioFormat(48_000.0, 2, 32);
+    private static final int FRAMES = 128;
+    private static final long AWAIT_SECONDS = 10;
+
+    private Arena arena;
+    private List<String> calls;
+    private StubDriverShim driver;
+    private AsioBackend backend;
+    private MemorySegment[][] inputBuffers;
+    private MemorySegment[][] outputBuffers;
+    private List<AsioStreamingShim.BufferInfo> bufferInfos;
+
+    // Behaviour switches read by every StubStreamingShim the factory creates.
+    private boolean streamingAvailable = true;
+    private boolean createSucceeds = true;
+    private boolean startSucceeds = true;
+    private boolean stopSucceeds = true;
+    private boolean disposeSucceeds = true;
+    private boolean resetFromInsideCreateBuffers;
+
+    // Capture of AsioBackend's own logger, for the teardown-refusal warnings.
+    private Logger backendLog;
+    private Handler logCapture;
+    private List<LogRecord> logRecords;
+    private boolean logUsedParentHandlers;
+    private Level logLevel;
+
+    @BeforeEach
+    void setUp() {
+        arena = Arena.ofShared();
+        calls = Collections.synchronizedList(new ArrayList<>());
+        bufferInfos = driverBufferInfos();
+        driver = new StubDriverShim();
+        AsioBackend.setDriverShimFactory(() -> driver);
+        AsioBackend.setStreamingShimFactory(StubStreamingShim::new);
+        backend = new AsioBackend();
+        installLogCapture();
+    }
+
+    @AfterEach
+    void tearDown() {
+        backend.close();
+        AsioBackend.resetDriverShimFactory();
+        AsioBackend.resetStreamingShimFactory();
+        AsioBackend.resetCapabilityShimFactory();
+        removeLogCapture();
+        arena.close();
+    }
+
+    // ------------------------------------------------------------------
+    // Open / close ordering
+    // ------------------------------------------------------------------
+
+    /**
+     * The story's headline ordering assertion. {@code asioMessageShimInstalled}
+     * is sampled from live backend state <em>inside</em> the
+     * {@code createBuffers} stand-in, so it genuinely proves the story-218
+     * upcall is registered before {@code ASIOCreateBuffers} runs — real drivers
+     * issue {@code kAsioEngineVersion} / {@code kAsioSelectorSupported} /
+     * {@code kAsioSupportsTimeInfo} synchronously from inside that call, and an
+     * unanswered engine-version query makes them fall back to ASIO 1.0.
+     */
+    @Test
+    void openInstallsTheMessageCallbackBeforeCreatingBuffersThenStarts() {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+
+        assertThat(backend.isOpen()).isTrue();
+        assertThat(calls).containsExactly(
+                "asioMessageShimInstalled=true",
+                "createBuffers:in=[0, 1]:out=[0, 1]:frames=128",
+                "getBufferInfos",
+                "installBufferSwitchCallback",
+                "start");
+        assertThat(backend.activeBufferSwitchShim()).isNotNull();
+        assertThat(backend.activeBufferSwitchShim().bufferFrames()).isEqualTo(FRAMES);
+        assertThat(backend.activeFormatChangeShim()).isNotNull();
+    }
+
+    @Test
+    void closeStopsDisposesThenUninstallsBeforeTheDriverUnload() {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        calls.clear();
+
+        backend.close();
+
+        assertThat(calls).containsExactly(
+                "stop", "disposeBuffers", "uninstallBufferSwitchCallback", "close",
+                "unload");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(backend.activeBufferSwitchShim()).isNull();
+        assertThat(backend.activeFormatChangeShim()).isNull();
+    }
+
+    /**
+     * Story 311 (G1): {@code asioshim_stop} no longer always answers "OK" — it
+     * reports success only for the genuine "nothing to do" cases (not started,
+     * no buffers, no driver loaded) and failure when {@code ASIOStop} was
+     * actually issued and the driver refused it. A refusal must be logged, and
+     * the teardown must still run to completion.
+     *
+     * <p>Continuing is the safe response, not a compromise: the native shim
+     * drains its in-flight callback barrier before {@code ASIODisposeBuffers}
+     * and again inside {@code uninstallAsioBufferSwitchCallback}, after which
+     * the trampoline loads a null callback and returns without touching the
+     * upcall stub. Aborting would skip the very uninstall that protects the
+     * arena, and would leak that arena plus the {@code asio-input-drain} thread
+     * for the life of the process.</p>
+     */
+    @Test
+    void aRefusedAsioStopIsLoggedAndTheTeardownStillCompletesInOrder() {
+        stopSucceeds = false;
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        calls.clear();
+
+        backend.close();
+
+        assertThat(calls)
+                .as("a driver that refuses ASIOStop must still reach dispose, "
+                        + "uninstall and the driver unload, in order")
+                .containsExactly(
+                        "stop", "disposeBuffers", "uninstallBufferSwitchCallback",
+                        "close", "unload");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(backend.activeBufferSwitchShim()).isNull();
+        assertThat(driver.unloaded).isTrue();
+        assertWarningLogged("refused ASIOStop during teardown", "Driver A");
+    }
+
+    @Test
+    void closeIsIdempotent() {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        backend.close();
+        calls.clear();
+
+        assertThatCode(backend::close).doesNotThrowAnyException();
+        assertThat(calls).isEmpty();
+    }
+
+    /**
+     * Story 311 (S5): the shim's own {@code close()} releases its FFM arena and
+     * nothing else. {@link AsioBackend} owns the
+     * stop &rarr; dispose &rarr; uninstall ordering, so repeating it here would
+     * make the headline ordering test above assert a shape production does not
+     * have.
+     */
+    @Test
+    void streamingShimCloseReleasesOnlyItsArenaAndNeverRepeatsTheTeardown() {
+        AsioStreamingShim shim = new StubStreamingShim();
+        calls.clear();
+
+        shim.close();
+
+        assertThat(calls)
+                .as("close() must not re-run stop / disposeBuffers / uninstall")
+                .containsExactly("close");
+    }
+
+    // ------------------------------------------------------------------
+    // Buffer-size negotiation (stories 213 / 220)
+    // ------------------------------------------------------------------
+
+    @Test
+    void bufferSizeOutsideTheDriverReportedRangeIsRejectedWithoutResizing() {
+        // Driver reports {min 96, max 384, granularity 96}; 128 is off-ladder.
+        AsioBackend.setCapabilityShimFactory(
+                () -> StubCapabilityShim.withRange(new BufferSizeRange(96, 384, 192, 96)));
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, FORMAT, FRAMES))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("rejected buffer size 128")
+                .hasMessageContaining("min=96")
+                .hasMessageContaining("max=384")
+                .hasMessageContaining("preferred=192")
+                .hasMessageContaining("granularity=96");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(driver.unloaded).isTrue();
+        assertThat(calls)
+                .as("no buffers may be created when the size was rejected")
+                .containsExactly("unload");
+    }
+
+    @Test
+    void bufferSizeOnTheDriverReportedLadderIsAccepted() {
+        AsioBackend.setCapabilityShimFactory(
+                () -> StubCapabilityShim.withRange(new BufferSizeRange(96, 384, 192, 96)));
+
+        backend.open(DRIVER_A, FORMAT, 192);
+
+        assertThat(backend.isOpen()).isTrue();
+        assertThat(calls).contains("start");
+    }
+
+    // ------------------------------------------------------------------
+    // Channel negotiation (S1 / F9)
+    // ------------------------------------------------------------------
+
+    @Test
+    void aPlaybackOnlyDriverIsAskedForNoInputChannels() {
+        AsioBackend.setCapabilityShimFactory(
+                () -> StubCapabilityShim.withChannels(0, 8));
+
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+
+        assertThat(backend.isOpen()).isTrue();
+        assertThat(calls)
+                .as("requesting phantom inputs makes ASIOCreateBuffers fail on "
+                        + "playback-only devices")
+                .contains("createBuffers:in=[]:out=[0, 1]:frames=128");
+    }
+
+    @Test
+    void aCaptureOnlyDriverIsAskedForNoOutputChannels() {
+        AsioBackend.setCapabilityShimFactory(
+                () -> StubCapabilityShim.withChannels(8, 0));
+
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+
+        assertThat(backend.isOpen()).isTrue();
+        assertThat(calls).contains("createBuffers:in=[0, 1]:out=[]:frames=128");
+    }
+
+    @Test
+    void eachDirectionIsClampedToTheDriverReportedChannelCount() {
+        AsioBackend.setCapabilityShimFactory(
+                () -> StubCapabilityShim.withChannels(1, 1));
+
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+
+        assertThat(calls).contains("createBuffers:in=[0]:out=[0]:frames=128");
+    }
+
+    @Test
+    void aCombinedChannelRequestAboveTheNativeCapIsRejectedUpFront() {
+        AudioFormat wide = new AudioFormat(48_000.0, 40, 32);
+        AsioBackend.setCapabilityShimFactory(
+                () -> StubCapabilityShim.withChannels(40, 40));
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, wide, FRAMES))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("40 input(s) + 40 output(s)")
+                .hasMessageContaining("64")
+                .hasMessageContaining("32");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(driver.unloaded).isTrue();
+        assertThat(calls)
+                .as("the cap must be enforced before ASIOCreateBuffers is called")
+                .noneMatch(call -> call.startsWith("createBuffers"));
+    }
+
+    // ------------------------------------------------------------------
+    // Degradation and rollback
+    // ------------------------------------------------------------------
+
+    @Test
+    void unavailableStreamingShimLeavesTheStory310OpenPathUntouched() {
+        streamingAvailable = false;
+
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+
+        assertThat(backend.isOpen()).isTrue();
+        assertThat(backend.activeBufferSwitchShim()).isNull();
+        assertThat(calls).containsExactly("close");
+
+        backend.close();
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(calls).containsExactly("close", "unload");
+    }
+
+    @Test
+    void failedCreateBuffersRollsBackAndLeavesTheBackendClosed() {
+        createSucceeds = false;
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, FORMAT, FRAMES))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("ASIOCreateBuffers");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(driver.unloaded).isTrue();
+        assertThat(calls).containsSubsequence(
+                "createBuffers:in=[0, 1]:out=[0, 1]:frames=128",
+                "stop", "disposeBuffers", "uninstallBufferSwitchCallback",
+                "close", "unload");
+        assertThat(backend.activeFormatChangeShim())
+                .as("a failed open must not leave the asioMessage upcall registered")
+                .isNull();
+    }
+
+    @Test
+    void failedStartRollsBackAndTearsTheDriverDownInOrder() {
+        startSucceeds = false;
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, FORMAT, FRAMES))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("ASIOStart failed");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(calls).containsSubsequence(
+                "start", "stop", "disposeBuffers",
+                "uninstallBufferSwitchCallback", "close");
+        assertThat(driver.unloaded).isTrue();
+        assertThat(backend.activeBufferSwitchShim()).isNull();
+    }
+
+    /**
+     * Story 311 (G1), rollback counterpart: {@code rollbackOpen(...)} discards
+     * the same two status codes {@code close()} does, so it gets the same
+     * treatment — log the refusal, then finish the teardown.
+     */
+    @Test
+    void aRefusedTeardownDuringRollbackStillUninstallsAndUnloads() {
+        startSucceeds = false;
+        stopSucceeds = false;
+        disposeSucceeds = false;
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, FORMAT, FRAMES))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("ASIOStart failed");
+
+        assertThat(calls).containsSubsequence(
+                "start", "stop", "disposeBuffers",
+                "uninstallBufferSwitchCallback", "close", "unload");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(driver.unloaded).isTrue();
+        assertWarningLogged(
+                "refused ASIOStop and ASIODisposeBuffers during teardown", "Driver A");
+    }
+
+    @Test
+    void emptyBufferInfoListRollsBack() {
+        bufferInfos = List.of();
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, FORMAT, FRAMES))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("no buffer descriptors");
+        assertThat(backend.isOpen()).isFalse();
+        assertThat(driver.unloaded).isTrue();
+    }
+
+    // ------------------------------------------------------------------
+    // sink(...)
+    // ------------------------------------------------------------------
+
+    @Test
+    void sinkBeforeOpenValidatesAndDoesNotThrow() {
+        AudioBlock block = AudioBlock.silence(48_000.0, 2, FRAMES);
+
+        assertThatCode(() -> backend.sink(block)).doesNotThrowAnyException();
+        assertThat(calls).isEmpty();
+    }
+
+    @Test
+    void sinkAfterOpenReachesTheDriverOutputBuffersOnTheNextCallback() {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        float[] samples = new float[2 * FRAMES];
+        for (int frame = 0; frame < FRAMES; frame++) {
+            samples[frame * 2] = 0.5f;
+            samples[frame * 2 + 1] = -0.5f;
+        }
+        backend.sink(new AudioBlock(48_000.0, 2, FRAMES, samples));
+
+        backend.activeBufferSwitchShim().bufferSwitch(0, 1);
+
+        assertThat(readDriverBuffer(outputBuffers[0][0])).containsOnly(0.5f);
+        assertThat(readDriverBuffer(outputBuffers[0][1])).containsOnly(-0.5f);
+    }
+
+    /**
+     * Story 311 (S7): an engine rendering 64-frame blocks into a 128-frame ASIO
+     * stream would otherwise produce half-audio / half-silence buffers with no
+     * diagnostic. The story requires a buffer-size mismatch to surface as an
+     * {@link AudioBackendException} "rather than silently resizing".
+     */
+    @Test
+    void sinkRejectsABlockWhoseFrameCountDoesNotMatchTheOpenedBufferSize() {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        AudioBlock halfSized = AudioBlock.silence(48_000.0, 2, FRAMES / 2);
+
+        assertThatThrownBy(() -> backend.sink(halfSized))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("rejected block size 64")
+                .hasMessageContaining("128 frames per buffer");
+    }
+
+    // ------------------------------------------------------------------
+    // Driver reset (stories 218 x 311)
+    // ------------------------------------------------------------------
+
+    @Test
+    void stopStreamingForDriverResetQuiescesTheBridgeAndTearsDownAsynchronously()
+            throws Exception {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        calls.clear();
+
+        backend.stopStreamingForDriverReset();
+
+        assertThat(backend.activeBufferSwitchShim().isStreaming()).isFalse();
+        awaitCall("disposeBuffers");
+        assertThat(calls).containsExactly("stop", "disposeBuffers");
+    }
+
+    /**
+     * Story 311 (S3): a reset does not close the backend — the driver is still
+     * loaded, and short-circuiting {@code close()} would leak the driver shim.
+     * The documented contract is therefore reset &rarr; {@code close()} &rarr;
+     * {@code open()}, and the reopen must re-create the driver's buffers.
+     */
+    @Test
+    void afterAResetTheBackendMustBeClosedBeforeItCanBeReopened() throws Exception {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+
+        backend.stopStreamingForDriverReset();
+        awaitCall("disposeBuffers");
+
+        assertThat(backend.isOpen())
+                .as("a reset leaves the driver loaded, so the backend stays open")
+                .isTrue();
+        assertThatThrownBy(() -> backend.open(DRIVER_A, FORMAT, FRAMES))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already has an open stream");
+
+        backend.close();
+        assertThat(backend.isOpen()).isFalse();
+        calls.clear();
+
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+
+        assertThat(backend.isOpen()).isTrue();
+        assertThat(calls).containsExactly(
+                "asioMessageShimInstalled=true",
+                "createBuffers:in=[0, 1]:out=[0, 1]:frames=128",
+                "getBufferInfos",
+                "installBufferSwitchCallback",
+                "start");
+        assertThat(backend.activeBufferSwitchShim().isStreaming()).isTrue();
+    }
+
+    /**
+     * Story 311 (B3, was S4): the {@code asioMessage} upcall is now live before
+     * {@code ASIOCreateBuffers}, so a driver can dispatch
+     * {@code kAsioResetRequest} from inside it — before either streaming field
+     * is published. Without the latch the reset would silently no-op and
+     * {@code open()} would go on to start a driver that just asked to be reset.
+     */
+    @Test
+    void aResetDispatchedFromInsideCreateBuffersIsAppliedOnceTheStreamIsLive()
+            throws Exception {
+        resetFromInsideCreateBuffers = true;
+
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+
+        assertThat(backend.activeBufferSwitchShim())
+                .as("open() still completes; the stream is simply quiesced")
+                .isNotNull();
+        assertThat(backend.activeBufferSwitchShim().isStreaming())
+                .as("open() must re-run the teardown the early reset could only latch")
+                .isFalse();
+        awaitCall("disposeBuffers");
+        assertThat(calls).containsSubsequence("start", "stop", "disposeBuffers");
+    }
+
+    /**
+     * Story 311 (G1), reset counterpart: the asynchronous reset teardown runs
+     * the same two calls and would otherwise discard the same information. It
+     * frees nothing — the upcall stays installed and the bridge alive — so a
+     * refusal here is purely a diagnostic.
+     */
+    @Test
+    void aRefusedDisposeDuringADriverResetIsLogged() throws Exception {
+        disposeSucceeds = false;
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        calls.clear();
+
+        backend.stopStreamingForDriverReset();
+
+        awaitCall("disposeBuffers");
+        assertThat(calls).containsExactly("stop", "disposeBuffers");
+        awaitWarning("refused ASIODisposeBuffers during teardown");
+    }
+
+    @Test
+    void stopStreamingForDriverResetIsSafeWhenNothingIsStreaming() {
+        assertThatCode(backend::stopStreamingForDriverReset)
+                .doesNotThrowAnyException();
+        assertThat(calls).isEmpty();
+    }
+
+    /** N10: the opened-then-already-torn-down case, not just the null branch. */
+    @Test
+    void stopStreamingForDriverResetIsSafeAfterTheBackendWasClosed() {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        backend.close();
+        calls.clear();
+
+        assertThatCode(backend::stopStreamingForDriverReset)
+                .doesNotThrowAnyException();
+
+        assertThat(calls)
+                .as("both shims are already released, so there is nothing to tear down")
+                .isEmpty();
+    }
+
+    @Test
+    void repeatedResetsAreIdempotent() throws Exception {
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        calls.clear();
+
+        backend.stopStreamingForDriverReset();
+        backend.stopStreamingForDriverReset();
+        awaitCall("disposeBuffers");
+
+        assertThat(backend.activeBufferSwitchShim().isStreaming()).isFalse();
+        assertThatCode(backend::close).doesNotThrowAnyException();
+    }
+
+    // ------------------------------------------------------------------
+    // Production shim degradation
+    // ------------------------------------------------------------------
+
+    @Test
+    void productionStreamingShimConstructsAndClosesIdempotentlyOnEveryHost() {
+        AsioStreamingShim shim = new AsioStreamingShim();
+        try {
+            assertThatCode(shim::uninstallBufferSwitchCallback)
+                    .doesNotThrowAnyException();
+            assertThat(shim.installBufferSwitchCallback(MemorySegment.NULL)).isFalse();
+        } finally {
+            shim.close();
+            shim.close();
+        }
+    }
+
+    /**
+     * Story 311 (S6): gated, because on the {@code windows-asioshim.yml} lane —
+     * the one lane this story exists to serve — {@code asioshim.dll} <em>is</em>
+     * discoverable and the shim is expected to resolve. Only the no-library
+     * degradation path is asserted here.
+     */
+    @Test
+    void productionStreamingShimIsUnavailableWhenAsioshimLibraryIsMissing() {
+        assumeFalse(asioshimAvailable(),
+                "asioshim is on the FFM library path — the missing-library "
+                        + "degradation path is not exercisable on this host");
+        AsioStreamingShim shim = new AsioStreamingShim();
+        try {
+            assertThat(shim.isStreamingAvailable()).isFalse();
+            assertThat(shim.createBuffers(new int[] {0}, new int[] {0}, 128)).isFalse();
+            assertThat(shim.getBufferInfos()).isEmpty();
+            assertThat(shim.start()).isFalse();
+            assertThat(shim.stop()).isFalse();
+            assertThat(shim.disposeBuffers()).isFalse();
+        } finally {
+            shim.close();
+        }
+    }
+
+    /**
+     * Lightweight FFM probe for the {@code asioshim} library, copied from
+     * {@code AsioFormatChangeShimTest}.
+     */
+    private static boolean asioshimAvailable() {
+        try (Arena probe = Arena.ofConfined()) {
+            SymbolLookup.libraryLookup("asioshim", probe);
+            return true;
+        } catch (IllegalArgumentException | UnsatisfiedLinkError ignored) {
+            return false;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Fixture helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Captures {@link AsioBackend}'s own {@code java.util.logging} output for
+     * the duration of one test, following the idiom in
+     * {@code AsioBackendCapabilityTest#shimAbsenceIsLoggedExactlyOncePerProcess}.
+     * Parent handlers are muted so the expected teardown warnings do not spam
+     * the build log.
+     */
+    private void installLogCapture() {
+        logRecords = new CopyOnWriteArrayList<>();
+        logCapture = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logRecords.add(record);
+            }
+
+            @Override public void flush() { }
+
+            @Override public void close() { }
+        };
+        backendLog = Logger.getLogger(AsioBackend.class.getName());
+        logUsedParentHandlers = backendLog.getUseParentHandlers();
+        logLevel = backendLog.getLevel();
+        backendLog.addHandler(logCapture);
+        backendLog.setUseParentHandlers(false);
+        backendLog.setLevel(Level.ALL);
+    }
+
+    private void removeLogCapture() {
+        backendLog.removeHandler(logCapture);
+        backendLog.setUseParentHandlers(logUsedParentHandlers);
+        backendLog.setLevel(logLevel);
+    }
+
+    private void assertWarningLogged(String... fragments) {
+        assertThat(logRecords)
+                .as("a teardown the driver refused must be logged at WARNING "
+                        + "containing %s", java.util.Arrays.toString(fragments))
+                .anySatisfy(record -> {
+                    assertThat(record.getLevel()).isEqualTo(Level.WARNING);
+                    assertThat(record.getMessage()).contains(fragments);
+                });
+    }
+
+    /** {@link #assertWarningLogged} for the asynchronous reset teardown. */
+    private void awaitWarning(String fragment) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(AWAIT_SECONDS);
+        while (System.nanoTime() < deadline && !warningLogged(fragment)) {
+            Thread.sleep(5);
+        }
+        assertWarningLogged(fragment);
+    }
+
+    private boolean warningLogged(String fragment) {
+        return logRecords.stream().anyMatch(
+                record -> Level.WARNING.equals(record.getLevel())
+                        && record.getMessage() != null
+                        && record.getMessage().contains(fragment));
+    }
+
+    private void awaitCall(String call) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(AWAIT_SECONDS);
+        while (System.nanoTime() < deadline && !calls.contains(call)) {
+            Thread.sleep(5);
+        }
+        assertThat(calls)
+                .as("the asynchronous reset teardown must reach %s", call)
+                .contains(call);
+    }
+
+    private List<AsioStreamingShim.BufferInfo> driverBufferInfos() {
+        inputBuffers = new MemorySegment[2][2];
+        outputBuffers = new MemorySegment[2][2];
+        List<AsioStreamingShim.BufferInfo> infos = new ArrayList<>();
+        for (int channel = 0; channel < 2; channel++) {
+            inputBuffers[0][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, FRAMES);
+            inputBuffers[1][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, FRAMES);
+            infos.add(new AsioStreamingShim.BufferInfo(channel, true, 19,
+                    inputBuffers[0][channel].address(),
+                    inputBuffers[1][channel].address()));
+        }
+        for (int channel = 0; channel < 2; channel++) {
+            outputBuffers[0][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, FRAMES);
+            outputBuffers[1][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, FRAMES);
+            infos.add(new AsioStreamingShim.BufferInfo(channel, false, 19,
+                    outputBuffers[0][channel].address(),
+                    outputBuffers[1][channel].address()));
+        }
+        return List.copyOf(infos);
+    }
+
+    private static float[] readDriverBuffer(MemorySegment buffer) {
+        float[] values = new float[FRAMES];
+        for (int frame = 0; frame < FRAMES; frame++) {
+            values[frame] = buffer.get(ValueLayout.JAVA_FLOAT_UNALIGNED,
+                    (long) frame * Float.BYTES);
+        }
+        return values;
+    }
+
+    // ------------------------------------------------------------------
+    // Stubs
+    // ------------------------------------------------------------------
+
+    /**
+     * Records every streaming call. An inner (non-static) class so the
+     * {@code createBuffers} stand-in can sample live {@link AsioBackend} state
+     * exactly as a real driver's synchronous callbacks would see it.
+     */
+    private final class StubStreamingShim extends AsioStreamingShim {
+
+        private boolean closed;
+
+        @Override
+        boolean isStreamingAvailable() {
+            return streamingAvailable && !closed;
+        }
+
+        @Override
+        boolean createBuffers(int[] inputChannels, int[] outputChannels, int bufferFrames) {
+            calls.add("asioMessageShimInstalled="
+                    + (backend.activeFormatChangeShim() != null));
+            calls.add("createBuffers:in=" + java.util.Arrays.toString(inputChannels)
+                    + ":out=" + java.util.Arrays.toString(outputChannels)
+                    + ":frames=" + bufferFrames);
+            if (resetFromInsideCreateBuffers) {
+                // Real drivers dispatch host callbacks from inside
+                // ASIOCreateBuffers; kAsioResetRequest routes here.
+                backend.stopStreamingForDriverReset();
+            }
+            return createSucceeds;
+        }
+
+        @Override
+        List<BufferInfo> getBufferInfos() {
+            calls.add("getBufferInfos");
+            return bufferInfos;
+        }
+
+        @Override
+        boolean start() {
+            calls.add("start");
+            return startSucceeds;
+        }
+
+        @Override
+        boolean stop() {
+            calls.add("stop");
+            return stopSucceeds;
+        }
+
+        @Override
+        boolean disposeBuffers() {
+            calls.add("disposeBuffers");
+            // Independent of stopSucceeds on purpose: asioshim_stop clears the
+            // native "started" flag before it calls ASIOStop, so the stop that
+            // asioshim_disposeBuffers performs first is then a successful
+            // "nothing to do" even when the driver refused the real one.
+            return disposeSucceeds;
+        }
+
+        @Override
+        boolean installBufferSwitchCallback(MemorySegment upcallStub) {
+            calls.add("installBufferSwitchCallback");
+            return true;
+        }
+
+        @Override
+        void uninstallBufferSwitchCallback() {
+            calls.add("uninstallBufferSwitchCallback");
+        }
+
+        @Override
+        public void close() {
+            if (!closed) {
+                closed = true;
+                calls.add("close");
+            }
+            // Release the real superclass's Arena.ofShared() rather than
+            // leaking one per stub instance.
+            super.close();
+        }
+    }
+
+    private final class StubDriverShim extends AsioDriverShim {
+
+        private boolean loaded;
+        private boolean unloaded;
+
+        @Override
+        boolean isEnumerationAvailable() {
+            return true;
+        }
+
+        @Override
+        boolean isLifecycleAvailable() {
+            return true;
+        }
+
+        @Override
+        List<DriverDescriptor> listDrivers() {
+            return List.of(new DriverDescriptor("Driver A",
+                    "{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"));
+        }
+
+        @Override
+        boolean loadDriver(String driverName) {
+            loaded = true;
+            return true;
+        }
+
+        @Override
+        Optional<DriverInfo> getDriverInfo() {
+            return loaded
+                    ? Optional.of(new DriverInfo(2, 1, "Driver A", "ready"))
+                    : Optional.empty();
+        }
+
+        @Override
+        public void close() {
+            if (loaded) {
+                loaded = false;
+                unloaded = true;
+                calls.add("unload");
+            }
+            super.close();
+        }
+    }
+
+    /** Reports a fixed, driver-style capability answer. */
+    private static final class StubCapabilityShim extends AsioCapabilityShim {
+
+        private final Optional<BufferSizeRange> range;
+        private final Optional<int[]> channelCounts;
+
+        private StubCapabilityShim(Optional<BufferSizeRange> range,
+                                   Optional<int[]> channelCounts) {
+            this.range = range;
+            this.channelCounts = channelCounts;
+        }
+
+        static StubCapabilityShim withRange(BufferSizeRange range) {
+            return new StubCapabilityShim(Optional.of(range), Optional.empty());
+        }
+
+        static StubCapabilityShim withChannels(int inputs, int outputs) {
+            return new StubCapabilityShim(Optional.empty(),
+                    Optional.of(new int[] {inputs, outputs}));
+        }
+
+        @Override
+        boolean isAvailable() {
+            return true;
+        }
+
+        @Override
+        Optional<BufferSizeRange> getBufferSize() {
+            return range;
+        }
+
+        @Override
+        Optional<int[]> getChannelCount() {
+            return channelCounts;
+        }
+
+        @Override
+        public void close() {
+            // Release the real superclass's Arena.ofShared().
+            super.close();
+        }
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBackendStreamingTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBackendStreamingTest.java
@@ -441,6 +441,38 @@ class AsioBackendStreamingTest {
         assertThat(calls).containsExactly("stop", "disposeBuffers");
     }
 
+    @Test
+    void queuedResetTeardownSkipsAStreamThatWasClosedAndReopened() {
+        List<Runnable> queuedTeardowns = new ArrayList<>();
+        backend.close();
+        backend = new AsioBackend(queuedTeardowns::add);
+        calls.clear();
+
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        backend.stopStreamingForDriverReset();
+        assertThat(queuedTeardowns).hasSize(1);
+
+        backend.close();
+        backend.open(DRIVER_A, FORMAT, FRAMES);
+        assertThat(backend.activeBufferSwitchShim().isStreaming()).isTrue();
+        calls.clear();
+        logRecords.clear();
+        stopSucceeds = false;
+        disposeSucceeds = false;
+
+        queuedTeardowns.getFirst().run();
+
+        assertThat(calls)
+                .as("a reset task captured from the previous stream must make no native calls")
+                .isEmpty();
+        assertThat(logRecords)
+                .as("a stale reset task must not report refusals from an obsolete shim")
+                .noneMatch(record -> Level.WARNING.equals(record.getLevel()));
+        assertThat(backend.activeBufferSwitchShim().isStreaming())
+                .as("the reopened stream remains current and running")
+                .isTrue();
+    }
+
     /**
      * Story 311 (S3): a reset does not close the backend — the driver is still
      * loaded, and short-circuiting {@code close()} would leak the driver shim.

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBufferSwitchShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBufferSwitchShimTest.java
@@ -1,0 +1,645 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 311 headline acceptance test for {@link AsioBufferSwitchShim}.
+ *
+ * <p>Fake "driver" buffers are allocated from a test-owned
+ * {@link Arena#ofShared()} and their raw addresses are handed to the shim as
+ * {@link AsioStreamingShim.BufferInfo} records with
+ * {@code sampleType = 19 (ASIOSTFloat32LSB)}, exactly as
+ * {@code asioshim_getBufferInfos} would. Synthetic
+ * {@link AsioBufferSwitchShim#bufferSwitch(int, int)} calls then stand in for
+ * the driver's real-time callback — the same "drive the package-private
+ * entrypoint directly" idiom {@code AsioFormatChangeShimTest} uses for
+ * {@code dispatch}.</p>
+ *
+ * <p>Every channel carries distinct, non-zero values so a stride error or a
+ * channel swap fails loudly instead of silently passing.</p>
+ *
+ * <p>Assertions about <em>how many</em> blocks a callback published are made
+ * deterministic without a sleep-based quiet period: the test closes the shim
+ * (which joins the {@code asio-input-drain} thread after a final flush) and
+ * only then publishes a recognisable <em>sentinel</em> straight through
+ * {@link AudioBackendSupport#publishInput(AudioBlock)}. A
+ * {@code SubmissionPublisher} preserves per-subscriber order, so the sentinel's
+ * index in the received list is an exact count of what the callbacks
+ * published.</p>
+ */
+class AsioBufferSwitchShimTest {
+
+    /** {@code ASIOSTFloat32LSB} — the only type story 311 converts. */
+    private static final int FLOAT32_LSB = 19;
+    /** {@code ASIOSTInt32LSB} — deferred to story 312. */
+    private static final int INT32_LSB = 17;
+
+    private static final int HALVES = 2;
+    private static final long AWAIT_SECONDS = 10;
+    private static final float SENTINEL = 12_345f;
+
+    private Arena arena;
+    private AudioBackendSupport support;
+    private AsioBufferSwitchShim shim;
+
+    private int channels;
+    private int frames;
+    private AudioFormat format;
+    private MemorySegment[][] driverInputs;
+    private MemorySegment[][] driverOutputs;
+
+    @BeforeEach
+    void setUp() {
+        arena = Arena.ofShared();
+        fixture(2, 4);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (shim != null) {
+            shim.close();
+            shim = null;
+        }
+        support.close();
+        arena.close();
+    }
+
+    // ------------------------------------------------------------------
+    // Capture (driver -> engine)
+    // ------------------------------------------------------------------
+
+    @Test
+    void eachCallbackPublishesExactlyOneDeinterleavedInputBlock() throws Exception {
+        buildShim(FLOAT32_LSB);
+        writeDriverBuffer(driverInputs[0][0], 0.1f, 0.2f, 0.3f, 0.4f);
+        writeDriverBuffer(driverInputs[0][1], -0.5f, -0.6f, -0.7f, -0.8f);
+        CapturingSubscriber subscriber = subscribe();
+
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(2)).isTrue();
+        assertThat(subscriber.blocks()).hasSize(2);
+        AudioBlock first = subscriber.blocks().get(0);
+        assertThat(first.channels()).isEqualTo(channels);
+        assertThat(first.frames()).isEqualTo(frames);
+        assertThat(first.samples()).containsExactly(
+                0.1f, -0.5f,
+                0.2f, -0.6f,
+                0.3f, -0.7f,
+                0.4f, -0.8f);
+    }
+
+    @Test
+    void secondHalfIsReadFromTheSecondDriverBufferAndPublishesOneMoreBlock()
+            throws Exception {
+        buildShim(FLOAT32_LSB);
+        writeDriverBuffer(driverInputs[0][0], 0.1f, 0.2f, 0.3f, 0.4f);
+        writeDriverBuffer(driverInputs[0][1], -0.5f, -0.6f, -0.7f, -0.8f);
+        writeDriverBuffer(driverInputs[1][0], 1.1f, 1.2f, 1.3f, 1.4f);
+        writeDriverBuffer(driverInputs[1][1], -1.5f, -1.6f, -1.7f, -1.8f);
+        CapturingSubscriber subscriber = subscribe();
+
+        shim.bufferSwitch(0, 1);
+        shim.bufferSwitch(1, 1);
+
+        assertThat(subscriber.await(2)).isTrue();
+        assertThat(subscriber.blocks()).hasSize(2);
+        assertThat(subscriber.blocks().get(1).samples()).containsExactly(
+                1.1f, -1.5f,
+                1.2f, -1.6f,
+                1.3f, -1.7f,
+                1.4f, -1.8f);
+    }
+
+    /**
+     * A 3&nbsp;&times;&nbsp;5 case with a distinct value per (channel, frame):
+     * the 2&nbsp;&times;&nbsp;4 fixture above cannot catch an off-by-one on the
+     * frame count or a channel-count / frame-count transposition.
+     */
+    @Test
+    void deinterleaveAndInterleaveAreCorrectForThreeChannelsAndFiveFrames()
+            throws Exception {
+        fixture(3, 5);
+        buildShim(FLOAT32_LSB);
+        for (int channel = 0; channel < 3; channel++) {
+            for (int frame = 0; frame < 5; frame++) {
+                driverInputs[0][channel].set(ValueLayout.JAVA_FLOAT_UNALIGNED,
+                        (long) frame * Float.BYTES, cell(channel, frame));
+            }
+        }
+        float[] outgoing = new float[3 * 5];
+        for (int frame = 0; frame < 5; frame++) {
+            for (int channel = 0; channel < 3; channel++) {
+                outgoing[frame * 3 + channel] = -cell(channel, frame);
+            }
+        }
+        CapturingSubscriber subscriber = subscribe();
+        shim.write(new AudioBlock(format.sampleRate(), 3, 5, outgoing));
+
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(2)).isTrue();
+        float[] captured = subscriber.blocks().get(0).samples();
+        assertThat(captured).hasSize(15);
+        for (int frame = 0; frame < 5; frame++) {
+            for (int channel = 0; channel < 3; channel++) {
+                assertThat(captured[frame * 3 + channel])
+                        .as("captured channel %d frame %d", channel, frame)
+                        .isEqualTo(cell(channel, frame));
+            }
+        }
+        for (int channel = 0; channel < 3; channel++) {
+            float[] played = readDriverBuffer(driverOutputs[0][channel], 5);
+            for (int frame = 0; frame < 5; frame++) {
+                assertThat(played[frame])
+                        .as("played channel %d frame %d", channel, frame)
+                        .isEqualTo(-cell(channel, frame));
+            }
+        }
+    }
+
+    /**
+     * B1's restructure: captured blocks are freshly allocated on the
+     * {@code asio-input-drain} thread, so two consecutive blocks must be
+     * independent objects — there is no recycled pool and no aliasing window.
+     */
+    @Test
+    void publishedBlocksAreIndependentInstancesRatherThanRecycledSlots()
+            throws Exception {
+        buildShim(FLOAT32_LSB);
+        CapturingSubscriber subscriber = subscribe();
+
+        writeDriverBuffer(driverInputs[0][0], 1f, 1f, 1f, 1f);
+        writeDriverBuffer(driverInputs[0][1], 1f, 1f, 1f, 1f);
+        shim.bufferSwitch(0, 1);
+        writeDriverBuffer(driverInputs[0][0], 2f, 2f, 2f, 2f);
+        writeDriverBuffer(driverInputs[0][1], 2f, 2f, 2f, 2f);
+        shim.bufferSwitch(0, 1);
+
+        assertThat(subscriber.await(2)).isTrue();
+        AudioBlock first = subscriber.blocks().get(0);
+        AudioBlock second = subscriber.blocks().get(1);
+        assertThat(first.samples())
+                .as("the first block must not be overwritten by the second")
+                .containsOnly(1f);
+        assertThat(second.samples()).containsOnly(2f);
+        assertThat(first.samples())
+                .as("blocks must not share a sample array")
+                .isNotSameAs(second.samples());
+    }
+
+    @Test
+    void drainThreadDeliversEveryCapturedBlockInOrder() throws Exception {
+        buildShim(FLOAT32_LSB);
+        CapturingSubscriber subscriber = subscribe();
+        int callbacks = 16; // well inside the 32-slot capture ring: no drops
+
+        for (int i = 1; i <= callbacks; i++) {
+            int half = i & 1;
+            for (int channel = 0; channel < channels; channel++) {
+                writeDriverBuffer(driverInputs[half][channel], i, i, i, i);
+            }
+            shim.bufferSwitch(half, 1);
+        }
+
+        assertThat(subscriber.await(callbacks)).isTrue();
+        List<AudioBlock> blocks = subscriber.blocks();
+        assertThat(blocks).hasSize(callbacks);
+        for (int i = 0; i < callbacks; i++) {
+            assertThat(blocks.get(i).samples())
+                    .as("captured block %d must arrive in order and intact", i)
+                    .containsOnly((float) (i + 1));
+        }
+    }
+
+    /**
+     * The property the whole off-thread restructure buys: a subscriber that
+     * never calls {@link Flow.Subscription#request} saturates the publisher's
+     * per-subscriber buffer, and the driver's callback must still return
+     * promptly. It cannot touch the publisher at all, so nothing on the
+     * callback thread can allocate, lock or stall.
+     */
+    @Test
+    void bufferSwitchNeverBlocksEvenWhenTheInputSubscriberNeverRequests()
+            throws Exception {
+        buildShim(FLOAT32_LSB);
+        NeverRequestingSubscriber saturated = new NeverRequestingSubscriber();
+        support.inputBlocks().subscribe(saturated);
+        assertThat(saturated.awaitSubscription()).isTrue();
+
+        int callbacks = Flow.defaultBufferSize() * 4; // 1024 — far past the buffer
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicLong slowestNanos = new AtomicLong();
+        Thread driverThread = new Thread(() -> {
+            for (int i = 0; i < callbacks; i++) {
+                long start = System.nanoTime();
+                shim.bufferSwitch(i & 1, 1);
+                slowestNanos.accumulateAndGet(System.nanoTime() - start, Math::max);
+            }
+            done.countDown();
+        }, "fake-asio-callback");
+        driverThread.setDaemon(true);
+        driverThread.start();
+
+        assertThat(done.await(AWAIT_SECONDS, TimeUnit.SECONDS))
+                .as("%d bufferSwitch callbacks must complete against a saturated "
+                        + "subscriber — the callback must never publish", callbacks)
+                .isTrue();
+        driverThread.join(TimeUnit.SECONDS.toMillis(AWAIT_SECONDS));
+        assertThat(driverThread.isAlive()).isFalse();
+        assertThat(slowestNanos.get())
+                .as("no single bufferSwitch may take a full second")
+                .isLessThan(TimeUnit.SECONDS.toNanos(1));
+    }
+
+    @Test
+    void inputBlocksAreMarshalledByANamedDaemonDrainThreadThatCloseStops() {
+        buildShim(FLOAT32_LSB);
+        Thread drain = shim.drainThread();
+
+        assertThat(drain.getName()).isEqualTo(AsioBufferSwitchShim.DRAIN_THREAD_NAME);
+        assertThat(drain.isDaemon())
+                .as("the drain thread must never keep the JVM alive")
+                .isTrue();
+        assertThat(drain.isAlive()).isTrue();
+
+        shim.close();
+
+        assertThat(drain.isAlive())
+                .as("close() must join the drain thread before freeing the arena")
+                .isFalse();
+    }
+
+    // ------------------------------------------------------------------
+    // Playback (engine -> driver)
+    // ------------------------------------------------------------------
+
+    @Test
+    void blockWrittenToSinkIsInterleavedIntoTheDriverBuffersOnTheNextCallback() {
+        buildShim(FLOAT32_LSB);
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames, new float[] {
+                0.25f, -0.75f,
+                0.26f, -0.76f,
+                0.27f, -0.77f,
+                0.28f, -0.78f}));
+
+        shim.bufferSwitch(1, 1);
+
+        assertThat(readDriverBuffer(driverOutputs[1][0], frames))
+                .containsExactly(0.25f, 0.26f, 0.27f, 0.28f);
+        assertThat(readDriverBuffer(driverOutputs[1][1], frames))
+                .containsExactly(-0.75f, -0.76f, -0.77f, -0.78f);
+    }
+
+    /**
+     * Two blocks sunk before a single callback: the driver must receive the
+     * <em>second</em> one. A FIFO-oldest implementation passes every other
+     * playback test in this class.
+     */
+    @Test
+    void theMostRecentSunkBlockWinsWhenTwoArriveBetweenCallbacks() {
+        buildShim(FLOAT32_LSB);
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames, new float[] {
+                1f, -1f, 1f, -1f, 1f, -1f, 1f, -1f}));
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames, new float[] {
+                2f, -2f, 2f, -2f, 2f, -2f, 2f, -2f}));
+
+        shim.bufferSwitch(0, 1);
+
+        assertThat(readDriverBuffer(driverOutputs[0][0], frames))
+                .as("the freshest rendered block must reach the driver")
+                .containsOnly(2f);
+        assertThat(readDriverBuffer(driverOutputs[0][1], frames)).containsOnly(-2f);
+    }
+
+    @Test
+    void outputIsZeroFilledWhenNothingWasRenderedRatherThanRepeatingStaleAudio() {
+        buildShim(FLOAT32_LSB);
+        writeDriverBuffer(driverOutputs[0][0], 9f, 9f, 9f, 9f);
+        writeDriverBuffer(driverOutputs[0][1], 9f, 9f, 9f, 9f);
+
+        shim.bufferSwitch(0, 1);
+
+        assertThat(readDriverBuffer(driverOutputs[0][0], frames)).containsOnly(0f);
+        assertThat(readDriverBuffer(driverOutputs[0][1], frames)).containsOnly(0f);
+    }
+
+    @Test
+    void previouslyWrittenBlockIsNotReplayedOnTheFollowingCallback() {
+        buildShim(FLOAT32_LSB);
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames, new float[] {
+                1f, 2f, 1f, 2f, 1f, 2f, 1f, 2f}));
+
+        shim.bufferSwitch(0, 1);
+        shim.bufferSwitch(1, 1);
+
+        assertThat(readDriverBuffer(driverOutputs[0][0], frames)).containsOnly(1f);
+        assertThat(readDriverBuffer(driverOutputs[1][0], frames))
+                .as("a consumed block must not be replayed into the next half")
+                .containsOnly(0f);
+    }
+
+    // ------------------------------------------------------------------
+    // Degradation
+    // ------------------------------------------------------------------
+
+    /**
+     * Story 312 owns the general {@code ASIOSampleType} conversion. Until then
+     * an unsupported type must play <em>silence</em>: leaving the driver's own
+     * bytes in place would replay them every block as a fixed-pitch buzz, and
+     * most real drivers report {@code ASIOSTInt32LSB} rather than float32.
+     */
+    @Test
+    void unsupportedSampleTypeSilencesBothTheInputBlockAndTheDriverOutput()
+            throws Exception {
+        buildShim(INT32_LSB);
+        writeDriverBuffer(driverInputs[0][0], 0.1f, 0.2f, 0.3f, 0.4f);
+        writeDriverBuffer(driverOutputs[0][0], 7f, 7f, 7f, 7f);
+        writeDriverBuffer(driverOutputs[0][1], 7f, 7f, 7f, 7f);
+        CapturingSubscriber subscriber = subscribe();
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames,
+                new float[channels * frames]));
+
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(2)).isTrue();
+        assertThat(subscriber.blocks().get(0).samples()).containsOnly(0f);
+        assertThat(readDriverBuffer(driverOutputs[0][0], frames))
+                .as("driver garbage must be overwritten with silence, not replayed")
+                .containsOnly(0f);
+        assertThat(readDriverBuffer(driverOutputs[0][1], frames)).containsOnly(0f);
+    }
+
+    /**
+     * Story 311 (S1): a driver may expose fewer channels than the opened format
+     * asks for — a playback-only interface reports no inputs at all. Unbound
+     * channels capture silence and are skipped on output; they must not throw.
+     */
+    @Test
+    void channelsTheDriverDoesNotExposeCaptureSilenceAndAreSkippedOnOutput()
+            throws Exception {
+        List<AsioStreamingShim.BufferInfo> infos = List.of(
+                new AsioStreamingShim.BufferInfo(0, true, FLOAT32_LSB,
+                        driverInputs[0][0].address(), driverInputs[1][0].address()),
+                new AsioStreamingShim.BufferInfo(0, false, FLOAT32_LSB,
+                        driverOutputs[0][0].address(), driverOutputs[1][0].address()));
+        shim = new AsioBufferSwitchShim(support, format, frames, infos);
+        writeDriverBuffer(driverInputs[0][0], 0.1f, 0.2f, 0.3f, 0.4f);
+        writeDriverBuffer(driverOutputs[0][1], 5f, 5f, 5f, 5f);
+        CapturingSubscriber subscriber = subscribe();
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames, new float[] {
+                0.9f, 0.8f, 0.9f, 0.8f, 0.9f, 0.8f, 0.9f, 0.8f}));
+
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(2)).isTrue();
+        assertThat(subscriber.blocks().get(0).samples()).containsExactly(
+                0.1f, 0f,
+                0.2f, 0f,
+                0.3f, 0f,
+                0.4f, 0f);
+        assertThat(readDriverBuffer(driverOutputs[0][0], frames))
+                .containsOnly(0.9f);
+        assertThat(readDriverBuffer(driverOutputs[0][1], frames))
+                .as("a channel the driver never reported has no buffer to write")
+                .containsOnly(5f);
+    }
+
+    /**
+     * Out-of-range halves publish nothing. Deterministic without a quiet
+     * period: the capture ring is FIFO, so a block produced by the ignored
+     * callbacks would necessarily arrive <em>before</em> the valid one.
+     */
+    @Test
+    void outOfRangeBufferIndexIsIgnored() throws Exception {
+        buildShim(FLOAT32_LSB);
+        writeDriverBuffer(driverInputs[0][0], 4f, 4f, 4f, 4f);
+        writeDriverBuffer(driverInputs[0][1], 4f, 4f, 4f, 4f);
+        CapturingSubscriber subscriber = subscribe();
+
+        shim.bufferSwitch(-1, 1);
+        shim.bufferSwitch(2, 1);
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(2)).isTrue();
+        assertThat(subscriber.blocks()).hasSize(2);
+        assertThat(subscriber.blocks().get(0).samples()).containsOnly(4f);
+    }
+
+    @Test
+    void quiescedBridgeStopsTouchingDriverBuffersAndPublishesNothing()
+            throws Exception {
+        buildShim(FLOAT32_LSB);
+        writeDriverBuffer(driverOutputs[0][0], 3f, 3f, 3f, 3f);
+        writeDriverBuffer(driverInputs[0][0], 6f, 6f, 6f, 6f);
+        CapturingSubscriber subscriber = subscribe();
+
+        shim.stopStreaming();
+        assertThat(shim.isStreaming()).isFalse();
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(1)).isTrue();
+        assertThat(subscriber.blocks()).hasSize(1);
+        assertThat(subscriber.blocks().get(0).samples())
+                .as("the sentinel must be the first block: the quiesced callback "
+                        + "published nothing before it")
+                .containsOnly(SENTINEL);
+        assertThat(readDriverBuffer(driverOutputs[0][0], frames)).containsOnly(3f);
+    }
+
+    @Test
+    void upcallStubIsBuiltOnEveryPlatformAndCloseIsIdempotent() {
+        buildShim(FLOAT32_LSB);
+        assertThat(shim.upcallStub()).isNotNull();
+        assertThat(shim.upcallStub().equals(MemorySegment.NULL)).isFalse();
+        assertThat(shim.bufferFrames()).isEqualTo(frames);
+        shim.close();
+        shim.close();
+        assertThat(shim.isStreaming()).isFalse();
+    }
+
+    // ------------------------------------------------------------------
+    // Fixture helpers
+    // ------------------------------------------------------------------
+
+    /** A distinct, non-zero value per (channel, frame) pair. */
+    private static float cell(int channel, int frame) {
+        return (channel + 1) * 100f + (frame + 1);
+    }
+
+    /**
+     * (Re)builds the driver-buffer fixture and the backend support for a given
+     * geometry. Called from {@code setUp} with the default 2 &times; 4 shape.
+     */
+    private void fixture(int channelCount, int frameCount) {
+        if (support != null) {
+            support.close();
+        }
+        this.channels = channelCount;
+        this.frames = frameCount;
+        this.format = new AudioFormat(48_000.0, channelCount, 32);
+        this.driverInputs = allocateHalves();
+        this.driverOutputs = allocateHalves();
+        this.support = new AudioBackendSupport();
+        support.markOpen(format, frameCount);
+    }
+
+    private void buildShim(int sampleType) {
+        List<AsioStreamingShim.BufferInfo> infos = new ArrayList<>();
+        for (int channel = 0; channel < channels; channel++) {
+            infos.add(new AsioStreamingShim.BufferInfo(channel, true, sampleType,
+                    driverInputs[0][channel].address(),
+                    driverInputs[1][channel].address()));
+        }
+        for (int channel = 0; channel < channels; channel++) {
+            infos.add(new AsioStreamingShim.BufferInfo(channel, false, sampleType,
+                    driverOutputs[0][channel].address(),
+                    driverOutputs[1][channel].address()));
+        }
+        shim = new AsioBufferSwitchShim(support, format, frames, List.copyOf(infos));
+    }
+
+    private MemorySegment[][] allocateHalves() {
+        MemorySegment[][] halves = new MemorySegment[HALVES][channels];
+        for (int half = 0; half < HALVES; half++) {
+            for (int channel = 0; channel < channels; channel++) {
+                halves[half][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, frames);
+            }
+        }
+        return halves;
+    }
+
+    private static void writeDriverBuffer(MemorySegment buffer, float... values) {
+        for (int frame = 0; frame < values.length; frame++) {
+            buffer.set(ValueLayout.JAVA_FLOAT_UNALIGNED,
+                    (long) frame * Float.BYTES, values[frame]);
+        }
+    }
+
+    private static float[] readDriverBuffer(MemorySegment buffer, int frameCount) {
+        float[] values = new float[frameCount];
+        for (int frame = 0; frame < frameCount; frame++) {
+            values[frame] = buffer.get(ValueLayout.JAVA_FLOAT_UNALIGNED,
+                    (long) frame * Float.BYTES);
+        }
+        return values;
+    }
+
+    /**
+     * Terminates the drain thread — {@link AsioBufferSwitchShim#close()} flushes
+     * the capture ring and joins it — and only then publishes a recognisable
+     * block straight through the support. Because the drain thread is provably
+     * finished before the sentinel is offered, and a
+     * {@code SubmissionPublisher} preserves per-subscriber order, the
+     * sentinel's index is an exact count of what the callbacks published.
+     */
+    private void flushAndPublishSentinel() {
+        shim.close();
+        float[] samples = new float[channels * frames];
+        java.util.Arrays.fill(samples, SENTINEL);
+        support.publishInput(
+                new AudioBlock(format.sampleRate(), channels, frames, samples));
+    }
+
+    private CapturingSubscriber subscribe() throws InterruptedException {
+        CapturingSubscriber subscriber = new CapturingSubscriber();
+        support.inputBlocks().subscribe(subscriber);
+        assertThat(subscriber.awaitSubscription())
+                .as("the subscription must be established before blocks are driven")
+                .isTrue();
+        return subscriber;
+    }
+
+    /**
+     * Collects published blocks. Story 311's drain thread allocates a fresh
+     * {@link AudioBlock} per callback, so the received instances are safe to
+     * retain — no defensive copy is needed here, and
+     * {@code publishedBlocksAreIndependentInstancesRatherThanRecycledSlots}
+     * asserts exactly that.
+     */
+    private static final class CapturingSubscriber implements Flow.Subscriber<AudioBlock> {
+
+        private final List<AudioBlock> received =
+                Collections.synchronizedList(new ArrayList<>());
+        private final CountDownLatch subscribed = new CountDownLatch(1);
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+            subscribed.countDown();
+        }
+
+        @Override
+        public void onNext(AudioBlock item) {
+            received.add(item);
+        }
+
+        @Override public void onError(Throwable throwable) { }
+
+        @Override public void onComplete() { }
+
+        boolean awaitSubscription() throws InterruptedException {
+            return subscribed.await(AWAIT_SECONDS, TimeUnit.SECONDS);
+        }
+
+        List<AudioBlock> blocks() {
+            return List.copyOf(received);
+        }
+
+        boolean await(int expected) throws InterruptedException {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(AWAIT_SECONDS);
+            while (System.nanoTime() < deadline) {
+                if (received.size() >= expected) {
+                    return true;
+                }
+                Thread.sleep(5);
+            }
+            return received.size() >= expected;
+        }
+    }
+
+    /** Never requests, so the publisher's per-subscriber buffer saturates. */
+    private static final class NeverRequestingSubscriber
+            implements Flow.Subscriber<AudioBlock> {
+
+        private final CountDownLatch subscribed = new CountDownLatch(1);
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            // Deliberately no request(...) — this is the back-pressure the
+            // callback thread must never wait on.
+            subscribed.countDown();
+        }
+
+        @Override public void onNext(AudioBlock item) { }
+
+        @Override public void onError(Throwable throwable) { }
+
+        @Override public void onComplete() { }
+
+        boolean awaitSubscription() throws InterruptedException {
+            return subscribed.await(AWAIT_SECONDS, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioFormatChangeShimTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.condition.OS;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
@@ -143,6 +146,60 @@ class AsioFormatChangeShimTest {
         assertThat(fc.proposedFormat()).isEmpty();
     }
 
+    /**
+     * Story 311 makes the {@code ASIOCallbacks} struct real for the first
+     * time, so the driver now sends the ASIO handshake selectors the shim
+     * previously answered with {@code ASE_NotPresent}.
+     */
+    @Test
+    void engineVersionSelectorReportsAsioTwo() {
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        try (AsioFormatChangeShim shim = new AsioFormatChangeShim(backend, support, DEVICE)) {
+            assertThat(shim.dispatch(AsioFormatChangeShim.kAsioEngineVersion, 0L))
+                    .as("answering 0 would make drivers fall back to ASIO 1.0")
+                    .isEqualTo(2L);
+        }
+    }
+
+    @Test
+    void supportsTimeInfoAndLatenciesChangedSelectorsAreAccepted() {
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        try (AsioFormatChangeShim shim = new AsioFormatChangeShim(backend, support, DEVICE)) {
+            assertThat(shim.dispatch(AsioFormatChangeShim.kAsioSupportsTimeInfo, 0L))
+                    .isEqualTo(1L);
+            assertThat(shim.dispatch(AsioFormatChangeShim.kAsioLatenciesChanged, 0L))
+                    .isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void selectorSupportedAnswersOnlyForSelectorsTheShimHandles() {
+        AsioBackend backend = new AsioBackend();
+        AudioBackendSupport support = new AudioBackendSupport();
+        try (AsioFormatChangeShim shim = new AsioFormatChangeShim(backend, support, DEVICE)) {
+            int[] handled = {
+                    AsioFormatChangeShim.kAsioSelectorSupported,
+                    AsioFormatChangeShim.kAsioEngineVersion,
+                    AsioFormatChangeShim.kAsioResetRequest,
+                    AsioFormatChangeShim.kAsioResyncRequest,
+                    AsioFormatChangeShim.kAsioSupportsTimeInfo,
+                    AsioFormatChangeShim.kAsioLatenciesChanged,
+                    AsioFormatChangeShim.kAsioBufferSizeChange};
+            for (int selector : handled) {
+                assertThat(shim.dispatch(
+                        AsioFormatChangeShim.kAsioSelectorSupported, selector))
+                        .as("selector %d must be advertised as supported", selector)
+                        .isEqualTo(1L);
+            }
+            assertThat(shim.dispatch(AsioFormatChangeShim.kAsioSelectorSupported, 9999))
+                    .isEqualTo(0L);
+            assertThat(shim.dispatch(AsioFormatChangeShim.kAsioSelectorSupported, 8))
+                    .isEqualTo(0L);
+        }
+    }
+
     @Test
     void unknownSelectorReturnsZeroAndEmitsNothing() throws Exception {
         AsioBackend backend = new AsioBackend();
@@ -156,6 +213,223 @@ class AsioFormatChangeShimTest {
         }
         Thread.sleep(50);
         assertThat(ref.get()).isNull();
+    }
+
+    /**
+     * Story 218 &times; 311: a driver-initiated reset invalidates the ASIO
+     * buffers, so the streaming bridge must be quiesced before the event is
+     * announced.
+     *
+     * <p>The quiesce is asserted <strong>synchronously, on the dispatching
+     * thread, the instant {@code dispatch} returns</strong> — not sampled
+     * inside {@code onNext}. The previous shape sampled the flag from the
+     * subscriber, which runs on the publisher's executor: it would have passed
+     * just as often had the quiesce happened <em>after</em> the publish, and it
+     * could equally have failed for pure scheduling reasons. The synchronous
+     * assertion is deterministic in both directions: if
+     * {@code stopStreamingForDriverReset()} were not called at all — the actual
+     * regression this guards — the flag is still {@code true} and the test
+     * fails every time.</p>
+     *
+     * <p>Ordering <em>relative to the publish</em> is guaranteed by program
+     * order inside {@code dispatch}; it is not separately observable, because
+     * the inline quiesce has no injectable seam
+     * ({@link AsioBufferSwitchShim} is created inside
+     * {@code AsioBackend#open}) and a {@code SubmissionPublisher} exposes no
+     * synchronous publish hook. Comparing a stamp taken in the stub's
+     * {@code stop()} would be wrong: that runs on the
+     * {@code asio-reset-teardown} executor, deliberately <em>after</em> the
+     * announcement.</p>
+     */
+    @Test
+    void resetRequestQuiescesTheStreamingBridgeAndAnnouncesTheEvent()
+            throws Exception {
+        DispatchOutcome outcome = dispatchAgainstOpenBackend(
+                AsioFormatChangeShim.kAsioResetRequest, 0L);
+
+        assertThat(outcome.streamingAfterDispatch())
+                .as("kAsioResetRequest must stop the bridge touching driver buffers "
+                        + "before dispatch returns")
+                .isFalse();
+        assertThat(outcome.eventAnnounced()).isTrue();
+        assertThat(outcome.driverTornDown())
+                .as("ASIOStop / ASIODisposeBuffers must follow on the teardown thread")
+                .isTrue();
+    }
+
+    @Test
+    void bufferSizeChangeQuiescesTheStreamingBridgeAndAnnouncesTheEvent()
+            throws Exception {
+        DispatchOutcome outcome = dispatchAgainstOpenBackend(
+                AsioFormatChangeShim.kAsioBufferSizeChange, 512L);
+
+        assertThat(outcome.streamingAfterDispatch())
+                .as("kAsioBufferSizeChange invalidates the buffers, so it must quiesce")
+                .isFalse();
+        assertThat(outcome.eventAnnounced()).isTrue();
+        assertThat(outcome.driverTornDown()).isTrue();
+    }
+
+    @Test
+    void resyncRequestLeavesTheStreamingBridgeRunning() throws Exception {
+        DispatchOutcome outcome = dispatchAgainstOpenBackend(
+                AsioFormatChangeShim.kAsioResyncRequest, 0L);
+
+        assertThat(outcome.streamingAfterDispatch())
+                .as("a resync does not invalidate the driver's buffers")
+                .isTrue();
+        assertThat(outcome.eventAnnounced()).isTrue();
+        assertThat(outcome.driverTornDown())
+                .as("a resync must not schedule ASIOStop / ASIODisposeBuffers — the "
+                        + "inline quiesce above proves the reset path was not taken")
+                .isFalse();
+    }
+
+    /**
+     * Outcome of one {@code dispatch} against a fully opened backend.
+     *
+     * @param streamingAfterDispatch the bridge's flag sampled synchronously
+     *                               once {@code dispatch} returned
+     * @param eventAnnounced         whether the device event was delivered
+     * @param driverTornDown         whether the asynchronous teardown reached
+     *                               {@code stop()} + {@code disposeBuffers()}
+     */
+    private record DispatchOutcome(boolean streamingAfterDispatch,
+                                   boolean eventAnnounced, boolean driverTornDown) {
+    }
+
+    /**
+     * Opens a backend against stub driver / streaming shims, dispatches the
+     * selector, and reports what the dispatch did.
+     */
+    private static DispatchOutcome dispatchAgainstOpenBackend(int selector, long value)
+            throws Exception {
+        AudioFormat format = new AudioFormat(48_000.0, 2, 32);
+        List<String> driverCalls = Collections.synchronizedList(new ArrayList<>());
+        try (Arena buffers = Arena.ofShared()) {
+            StubStreamingShim streaming =
+                    new StubStreamingShim(buffers, format, 128, driverCalls);
+            AsioBackend.setDriverShimFactory(StubDriverShim::new);
+            AsioBackend.setStreamingShimFactory(() -> streaming);
+            AsioBackend backend = new AsioBackend();
+            AudioBackendSupport support = new AudioBackendSupport();
+            support.markOpen(format, 128);
+            try {
+                backend.open(DEVICE, format, 128);
+                assertThat(backend.activeBufferSwitchShim()).isNotNull();
+                driverCalls.clear();
+
+                CountDownLatch latch = new CountDownLatch(1);
+                backend.deviceEvents().subscribe(new Flow.Subscriber<AudioDeviceEvent>() {
+                    @Override public void onSubscribe(Flow.Subscription s) {
+                        s.request(Long.MAX_VALUE);
+                    }
+                    @Override public void onNext(AudioDeviceEvent event) {
+                        latch.countDown();
+                    }
+                    @Override public void onError(Throwable throwable) { }
+                    @Override public void onComplete() { }
+                });
+                Thread.sleep(50);
+
+                boolean streamingAfterDispatch;
+                try (AsioFormatChangeShim shim =
+                             new AsioFormatChangeShim(backend, support, DEVICE)) {
+                    shim.dispatch(selector, value);
+                    AsioBufferSwitchShim bridge = backend.activeBufferSwitchShim();
+                    streamingAfterDispatch = bridge != null && bridge.isStreaming();
+                }
+                boolean announced = latch.await(10, TimeUnit.SECONDS);
+                boolean tornDown = awaitTeardown(driverCalls, streamingAfterDispatch);
+                return new DispatchOutcome(streamingAfterDispatch, announced, tornDown);
+            } finally {
+                backend.close();
+                AsioBackend.resetDriverShimFactory();
+                AsioBackend.resetStreamingShimFactory();
+            }
+        }
+    }
+
+    /**
+     * Waits for the asynchronous {@code asio-reset-teardown} work. When the
+     * bridge is still streaming no teardown was scheduled at all, so a short
+     * bounded settle is enough to assert the negative.
+     */
+    private static boolean awaitTeardown(List<String> driverCalls,
+                                         boolean stillStreaming) throws Exception {
+        long budgetMillis = stillStreaming ? 500 : 10_000;
+        long deadline = System.nanoTime()
+                + TimeUnit.MILLISECONDS.toNanos(budgetMillis);
+        while (System.nanoTime() < deadline) {
+            if (driverCalls.contains("stop") && driverCalls.contains("disposeBuffers")) {
+                return true;
+            }
+            Thread.sleep(5);
+        }
+        return false;
+    }
+
+    /** Minimal driver shim that reports one loadable driver. */
+    private static final class StubDriverShim extends AsioDriverShim {
+        @Override boolean isEnumerationAvailable() { return true; }
+        @Override boolean isLifecycleAvailable() { return true; }
+        @Override java.util.List<DriverDescriptor> listDrivers() {
+            return java.util.List.of(new DriverDescriptor(
+                    DEVICE.name(), "{00000000-0000-0000-0000-000000000000}"));
+        }
+        @Override boolean loadDriver(String driverName) { return true; }
+        @Override public void close() {
+            // Release the real superclass's Arena.ofShared().
+            super.close();
+        }
+    }
+
+    /** Streaming shim backed by test-owned memory instead of a real driver. */
+    private static final class StubStreamingShim extends AsioStreamingShim {
+
+        private final java.util.List<BufferInfo> bufferInfos;
+        private final List<String> driverCalls;
+
+        StubStreamingShim(Arena arena, AudioFormat format, int frames,
+                          List<String> driverCalls) {
+            super();
+            this.driverCalls = driverCalls;
+            java.util.List<BufferInfo> infos = new java.util.ArrayList<>();
+            for (int channel = 0; channel < format.channels(); channel++) {
+                infos.add(new BufferInfo(channel, true, 19,
+                        arena.allocate(java.lang.foreign.ValueLayout.JAVA_FLOAT, frames)
+                                .address(),
+                        arena.allocate(java.lang.foreign.ValueLayout.JAVA_FLOAT, frames)
+                                .address()));
+            }
+            for (int channel = 0; channel < format.channels(); channel++) {
+                infos.add(new BufferInfo(channel, false, 19,
+                        arena.allocate(java.lang.foreign.ValueLayout.JAVA_FLOAT, frames)
+                                .address(),
+                        arena.allocate(java.lang.foreign.ValueLayout.JAVA_FLOAT, frames)
+                                .address()));
+            }
+            bufferInfos = java.util.List.copyOf(infos);
+        }
+
+        @Override boolean isStreamingAvailable() { return true; }
+        @Override boolean createBuffers(int[] in, int[] out, int frames) { return true; }
+        @Override java.util.List<BufferInfo> getBufferInfos() { return bufferInfos; }
+        @Override boolean start() { return true; }
+        @Override boolean stop() {
+            driverCalls.add("stop");
+            return true;
+        }
+        @Override boolean disposeBuffers() {
+            driverCalls.add("disposeBuffers");
+            return true;
+        }
+        @Override boolean installBufferSwitchCallback(MemorySegment stub) { return true; }
+        @Override void uninstallBufferSwitchCallback() { }
+        @Override public void close() {
+            // Release the real superclass's Arena.ofShared().
+            super.close();
+        }
     }
 
     /** Subscribes, dispatches via the shim, and returns the first event. */

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioStreamingShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioStreamingShimTest.java
@@ -1,0 +1,303 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ABI and decoding tests for {@link AsioStreamingShim} (story 311).
+ *
+ * <p>The seven {@link FunctionDescriptor}s at the top of the shim <em>are</em>
+ * the native contract, and until now they were only validated at runtime on a
+ * machine that actually has {@code asioshim.dll} — exactly what CI lacks. The
+ * round-trip tests below build a {@link Linker#upcallStub} from a plain Java
+ * method using the production descriptor and then call it back through a
+ * {@link Linker#downcallHandle} built from the <em>same</em> constant, so an
+ * argument-count or carrier-type drift fails here with no native library
+ * present.</p>
+ */
+class AsioStreamingShimTest {
+
+    private Arena arena;
+    private Linker linker;
+
+    @BeforeEach
+    void setUp() {
+        arena = Arena.ofShared();
+        linker = Linker.nativeLinker();
+    }
+
+    @AfterEach
+    void tearDown() {
+        arena.close();
+    }
+
+    // ------------------------------------------------------------------
+    // Record decoding
+    // ------------------------------------------------------------------
+
+    @Test
+    void bufferInfoRecordsAreDecodedFromTheThirtyTwoByteNativeLayout() {
+        MemorySegment records = arena.allocate(
+                (long) AsioStreamingShim.BUFFER_INFO_STRIDE * 2,
+                AsioStreamingShim.BUFFER_INFO_ALIGNMENT);
+        writeRecord(records, 0, 3, 1, 19, 0x1111L, 0x2222L);
+        writeRecord(records, AsioStreamingShim.BUFFER_INFO_STRIDE, 5, 0, 17,
+                0x3333L, 0x4444L);
+
+        assertThat(AsioStreamingShim.decodeBufferInfos(records, 2)).containsExactly(
+                new AsioStreamingShim.BufferInfo(3, true, 19, 0x1111L, 0x2222L),
+                new AsioStreamingShim.BufferInfo(5, false, 17, 0x3333L, 0x4444L));
+    }
+
+    /**
+     * F7: the decode must not impose an alignment the segment cannot advertise.
+     * A heap segment has maximum alignment 1, so the aligned {@code JAVA_LONG}
+     * layout would throw {@link IllegalArgumentException} — and inside
+     * {@link AsioStreamingShim#getBufferInfos()} that throw is swallowed into
+     * {@code List.of()} and resurfaces as the misleading "ASIO driver reported
+     * no buffer descriptors after ASIOCreateBuffers".
+     */
+    @Test
+    void bufferInfoRecordsDecodeFromAHeapSegmentWithNoAlignmentGuarantee() {
+        byte[] backing = new byte[AsioStreamingShim.BUFFER_INFO_STRIDE];
+        MemorySegment heap = MemorySegment.ofArray(backing);
+        assertThat(heap.maxByteAlignment())
+                .as("a byte[] segment cannot promise 8-byte alignment")
+                .isEqualTo(1L);
+        writeRecord(heap, 0, 7, 1, 19, 0x0102030405060708L, 0x1112131415161718L);
+
+        assertThat(AsioStreamingShim.decodeBufferInfos(heap, 1)).containsExactly(
+                new AsioStreamingShim.BufferInfo(
+                        7, true, 19, 0x0102030405060708L, 0x1112131415161718L));
+    }
+
+    @Test
+    void decodingZeroRecordsYieldsAnEmptyList() {
+        MemorySegment records = arena.allocate(
+                AsioStreamingShim.BUFFER_INFO_STRIDE,
+                AsioStreamingShim.BUFFER_INFO_ALIGNMENT);
+
+        assertThat(AsioStreamingShim.decodeBufferInfos(records, 0)).isEmpty();
+        assertThat(AsioStreamingShim.decodeBufferInfos(records, -4)).isEmpty();
+    }
+
+    @Test
+    void theNativeChannelCapMatchesTheBufferInfoCapacity() {
+        // asioshim.cpp rejects numInputs + numOutputs > MAX_STREAM_CHANNELS (64),
+        // so at most that many descriptors can ever come back.
+        assertThat(AsioStreamingShim.MAX_STREAM_CHANNELS).isEqualTo(64);
+        assertThat(AsioStreamingShim.BUFFER_INFO_CAPACITY)
+                .isEqualTo(AsioStreamingShim.MAX_STREAM_CHANNELS);
+    }
+
+    // ------------------------------------------------------------------
+    // ABI round trips — one per exported symbol
+    // ------------------------------------------------------------------
+
+    @Test
+    void createBuffersDescriptorRoundTripsAllFiveArguments() throws Throwable {
+        AtomicReference<String> observed = new AtomicReference<>();
+        Recorder recorder = new Recorder(observed);
+        MethodHandle target = MethodHandles.lookup().findVirtual(Recorder.class,
+                        "createBuffers",
+                        MethodType.methodType(int.class, MemorySegment.class, int.class,
+                                MemorySegment.class, int.class, int.class))
+                .bindTo(recorder);
+        MethodHandle call = bind(target, AsioStreamingShim.CREATE_BUFFERS);
+
+        MemorySegment inputs = arena.allocateFrom(ValueLayout.JAVA_INT, 0, 1);
+        MemorySegment outputs = arena.allocateFrom(ValueLayout.JAVA_INT, 2, 3, 4);
+        int status = (int) call.invokeExact(inputs, 2, outputs, 3, 128);
+
+        assertThat(status).isEqualTo(1);
+        assertThat(observed.get()).isEqualTo("createBuffers:2:3:128");
+    }
+
+    @Test
+    void getBufferInfosDescriptorRoundTripsBothPointers() throws Throwable {
+        AtomicReference<String> observed = new AtomicReference<>();
+        Recorder recorder = new Recorder(observed);
+        MethodHandle target = MethodHandles.lookup().findVirtual(Recorder.class,
+                        "getBufferInfos",
+                        MethodType.methodType(int.class,
+                                MemorySegment.class, MemorySegment.class))
+                .bindTo(recorder);
+        MethodHandle call = bind(target, AsioStreamingShim.GET_BUFFER_INFOS);
+
+        MemorySegment records = arena.allocate(
+                AsioStreamingShim.BUFFER_INFO_STRIDE,
+                AsioStreamingShim.BUFFER_INFO_ALIGNMENT);
+        MemorySegment count = arena.allocate(ValueLayout.JAVA_INT);
+
+        int status = (int) call.invokeExact(records, count);
+
+        assertThat(status).isEqualTo(1);
+        assertThat(observed.get())
+                .as("both pointers must survive the ADDRESS marshalling unchanged")
+                .isEqualTo("getBufferInfos:" + records.address() + ":" + count.address());
+    }
+
+    @Test
+    void nullaryIntReturningDescriptorsRoundTrip() throws Throwable {
+        assertThat(invokeNullaryStatus(AsioStreamingShim.START)).isEqualTo(1);
+        assertThat(invokeNullaryStatus(AsioStreamingShim.STOP)).isEqualTo(1);
+        assertThat(invokeNullaryStatus(AsioStreamingShim.DISPOSE_BUFFERS)).isEqualTo(1);
+    }
+
+    @Test
+    void installAndUninstallCallbackDescriptorsRoundTrip() throws Throwable {
+        AtomicReference<String> observed = new AtomicReference<>();
+        Recorder recorder = new Recorder(observed);
+
+        MethodHandle install = bind(MethodHandles.lookup().findVirtual(Recorder.class,
+                        "installCallback",
+                        MethodType.methodType(void.class, MemorySegment.class))
+                .bindTo(recorder), AsioStreamingShim.INSTALL_BUFFER_SWITCH_CALLBACK);
+        MemorySegment fakeStub = arena.allocate(ValueLayout.JAVA_LONG);
+        install.invokeExact(fakeStub);
+        assertThat(observed.get()).isEqualTo("install:" + fakeStub.address());
+
+        MethodHandle uninstall = bind(MethodHandles.lookup().findVirtual(Recorder.class,
+                        "uninstallCallback", MethodType.methodType(void.class))
+                .bindTo(recorder), AsioStreamingShim.UNINSTALL_BUFFER_SWITCH_CALLBACK);
+        uninstall.invokeExact();
+        assertThat(observed.get()).isEqualTo("uninstall");
+    }
+
+    /**
+     * The ASIO SDK's {@code long} is 32 bits on Win64, so every callback
+     * parameter must map to {@code JAVA_INT}. Mapping it to Java's 64-bit
+     * {@code long} would silently corrupt the buffer index.
+     */
+    @Test
+    void everyIntegerInTheStreamingAbiIsThirtyTwoBitsWide() {
+        assertThat(AsioStreamingShim.CREATE_BUFFERS.argumentLayouts())
+                .containsExactly(ValueLayout.ADDRESS, ValueLayout.JAVA_INT,
+                        ValueLayout.ADDRESS, ValueLayout.JAVA_INT, ValueLayout.JAVA_INT);
+        assertThat(AsioStreamingShim.CREATE_BUFFERS.returnLayout())
+                .contains(ValueLayout.JAVA_INT);
+        assertThat(AsioStreamingShim.GET_BUFFER_INFOS.argumentLayouts())
+                .containsExactly(ValueLayout.ADDRESS, ValueLayout.ADDRESS);
+        assertThat(AsioStreamingShim.START.argumentLayouts()).isEmpty();
+        assertThat(AsioStreamingShim.INSTALL_BUFFER_SWITCH_CALLBACK.returnLayout())
+                .isEmpty();
+        assertThat(AsioStreamingShim.UNINSTALL_BUFFER_SWITCH_CALLBACK.argumentLayouts())
+                .isEmpty();
+    }
+
+    // ------------------------------------------------------------------
+    // Degradation
+    // ------------------------------------------------------------------
+
+    @Test
+    void everyOperationDegradesGracefullyOnAShimThatWasAlreadyClosed() {
+        AsioStreamingShim shim = new AsioStreamingShim();
+        shim.close();
+
+        assertThat(shim.isStreamingAvailable()).isFalse();
+        assertThat(shim.createBuffers(new int[] {0}, new int[] {0}, 64)).isFalse();
+        assertThat(shim.getBufferInfos()).isEmpty();
+        assertThat(shim.start()).isFalse();
+        assertThat(shim.stop()).isFalse();
+        assertThat(shim.disposeBuffers()).isFalse();
+        assertThatCode(shim::uninstallBufferSwitchCallback).doesNotThrowAnyException();
+        assertThatCode(shim::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    void bufferInfoRejectsANegativeChannelIndex() {
+        assertThatCode(() -> new AsioStreamingShim.BufferInfo(0, true, 19, 1L, 2L))
+                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> new AsioStreamingShim.BufferInfo(-1, true, 19, 1L, 2L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("channel");
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Turns a Java method into a native function pointer with
+     * {@code descriptor}, then binds a downcall handle to that same pointer
+     * with the same descriptor. Any mismatch between the descriptor and the
+     * Java signature fails at stub-creation time.
+     */
+    private MethodHandle bind(MethodHandle target, FunctionDescriptor descriptor) {
+        MemorySegment stub = linker.upcallStub(target, descriptor, arena);
+        return linker.downcallHandle(stub, descriptor);
+    }
+
+    private int invokeNullaryStatus(FunctionDescriptor descriptor) throws Throwable {
+        MethodHandle target = MethodHandles.lookup()
+                .findStatic(AsioStreamingShimTest.class, "alwaysOk",
+                        MethodType.methodType(int.class));
+        MethodHandle call = bind(target, descriptor);
+        return (int) call.invokeExact();
+    }
+
+    @SuppressWarnings("unused") // bound into an upcall stub
+    private static int alwaysOk() {
+        return 1;
+    }
+
+    private static void writeRecord(MemorySegment segment, long base, int channel,
+                                    int isInput, int sampleType,
+                                    long buffer0, long buffer1) {
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, base, channel);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, base + 4, isInput);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, base + 8, sampleType);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, base + 12, 0);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, base + 16, buffer0);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, base + 24, buffer1);
+    }
+
+    /** Upcall target that records the arguments the descriptor delivered. */
+    public static final class Recorder {
+
+        private final AtomicReference<String> observed;
+
+        Recorder(AtomicReference<String> observed) {
+            this.observed = observed;
+        }
+
+        public int createBuffers(MemorySegment inputs, int numInputs,
+                                 MemorySegment outputs, int numOutputs,
+                                 int bufferFrames) {
+            // Reinterpret is unnecessary: only the marshalled scalars are under
+            // test here, and the pointers arrive as zero-length segments.
+            observed.set("createBuffers:" + numInputs + ":" + numOutputs
+                    + ":" + bufferFrames);
+            return 1;
+        }
+
+        public int getBufferInfos(MemorySegment records, MemorySegment count) {
+            observed.set("getBufferInfos:" + records.address()
+                    + ":" + count.address());
+            return 1;
+        }
+
+        public void installCallback(MemorySegment callback) {
+            observed.set("install:" + callback.address());
+        }
+
+        public void uninstallCallback() {
+            observed.set("uninstall");
+        }
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AudioBackendSupportTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AudioBackendSupportTest.java
@@ -1,0 +1,72 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+import java.util.function.BiPredicate;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AudioBackendSupportTest {
+
+    private static final AudioFormat FORMAT = new AudioFormat(48_000.0, 2, 32);
+    private static final AudioBlock BLOCK = AudioBlock.silence(48_000.0, 2, 128);
+    private static final AudioDeviceEvent EVENT = new AudioDeviceEvent.DeviceArrived(
+            new DeviceId("ASIO", "Driver A"));
+
+    @Test
+    void publishDeviceEventToleratesCloseBetweenTheGuardAndOffer() {
+        var devicePublisher = new CloseBeforeOfferPublisher<AudioDeviceEvent>();
+        try (var support = new AudioBackendSupport(
+                new SubmissionPublisher<>(), devicePublisher)) {
+            assertThatCode(() -> support.publishDeviceEvent(EVENT))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    void publishInputToleratesCloseBetweenTheGuardAndOffer() {
+        var inputPublisher = new CloseBeforeOfferPublisher<AudioBlock>();
+        try (var support = new AudioBackendSupport(
+                inputPublisher, new SubmissionPublisher<>())) {
+            support.markOpen(FORMAT, BLOCK.frames());
+
+            assertThatCode(() -> support.publishInput(BLOCK))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    void publishDoesNotMaskAnIllegalStateExceptionFromAnOpenPublisher() {
+        var devicePublisher = new FailingPublisher<AudioDeviceEvent>();
+        try (var support = new AudioBackendSupport(
+                new SubmissionPublisher<>(), devicePublisher)) {
+            assertThatThrownBy(() -> support.publishDeviceEvent(EVENT))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("unexpected publisher failure");
+        }
+    }
+
+    private static final class CloseBeforeOfferPublisher<T> extends SubmissionPublisher<T> {
+
+        @Override
+        public int offer(
+                T item,
+                BiPredicate<Flow.Subscriber<? super T>, ? super T> dropHandler) {
+            close();
+            return super.offer(item, dropHandler);
+        }
+    }
+
+    private static final class FailingPublisher<T> extends SubmissionPublisher<T> {
+
+        @Override
+        public int offer(
+                T item,
+                BiPredicate<Flow.Subscriber<? super T>, ? super T> dropHandler) {
+            throw new IllegalStateException("unexpected publisher failure");
+        }
+    }
+}

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AudioBlockRingTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AudioBlockRingTest.java
@@ -1,0 +1,322 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link AudioBlockRing} — the lock-free SPSC hand-off used in
+ * both directions by the ASIO streaming bridge (story 311): render thread
+ * &rarr; buffer-switch callback for playback, and buffer-switch callback
+ * &rarr; {@code asio-input-drain} for capture.
+ */
+class AudioBlockRingTest {
+
+    /** Bounds every concurrent wait so a regression fails instead of hanging. */
+    private static final long DEADLINE_SECONDS = 30;
+
+    @Test
+    void capacityIsRoundedUpToThePowerOfTwo() {
+        assertThat(new AudioBlockRing(1, 4).capacity()).isEqualTo(1);
+        assertThat(new AudioBlockRing(3, 4).capacity()).isEqualTo(4);
+        assertThat(new AudioBlockRing(5, 4).capacity()).isEqualTo(8);
+        assertThat(new AudioBlockRing(8, 4).capacity()).isEqualTo(8);
+    }
+
+    @Test
+    void rejectsNonPositiveGeometry() {
+        assertThatThrownBy(() -> new AudioBlockRing(0, 4))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("capacity");
+        assertThatThrownBy(() -> new AudioBlockRing(4, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("samplesPerBlock");
+    }
+
+    @Test
+    void drainOnAnEmptyRingReturnsFalseAndLeavesDestinationUntouched() {
+        AudioBlockRing ring = new AudioBlockRing(4, 4);
+        float[] destination = {9f, 9f, 9f, 9f};
+
+        assertThat(ring.isEmpty()).isTrue();
+        assertThat(ring.drainLatestInto(destination)).isFalse();
+        assertThat(ring.readInto(destination)).isFalse();
+        assertThat(destination).containsExactly(9f, 9f, 9f, 9f);
+    }
+
+    @Test
+    void writeThenDrainRoundTripsTheSamples() {
+        AudioBlockRing ring = new AudioBlockRing(4, 4);
+
+        assertThat(ring.write(new float[] {0.1f, 0.2f, 0.3f, 0.4f}, 4)).isTrue();
+        assertThat(ring.isEmpty()).isFalse();
+
+        float[] destination = new float[4];
+        assertThat(ring.drainLatestInto(destination)).isTrue();
+        assertThat(destination).containsExactly(0.1f, 0.2f, 0.3f, 0.4f);
+        assertThat(ring.isEmpty()).isTrue();
+    }
+
+    @Test
+    void drainConsumesEveryPendingSlotAndYieldsTheMostRecentBlock() {
+        AudioBlockRing ring = new AudioBlockRing(4, 2);
+        ring.write(new float[] {1f, 1f}, 2);
+        ring.write(new float[] {2f, 2f}, 2);
+        ring.write(new float[] {3f, 3f}, 2);
+
+        assertThat(ring.size()).isEqualTo(3);
+        float[] destination = new float[2];
+        assertThat(ring.drainLatestInto(destination)).isTrue();
+        assertThat(destination).containsExactly(3f, 3f);
+        // All three slots were consumed, not just the newest one.
+        assertThat(ring.isEmpty()).isTrue();
+        assertThat(ring.drainLatestInto(destination)).isFalse();
+    }
+
+    /**
+     * The capture direction must never skip a block: {@code readInto} is the
+     * in-order consumer the {@code asio-input-drain} thread uses.
+     */
+    @Test
+    void readIntoConsumesExactlyOneSlotPerCallOldestFirst() {
+        AudioBlockRing ring = new AudioBlockRing(4, 2);
+        ring.write(new float[] {1f, 1f}, 2);
+        ring.write(new float[] {2f, 2f}, 2);
+        ring.write(new float[] {3f, 3f}, 2);
+
+        float[] destination = new float[2];
+        assertThat(ring.readInto(destination)).isTrue();
+        assertThat(destination).containsExactly(1f, 1f);
+        assertThat(ring.size()).isEqualTo(2);
+
+        assertThat(ring.readInto(destination)).isTrue();
+        assertThat(destination).containsExactly(2f, 2f);
+
+        assertThat(ring.readInto(destination)).isTrue();
+        assertThat(destination).containsExactly(3f, 3f);
+
+        assertThat(ring.isEmpty()).isTrue();
+        assertThat(ring.readInto(destination)).isFalse();
+    }
+
+    @Test
+    void readIntoZeroPadsAndTruncatesLikeDrainLatest() {
+        AudioBlockRing ring = new AudioBlockRing(2, 2);
+        ring.write(new float[] {1f, 2f}, 2);
+
+        float[] longer = new float[4];
+        assertThat(ring.readInto(longer)).isTrue();
+        assertThat(longer).containsExactly(1f, 2f, 0f, 0f);
+
+        ring.write(new float[] {3f, 4f}, 2);
+        float[] shorter = new float[1];
+        assertThat(ring.readInto(shorter)).isTrue();
+        assertThat(shorter).containsExactly(3f);
+    }
+
+    @Test
+    void writeDropsRatherThanBlocksWhenFull() {
+        AudioBlockRing ring = new AudioBlockRing(2, 1);
+
+        assertThat(ring.write(new float[] {1f}, 1)).isTrue();
+        assertThat(ring.write(new float[] {2f}, 1)).isTrue();
+        assertThat(ring.write(new float[] {3f}, 1))
+                .as("third write into a 2-slot ring must be dropped, not blocked")
+                .isFalse();
+
+        float[] destination = new float[1];
+        assertThat(ring.drainLatestInto(destination)).isTrue();
+        assertThat(destination)
+                .as("the newest block is dropped on overflow; the queued ones survive")
+                .containsExactly(2f);
+    }
+
+    @Test
+    void shorterSourceIsZeroPaddedAndLongerSourceIsTruncated() {
+        AudioBlockRing ring = new AudioBlockRing(2, 4);
+
+        ring.write(new float[] {1f, 2f}, 2);
+        float[] destination = new float[4];
+        assertThat(ring.drainLatestInto(destination)).isTrue();
+        assertThat(destination).containsExactly(1f, 2f, 0f, 0f);
+
+        ring.write(new float[] {5f, 6f, 7f, 8f, 9f}, 5);
+        assertThat(ring.drainLatestInto(destination)).isTrue();
+        assertThat(destination).containsExactly(5f, 6f, 7f, 8f);
+    }
+
+    @Test
+    void slotsAreReusedAfterDrainSoTheRingNeverPermanentlyFills() {
+        AudioBlockRing ring = new AudioBlockRing(2, 1);
+        float[] destination = new float[1];
+
+        for (int i = 1; i <= 10; i++) {
+            assertThat(ring.write(new float[] {i}, 1)).isTrue();
+            assertThat(ring.drainLatestInto(destination)).isTrue();
+            assertThat(destination[0]).isEqualTo(i);
+        }
+    }
+
+    @Test
+    void nullArgumentsDegradeInsteadOfThrowingOnTheRealTimeThread() {
+        AudioBlockRing ring = new AudioBlockRing(2, 2);
+        assertThat(ring.write(null, 2)).isFalse();
+        assertThat(ring.drainLatestInto(null)).isFalse();
+        assertThat(ring.readInto(null)).isFalse();
+    }
+
+    @Test
+    void toStringDescribesTheGeometry() {
+        assertThat(new AudioBlockRing(3, 8))
+                .hasToString("AudioBlockRing[capacity=4, samplesPerBlock=8]");
+    }
+
+    // ------------------------------------------------------------------
+    // Concurrency — the single property the class exists for
+    // ------------------------------------------------------------------
+
+    /**
+     * The capture path's real contract: one producer thread and one consumer
+     * thread, no lock, no torn slot, no reordering, no lost block.
+     *
+     * <p>The producer retries on full so nothing is legitimately dropped, which
+     * makes the expected consumer output exactly {@code 1..N} in order. Each
+     * block is filled with a single distinct value, so a torn slot (the
+     * consumer reading a slot the producer is still filling) shows up as a
+     * block whose elements are not all equal.</p>
+     */
+    @Test
+    void inOrderConsumerSeesEveryBlockExactlyOnceUnderConcurrentProduction()
+            throws Exception {
+        int blocks = 20_000;
+        int samplesPerBlock = 64;
+        AudioBlockRing ring = new AudioBlockRing(8, samplesPerBlock);
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DEADLINE_SECONDS);
+
+        CountDownLatch started = new CountDownLatch(2);
+        AtomicReference<String> producerFailure = new AtomicReference<>();
+        List<Float> consumed = new ArrayList<>(blocks);
+        AtomicReference<String> tornSlot = new AtomicReference<>();
+
+        Thread producer = new Thread(() -> {
+            started.countDown();
+            float[] source = new float[samplesPerBlock];
+            for (int i = 1; i <= blocks; i++) {
+                java.util.Arrays.fill(source, i);
+                while (!ring.write(source, samplesPerBlock)) {
+                    if (System.nanoTime() > deadline) {
+                        producerFailure.set("producer stalled at block " + i);
+                        return;
+                    }
+                    Thread.onSpinWait();
+                }
+            }
+        }, "ring-producer");
+
+        Thread consumer = new Thread(() -> {
+            started.countDown();
+            float[] destination = new float[samplesPerBlock];
+            while (consumed.size() < blocks && System.nanoTime() < deadline) {
+                if (!ring.readInto(destination)) {
+                    Thread.onSpinWait();
+                    continue;
+                }
+                float first = destination[0];
+                for (int s = 1; s < samplesPerBlock; s++) {
+                    if (destination[s] != first) {
+                        tornSlot.compareAndSet(null,
+                                "torn slot at block " + consumed.size()
+                                        + ": [0]=" + first + " [" + s + "]="
+                                        + destination[s]);
+                    }
+                }
+                consumed.add(first);
+            }
+        }, "ring-consumer");
+
+        producer.start();
+        consumer.start();
+        assertThat(started.await(DEADLINE_SECONDS, TimeUnit.SECONDS)).isTrue();
+        producer.join(TimeUnit.SECONDS.toMillis(DEADLINE_SECONDS));
+        consumer.join(TimeUnit.SECONDS.toMillis(DEADLINE_SECONDS));
+
+        assertThat(producer.isAlive()).as("producer must have finished").isFalse();
+        assertThat(consumer.isAlive()).as("consumer must have finished").isFalse();
+        assertThat(producerFailure.get()).isNull();
+        assertThat(tornSlot.get()).isNull();
+        assertThat(consumed).hasSize(blocks);
+        for (int i = 0; i < blocks; i++) {
+            assertThat(consumed.get(i))
+                    .as("block %d must arrive in order and intact", i)
+                    .isEqualTo((float) (i + 1));
+        }
+    }
+
+    /**
+     * The playback path's contract: the latest-wins consumer may skip blocks
+     * (that is the point) but must never observe a torn slot or a value that
+     * moves backwards.
+     */
+    @Test
+    void latestWinsConsumerNeverSeesATornOrOutOfOrderSlot() throws Exception {
+        int blocks = 20_000;
+        int samplesPerBlock = 64;
+        AudioBlockRing ring = new AudioBlockRing(4, samplesPerBlock);
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DEADLINE_SECONDS);
+
+        AtomicReference<String> violation = new AtomicReference<>();
+        CountDownLatch producerDone = new CountDownLatch(1);
+
+        Thread producer = new Thread(() -> {
+            float[] source = new float[samplesPerBlock];
+            for (int i = 1; i <= blocks; i++) {
+                java.util.Arrays.fill(source, i);
+                // Latest-wins tolerates drops, so no retry loop here.
+                ring.write(source, samplesPerBlock);
+            }
+            producerDone.countDown();
+        }, "ring-producer-latest");
+
+        Thread consumer = new Thread(() -> {
+            float[] destination = new float[samplesPerBlock];
+            float previous = 0f;
+            while (System.nanoTime() < deadline) {
+                if (producerDone.getCount() == 0 && ring.isEmpty()) {
+                    return;
+                }
+                if (!ring.drainLatestInto(destination)) {
+                    Thread.onSpinWait();
+                    continue;
+                }
+                float first = destination[0];
+                for (int s = 1; s < samplesPerBlock; s++) {
+                    if (destination[s] != first) {
+                        violation.compareAndSet(null, "torn slot: [0]=" + first
+                                + " [" + s + "]=" + destination[s]);
+                    }
+                }
+                if (first < previous) {
+                    violation.compareAndSet(null,
+                            "out-of-order: " + first + " after " + previous);
+                }
+                previous = first;
+            }
+        }, "ring-consumer-latest");
+
+        producer.start();
+        consumer.start();
+        producer.join(TimeUnit.SECONDS.toMillis(DEADLINE_SECONDS));
+        consumer.join(TimeUnit.SECONDS.toMillis(DEADLINE_SECONDS));
+
+        assertThat(producer.isAlive()).as("producer must have finished").isFalse();
+        assertThat(consumer.isAlive()).as("consumer must have finished").isFalse();
+        assertThat(violation.get()).isNull();
+    }
+}


### PR DESCRIPTION
# ASIO Real-Time Audio Streaming via bufferSwitch (ASIOCreateBuffers / ASIOStart / ASIOStop)

## Motivation

Story 310 makes the DAW able to enumerate, load, and initialise an installed ASIO driver; stories 212–224 expose its capabilities (buffer size, sample rate, clock source, channel names, control panel). But after all of that, **no audio actually flows over ASIO.** The streaming path in `com.benesquivelmusic.daw.sdk.audio.AsioBackend` is entirely a no-op:

- `open(DeviceId, AudioFormat, int)` calls `support.markOpen(...)` and constructs an `AsioFormatChangeShim`, then comments that "Native ASIO buffer-switch wiring lives in the implementation layer that ships the Steinberg ASIO SDK shim" — but that wiring does not exist.
- `inputBlocks()` returns `support.inputBlocks()`, a `SubmissionPublisher` that is never fed: nothing ever calls `AudioBackendSupport#publishInput(AudioBlock)` for the ASIO backend.
- `sink(AudioBlock)` only calls `support.validateOutgoing(block)` — it validates channel count and then drops the block on the floor; the samples never reach the driver's output buffers.
- `asioshim.cpp` has no `ASIOCreateBuffers`, `ASIOStart`, `ASIOStop`, `ASIODisposeBuffers`, and no `bufferSwitch` / `bufferSwitchTimeInfo` callback — the heart of any ASIO host.

The result: a Windows user can select their interface's ASIO driver, open its control panel, read its buffer size — and hear nothing, record nothing. "Full ASIO driver support" is impossible without the buffer-switch streaming loop. This story implements it: create the driver's double-buffered I/O buffers, install the `bufferSwitch` callback, start/stop the driver, and bridge each callback into the engine's `inputBlocks()` publisher and out of `sink()`.

## Goals

- Add the streaming exports to the `daw-core/native/asio/` shim (header-documented per the existing ABI convention):
  - `asioshim_createBuffers(const int* inputChannels, int numInputs, const int* outputChannels, int numOutputs, int bufferFrames)` — call `ASIOCreateBuffers` for the requested active channels with the host-callback set whose `bufferSwitch` / `bufferSwitchTimeInfo` slot routes into the shim's trampoline (the same pattern already used for `asioshim_messageTrampoline` in story 218).
  - `asioshim_start(void)` / `asioshim_stop(void)` wrapping `ASIOStart` / `ASIOStop`.
  - `asioshim_disposeBuffers(void)` wrapping `ASIODisposeBuffers`.
  - `installAsioBufferSwitchCallback(void* upcall)` / `uninstallAsioBufferSwitchCallback()` — register the JVM FFM upcall the shim invokes from each `bufferSwitch(long bufferIndex, long directProcess)`, mirroring `installAsioMessageCallback` from story 218.
- Bridge the buffer-switch callback into the Java backend on the **driver's** ASIO callback thread:
  - On each `bufferSwitch`, copy the active input channels' driver buffers for `bufferIndex` into an `AudioBlock` and publish it via `AudioBackendSupport#publishInput(AudioBlock)` so `inputBlocks()` subscribers (recording / monitoring) receive live input.
  - Pull the most recent block delivered to `AsioBackend#sink(AudioBlock)` and copy it into the active output channels' driver buffers for `bufferIndex`, then call `ASIOOutputReady()` when the driver advertises it. `sink(...)` must hand the block to a lock-free single-producer / single-consumer buffer (no allocation, no locking) so the callback thread never blocks — consistent with the project's real-time-safety conventions (`@RealTimeSafe`, lock-free ring buffers).
- Wire `AsioBackend#open(...)` to, after the story-310 driver load, call `asioshim_createBuffers(...)` for the opened `AudioFormat`'s channel set and `bufferFrames`, install the buffer-switch upcall, then `asioshim_start()`. Wire `close()` to `asioshim_stop()` → `asioshim_disposeBuffers()` → uninstall the upcall, in that order, before the story-310 `asioshim_unloadDriver()`.
- Honour the driver-reported preferred buffer size (story 213 / 220): `open(...)` uses the negotiated `bufferFrames`, and a buffer-size mismatch surfaces the same `AudioBackendException` style already used elsewhere in `AsioBackend` rather than silently resizing.
- Real-time safety: the FFM upcall body and `publishInput` path on the callback thread must not allocate, lock, or block (the existing `AudioBackendSupport#publishDeviceEvent` already documents the `offer()`-with-drop rationale for callback-thread safety; apply the same discipline to the input publish and output pull). Add or extend a contract test in the spirit of `RealTimeSafeContractTest` asserting the buffer-switch bridge method is real-time annotated.
- Integrate with the format-change path (story 218): a `kAsioBufferSizeChange` / `kAsioResetRequest` during streaming stops and disposes buffers cleanly before the backend reopens, so a driver-initiated reset does not race the running `bufferSwitch`.

## Goals — Tests

- A JVM-level test using a stub buffer-switch shim (injected via the same factory-hook pattern as `AsioBackend#setCapabilityShimFactory`) drives synthetic `bufferSwitch` callbacks and asserts: (a) each callback publishes exactly one `AudioBlock` of the opened channel count and `bufferFrames` length to `inputBlocks()`; (b) a block written to `sink(...)` is the one copied into the stub's output buffer on the next callback; (c) `open` → `start`, `close` → `stop` → `dispose` ordering holds.
- A Windows-gated integration test (`Assumptions.assumeTrue(NativeLibraryDetector.isAvailable("asioshim"))`, matching story 224's CI gating) opens ASIO4ALL against the system default device, starts streaming, confirms ≥1 real `bufferSwitch` fires within a timeout, and stops cleanly with no leaked driver state.

## Non-Goals

- Driver enumeration / load / `ASIOInit` / `ASIOExit` — owned by story 310 (prerequisite).
- Sample-format conversion between the driver's `ASIOSampleType` and the engine's float32 — owned by story 312; this story may assume a single format for its tests and let 312 generalise the conversion at the copy boundary.
- Changing `AudioBackend`, `AudioBlock`, `AudioFormat`, or `DeviceId` shapes.
- Round-trip latency reporting / compensation — owned by story 217; this story exposes the buffers, 217 measures the delay.
- Multi-driver simultaneous streaming — ASIO's single-driver-per-process model means exactly one driver streams at a time.
- macOS / Linux; x64 Windows only, consistent with story 224.

## Technical Notes

- Files: `daw-core/native/asio/asioshim.cpp` + `asioshim.h` (streaming exports + `bufferSwitch` trampoline), `daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBackend.java` (`open` / `sink` / `close` + a new `AsioBufferSwitchShim` alongside `AsioFormatChangeShim.java`), `daw-sdk/.../AudioBackendSupport.java` (already exposes `publishInput`).
- `AsioFormatChangeShim` (story 218) is the canonical reference for the FFM upcall install / trampoline pattern; the `bufferSwitch` upcall follows the same `installX` / `uninstallX` / `asioshim_xTrampoline` shape.
- The lock-free single-producer/single-consumer hand-off for `sink(...)` → callback thread should reuse the project's existing ring-buffer / lock-free conventions (see story 128 — Crash-Safe Audio Thread Isolation, story 123 — Buffer-Underrun Detection).
- Research backing: `docs/research/audio-development-tools.md` (JAsioHost, relevance High) is the reference Java ASIO host whose `bufferSwitch`-driven streaming model this story mirrors; `docs/research/open-source-daw-tools.md` § Real-Time Audio Processing (lock-free audio thread, ring buffers, fixed-size blocks) describes the callback-thread discipline required here.
- Reference original stories: **310 — ASIO Driver Enumeration and Lifecycle** (prerequisite), **218 — Driver-Initiated Reset Request Handling** (upcall pattern), **130 / 219** (backend selection / instantiation), **128 / 123** (real-time thread isolation / underrun handling).
