### PR TITLE
312-asio-sample-format-conversion.md implementation.

### DIFF
--- a/daw-core/native/asio/README.md
+++ b/daw-core/native/asio/README.md
@@ -235,11 +235,38 @@ a successful no-op; the call fails with `*outCount == 0` when no driver is
 loaded or buffers have not been created.
 
 The raw addresses are deliberate: the sample-format conversion boundary lives
-in Java (story 312 generalises it), so the JVM reads and writes the driver's
-buffers directly through FFM. They are valid only between a successful
-`asioshim_createBuffers` and the matching `asioshim_disposeBuffers` /
-`asioshim_unloadDriver`, and carry no alignment guarantee — the Java side must
-use the `*_UNALIGNED` value layouts.
+in Java, so the JVM reads and writes the driver's buffers directly through FFM.
+They are valid only between a successful `asioshim_createBuffers` and the
+matching `asioshim_disposeBuffers` / `asioshim_unloadDriver`, and carry no
+alignment guarantee — the Java side must use the `*_UNALIGNED` value layouts.
+
+### Sample-format conversion (story 312)
+
+Story 312 converts the full `ASIOSampleType` matrix **in Java**, in
+`daw-sdk`'s `AsioSampleType`, driven by the per-channel `sampleType` the record
+above already reports. The shim therefore needs no
+`asioshim_getChannelSampleType` export and moves no samples of its own.
+
+| Reported `ASIOSampleType` | Codes | Driver bytes per sample |
+| --- | --- | --- |
+| `Int16MSB` / `Int16LSB` | 0, 16 | 2 |
+| `Int24MSB` / `Int24LSB` (packed) | 1, 17 | 3 |
+| `Int32MSB` / `Int32LSB` | 2, 18 | 4 |
+| `Int32MSB16/18/20/24`, `Int32LSB16/18/20/24` (right-justified) | 8–11, 24–27 | 4 |
+| `Float32MSB` / `Float32LSB` | 3, 19 | 4 |
+| `Float64MSB` / `Float64LSB` | 4, 20 | 8 |
+
+Anything outside that matrix — the DSD types (32, 33, 40), an unassigned code,
+or the `-1` this shim reports when `ASIOGetChannelInfo` refused — fails
+`AsioBackend#open` with an `AudioBackendException` naming every offending
+channel. Guessing at the layout would hand the driver the engine's float bytes
+reinterpreted as integers, which is loud enough to damage speakers.
+
+The choice of Java over the native trampoline is deliberate: this shim is
+skipped entirely by CMake unless `-DASIO_SDK_DIR=...` is supplied (see
+*Building* below), so conversion code placed here would compile — and be
+tested — on the release lane only, whereas the Java converter is covered by
+`AsioSampleTypeTest` on every build.
 
 ## Building
 

--- a/daw-core/native/asio/asioshim.cpp
+++ b/daw-core/native/asio/asioshim.cpp
@@ -181,8 +181,12 @@ namespace {
     constexpr int MAX_STREAM_CHANNELS = 64;
     constexpr int BUFFER_INFO_STRIDE = 32;
     // Not a valid ASIOSampleType; means "the driver refused to report a
-    // sample type for this channel". The Java side treats anything other
-    // than ASIOSTFloat32LSB as unsupported (story 312 generalises it).
+    // sample type for this channel". Story 312 converts the whole SDK
+    // matrix on the Java side — Int16, packed Int24, Int32 (including the
+    // right-justified Int32LSB/MSB16/18/20/24 variants), Float32 and
+    // Float64, in both byte orders — so this value, the DSD types, and any
+    // code outside that matrix make the Java side reject the open with an
+    // AudioBackendException rather than mis-decode the channel.
     constexpr int32_t SAMPLE_TYPE_UNKNOWN = -1;
     // Upper bound on how long a control-path teardown waits for in-flight
     // driver callbacks to drain. Best-effort by design: a driver whose
@@ -1037,8 +1041,12 @@ ASIOSHIM_EXPORT int asioshim_createBuffers(const int* inputChannels,
 }
 
 // Reports the buffer addresses ASIOCreateBuffers handed back, so the JVM
-// can read and write the driver's buffers directly (the sample-format
-// conversion boundary lives in Java — story 312 generalises it).
+// can read and write the driver's buffers directly. The sample-format
+// conversion boundary lives in Java: story 312 converts the whole
+// ASIOSampleType matrix in AsioSampleType, keyed off the per-channel
+// sampleType this record already carries, so no separate
+// asioshim_getChannelSampleType export is needed and this trampoline moves
+// no samples itself.
 //
 // Writes a fixed 32-byte record per active channel, in exactly the order
 // passed to asioshim_createBuffers:

--- a/daw-core/native/asio/asioshim.h
+++ b/daw-core/native/asio/asioshim.h
@@ -118,8 +118,10 @@
 //   offset 24..32  int64 buffer1     address of `ASIOBufferInfo.buffers[1]`
 // The two addresses are the driver's own double-buffer halves; the JVM
 // reads and writes them directly because the sample-format conversion
-// boundary lives in Java (story 312 generalises it). They are valid only
-// between a successful `asioshim_createBuffers` and the matching
+// boundary lives in Java. Story 312 converts the whole ASIOSampleType
+// matrix there (`AsioSampleType`), keyed off the `sampleType` field above,
+// which is why no `asioshim_getChannelSampleType` export exists. They are
+// valid only between a successful `asioshim_createBuffers` and the matching
 // `asioshim_disposeBuffers` / `asioshim_unloadDriver`.
 //
 // All struct layouts are normalised to 32-bit integer fields (plus the

--- a/daw-core/src/test/java/com/benesquivelmusic/daw/core/annotation/RealTimeSafeContractTest.java
+++ b/daw-core/src/test/java/com/benesquivelmusic/daw/core/annotation/RealTimeSafeContractTest.java
@@ -75,6 +75,14 @@ class RealTimeSafeContractTest {
      */
     private static final String ASIO_BRIDGE_METHOD = "bufferSwitch";
 
+    /**
+     * Story 312 — the {@code ASIOSampleType} converter the bridge calls per
+     * channel per block. Package-private in another module, so it is reached
+     * the same way {@link #ASIO_BRIDGE_CLASS} is.
+     */
+    private static final String ASIO_SAMPLE_TYPE_CLASS =
+            "com.benesquivelmusic.daw.sdk.audio.AsioSampleType";
+
     // ------------------------------------------------------------------
     // Discovery
     // ------------------------------------------------------------------
@@ -172,6 +180,30 @@ class RealTimeSafeContractTest {
                 "write", Class.forName("com.benesquivelmusic.daw.sdk.audio.AudioBlock"));
         assertThat(isRealTimeSafe(write))
                 .as("AsioBufferSwitchShim.write must be annotated @RealTimeSafe")
+                .isTrue();
+    }
+
+    /**
+     * Story 312 — the two sample-format conversion seams the bridge calls once
+     * per channel per block, still on the driver's real-time thread. The
+     * generic bytecode / varargs / boxing sweep above already covers them once
+     * they carry the annotation; this asserts that they do, and — because
+     * {@code getDeclaredMethod} throws {@link NoSuchMethodException} rather
+     * than passing vacuously — that neither has been renamed or had its
+     * signature changed out from under the sweep.
+     */
+    @Test
+    void asioSampleTypeConversionSeamsShouldBeRealTimeSafe() throws Exception {
+        Class<?> sampleType = Class.forName(ASIO_SAMPLE_TYPE_CLASS);
+        Method decode = sampleType.getDeclaredMethod(
+                "decode", java.lang.foreign.MemorySegment.class, float[].class, int.class);
+        assertThat(isRealTimeSafe(decode))
+                .as("AsioSampleType.decode must be annotated @RealTimeSafe")
+                .isTrue();
+        Method encode = sampleType.getDeclaredMethod(
+                "encode", float[].class, java.lang.foreign.MemorySegment.class, int.class);
+        assertThat(isRealTimeSafe(encode))
+                .as("AsioSampleType.encode must be annotated @RealTimeSafe")
                 .isTrue();
     }
 

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBufferSwitchShim.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioBufferSwitchShim.java
@@ -13,9 +13,8 @@ import java.lang.invoke.MethodType;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.LockSupport;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * FFM (JEP 454) upcall that bridges the ASIO driver's
@@ -70,23 +69,31 @@ import java.util.logging.Logger;
  * recorded audio must stay contiguous.</p>
  *
  * <h2>Sample format</h2>
- * <p>Story 311 implements {@code ASIOSTFloat32LSB} ({@value #ASIOST_FLOAT32_LSB})
- * only; generalising the conversion is story 312's job. Channels whose driver
- * reported any other {@code ASIOSampleType} are zero-filled on input
- * <em>and</em> on output — leaving the driver's own output bytes in place would
- * replay them every block as a fixed-pitch buzz. The unsupported types are
- * logged once at construction time, never from the callback thread.</p>
+ * <p>Story 312 converts the full {@code ASIOSampleType} matrix here:
+ * {@code Int16}, packed 3-byte {@code Int24}, {@code Int32} — including the
+ * right-justified {@code Int32×16/18/20/24} variants — and IEEE 754
+ * {@code Float32} / {@code Float64}, in both byte orders. {@link AsioSampleType}
+ * owns every layout fact; this class only decides <em>which</em> converter each
+ * channel gets.</p>
+ *
+ * <p>The conversion locus is Java rather than the shim's native
+ * {@code bufferSwitch} trampoline. That trampoline hands the JVM the driver's
+ * raw buffer addresses and moves no samples at all, as {@code asioshim.cpp},
+ * {@code asioshim.h} and {@code native/asio/README.md} all record; the shim is
+ * also skipped by CMake in any checkout without the non-redistributable
+ * Steinberg SDK, so conversion code placed there would compile — and be
+ * tested — nowhere.</p>
+ *
+ * <p>Each channel's converter is resolved <em>once</em>, here at construction
+ * time, from the {@code ASIOSampleType} the driver reported for that channel;
+ * the callback thread never inspects a sample type. A channel whose reported
+ * type this DAW cannot convert (a DSD layout, an unassigned code, or the
+ * shim's {@code -1} "the driver refused to say") now fails
+ * {@link AsioBackend#open(DeviceId, AudioFormat, int)} with an
+ * {@link AudioBackendException} naming every offending channel, rather than
+ * being silently mis-decoded or silenced.</p>
  */
 final class AsioBufferSwitchShim implements AutoCloseable {
-
-    private static final Logger LOG =
-            Logger.getLogger(AsioBufferSwitchShim.class.getName());
-
-    /** {@code ASIOSTFloat32LSB} — the only sample type story 311 converts. */
-    static final int ASIOST_FLOAT32_LSB = 19;
-
-    /** Bytes per {@code ASIOSTFloat32LSB} sample. */
-    private static final int BYTES_PER_SAMPLE = 4;
 
     /** Name of the daemon thread that marshals captured blocks off the RT thread. */
     static final String DRAIN_THREAD_NAME = "asio-input-drain";
@@ -127,12 +134,18 @@ final class AsioBufferSwitchShim implements AutoCloseable {
     private final MemorySegment[][] inputBuffers;
     /** Driver output buffers indexed {@code [half][channel]}. */
     private final MemorySegment[][] outputBuffers;
-    /** Whether channel {@code c} has a usable float32 input buffer. */
-    private final boolean[] inputReady;
-    /** Whether the driver exposed any output buffer at all for channel {@code c}. */
-    private final boolean[] outputBound;
-    /** Whether channel {@code c} has a usable float32 output buffer. */
-    private final boolean[] outputReady;
+    /**
+     * Per-channel input converter, or {@code null} when the channel has no
+     * usable driver buffer — the driver exposed none, or its address could not
+     * be reinterpreted. Such a channel captures silence.
+     */
+    private final AsioSampleType[] inputTypes;
+    /**
+     * Per-channel output converter, or {@code null} when the channel has no
+     * usable driver buffer. Such a channel is left completely untouched: there
+     * is no buffer to write to.
+     */
+    private final AsioSampleType[] outputTypes;
 
     /** Interleaved capture staging buffer; callback thread only. */
     private final float[] inputScratch;
@@ -169,6 +182,10 @@ final class AsioBufferSwitchShim implements AutoCloseable {
      * @param bufferFrames the negotiated buffer size in sample frames; must be positive
      * @param bufferInfos  the descriptors returned by
      *                     {@link AsioStreamingShim#getBufferInfos()}; must not be null
+     * @throws AudioBackendException when the driver reports an
+     *                               {@code ASIOSampleType} this DAW cannot
+     *                               convert for a channel it actually exposed
+     *                               a buffer for
      */
     AsioBufferSwitchShim(AudioBackendSupport support, AudioFormat format,
                          int bufferFrames, List<AsioStreamingShim.BufferInfo> bufferInfos) {
@@ -184,16 +201,18 @@ final class AsioBufferSwitchShim implements AutoCloseable {
         this.bufferFrames = bufferFrames;
         this.inputBuffers = new MemorySegment[HALVES][channels];
         this.outputBuffers = new MemorySegment[HALVES][channels];
-        this.inputReady = new boolean[channels];
-        this.outputBound = new boolean[channels];
-        this.outputReady = new boolean[channels];
+        this.inputTypes = new AsioSampleType[channels];
+        this.outputTypes = new AsioSampleType[channels];
         for (int half = 0; half < HALVES; half++) {
             Arrays.fill(inputBuffers[half], MemorySegment.NULL);
             Arrays.fill(outputBuffers[half], MemorySegment.NULL);
         }
-        long byteSize = (long) bufferFrames * BYTES_PER_SAMPLE;
-        String unsupportedTypes = bindDriverBuffers(bufferInfos, byteSize);
-        warnAboutUnsupportedSampleTypes(unsupportedTypes);
+        // Load-bearing ordering: binding rejects an unconvertible channel by
+        // throwing, and it runs BEFORE Arena.ofShared() and before
+        // drainThread.start(). A rejected open therefore leaks neither the
+        // upcall arena nor the drain thread, and AsioBackend#open's
+        // catch (RuntimeException | Error) rolls back with bridge == null.
+        bindDriverBuffers(bufferInfos);
 
         int samplesPerBlock = channels * bufferFrames;
         this.inputScratch = new float[samplesPerBlock];
@@ -218,56 +237,73 @@ final class AsioBufferSwitchShim implements AutoCloseable {
     }
 
     /**
-     * Reinterprets each descriptor's raw {@code buffers[0]} / {@code buffers[1]}
-     * addresses into bounded {@link MemorySegment} views.
+     * Resolves each descriptor's {@code ASIOSampleType} and reinterprets its
+     * raw {@code buffers[0]} / {@code buffers[1]} addresses into bounded
+     * {@link MemorySegment} views sized for <em>that channel's</em> format.
      *
      * <p>Descriptors for channels the opened format does not cover are ignored,
      * and channels the driver never reported keep their
-     * {@link MemorySegment#NULL} placeholder — a playback-only device simply
-     * captures silence, and an interface with fewer outputs than the format
-     * asks for leaves the extra channels unwritten (story 311, S1).</p>
+     * {@link MemorySegment#NULL} placeholder and a {@code null} converter — a
+     * playback-only device simply captures silence, and an interface with fewer
+     * outputs than the format asks for leaves the extra channels unwritten
+     * (story 311, S1).</p>
      *
-     * @return a comma-separated list of the {@code ASIOSampleType}s story 311
-     *         cannot convert, or an empty string when every channel is float32
+     * <p>The view's byte size is per channel, not global: a
+     * {@code frames * 4} view over an {@code ASIOSTFloat64LSB} buffer would
+     * cover only the first half of it and every access past
+     * {@code frames / 2} would throw {@link IndexOutOfBoundsException} on the
+     * driver's real-time thread.</p>
+     *
+     * @throws AudioBackendException when any channel the driver actually bound
+     *                               buffers for reports a type this DAW cannot
+     *                               convert
      */
-    private String bindDriverBuffers(List<AsioStreamingShim.BufferInfo> bufferInfos,
-                                     long byteSize) {
+    private void bindDriverBuffers(List<AsioStreamingShim.BufferInfo> bufferInfos) {
         StringBuilder unsupported = new StringBuilder();
         for (AsioStreamingShim.BufferInfo info : bufferInfos) {
             int channel = info.channel();
             if (channel < 0 || channel >= channels) {
                 continue;
             }
-            boolean supported = info.sampleType() == ASIOST_FLOAT32_LSB;
-            if (!supported) {
+            Optional<AsioSampleType> resolved = AsioSampleType.forCode(info.sampleType());
+            // An unresolved type has no byte size, so the view is sized from
+            // the widest container the SDK defines. It is never read: the
+            // rejection below fails the open before any callback can run.
+            int bytesPerSample = resolved.isPresent()
+                    ? resolved.get().bytesPerSample()
+                    : Long.BYTES;
+            long byteSize = (long) bufferFrames * bytesPerSample;
+            MemorySegment half0 = viewOf(info.buffer0(), byteSize);
+            MemorySegment half1 = viewOf(info.buffer1(), byteSize);
+            boolean bound = !half0.equals(MemorySegment.NULL)
+                    && !half1.equals(MemorySegment.NULL);
+            if (bound && resolved.isEmpty()) {
+                // Only a channel we would actually touch can fail the open. A
+                // descriptor with no usable buffer is never decoded or
+                // encoded, so its type is irrelevant.
                 if (!unsupported.isEmpty()) {
                     unsupported.append(", ");
                 }
                 unsupported.append(info.input() ? "input " : "output ")
                         .append(channel).append('=').append(info.sampleType());
             }
-            MemorySegment half0 = viewOf(info.buffer0(), byteSize);
-            MemorySegment half1 = viewOf(info.buffer1(), byteSize);
-            boolean bound = !half0.equals(MemorySegment.NULL)
-                    && !half1.equals(MemorySegment.NULL);
             if (info.input()) {
                 inputBuffers[0][channel] = half0;
                 inputBuffers[1][channel] = half1;
-                inputReady[channel] = bound && supported;
+                inputTypes[channel] = bound ? resolved.orElse(null) : null;
             } else {
                 outputBuffers[0][channel] = half0;
                 outputBuffers[1][channel] = half1;
-                outputBound[channel] = bound;
-                outputReady[channel] = bound && supported;
+                outputTypes[channel] = bound ? resolved.orElse(null) : null;
             }
         }
-        return unsupported.toString();
+        rejectUnsupportedSampleTypes(unsupported.toString());
     }
 
     /**
      * Builds a bounded view over a raw driver buffer address. The resulting
      * segment carries <em>no</em> alignment guarantee, which is why every
-     * access uses {@code JAVA_FLOAT_UNALIGNED}.
+     * access uses a {@code JAVA_*_UNALIGNED} layout.
      */
     private static MemorySegment viewOf(long address, long byteSize) {
         if (address == 0L) {
@@ -283,18 +319,25 @@ final class AsioBufferSwitchShim implements AutoCloseable {
     }
 
     /**
-     * Logs the unsupported {@code ASIOSampleType}s exactly once, here at
-     * construction time. The callback thread must never log.
+     * Fails the open for every {@code ASIOSampleType} this DAW cannot convert,
+     * naming all of them in one message rather than reporting the first and
+     * hiding the rest.
+     *
+     * <p>Mis-decoding is the alternative, and at a hardware boundary it is
+     * loud: the driver would read the engine's float bytes as integers. The
+     * story's Non-Goals require a clear {@link AudioBackendException}
+     * instead.</p>
      */
-    private static void warnAboutUnsupportedSampleTypes(String unsupportedTypes) {
+    private static void rejectUnsupportedSampleTypes(String unsupportedTypes) {
         if (unsupportedTypes.isEmpty()) {
             return;
         }
-        LOG.log(Level.WARNING,
+        throw new AudioBackendException(
                 "ASIO driver reported unsupported ASIOSampleType(s) [" + unsupportedTypes
-                        + "]; story 311 converts ASIOSTFloat32LSB (" + ASIOST_FLOAT32_LSB
-                        + ") only, so those channels are silenced until story 312 "
-                        + "(ASIO sample-format conversion) generalises the copy boundary.");
+                        + "]; this DAW converts Int16, Int24 (packed 3-byte) and Int32 "
+                        + "— including the right-justified Int32x16/18/20/24 variants — "
+                        + "plus Float32 and Float64, in both byte orders. DSD types and "
+                        + "a driver that reports no type at all (-1) are not supported.");
     }
 
     private MemorySegment buildUpcallStub() {
@@ -360,7 +403,7 @@ final class AsioBufferSwitchShim implements AutoCloseable {
         float[] incoming = inputScratch;
         MemorySegment[] inputs = inputBuffers[bufferIndex];
         for (int channel = 0; channel < channelCount; channel++) {
-            copyInputChannel(inputs[channel], inputReady[channel],
+            copyInputChannel(inputs[channel], inputTypes[channel],
                     incoming, channel, channelCount, frames);
         }
         // Drop-on-full rather than block: a stalled drain thread must never
@@ -375,43 +418,38 @@ final class AsioBufferSwitchShim implements AutoCloseable {
         }
         MemorySegment[] outputs = outputBuffers[bufferIndex];
         for (int channel = 0; channel < channelCount; channel++) {
-            copyOutputChannel(outputs[channel], outputBound[channel],
-                    outputReady[channel], outputScratch, channel, channelCount, frames);
+            copyOutputChannel(outputs[channel], outputTypes[channel],
+                    outputScratch, channel, channelCount, frames);
         }
     }
 
     /**
-     * Driver &rarr; engine copy for one channel: bulk-reads the per-channel
-     * driver buffer into a scratch array, then de-interleaves it into the
-     * interleaved {@link AudioBlock} layout.
+     * Driver &rarr; engine copy for one channel: decodes the driver buffer
+     * into a per-channel scratch array of normalised float32, then
+     * de-interleaves it into the interleaved {@link AudioBlock} layout.
      *
-     * <p>One {@link MemorySegment#copy} per channel replaces {@code frames}
-     * individually bounds-checked {@code get} calls (8192 of them at
-     * 32&nbsp;channels &times; 128&nbsp;frames) and is still allocation-free.</p>
+     * <p>The decode is story 312's driver-side conversion seam.
+     * {@link AsioSampleType#decode} branches on the channel's format once and
+     * then runs a flat loop; for {@code ASIOSTFloat32LSB} on x64 it is still
+     * the single bulk {@link MemorySegment#copy} story 311 established, which
+     * replaces {@code frames} individually bounds-checked {@code get} calls
+     * (8192 of them at 32&nbsp;channels &times; 128&nbsp;frames).</p>
      *
-     * <p>story 312: this is one of the two sample-format conversion seams.
-     * Story 311 only decodes {@code ASIOSTFloat32LSB}; every other
-     * {@code ASIOSampleType} — and every channel the driver did not expose —
-     * arrives here with {@code ready == false} and is silenced. Story 312
-     * generalises the decode based on the per-channel {@code ASIOSampleType}
-     * captured at construction.</p>
+     * @param type the channel's converter, or {@code null} when the driver
+     *             exposed no usable buffer — that channel captures silence
      */
     @RealTimeSafe
-    private void copyInputChannel(MemorySegment source, boolean ready,
+    private void copyInputChannel(MemorySegment source, AsioSampleType type,
                                   float[] destination, int channel,
                                   int channelCount, int frames) {
-        if (!ready) {
+        if (type == null) {
             for (int frame = 0; frame < frames; frame++) {
                 destination[frame * channelCount + channel] = 0f;
             }
             return;
         }
         float[] scratch = inputChannelScratch;
-        // JAVA_FLOAT_UNALIGNED: a reinterpreted native segment carries no
-        // alignment guarantee, and the aligned layout would throw
-        // IllegalArgumentException on a misaligned driver buffer.
-        MemorySegment.copy(source, ValueLayout.JAVA_FLOAT_UNALIGNED, 0L,
-                scratch, 0, frames);
+        type.decode(source, scratch, frames);
         for (int frame = 0; frame < frames; frame++) {
             destination[frame * channelCount + channel] = scratch[frame];
         }
@@ -419,36 +457,27 @@ final class AsioBufferSwitchShim implements AutoCloseable {
 
     /**
      * Engine &rarr; driver copy for one channel: interleaved scratch into a
-     * per-channel scratch array, then one bulk {@link MemorySegment#copy} into
-     * the driver's buffer.
+     * per-channel scratch array, then one encode pass into the driver's
+     * buffer. The encode counterpart of {@link #copyInputChannel}.
      *
-     * <p>story 312: the encode counterpart of {@link #copyInputChannel}. Story
-     * 311 only encodes {@code ASIOSTFloat32LSB}; a channel of any other
-     * {@code ASIOSampleType} has its driver buffer <strong>zero-filled</strong>
-     * rather than skipped. A zero byte pattern is silence for every integer PCM
-     * and float {@code ASIOSampleType}, whereas leaving the driver's bytes
-     * alone would replay them every block as a fixed-pitch buzz. Story 312
-     * generalises the encode.</p>
+     * @param type the channel's converter, or {@code null} when the driver
+     *             exposed no usable buffer — there is nothing to write to, so
+     *             that channel is skipped entirely
      */
     @RealTimeSafe
-    private void copyOutputChannel(MemorySegment destination, boolean bound,
-                                   boolean ready, float[] source, int channel,
+    private void copyOutputChannel(MemorySegment destination, AsioSampleType type,
+                                   float[] source, int channel,
                                    int channelCount, int frames) {
-        if (!bound) {
+        if (type == null) {
             // The driver exposes no output buffer for this channel (fewer
             // hardware outputs than the opened format asks for).
-            return;
-        }
-        if (!ready) {
-            destination.fill((byte) 0);
             return;
         }
         float[] scratch = outputChannelScratch;
         for (int frame = 0; frame < frames; frame++) {
             scratch[frame] = source[frame * channelCount + channel];
         }
-        MemorySegment.copy(scratch, 0, destination,
-                ValueLayout.JAVA_FLOAT_UNALIGNED, 0L, frames);
+        type.encode(scratch, destination, frames);
     }
 
     /**

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioSampleType.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioSampleType.java
@@ -1,0 +1,521 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import com.benesquivelmusic.daw.sdk.annotation.RealTimeSafe;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The Steinberg {@code ASIOSampleType} matrix and its conversion to and from
+ * the engine's normalised float32 bus (story 312).
+ *
+ * <p>ASIO drivers do not all hand the host float32. A multi-channel USB
+ * interface — this project's primary target — commonly exposes
+ * {@code ASIOSTInt24LSB} or {@code ASIOSTInt32LSB}, and copying those bytes
+ * verbatim into a float buffer reinterprets them as garbage: full-scale noise
+ * on capture, and on playback the driver reads the host's float bytes as
+ * integers, which is loud enough to damage speakers. This enum is the single
+ * place that knows how to decode and encode each layout.</p>
+ *
+ * <h2>Conversion locus</h2>
+ * <p>The conversion lives in Java rather than in the native shim's
+ * {@code bufferSwitch} trampoline. The trampoline hands the JVM the driver's
+ * raw buffer addresses and does no sample movement at all, as
+ * {@code asioshim.cpp}, {@code asioshim.h} and {@code native/asio/README.md}
+ * all record. The shim is also never compiled in a normal checkout — its
+ * CMake target is skipped unless the non-redistributable Steinberg SDK is
+ * supplied — so conversion code placed there would carry no test coverage,
+ * whereas everything here is exercised by {@code AsioSampleTypeTest}.</p>
+ *
+ * <h2>Normalisation</h2>
+ * <p>Decoding an integer format divides by {@code 2^(significantBits - 1)};
+ * encoding clamps the float to {@code [-1, 1]} <em>first</em> and then scales
+ * by {@code 2^(significantBits - 1) - 1}. Clamping before the scale is what
+ * makes saturation structural: no finite float can reach a product outside
+ * the container's range, so wraparound is unreachable. The clamp applied to
+ * the rounded integer afterwards is belt-and-braces only. This matches the
+ * convention already used by {@code WavFileReader}, {@code AiffFileReader}
+ * and {@code WavExporter}.</p>
+ *
+ * <p>A {@code NaN} sample survives the float clamp as {@code NaN} and then
+ * {@code Math.round} maps it to {@code 0}, so a {@code NaN} on the bus is
+ * encoded as digital silence for that sample. That is deliberate: branching
+ * on {@code NaN} would cost a comparison per sample on the driver's real-time
+ * thread, and silence is the only safe interpretation at a hardware boundary.
+ * The float formats are <em>not</em> clamped — the engine's float bus may
+ * legitimately exceed &plusmn;1.0, and {@code FLOAT32_LSB} must round-trip
+ * bit-exactly.</p>
+ *
+ * <h2>Right-justified {@code Int32} variants</h2>
+ * <p>{@code ASIOSTInt32LSB16/18/20/24} (and their MSB twins) carry an
+ * <em>N</em>-bit sample in the low <em>N</em> bits of a 32-bit container.
+ * PortAudio's {@code pa_asio.cpp} confirms the reading: its ASIO&rarr;host
+ * converter left-shifts by {@code 32 - N} (16, 14, 12, 8 respectively) to
+ * fill a 32-bit container. The unused high bits are never trusted here —
+ * {@code raw << shift >> shift} re-derives the sign locally rather than
+ * assuming the driver sign-extended.</p>
+ *
+ * <h2>Real-time discipline</h2>
+ * <p>{@link #decode} and {@link #encode} run on the driver's
+ * {@code bufferSwitch} thread. They allocate nothing, lock nothing, log
+ * nothing and box nothing. The format is resolved once per channel at
+ * {@code ASIOCreateBuffers} time via {@link #forCode(int)}, and each call
+ * performs at most one dispatch — on an {@code int} discriminant, so the
+ * hot path is a {@code tableswitch} with neither an {@code invokedynamic}
+ * bootstrap nor a synthetic {@code $SwitchMap} holder to initialise on the
+ * real-time thread.</p>
+ *
+ * <p>Every {@link MemorySegment} access uses a {@code JAVA_*_UNALIGNED}
+ * layout (or {@code JAVA_BYTE}). Driver buffers reach the JVM through
+ * {@code MemorySegment.ofAddress(...).reinterpret(...)} and carry no
+ * alignment guarantee at all; an aligned layout would throw
+ * {@link IllegalArgumentException} on a misaligned driver buffer.</p>
+ *
+ * <p>DSD ({@code ASIOSTDSDInt8LSB1} / {@code MSB1} / {@code NER8}) is out of
+ * scope by the story's Non-Goals and is reported as unsupported rather than
+ * guessed at, as is any code the driver reports that is not in this table —
+ * including the shim's {@code -1} "the driver refused to say".</p>
+ */
+enum AsioSampleType {
+
+    /** {@code ASIOSTInt16MSB} — 16-bit signed, big-endian. */
+    INT16_MSB(0, AsioSampleType.ENC_INT16, 2, 16, false),
+    /** {@code ASIOSTInt24MSB} — 24-bit signed, packed 3 bytes, big-endian. */
+    INT24_MSB(1, AsioSampleType.ENC_INT24, 3, 24, false),
+    /** {@code ASIOSTInt32MSB} — 32-bit signed, big-endian. */
+    INT32_MSB(2, AsioSampleType.ENC_INT32, 4, 32, false),
+    /** {@code ASIOSTFloat32MSB} — IEEE&nbsp;754 binary32, big-endian. */
+    FLOAT32_MSB(3, AsioSampleType.ENC_FLOAT32, 4, 0, false),
+    /** {@code ASIOSTFloat64MSB} — IEEE&nbsp;754 binary64, big-endian. */
+    FLOAT64_MSB(4, AsioSampleType.ENC_FLOAT64, 8, 0, false),
+    /** {@code ASIOSTInt32MSB16} — 16 significant bits, right-justified in 32, big-endian. */
+    INT32_MSB16(8, AsioSampleType.ENC_INT32, 4, 16, false),
+    /** {@code ASIOSTInt32MSB18} — 18 significant bits, right-justified in 32, big-endian. */
+    INT32_MSB18(9, AsioSampleType.ENC_INT32, 4, 18, false),
+    /** {@code ASIOSTInt32MSB20} — 20 significant bits, right-justified in 32, big-endian. */
+    INT32_MSB20(10, AsioSampleType.ENC_INT32, 4, 20, false),
+    /** {@code ASIOSTInt32MSB24} — 24 significant bits, right-justified in 32, big-endian. */
+    INT32_MSB24(11, AsioSampleType.ENC_INT32, 4, 24, false),
+    /** {@code ASIOSTInt16LSB} — 16-bit signed, little-endian. */
+    INT16_LSB(16, AsioSampleType.ENC_INT16, 2, 16, true),
+    /** {@code ASIOSTInt24LSB} — 24-bit signed, packed 3 bytes, little-endian. */
+    INT24_LSB(17, AsioSampleType.ENC_INT24, 3, 24, true),
+    /** {@code ASIOSTInt32LSB} — 32-bit signed, little-endian. */
+    INT32_LSB(18, AsioSampleType.ENC_INT32, 4, 32, true),
+    /** {@code ASIOSTFloat32LSB} — IEEE&nbsp;754 binary32, little-endian; the x86 fast path. */
+    FLOAT32_LSB(19, AsioSampleType.ENC_FLOAT32, 4, 0, true),
+    /** {@code ASIOSTFloat64LSB} — IEEE&nbsp;754 binary64, little-endian. */
+    FLOAT64_LSB(20, AsioSampleType.ENC_FLOAT64, 8, 0, true),
+    /** {@code ASIOSTInt32LSB16} — 16 significant bits, right-justified in 32, little-endian. */
+    INT32_LSB16(24, AsioSampleType.ENC_INT32, 4, 16, true),
+    /** {@code ASIOSTInt32LSB18} — 18 significant bits, right-justified in 32, little-endian. */
+    INT32_LSB18(25, AsioSampleType.ENC_INT32, 4, 18, true),
+    /** {@code ASIOSTInt32LSB20} — 20 significant bits, right-justified in 32, little-endian. */
+    INT32_LSB20(26, AsioSampleType.ENC_INT32, 4, 20, true),
+    /** {@code ASIOSTInt32LSB24} — 24 significant bits, right-justified in 32, little-endian. */
+    INT32_LSB24(27, AsioSampleType.ENC_INT32, 4, 24, true);
+
+    // ------------------------------------------------------------------
+    // Hot-path dispatch discriminants
+    // ------------------------------------------------------------------
+    //
+    // Plain compile-time int constants rather than a nested enum: javac
+    // inlines them into both the constant table above and the switch below,
+    // so the dispatch is a bare tableswitch. A switch over a nested enum
+    // would instead read a synthetic $SwitchMap array whose holder class is
+    // initialised — under the JVM's class-init lock — on whichever thread
+    // executes the switch first. That thread is the driver's real-time
+    // callback thread, which must never take a lock.
+
+    /** 2-byte signed container, all 16 bits significant. */
+    private static final int ENC_INT16 = 0;
+    /** 3-byte packed signed container, all 24 bits significant. */
+    private static final int ENC_INT24 = 1;
+    /** 4-byte signed container; {@code significantBits} may be 16/18/20/24/32. */
+    private static final int ENC_INT32 = 2;
+    /** 4-byte IEEE 754 binary32 container. */
+    private static final int ENC_FLOAT32 = 3;
+    /** 8-byte IEEE 754 binary64 container. */
+    private static final int ENC_FLOAT64 = 4;
+
+    /** Bytes in a packed 24-bit sample; not a {@code ValueLayout} size. */
+    private static final int INT24_BYTES = 3;
+
+    private final int code;
+    private final int encoding;
+    private final int bytesPerSample;
+    private final int significantBits;
+
+    /** The format's own byte order, used directly by the packed 24-bit paths. */
+    private final boolean littleEndian;
+    /** Whether the format's order differs from the host's, so bytes need swapping. */
+    private final boolean swap;
+
+    /** {@code 1 / 2^(significantBits - 1)}; unused (1.0) for the float formats. */
+    private final float decodeScale;
+    /** {@code 2^(significantBits - 1) - 1}; unused (1.0) for the float formats. */
+    private final double encodeScale;
+    /** {@code 2^(significantBits - 1) - 1}; the saturation limit. */
+    private final int peak;
+
+    AsioSampleType(int code, int encoding, int bytesPerSample,
+                   int significantBits, boolean littleEndian) {
+        this.code = code;
+        this.encoding = encoding;
+        this.bytesPerSample = bytesPerSample;
+        this.significantBits = significantBits;
+        this.littleEndian = littleEndian;
+        // ByteOrder.nativeOrder() is called rather than read from a static
+        // field: enum constants are constructed before any other static
+        // field of the enum is assigned, so such a field would still be
+        // false here.
+        this.swap = littleEndian
+                != (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
+        boolean integer = encoding != ENC_FLOAT32 && encoding != ENC_FLOAT64;
+        // 1L, not 1: 1 << 31 overflows int and yields Integer.MIN_VALUE.
+        long fullScale = integer ? 1L << (significantBits - 1) : 1L;
+        this.decodeScale = integer ? 1f / fullScale : 1f;
+        this.encodeScale = integer ? fullScale - 1L : 1.0;
+        this.peak = (int) (fullScale - 1L);
+    }
+
+    // ------------------------------------------------------------------
+    // Resolution (control thread only)
+    // ------------------------------------------------------------------
+
+    /**
+     * Resolves a driver-reported {@code ASIOSampleType} code.
+     *
+     * <p>Called once per channel at {@code ASIOCreateBuffers} time, never
+     * from the real-time thread — the {@link Optional} allocation is
+     * deliberate and safe there. A plain {@code switch} rather than a scan
+     * over {@link #values()}, which would clone the constant array on every
+     * call.</p>
+     *
+     * @param code the raw {@code ASIOSampleType} the driver reported, or
+     *             {@code -1} when the shim could not obtain one
+     * @return the matching format, or {@link Optional#empty()} for a DSD
+     *         type, an unassigned code, or {@code -1}
+     */
+    static Optional<AsioSampleType> forCode(int code) {
+        return switch (code) {
+            case 0 -> Optional.of(INT16_MSB);
+            case 1 -> Optional.of(INT24_MSB);
+            case 2 -> Optional.of(INT32_MSB);
+            case 3 -> Optional.of(FLOAT32_MSB);
+            case 4 -> Optional.of(FLOAT64_MSB);
+            case 8 -> Optional.of(INT32_MSB16);
+            case 9 -> Optional.of(INT32_MSB18);
+            case 10 -> Optional.of(INT32_MSB20);
+            case 11 -> Optional.of(INT32_MSB24);
+            case 16 -> Optional.of(INT16_LSB);
+            case 17 -> Optional.of(INT24_LSB);
+            case 18 -> Optional.of(INT32_LSB);
+            case 19 -> Optional.of(FLOAT32_LSB);
+            case 20 -> Optional.of(FLOAT64_LSB);
+            case 24 -> Optional.of(INT32_LSB16);
+            case 25 -> Optional.of(INT32_LSB18);
+            case 26 -> Optional.of(INT32_LSB20);
+            case 27 -> Optional.of(INT32_LSB24);
+            // 32 / 33 / 40 are the DSD types, explicitly out of scope; every
+            // other code is unassigned in the SDK, and -1 means the driver
+            // refused to report one.
+            default -> Optional.empty();
+        };
+    }
+
+    /** Returns the {@code ASIOSampleType} enum value this format is declared as. */
+    int code() {
+        return code;
+    }
+
+    /**
+     * Returns how many bytes one sample of one channel occupies in the
+     * driver's buffer — 2, 3 (packed 24-bit), 4 or 8.
+     *
+     * <p>This is what sizes the {@link MemorySegment} view over a driver
+     * buffer. Assuming 4 for every format under-sizes an
+     * {@code ASIOSTFloat64*} view by half and over-sizes an
+     * {@code ASIOSTInt16*} one.</p>
+     *
+     * @return the driver-side container size in bytes
+     */
+    int bytesPerSample() {
+        return bytesPerSample;
+    }
+
+    /**
+     * Returns how many bits of the container carry the sample, or {@code 0}
+     * for the IEEE 754 float formats.
+     */
+    int significantBits() {
+        return significantBits;
+    }
+
+    // ------------------------------------------------------------------
+    // Decode (driver -> engine)
+    // ------------------------------------------------------------------
+
+    /**
+     * Decodes {@code frames} driver samples into normalised float32.
+     *
+     * <p>Integer formats land in {@code [-1, 1]}; the float formats are
+     * passed through unscaled, so a driver that hands back an out-of-range
+     * float keeps it. Runs on the driver's real-time callback thread.</p>
+     *
+     * @param source      the driver's buffer for one channel; must hold at
+     *                    least {@code frames * bytesPerSample()} bytes and
+     *                    must not be null
+     * @param destination receives the decoded samples in {@code [0, frames)};
+     *                    must not be null
+     * @param frames      how many samples to decode
+     */
+    @RealTimeSafe
+    void decode(MemorySegment source, float[] destination, int frames) {
+        Objects.requireNonNull(source, "source must not be null");
+        Objects.requireNonNull(destination, "destination must not be null");
+        switch (encoding) {
+            case ENC_FLOAT32 -> decodeFloat32(source, destination, frames);
+            case ENC_FLOAT64 -> decodeFloat64(source, destination, frames);
+            case ENC_INT16 -> decodeInt16(source, destination, frames);
+            case ENC_INT24 -> decodeInt24(source, destination, frames);
+            default -> decodeInt32(source, destination, frames);
+        }
+    }
+
+    /**
+     * Bit-exact passthrough. On the only supported target (x64 Windows)
+     * {@code FLOAT32_LSB} needs no swap, so this stays the single bulk
+     * {@link MemorySegment#copy} story 311 established.
+     */
+    @RealTimeSafe
+    private void decodeFloat32(MemorySegment source, float[] destination, int frames) {
+        if (!swap) {
+            MemorySegment.copy(source, ValueLayout.JAVA_FLOAT_UNALIGNED, 0L,
+                    destination, 0, frames);
+            return;
+        }
+        for (int frame = 0; frame < frames; frame++) {
+            int raw = source.get(ValueLayout.JAVA_INT_UNALIGNED,
+                    (long) frame * Integer.BYTES);
+            destination[frame] = Float.intBitsToFloat(Integer.reverseBytes(raw));
+        }
+    }
+
+    @RealTimeSafe
+    private void decodeFloat64(MemorySegment source, float[] destination, int frames) {
+        boolean reverse = swap;
+        for (int frame = 0; frame < frames; frame++) {
+            long raw = source.get(ValueLayout.JAVA_LONG_UNALIGNED,
+                    (long) frame * Long.BYTES);
+            if (reverse) {
+                raw = Long.reverseBytes(raw);
+            }
+            destination[frame] = (float) Double.longBitsToDouble(raw);
+        }
+    }
+
+    @RealTimeSafe
+    private void decodeInt16(MemorySegment source, float[] destination, int frames) {
+        boolean reverse = swap;
+        float scale = decodeScale;
+        for (int frame = 0; frame < frames; frame++) {
+            short raw = source.get(ValueLayout.JAVA_SHORT_UNALIGNED,
+                    (long) frame * Short.BYTES);
+            if (reverse) {
+                raw = Short.reverseBytes(raw);
+            }
+            destination[frame] = raw * scale;
+        }
+    }
+
+    /**
+     * Packed 24-bit: exactly three bytes per sample, assembled into the top
+     * 24 bits of an {@code int} and then arithmetically shifted down, which
+     * sign-extends. Same construction as {@code WavFileReader} (little-endian)
+     * and {@code AiffFileReader} (big-endian).
+     */
+    @RealTimeSafe
+    private void decodeInt24(MemorySegment source, float[] destination, int frames) {
+        boolean little = littleEndian;
+        float scale = decodeScale;
+        for (int frame = 0; frame < frames; frame++) {
+            long offset = (long) frame * INT24_BYTES;
+            int b0 = source.get(ValueLayout.JAVA_BYTE, offset) & 0xFF;
+            int b1 = source.get(ValueLayout.JAVA_BYTE, offset + 1) & 0xFF;
+            int b2 = source.get(ValueLayout.JAVA_BYTE, offset + 2) & 0xFF;
+            int value = little
+                    ? ((b2 << 24) | (b1 << 16) | (b0 << 8)) >> 8
+                    : ((b0 << 24) | (b1 << 16) | (b2 << 8)) >> 8;
+            destination[frame] = value * scale;
+        }
+    }
+
+    /**
+     * Covers the full 32-bit formats and the right-justified 16/18/20/24
+     * variants alike: {@code shift} is {@code 32 - significantBits}, which is
+     * zero — and therefore a no-op — for the full-width types.
+     */
+    @RealTimeSafe
+    private void decodeInt32(MemorySegment source, float[] destination, int frames) {
+        boolean reverse = swap;
+        float scale = decodeScale;
+        int shift = Integer.SIZE - significantBits;
+        for (int frame = 0; frame < frames; frame++) {
+            int raw = source.get(ValueLayout.JAVA_INT_UNALIGNED,
+                    (long) frame * Integer.BYTES);
+            if (reverse) {
+                raw = Integer.reverseBytes(raw);
+            }
+            // The driver is not trusted to have sign-extended the unused
+            // high bits of a right-justified sample; this re-derives the
+            // sign from bit (significantBits - 1) locally.
+            destination[frame] = (raw << shift >> shift) * scale;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Encode (engine -> driver)
+    // ------------------------------------------------------------------
+
+    /**
+     * Encodes {@code frames} normalised float32 samples into the driver's
+     * layout, saturating at full scale for the integer formats.
+     *
+     * <p>Runs on the driver's real-time callback thread.</p>
+     *
+     * @param source      the engine's samples for one channel, read from
+     *                    {@code [0, frames)}; must not be null
+     * @param destination the driver's buffer for one channel; must hold at
+     *                    least {@code frames * bytesPerSample()} bytes and
+     *                    must not be null
+     * @param frames      how many samples to encode
+     */
+    @RealTimeSafe
+    void encode(float[] source, MemorySegment destination, int frames) {
+        Objects.requireNonNull(source, "source must not be null");
+        Objects.requireNonNull(destination, "destination must not be null");
+        switch (encoding) {
+            case ENC_FLOAT32 -> encodeFloat32(source, destination, frames);
+            case ENC_FLOAT64 -> encodeFloat64(source, destination, frames);
+            case ENC_INT16 -> encodeInt16(source, destination, frames);
+            case ENC_INT24 -> encodeInt24(source, destination, frames);
+            default -> encodeInt32(source, destination, frames);
+        }
+    }
+
+    /** Bit-exact passthrough; the no-swap case is story 311's bulk copy. */
+    @RealTimeSafe
+    private void encodeFloat32(float[] source, MemorySegment destination, int frames) {
+        if (!swap) {
+            MemorySegment.copy(source, 0, destination,
+                    ValueLayout.JAVA_FLOAT_UNALIGNED, 0L, frames);
+            return;
+        }
+        for (int frame = 0; frame < frames; frame++) {
+            int bits = Float.floatToRawIntBits(source[frame]);
+            destination.set(ValueLayout.JAVA_INT_UNALIGNED,
+                    (long) frame * Integer.BYTES, Integer.reverseBytes(bits));
+        }
+    }
+
+    @RealTimeSafe
+    private void encodeFloat64(float[] source, MemorySegment destination, int frames) {
+        boolean reverse = swap;
+        for (int frame = 0; frame < frames; frame++) {
+            long bits = Double.doubleToRawLongBits(source[frame]);
+            if (reverse) {
+                bits = Long.reverseBytes(bits);
+            }
+            destination.set(ValueLayout.JAVA_LONG_UNALIGNED,
+                    (long) frame * Long.BYTES, bits);
+        }
+    }
+
+    @RealTimeSafe
+    private void encodeInt16(float[] source, MemorySegment destination, int frames) {
+        boolean reverse = swap;
+        double scale = encodeScale;
+        int limit = peak;
+        for (int frame = 0; frame < frames; frame++) {
+            short value = (short) quantize(source[frame], scale, limit);
+            if (reverse) {
+                value = Short.reverseBytes(value);
+            }
+            destination.set(ValueLayout.JAVA_SHORT_UNALIGNED,
+                    (long) frame * Short.BYTES, value);
+        }
+    }
+
+    /**
+     * Packed 24-bit: exactly three bytes written per sample, so a
+     * {@code frames * 3}-byte driver buffer is filled precisely and no
+     * fourth byte is touched. Same byte order as {@code WavExporter}
+     * (little-endian) reversed for the MSB variant.
+     */
+    @RealTimeSafe
+    private void encodeInt24(float[] source, MemorySegment destination, int frames) {
+        boolean little = littleEndian;
+        double scale = encodeScale;
+        int limit = peak;
+        for (int frame = 0; frame < frames; frame++) {
+            int value = quantize(source[frame], scale, limit);
+            long offset = (long) frame * INT24_BYTES;
+            if (little) {
+                destination.set(ValueLayout.JAVA_BYTE, offset, (byte) value);
+                destination.set(ValueLayout.JAVA_BYTE, offset + 1, (byte) (value >> 8));
+                destination.set(ValueLayout.JAVA_BYTE, offset + 2, (byte) (value >> 16));
+            } else {
+                destination.set(ValueLayout.JAVA_BYTE, offset, (byte) (value >> 16));
+                destination.set(ValueLayout.JAVA_BYTE, offset + 1, (byte) (value >> 8));
+                destination.set(ValueLayout.JAVA_BYTE, offset + 2, (byte) value);
+            }
+        }
+    }
+
+    /**
+     * Covers the full 32-bit formats and the right-justified variants alike.
+     * {@link #quantize} already produces a signed value inside
+     * {@code [-peak, peak]}, which for a right-justified format occupies the
+     * low {@code significantBits} bits with the sign replicated above — the
+     * same bit pattern PortAudio's host&rarr;ASIO converter writes.
+     */
+    @RealTimeSafe
+    private void encodeInt32(float[] source, MemorySegment destination, int frames) {
+        boolean reverse = swap;
+        double scale = encodeScale;
+        int limit = peak;
+        for (int frame = 0; frame < frames; frame++) {
+            int value = quantize(source[frame], scale, limit);
+            if (reverse) {
+                value = Integer.reverseBytes(value);
+            }
+            destination.set(ValueLayout.JAVA_INT_UNALIGNED,
+                    (long) frame * Integer.BYTES, value);
+        }
+    }
+
+    /**
+     * Clamps a bus sample to {@code [-1, 1]} and scales it to the format's
+     * integer range.
+     *
+     * <p>Static, and given the scale and the limit as arguments rather than
+     * reading them from the enum's fields, so the caller can hoist both out
+     * of its loop and the JIT sees a trivially inlinable leaf.</p>
+     *
+     * <p>The clamp on the rounded result is redundant — the float was already
+     * clamped to {@code [-1, 1]} before the multiply, so the product cannot
+     * leave {@code [-limit, limit]} — and is kept as a belt-and-braces guard
+     * against a future scale-factor change reintroducing wraparound at the
+     * hardware boundary. {@code NaN} survives the float clamp and is mapped
+     * to {@code 0} by {@link Math#round(double)}: silence, not noise.</p>
+     */
+    @RealTimeSafe
+    private static int quantize(float sample, double scale, int limit) {
+        float clamped = Math.clamp(sample, -1f, 1f);
+        return Math.clamp(Math.round(clamped * scale), -limit, limit);
+    }
+}

--- a/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioSampleType.java
+++ b/daw-sdk/src/main/java/com/benesquivelmusic/daw/sdk/audio/AsioSampleType.java
@@ -516,6 +516,7 @@ enum AsioSampleType {
     @RealTimeSafe
     private static int quantize(float sample, double scale, int limit) {
         float clamped = Math.clamp(sample, -1f, 1f);
-        return Math.clamp(Math.round(clamped * scale), -limit, limit);
+        int rounded = (int) Math.round(clamped * scale);
+        return Math.clamp(rounded, -limit, limit);
     }
 }

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBackendStreamingTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBackendStreamingTest.java
@@ -47,6 +47,11 @@ class AsioBackendStreamingTest {
     private static final int FRAMES = 128;
     private static final long AWAIT_SECONDS = 10;
 
+    /** {@code ASIOSTFloat32LSB} — what the stub driver reports by default. */
+    private static final int FLOAT32_LSB = 19;
+    /** {@code ASIOSTDSDInt8LSB1} — out of scope by story 312's Non-Goals. */
+    private static final int DSD_INT8_LSB1 = 32;
+
     private Arena arena;
     private List<String> calls;
     private StubDriverShim driver;
@@ -377,6 +382,35 @@ class AsioBackendStreamingTest {
                 .hasMessageContaining("no buffer descriptors");
         assertThat(backend.isOpen()).isFalse();
         assertThat(driver.unloaded).isTrue();
+    }
+
+    /**
+     * Story 312: an {@code ASIOSampleType} this DAW cannot convert fails the
+     * open rather than silencing the channel. The bridge rejects it from its
+     * constructor — before it opens the upcall arena or starts the drain
+     * thread — so {@code rollbackOpen} runs the full teardown with a null
+     * bridge and the backend is not left marked open.
+     */
+    @Test
+    void anUnsupportedDriverSampleTypeRollsTheOpenBackInsteadOfStreamingGarbage() {
+        bufferInfos = driverBufferInfos(DSD_INT8_LSB1);
+
+        assertThatThrownBy(() -> backend.open(DRIVER_A, FORMAT, FRAMES))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("unsupported ASIOSampleType")
+                .hasMessageContaining("input 0=" + DSD_INT8_LSB1);
+        assertThat(backend.isOpen())
+                .as("a rejected sample type must not leave the backend marked open")
+                .isFalse();
+        assertThat(backend.activeBufferSwitchShim()).isNull();
+        assertThat(backend.activeFormatChangeShim()).isNull();
+        assertThat(driver.unloaded).isTrue();
+        assertThat(calls).containsSubsequence(
+                "getBufferInfos", "stop", "disposeBuffers",
+                "uninstallBufferSwitchCallback", "close", "unload");
+        assertThat(calls)
+                .as("ASIOStart must never be reached for a format the DAW cannot convert")
+                .doesNotContain("start", "installBufferSwitchCallback");
     }
 
     // ------------------------------------------------------------------
@@ -714,21 +748,26 @@ class AsioBackendStreamingTest {
                 .contains(call);
     }
 
+    /** The default fixture: every channel reports {@code ASIOSTFloat32LSB}. */
     private List<AsioStreamingShim.BufferInfo> driverBufferInfos() {
+        return driverBufferInfos(FLOAT32_LSB);
+    }
+
+    private List<AsioStreamingShim.BufferInfo> driverBufferInfos(int sampleType) {
         inputBuffers = new MemorySegment[2][2];
         outputBuffers = new MemorySegment[2][2];
         List<AsioStreamingShim.BufferInfo> infos = new ArrayList<>();
         for (int channel = 0; channel < 2; channel++) {
             inputBuffers[0][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, FRAMES);
             inputBuffers[1][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, FRAMES);
-            infos.add(new AsioStreamingShim.BufferInfo(channel, true, 19,
+            infos.add(new AsioStreamingShim.BufferInfo(channel, true, sampleType,
                     inputBuffers[0][channel].address(),
                     inputBuffers[1][channel].address()));
         }
         for (int channel = 0; channel < 2; channel++) {
             outputBuffers[0][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, FRAMES);
             outputBuffers[1][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, FRAMES);
-            infos.add(new AsioStreamingShim.BufferInfo(channel, false, 19,
+            infos.add(new AsioStreamingShim.BufferInfo(channel, false, sampleType,
                     outputBuffers[0][channel].address(),
                     outputBuffers[1][channel].address()));
         }

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBufferSwitchShimTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioBufferSwitchShimTest.java
@@ -16,9 +16,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Story 311 headline acceptance test for {@link AsioBufferSwitchShim}.
+ * Story 311 headline acceptance test for {@link AsioBufferSwitchShim},
+ * extended by story 312 with the non-float {@code ASIOSampleType} paths.
  *
  * <p>Fake "driver" buffers are allocated from a test-owned
  * {@link Arena#ofShared()} and their raw addresses are handed to the shim as
@@ -44,10 +46,31 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AsioBufferSwitchShimTest {
 
-    /** {@code ASIOSTFloat32LSB} — the only type story 311 converts. */
+    /** {@code ASIOSTInt24MSB} — packed 3-byte, big-endian. */
+    private static final int INT24_MSB = 1;
+    /** {@code ASIOSTInt32MSB24} — 24 significant bits right-justified in a big-endian word. */
+    private static final int INT32_MSB24 = 11;
+    /** {@code ASIOSTInt16LSB}. */
+    private static final int INT16_LSB = 16;
+    /** {@code ASIOSTInt24LSB} — packed 3-byte, the common USB-interface format. */
+    private static final int INT24_LSB = 17;
+    /** {@code ASIOSTInt32LSB}. */
+    private static final int INT32_LSB = 18;
+    /** {@code ASIOSTFloat32LSB} — story 311's original bulk-copy fast path. */
     private static final int FLOAT32_LSB = 19;
-    /** {@code ASIOSTInt32LSB} — deferred to story 312. */
-    private static final int INT32_LSB = 17;
+    /** {@code ASIOSTFloat64LSB} — the widest container the SDK defines. */
+    private static final int FLOAT64_LSB = 20;
+    /** {@code ASIOSTInt32LSB16} — 16 significant bits right-justified in a little-endian word. */
+    private static final int INT32_LSB16 = 24;
+    /** {@code ASIOSTDSDInt8LSB1} — out of scope by the story's Non-Goals. */
+    private static final int DSD_INT8_LSB1 = 32;
+    /** The native shim's "the driver refused to report a sample type". */
+    private static final int SAMPLE_TYPE_UNKNOWN = -1;
+
+    /** Full scale of a packed 24-bit sample: {@code 2^23}. */
+    private static final int INT24_FULL_SCALE = 8_388_608;
+    /** Bytes in a packed 24-bit sample. */
+    private static final int INT24_BYTES = 3;
 
     private static final int HALVES = 2;
     private static final long AWAIT_SECONDS = 10;
@@ -361,31 +384,231 @@ class AsioBufferSwitchShimTest {
     // ------------------------------------------------------------------
 
     /**
-     * Story 312 owns the general {@code ASIOSampleType} conversion. Until then
-     * an unsupported type must play <em>silence</em>: leaving the driver's own
-     * bytes in place would replay them every block as a fixed-pitch buzz, and
-     * most real drivers report {@code ASIOSTInt32LSB} rather than float32.
+     * Story 312: a type this DAW cannot convert now fails the open. Silencing
+     * the channel (story 311's behaviour) hid a driver the DAW could not
+     * actually drive, and guessing at the layout would hand the driver the
+     * engine's float bytes reinterpreted as integers — loud enough to damage
+     * speakers.
      */
     @Test
-    void unsupportedSampleTypeSilencesBothTheInputBlockAndTheDriverOutput()
+    void unsupportedSampleTypeRejectsTheOpenInsteadOfSilencingTheChannel() {
+        List<AsioStreamingShim.BufferInfo> dsd =
+                bufferInfos(DSD_INT8_LSB1, FLOAT32_LSB);
+
+        assertThatThrownBy(() ->
+                new AsioBufferSwitchShim(support, format, frames, dsd))
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("input 0=" + DSD_INT8_LSB1)
+                .hasMessageContaining("input 1=" + DSD_INT8_LSB1)
+                .hasMessageContaining("Int24");
+
+        List<AsioStreamingShim.BufferInfo> unknown =
+                bufferInfos(FLOAT32_LSB, SAMPLE_TYPE_UNKNOWN);
+
+        assertThatThrownBy(() ->
+                new AsioBufferSwitchShim(support, format, frames, unknown))
+                .as("a driver that reports no type at all must not be guessed at")
+                .isInstanceOf(AudioBackendException.class)
+                .hasMessageContaining("output 0=" + SAMPLE_TYPE_UNKNOWN)
+                .hasMessageContaining("output 1=" + SAMPLE_TYPE_UNKNOWN);
+    }
+
+    /**
+     * A descriptor with no usable driver buffer is never decoded or encoded,
+     * so its reported type is irrelevant and must not fail an otherwise
+     * workable open.
+     */
+    @Test
+    void anUnsupportedTypeOnAChannelWithNoDriverBufferDoesNotFailTheOpen() {
+        List<AsioStreamingShim.BufferInfo> infos = List.of(
+                new AsioStreamingShim.BufferInfo(0, true, FLOAT32_LSB,
+                        driverInputs[0][0].address(), driverInputs[1][0].address()),
+                new AsioStreamingShim.BufferInfo(1, true, DSD_INT8_LSB1, 0L, 0L),
+                new AsioStreamingShim.BufferInfo(0, false, FLOAT32_LSB,
+                        driverOutputs[0][0].address(), driverOutputs[1][0].address()));
+
+        shim = new AsioBufferSwitchShim(support, format, frames, infos);
+
+        assertThat(shim.isStreaming()).isTrue();
+    }
+
+    // ------------------------------------------------------------------
+    // Sample-format conversion (story 312)
+    // ------------------------------------------------------------------
+
+    /**
+     * The story's integration case: a driver reporting packed 24-bit — the
+     * format a multi-channel USB interface most often exposes — must reach the
+     * engine as correctly normalised float32, and the engine's float block must
+     * reach the driver as correctly packed 24-bit.
+     */
+    @Test
+    void int24DriverBuffersAreDecodedToFloatAndTheRenderedBlockIsPackedBack()
             throws Exception {
-        buildShim(INT32_LSB);
-        writeDriverBuffer(driverInputs[0][0], 0.1f, 0.2f, 0.3f, 0.4f);
-        writeDriverBuffer(driverOutputs[0][0], 7f, 7f, 7f, 7f);
-        writeDriverBuffer(driverOutputs[0][1], 7f, 7f, 7f, 7f);
+        fixture(2, 4, INT24_BYTES, INT24_BYTES);
+        buildShim(INT24_LSB);
+        // Exact powers of two, so the decode is exact and a tolerance would
+        // only hide an error.
+        writePacked24(driverInputs[0][0],
+                INT24_FULL_SCALE / 2, INT24_FULL_SCALE / 4,
+                -INT24_FULL_SCALE / 2, -INT24_FULL_SCALE);
+        writePacked24(driverInputs[0][1],
+                -INT24_FULL_SCALE / 4, 0, INT24_FULL_SCALE / 8, -INT24_FULL_SCALE / 8);
         CapturingSubscriber subscriber = subscribe();
-        shim.write(new AudioBlock(format.sampleRate(), channels, frames,
-                new float[channels * frames]));
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames, new float[] {
+                0.5f, -0.5f,
+                0.25f, -0.25f,
+                0f, 1f,
+                -1f, 0.125f}));
 
         shim.bufferSwitch(0, 1);
         flushAndPublishSentinel();
 
         assertThat(subscriber.await(2)).isTrue();
-        assertThat(subscriber.blocks().get(0).samples()).containsOnly(0f);
-        assertThat(readDriverBuffer(driverOutputs[0][0], frames))
-                .as("driver garbage must be overwritten with silence, not replayed")
-                .containsOnly(0f);
-        assertThat(readDriverBuffer(driverOutputs[0][1], frames)).containsOnly(0f);
+        assertThat(subscriber.blocks().get(0).samples())
+                .as("packed 24-bit must normalise to [-1, 1], not arrive as garbage")
+                .containsExactly(
+                        0.5f, -0.25f,
+                        0.25f, 0f,
+                        -0.5f, 0.125f,
+                        -1f, -0.125f);
+        // round(x * (2^23 - 1)): +0.5 -> 4194304, -0.5 -> -4194303,
+        // +1 -> 8388607, -1 -> -8388607.
+        assertThat(readPacked24(driverOutputs[0][0], frames))
+                .containsExactly(4_194_304, 2_097_152, 0, -8_388_607);
+        assertThat(readPacked24(driverOutputs[0][1], frames))
+                .containsExactly(-4_194_303, -2_097_152, 8_388_607, 1_048_576);
+    }
+
+    /**
+     * The converter is resolved per channel <em>and</em> per direction, so a
+     * driver that captures 24-bit and plays 32-bit — or any other asymmetric
+     * pairing — must be handled without a single global format assumption.
+     */
+    @Test
+    void inputAndOutputConvertersAreIndependentPerDirection() throws Exception {
+        fixture(2, 4, INT24_BYTES, Integer.BYTES);
+        buildShim(INT24_LSB, INT32_LSB);
+        writePacked24(driverInputs[0][0],
+                INT24_FULL_SCALE / 2, 0, -INT24_FULL_SCALE / 2, -INT24_FULL_SCALE);
+        writePacked24(driverInputs[0][1], 0, 0, 0, 0);
+        CapturingSubscriber subscriber = subscribe();
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames, new float[] {
+                0.5f, -0.5f,
+                0.5f, -0.5f,
+                0.5f, -0.5f,
+                0.5f, -0.5f}));
+
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(2)).isTrue();
+        assertThat(subscriber.blocks().get(0).samples()).containsExactly(
+                0.5f, 0f,
+                0f, 0f,
+                -0.5f, 0f,
+                -1f, 0f);
+        // round(0.5 * (2^31 - 1)) = 1073741824; round(-0.5 * (2^31 - 1)) = -1073741823.
+        assertThat(readRawInts(driverOutputs[0][0], frames))
+                .containsOnly(1_073_741_824);
+        assertThat(readRawInts(driverOutputs[0][1], frames))
+                .containsOnly(-1_073_741_823);
+    }
+
+    /**
+     * The converter and the driver-buffer stride are resolved per
+     * <em>channel</em>, not once per direction. The ASIO SDK carries
+     * {@code ASIOSampleType} in each channel's own {@code ASIOChannelInfo},
+     * and a host that samples one descriptor per direction and assumes the
+     * rest match (as PortAudio's ASIO host API does) mis-decodes every channel
+     * that differs. Six formats and three container sizes per direction in one
+     * shim, so a per-direction shortcut cannot pass.
+     *
+     * <p>This is also the only place an MSB variant, a 2-byte container and a
+     * right-justified variant are driven through {@code bufferSwitch} rather
+     * than exercised directly in {@code AsioSampleTypeTest}.</p>
+     */
+    @Test
+    void everyChannelGetsItsOwnConverterAndItsOwnDriverBufferStride() throws Exception {
+        fixture(3, 4, new int[] {2, 4, 8}, new int[] {3, 4, 4});
+        buildShim(new int[] {INT16_LSB, INT32_MSB24, FLOAT64_LSB},
+                new int[] {INT24_MSB, FLOAT32_LSB, INT32_LSB16});
+        // Every raw value is a power of two, so no decode needs a tolerance.
+        writeShorts(driverInputs[0][0], 16_384, -8_192, 4_096, -32_768);
+        writeRawIntsBigEndian(driverInputs[0][1], 4_194_304, -8_388_608, 2_097_152, 0);
+        writeDoubles(driverInputs[0][2], 0.75, -0.375, 0.0, 0.5);
+        CapturingSubscriber subscriber = subscribe();
+        shim.write(new AudioBlock(format.sampleRate(), 3, 4, new float[] {
+                0.5f, 0.1f, 1f,
+                -0.5f, -0.2f, -1f,
+                1f, 0.3f, 0.5f,
+                -1f, -0.4f, 0f}));
+
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(2)).isTrue();
+        assertThat(subscriber.blocks().get(0).samples())
+                .as("each capture channel must be decoded with its own ASIOSampleType "
+                        + "and read at its own stride")
+                .containsExactly(
+                        0.5f, 0.5f, 0.75f,
+                        -0.25f, -1f, -0.375f,
+                        0.125f, 0.25f, 0f,
+                        -1f, 0f, 0.5f);
+
+        // round(x * (2^23 - 1)) packed three bytes, most significant first.
+        assertThat(readPacked24BigEndian(driverOutputs[0][0], frames))
+                .as("Int24MSB output must be packed big-endian at a three-byte stride")
+                .containsExactly(4_194_304, -4_194_303, 8_388_607, -8_388_607);
+        assertThat(readDriverBuffer(driverOutputs[0][1], frames))
+                .as("Float32LSB output must stay bit-exact alongside two integer channels")
+                .containsExactly(0.1f, -0.2f, 0.3f, -0.4f);
+        // round(x * (2^15 - 1)), sign-extended, in the low 16 bits of the word.
+        assertThat(readRawInts(driverOutputs[0][2], frames))
+                .as("Int32LSB16 output must be right-justified, not left-justified")
+                .containsExactly(32_767, -32_767, 16_384, 0);
+    }
+
+    /**
+     * The discriminating regression guard for the per-channel view size.
+     * Story 311 reinterpreted <em>every</em> driver buffer to
+     * {@code bufferFrames * 4} bytes; an {@code ASIOSTFloat64LSB} channel needs
+     * eight bytes per frame, so that view covered only the first half of the
+     * buffer and every access from frame {@code frames / 2} onwards threw
+     * {@link IndexOutOfBoundsException} — on the driver's real-time thread.
+     */
+    @Test
+    void float64DriverBuffersAreConvertedAcrossTheWholeBufferNotJustItsFirstHalf()
+            throws Exception {
+        fixture(2, 4, Double.BYTES, Double.BYTES);
+        buildShim(FLOAT64_LSB);
+        writeDoubles(driverInputs[0][0], 0.1, 0.2, 0.3, 0.4);
+        writeDoubles(driverInputs[0][1], -0.5, -0.6, -0.7, -0.8);
+        CapturingSubscriber subscriber = subscribe();
+        shim.write(new AudioBlock(format.sampleRate(), channels, frames, new float[] {
+                0.25f, -0.75f,
+                0.26f, -0.76f,
+                0.27f, -0.77f,
+                0.28f, -0.78f}));
+
+        shim.bufferSwitch(0, 1);
+        flushAndPublishSentinel();
+
+        assertThat(subscriber.await(2)).isTrue();
+        assertThat(subscriber.blocks().get(0).samples())
+                .as("the second half of a Float64 buffer must be reachable")
+                .containsExactly(
+                        0.1f, -0.5f,
+                        0.2f, -0.6f,
+                        0.3f, -0.7f,
+                        0.4f, -0.8f);
+        // Widened from the float bus, so the stored doubles are exactly the
+        // float values promoted — not the decimal literals' own doubles.
+        assertThat(readDoubles(driverOutputs[0][0], frames)).containsExactly(
+                (double) 0.25f, (double) 0.26f, (double) 0.27f, (double) 0.28f);
+        assertThat(readDoubles(driverOutputs[0][1], frames)).containsExactly(
+                (double) -0.75f, (double) -0.76f, (double) -0.77f, (double) -0.78f);
     }
 
     /**
@@ -490,44 +713,175 @@ class AsioBufferSwitchShimTest {
 
     /**
      * (Re)builds the driver-buffer fixture and the backend support for a given
-     * geometry. Called from {@code setUp} with the default 2 &times; 4 shape.
+     * geometry, with float32-sized driver buffers. Called from {@code setUp}
+     * with the default 2 &times; 4 shape.
      */
     private void fixture(int channelCount, int frameCount) {
+        fixture(channelCount, frameCount, Float.BYTES, Float.BYTES);
+    }
+
+    /** One container size for every channel in each direction. */
+    private void fixture(int channelCount, int frameCount,
+                         int inputBytesPerSample, int outputBytesPerSample) {
+        fixture(channelCount, frameCount,
+                repeated(inputBytesPerSample, channelCount),
+                repeated(outputBytesPerSample, channelCount));
+    }
+
+    /**
+     * Story 312: the driver-side container is per <em>channel</em>, not per
+     * direction — the ASIO SDK carries {@code ASIOSampleType} in each
+     * channel's own {@code ASIOChannelInfo}. The halves are allocated with
+     * byte alignment rather than {@code ValueLayout.JAVA_FLOAT}, which is also
+     * what a reinterpreted driver address gives the shim: an aligned value
+     * layout would throw on one.
+     */
+    private void fixture(int channelCount, int frameCount,
+                         int[] inputBytesPerSample, int[] outputBytesPerSample) {
         if (support != null) {
             support.close();
         }
         this.channels = channelCount;
         this.frames = frameCount;
         this.format = new AudioFormat(48_000.0, channelCount, 32);
-        this.driverInputs = allocateHalves();
-        this.driverOutputs = allocateHalves();
+        this.driverInputs = allocateHalves(inputBytesPerSample);
+        this.driverOutputs = allocateHalves(outputBytesPerSample);
         this.support = new AudioBackendSupport();
         support.markOpen(format, frameCount);
     }
 
     private void buildShim(int sampleType) {
+        buildShim(sampleType, sampleType);
+    }
+
+    /** Story 312: separate input and output types, so a mixed-format driver can be stood in for. */
+    private void buildShim(int inputSampleType, int outputSampleType) {
+        buildShim(repeated(inputSampleType, channels),
+                repeated(outputSampleType, channels));
+    }
+
+    /** Story 312: a distinct {@code ASIOSampleType} per channel per direction. */
+    private void buildShim(int[] inputSampleTypes, int[] outputSampleTypes) {
+        shim = new AsioBufferSwitchShim(support, format, frames,
+                bufferInfos(inputSampleTypes, outputSampleTypes));
+    }
+
+    private List<AsioStreamingShim.BufferInfo> bufferInfos(int inputSampleType,
+                                                           int outputSampleType) {
+        return bufferInfos(repeated(inputSampleType, channels),
+                repeated(outputSampleType, channels));
+    }
+
+    private List<AsioStreamingShim.BufferInfo> bufferInfos(int[] inputSampleTypes,
+                                                           int[] outputSampleTypes) {
         List<AsioStreamingShim.BufferInfo> infos = new ArrayList<>();
         for (int channel = 0; channel < channels; channel++) {
-            infos.add(new AsioStreamingShim.BufferInfo(channel, true, sampleType,
+            infos.add(new AsioStreamingShim.BufferInfo(channel, true,
+                    inputSampleTypes[channel],
                     driverInputs[0][channel].address(),
                     driverInputs[1][channel].address()));
         }
         for (int channel = 0; channel < channels; channel++) {
-            infos.add(new AsioStreamingShim.BufferInfo(channel, false, sampleType,
+            infos.add(new AsioStreamingShim.BufferInfo(channel, false,
+                    outputSampleTypes[channel],
                     driverOutputs[0][channel].address(),
                     driverOutputs[1][channel].address()));
         }
-        shim = new AsioBufferSwitchShim(support, format, frames, List.copyOf(infos));
+        return List.copyOf(infos);
     }
 
-    private MemorySegment[][] allocateHalves() {
+    private MemorySegment[][] allocateHalves(int[] bytesPerSample) {
         MemorySegment[][] halves = new MemorySegment[HALVES][channels];
         for (int half = 0; half < HALVES; half++) {
             for (int channel = 0; channel < channels; channel++) {
-                halves[half][channel] = arena.allocate(ValueLayout.JAVA_FLOAT, frames);
+                halves[half][channel] =
+                        arena.allocate((long) frames * bytesPerSample[channel]);
             }
         }
         return halves;
+    }
+
+    private static int[] repeated(int value, int count) {
+        int[] values = new int[count];
+        java.util.Arrays.fill(values, value);
+        return values;
+    }
+
+    private static void writePacked24(MemorySegment buffer, int... values) {
+        for (int frame = 0; frame < values.length; frame++) {
+            long offset = (long) frame * INT24_BYTES;
+            buffer.set(ValueLayout.JAVA_BYTE, offset, (byte) values[frame]);
+            buffer.set(ValueLayout.JAVA_BYTE, offset + 1, (byte) (values[frame] >> 8));
+            buffer.set(ValueLayout.JAVA_BYTE, offset + 2, (byte) (values[frame] >> 16));
+        }
+    }
+
+    private static int[] readPacked24(MemorySegment buffer, int frameCount) {
+        int[] values = new int[frameCount];
+        for (int frame = 0; frame < frameCount; frame++) {
+            long offset = (long) frame * INT24_BYTES;
+            int b0 = buffer.get(ValueLayout.JAVA_BYTE, offset) & 0xFF;
+            int b1 = buffer.get(ValueLayout.JAVA_BYTE, offset + 1) & 0xFF;
+            int b2 = buffer.get(ValueLayout.JAVA_BYTE, offset + 2) & 0xFF;
+            values[frame] = ((b2 << 24) | (b1 << 16) | (b0 << 8)) >> 8;
+        }
+        return values;
+    }
+
+    private static int[] readPacked24BigEndian(MemorySegment buffer, int frameCount) {
+        int[] values = new int[frameCount];
+        for (int frame = 0; frame < frameCount; frame++) {
+            long offset = (long) frame * INT24_BYTES;
+            int b0 = buffer.get(ValueLayout.JAVA_BYTE, offset) & 0xFF;
+            int b1 = buffer.get(ValueLayout.JAVA_BYTE, offset + 1) & 0xFF;
+            int b2 = buffer.get(ValueLayout.JAVA_BYTE, offset + 2) & 0xFF;
+            values[frame] = ((b0 << 24) | (b1 << 16) | (b2 << 8)) >> 8;
+        }
+        return values;
+    }
+
+    private static void writeShorts(MemorySegment buffer, int... values) {
+        for (int frame = 0; frame < values.length; frame++) {
+            buffer.set(ValueLayout.JAVA_SHORT_UNALIGNED,
+                    (long) frame * Short.BYTES, (short) values[frame]);
+        }
+    }
+
+    /**
+     * Lays a right-justified 32-bit sample out big-endian, as an MSB driver
+     * would. {@code JAVA_INT_UNALIGNED} is native (little-endian) order on the
+     * only platform ASIO runs on, so the value is byte-reversed on the way in.
+     */
+    private static void writeRawIntsBigEndian(MemorySegment buffer, int... values) {
+        for (int frame = 0; frame < values.length; frame++) {
+            buffer.set(ValueLayout.JAVA_INT_UNALIGNED, (long) frame * Integer.BYTES,
+                    Integer.reverseBytes(values[frame]));
+        }
+    }
+
+    private static int[] readRawInts(MemorySegment buffer, int frameCount) {
+        int[] values = new int[frameCount];
+        for (int frame = 0; frame < frameCount; frame++) {
+            values[frame] = buffer.get(ValueLayout.JAVA_INT_UNALIGNED,
+                    (long) frame * Integer.BYTES);
+        }
+        return values;
+    }
+
+    private static void writeDoubles(MemorySegment buffer, double... values) {
+        for (int frame = 0; frame < values.length; frame++) {
+            buffer.set(ValueLayout.JAVA_DOUBLE_UNALIGNED,
+                    (long) frame * Double.BYTES, values[frame]);
+        }
+    }
+
+    private static double[] readDoubles(MemorySegment buffer, int frameCount) {
+        double[] values = new double[frameCount];
+        for (int frame = 0; frame < frameCount; frame++) {
+            values[frame] = buffer.get(ValueLayout.JAVA_DOUBLE_UNALIGNED,
+                    (long) frame * Double.BYTES);
+        }
+        return values;
     }
 
     private static void writeDriverBuffer(MemorySegment buffer, float... values) {

--- a/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioSampleTypeTest.java
+++ b/daw-sdk/src/test/java/com/benesquivelmusic/daw/sdk/audio/AsioSampleTypeTest.java
@@ -1,0 +1,516 @@
+package com.benesquivelmusic.daw.sdk.audio;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Story 312 acceptance tests for {@link AsioSampleType}: the full Steinberg
+ * {@code ASIOSampleType} matrix converted to and from the engine's normalised
+ * float32 bus.
+ *
+ * <p>The driver-side bytes are read back with a <em>test-local</em> decoder
+ * ({@link #storedInteger}) that assembles the integer from raw bytes and picks
+ * its byte order from the ASIO constant's own name, so a bug in the production
+ * decoder cannot cancel out the matching bug in the production encoder. Every
+ * segment is allocated from a test-owned {@link Arena}, exactly as
+ * {@code AsioBufferSwitchShimTest} stands in for a driver's buffers.</p>
+ *
+ * <p>The constant table itself was confirmed against two independent copies of
+ * Steinberg's {@code asio.h} (the ASIO SDK bundled in {@code thestk/rtaudio}
+ * and in {@code kxproject/kx-audio-driver}), and the right-justified reading of
+ * the {@code Int32×16/18/20/24} variants against PortAudio's
+ * {@code pa_asio.cpp}, whose ASIO&rarr;host converter left-shifts by
+ * {@code 32 - N}.</p>
+ */
+class AsioSampleTypeTest {
+
+    /** Sentinel written past the end of a packed 24-bit buffer. */
+    private static final byte TAIL = (byte) 0xA5;
+
+    private Arena arena;
+
+    @BeforeEach
+    void setUp() {
+        arena = Arena.ofConfined();
+    }
+
+    @AfterEach
+    void tearDown() {
+        arena.close();
+    }
+
+    // ------------------------------------------------------------------
+    // Resolution
+    // ------------------------------------------------------------------
+
+    @Test
+    void forCodeResolvesEveryConstantInTheSteinbergAsioSampleTypeTable() {
+        assertThat(AsioSampleType.forCode(0)).contains(AsioSampleType.INT16_MSB);
+        assertThat(AsioSampleType.forCode(1)).contains(AsioSampleType.INT24_MSB);
+        assertThat(AsioSampleType.forCode(2)).contains(AsioSampleType.INT32_MSB);
+        assertThat(AsioSampleType.forCode(3)).contains(AsioSampleType.FLOAT32_MSB);
+        assertThat(AsioSampleType.forCode(4)).contains(AsioSampleType.FLOAT64_MSB);
+        assertThat(AsioSampleType.forCode(8)).contains(AsioSampleType.INT32_MSB16);
+        assertThat(AsioSampleType.forCode(9)).contains(AsioSampleType.INT32_MSB18);
+        assertThat(AsioSampleType.forCode(10)).contains(AsioSampleType.INT32_MSB20);
+        assertThat(AsioSampleType.forCode(11)).contains(AsioSampleType.INT32_MSB24);
+        assertThat(AsioSampleType.forCode(16)).contains(AsioSampleType.INT16_LSB);
+        assertThat(AsioSampleType.forCode(17)).contains(AsioSampleType.INT24_LSB);
+        assertThat(AsioSampleType.forCode(18)).contains(AsioSampleType.INT32_LSB);
+        assertThat(AsioSampleType.forCode(19)).contains(AsioSampleType.FLOAT32_LSB);
+        assertThat(AsioSampleType.forCode(20)).contains(AsioSampleType.FLOAT64_LSB);
+        assertThat(AsioSampleType.forCode(24)).contains(AsioSampleType.INT32_LSB16);
+        assertThat(AsioSampleType.forCode(25)).contains(AsioSampleType.INT32_LSB18);
+        assertThat(AsioSampleType.forCode(26)).contains(AsioSampleType.INT32_LSB20);
+        assertThat(AsioSampleType.forCode(27)).contains(AsioSampleType.INT32_LSB24);
+    }
+
+    @Test
+    void everyConstantResolvesBackFromItsOwnDeclaredCode() {
+        for (AsioSampleType type : AsioSampleType.values()) {
+            assertThat(AsioSampleType.forCode(type.code()))
+                    .as("%s declares code %d", type, type.code())
+                    .contains(type);
+        }
+    }
+
+    /**
+     * DSD (32 / 33 / 40) is out of scope by the story's Non-Goals, {@code -1}
+     * is the native shim's "the driver refused to report a type", and the gap
+     * codes are unassigned in the SDK. None of them may be guessed at.
+     */
+    @Test
+    void forCodeRejectsDsdUnassignedAndUnknownCodes() {
+        int[] rejected = {-1, 5, 6, 7, 12, 13, 14, 15, 21, 22, 23, 28, 29,
+                32, 33, 40, 41, Integer.MIN_VALUE, Integer.MAX_VALUE};
+        for (int code : rejected) {
+            assertThat(AsioSampleType.forCode(code))
+                    .as("ASIOSampleType %d must not resolve to a converter", code)
+                    .isEmpty();
+        }
+    }
+
+    /**
+     * The byte size that sizes the {@link MemorySegment} view over a driver
+     * buffer. Assuming 4 for every format under-sizes a {@code Float64} view by
+     * half — the failure mode story 311's fixed {@code frames * 4} view had.
+     */
+    @Test
+    void bytesPerSampleMatchesEachDriverSideContainer() {
+        assertThat(AsioSampleType.INT16_MSB.bytesPerSample()).isEqualTo(2);
+        assertThat(AsioSampleType.INT16_LSB.bytesPerSample()).isEqualTo(2);
+        assertThat(AsioSampleType.INT24_MSB.bytesPerSample())
+                .as("packed 24-bit is exactly three bytes, not four")
+                .isEqualTo(3);
+        assertThat(AsioSampleType.INT24_LSB.bytesPerSample()).isEqualTo(3);
+        assertThat(AsioSampleType.INT32_MSB.bytesPerSample()).isEqualTo(4);
+        assertThat(AsioSampleType.INT32_LSB.bytesPerSample()).isEqualTo(4);
+        assertThat(AsioSampleType.FLOAT32_MSB.bytesPerSample()).isEqualTo(4);
+        assertThat(AsioSampleType.FLOAT32_LSB.bytesPerSample()).isEqualTo(4);
+        assertThat(AsioSampleType.FLOAT64_MSB.bytesPerSample())
+                .as("IEEE 754 binary64 is eight bytes")
+                .isEqualTo(8);
+        assertThat(AsioSampleType.FLOAT64_LSB.bytesPerSample()).isEqualTo(8);
+        for (AsioSampleType type : rightJustifiedInt32Formats()) {
+            assertThat(type.bytesPerSample())
+                    .as("%s is carried in a 32-bit container", type)
+                    .isEqualTo(4);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Round trip
+    // ------------------------------------------------------------------
+
+    @Test
+    void everyFormatRoundTripsThePatternWithinItsQuantisationTolerance() {
+        float[] pattern = pattern();
+        for (AsioSampleType type : AsioSampleType.values()) {
+            MemorySegment segment = allocate(type, pattern.length);
+            type.encode(pattern, segment, pattern.length);
+            float[] decoded = new float[pattern.length];
+            type.decode(segment, decoded, pattern.length);
+
+            for (int i = 0; i < pattern.length; i++) {
+                assertThat(decoded[i])
+                        .as("%s round-trip of sample %d (%s)", type, i, pattern[i])
+                        .isCloseTo(pattern[i], within(tolerance(type)));
+            }
+        }
+    }
+
+    /**
+     * The story requires {@code Float32LSB} to be bit-exact, which is also what
+     * keeps story 311's bulk-copy fast path honest. {@code Float64} is exact
+     * for any float-representable input because {@code float -> double ->
+     * float} loses nothing.
+     */
+    @Test
+    void theFloatFormatsRoundTripBitExactlyRatherThanApproximately() {
+        float[] pattern = pattern();
+        AsioSampleType[] floatFormats = {
+                AsioSampleType.FLOAT32_LSB, AsioSampleType.FLOAT32_MSB,
+                AsioSampleType.FLOAT64_LSB, AsioSampleType.FLOAT64_MSB};
+        for (AsioSampleType type : floatFormats) {
+            MemorySegment segment = allocate(type, pattern.length);
+            type.encode(pattern, segment, pattern.length);
+            float[] decoded = new float[pattern.length];
+            type.decode(segment, decoded, pattern.length);
+
+            assertThat(decoded)
+                    .as("%s must not quantise or rescale", type)
+                    .containsExactly(pattern);
+        }
+    }
+
+    /**
+     * The engine's float bus may legitimately exceed &plusmn;1.0 (story 127's
+     * 64-bit internal mix), and a driver that reports a float format expects
+     * that value through unchanged — clamping it here would be a silent
+     * limiter no one asked for.
+     */
+    @Test
+    void theFloatFormatsPassOutOfRangeSamplesThroughUnclamped() {
+        float[] hot = {4f, -4f, 1.5f};
+        for (AsioSampleType type : new AsioSampleType[] {
+                AsioSampleType.FLOAT32_LSB, AsioSampleType.FLOAT64_LSB}) {
+            MemorySegment segment = allocate(type, hot.length);
+            type.encode(hot, segment, hot.length);
+            float[] decoded = new float[hot.length];
+            type.decode(segment, decoded, hot.length);
+
+            assertThat(decoded).as("%s must not clamp", type).containsExactly(hot);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Saturation
+    // ------------------------------------------------------------------
+
+    /**
+     * The raw stored integer is asserted, not the re-decoded float: a
+     * wraparound to the opposite rail is the failure this guards against, and
+     * decoding {@code -peak - 1} back yields a perfectly plausible
+     * {@code -1.0f}.
+     */
+    @Test
+    void integerFormatsSaturateAtFullScaleInsteadOfWrappingAround() {
+        float[] tooLoud = {1.0001f, 2f, Float.MAX_VALUE, Float.POSITIVE_INFINITY};
+        float[] tooQuiet = {-1.0001f, -2f, -Float.MAX_VALUE, Float.NEGATIVE_INFINITY};
+        for (AsioSampleType type : integerFormats()) {
+            int peak = peakOf(type);
+            MemorySegment segment = allocate(type, tooLoud.length);
+
+            type.encode(tooLoud, segment, tooLoud.length);
+            for (int i = 0; i < tooLoud.length; i++) {
+                assertThat(storedInteger(segment, type, i))
+                        .as("%s must clamp %s to +%d", type, tooLoud[i], peak)
+                        .isEqualTo(peak);
+            }
+
+            type.encode(tooQuiet, segment, tooQuiet.length);
+            for (int i = 0; i < tooQuiet.length; i++) {
+                assertThat(storedInteger(segment, type, i))
+                        .as("%s must clamp %s to -%d", type, tooQuiet[i], peak)
+                        .isEqualTo(-peak);
+            }
+        }
+    }
+
+    /**
+     * {@code Math.clamp} propagates {@code NaN} and {@code Math.round(NaN)} is
+     * {@code 0}, so a {@code NaN} on the bus becomes digital silence rather
+     * than a full-scale rail. Documented behaviour, pinned here so a future
+     * refactor cannot change it unnoticed.
+     */
+    @Test
+    void aNotANumberSampleIsEncodedAsSilenceForEveryIntegerFormat() {
+        float[] nan = {Float.NaN};
+        for (AsioSampleType type : integerFormats()) {
+            MemorySegment segment = allocate(type, 1);
+            type.encode(nan, segment, 1);
+
+            assertThat(storedInteger(segment, type, 0))
+                    .as("%s must encode NaN as silence", type)
+                    .isZero();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Packed 24-bit
+    // ------------------------------------------------------------------
+
+    /**
+     * {@code Int24LSB} must consume and produce exactly three bytes per
+     * sample. A four-byte stride would silently double the buffer the driver
+     * hears and leave every other sample stale.
+     */
+    @Test
+    void int24LsbWritesExactlyThreeLittleEndianBytesPerSampleAndTouchesNoFourth() {
+        // round(0.5 * 8388607) = 4194304 = 0x400000
+        // round(-0.5 * 8388607) = -4194303 = 0xFFC00001
+        MemorySegment segment = arena.allocate(2L * 3 + 1);
+        segment.set(ValueLayout.JAVA_BYTE, 6, TAIL);
+
+        AsioSampleType.INT24_LSB.encode(new float[] {0.5f, -0.5f}, segment, 2);
+
+        assertThat(bytesOf(segment, 0, 3))
+                .as("+0.5 packs little-endian as 00 00 40")
+                .containsExactly((byte) 0x00, (byte) 0x00, (byte) 0x40);
+        assertThat(bytesOf(segment, 3, 3))
+                .as("-0.5 packs little-endian as 01 00 C0")
+                .containsExactly((byte) 0x01, (byte) 0x00, (byte) 0xC0);
+        assertThat(segment.get(ValueLayout.JAVA_BYTE, 6))
+                .as("a three-byte format must not spill into a fourth byte")
+                .isEqualTo(TAIL);
+    }
+
+    @Test
+    void int24MsbWritesTheSameSampleInReverseByteOrder() {
+        MemorySegment segment = arena.allocate(2L * 3);
+
+        AsioSampleType.INT24_MSB.encode(new float[] {0.5f, -0.5f}, segment, 2);
+
+        assertThat(bytesOf(segment, 0, 3))
+                .containsExactly((byte) 0x40, (byte) 0x00, (byte) 0x00);
+        assertThat(bytesOf(segment, 3, 3))
+                .containsExactly((byte) 0xC0, (byte) 0x00, (byte) 0x01);
+    }
+
+    @Test
+    void int24DecodeSignExtendsANegativeSampleRatherThanReadingItAsLarge() {
+        MemorySegment little = arena.allocate(3L);
+        // 00 00 80 little-endian is 0x800000 — the most negative 24-bit value.
+        little.set(ValueLayout.JAVA_BYTE, 0, (byte) 0x00);
+        little.set(ValueLayout.JAVA_BYTE, 1, (byte) 0x00);
+        little.set(ValueLayout.JAVA_BYTE, 2, (byte) 0x80);
+        MemorySegment big = arena.allocate(3L);
+        big.set(ValueLayout.JAVA_BYTE, 0, (byte) 0x80);
+        big.set(ValueLayout.JAVA_BYTE, 1, (byte) 0x00);
+        big.set(ValueLayout.JAVA_BYTE, 2, (byte) 0x00);
+
+        float[] decodedLittle = new float[1];
+        AsioSampleType.INT24_LSB.decode(little, decodedLittle, 1);
+        float[] decodedBig = new float[1];
+        AsioSampleType.INT24_MSB.decode(big, decodedBig, 1);
+
+        assertThat(decodedLittle[0])
+                .as("0x800000 is -8388608, so it normalises to exactly -1.0")
+                .isEqualTo(-1f);
+        assertThat(decodedBig[0]).isEqualTo(-1f);
+    }
+
+    // ------------------------------------------------------------------
+    // Endianness
+    // ------------------------------------------------------------------
+
+    /**
+     * Every MSB constant must produce exactly the byte reversal of its LSB
+     * twin for the same input — the property that makes the LSB variants the
+     * no-swap fast path on x64 Windows, the only target ASIO runs on.
+     */
+    @Test
+    void everyMsbFormatStoresTheByteReversalOfItsLsbTwin() {
+        AsioSampleType[][] twins = {
+                {AsioSampleType.INT16_MSB, AsioSampleType.INT16_LSB},
+                {AsioSampleType.INT24_MSB, AsioSampleType.INT24_LSB},
+                {AsioSampleType.INT32_MSB, AsioSampleType.INT32_LSB},
+                {AsioSampleType.FLOAT32_MSB, AsioSampleType.FLOAT32_LSB},
+                {AsioSampleType.FLOAT64_MSB, AsioSampleType.FLOAT64_LSB},
+                {AsioSampleType.INT32_MSB16, AsioSampleType.INT32_LSB16},
+                {AsioSampleType.INT32_MSB18, AsioSampleType.INT32_LSB18},
+                {AsioSampleType.INT32_MSB20, AsioSampleType.INT32_LSB20},
+                {AsioSampleType.INT32_MSB24, AsioSampleType.INT32_LSB24}};
+        float[] pattern = pattern();
+
+        for (AsioSampleType[] twin : twins) {
+            AsioSampleType msb = twin[0];
+            AsioSampleType lsb = twin[1];
+            int width = lsb.bytesPerSample();
+            MemorySegment big = allocate(msb, pattern.length);
+            MemorySegment little = allocate(lsb, pattern.length);
+            msb.encode(pattern, big, pattern.length);
+            lsb.encode(pattern, little, pattern.length);
+
+            for (int frame = 0; frame < pattern.length; frame++) {
+                byte[] bigBytes = bytesOf(big, (long) frame * width, width);
+                byte[] littleBytes = bytesOf(little, (long) frame * width, width);
+                assertThat(bigBytes)
+                        .as("%s frame %d must be %s byte-reversed", msb, frame, lsb)
+                        .containsExactly(reversed(littleBytes));
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Right-justified Int32 variants
+    // ------------------------------------------------------------------
+
+    /**
+     * The N significant bits sit in the <em>low</em> N bits of the 32-bit
+     * container, so full scale is {@code 32767} for {@code Int32LSB16} — not
+     * {@code 0x7FFF0000}, which is what a left-justified reading would store.
+     */
+    @Test
+    void rightJustifiedFormatsStoreFullScaleInTheLowBitsOfTheContainer() {
+        MemorySegment segment = allocate(AsioSampleType.INT32_LSB16, 1);
+        AsioSampleType.INT32_LSB16.encode(new float[] {1f}, segment, 1);
+        assertThat(storedInteger(segment, AsioSampleType.INT32_LSB16, 0))
+                .as("Int32LSB16 full scale is right-justified 32767")
+                .isEqualTo(32767);
+
+        MemorySegment wide = allocate(AsioSampleType.INT32_LSB24, 1);
+        AsioSampleType.INT32_LSB24.encode(new float[] {-1f}, wide, 1);
+        assertThat(storedInteger(wide, AsioSampleType.INT32_LSB24, 0))
+                .as("Int32LSB24 negative full scale is right-justified -8388607")
+                .isEqualTo(-8388607);
+    }
+
+    @Test
+    void rightJustifiedFormatsNormaliseAgainstTheirOwnBitDepth() {
+        MemorySegment segment = allocate(AsioSampleType.INT32_LSB16, 1);
+        writeStoredInteger(segment, AsioSampleType.INT32_LSB16, 0, 1);
+        float[] decoded = new float[1];
+
+        AsioSampleType.INT32_LSB16.decode(segment, decoded, 1);
+
+        assertThat(decoded[0])
+                .as("one LSB of a 16-bit sample is 1/32768, not 1/2^31")
+                .isEqualTo(1f / 32768f);
+    }
+
+    /**
+     * A driver is not obliged to sign-extend the unused high bits of a
+     * right-justified container. Reading {@code 0x0000FFFF} as a plain
+     * {@code int} would give {@code 65535} and normalise to {@code +2.0}
+     * — full-scale noise where the sample was one LSB below zero.
+     */
+    @Test
+    void rightJustifiedDecodeSignExtendsInsteadOfTrustingTheDriversHighBits() {
+        MemorySegment segment = allocate(AsioSampleType.INT32_LSB16, 1);
+        writeStoredInteger(segment, AsioSampleType.INT32_LSB16, 0, 0x0000FFFF);
+        float[] decoded = new float[1];
+
+        AsioSampleType.INT32_LSB16.decode(segment, decoded, 1);
+
+        assertThat(decoded[0])
+                .as("the low 16 bits all set is -1, so it normalises to -1/32768")
+                .isEqualTo(-1f / 32768f);
+    }
+
+    // ------------------------------------------------------------------
+    // Fixture helpers
+    // ------------------------------------------------------------------
+
+    /** Full scale, negative full scale, zero, &plusmn;0.5 and one sine cycle. */
+    private static float[] pattern() {
+        float[] values = new float[13];
+        values[0] = 1f;
+        values[1] = -1f;
+        values[2] = 0f;
+        values[3] = 0.5f;
+        values[4] = -0.5f;
+        for (int i = 0; i < 8; i++) {
+            values[5 + i] = (float) (0.8 * Math.sin(2 * Math.PI * i / 8));
+        }
+        return values;
+    }
+
+    /**
+     * One quantisation step plus the half-LSB rounding error the asymmetric
+     * {@code 2^(bits-1) - 1} encode scale introduces, rounded up to two steps,
+     * plus two float ULPs for the wide formats whose step is finer than
+     * float's own 24-bit mantissa. Zero for the float formats, which are
+     * bit-exact.
+     */
+    private static float tolerance(AsioSampleType type) {
+        int bits = type.significantBits();
+        if (bits == 0) {
+            return 0f;
+        }
+        return 2f / (float) (1L << (bits - 1)) + 2f * Math.ulp(1f);
+    }
+
+    private static int peakOf(AsioSampleType type) {
+        return (int) ((1L << (type.significantBits() - 1)) - 1);
+    }
+
+    private static AsioSampleType[] integerFormats() {
+        return Arrays.stream(AsioSampleType.values())
+                .filter(type -> type.significantBits() != 0)
+                .toArray(AsioSampleType[]::new);
+    }
+
+    private static AsioSampleType[] rightJustifiedInt32Formats() {
+        return new AsioSampleType[] {
+                AsioSampleType.INT32_MSB16, AsioSampleType.INT32_MSB18,
+                AsioSampleType.INT32_MSB20, AsioSampleType.INT32_MSB24,
+                AsioSampleType.INT32_LSB16, AsioSampleType.INT32_LSB18,
+                AsioSampleType.INT32_LSB20, AsioSampleType.INT32_LSB24};
+    }
+
+    private MemorySegment allocate(AsioSampleType type, int frames) {
+        return arena.allocate((long) frames * type.bytesPerSample());
+    }
+
+    /** Byte order taken from the ASIO constant's own name, not from the enum's fields. */
+    private static boolean isLittleEndian(AsioSampleType type) {
+        return type.name().contains("LSB");
+    }
+
+    /**
+     * Reassembles the signed integer a driver would see, independently of
+     * {@link AsioSampleType#decode}. The final shift sign-extends a 2- or
+     * 3-byte container; a 4-byte one is already full width, which is exactly
+     * what the right-justified assertions want to inspect.
+     */
+    private static int storedInteger(MemorySegment segment, AsioSampleType type, int frame) {
+        int width = type.bytesPerSample();
+        byte[] raw = bytesOf(segment, (long) frame * width, width);
+        if (isLittleEndian(type)) {
+            raw = reversed(raw);
+        }
+        int value = 0;
+        for (byte b : raw) {
+            value = (value << 8) | (b & 0xFF);
+        }
+        int shift = Integer.SIZE - width * Byte.SIZE;
+        return value << shift >> shift;
+    }
+
+    /** The inverse of {@link #storedInteger}: lays a raw integer out byte by byte. */
+    private static void writeStoredInteger(MemorySegment segment, AsioSampleType type,
+                                           int frame, int value) {
+        int width = type.bytesPerSample();
+        long offset = (long) frame * width;
+        for (int i = 0; i < width; i++) {
+            int shift = isLittleEndian(type) ? i * Byte.SIZE : (width - 1 - i) * Byte.SIZE;
+            segment.set(ValueLayout.JAVA_BYTE, offset + i, (byte) (value >> shift));
+        }
+    }
+
+    private static byte[] bytesOf(MemorySegment segment, long offset, int length) {
+        byte[] bytes = new byte[length];
+        for (int i = 0; i < length; i++) {
+            bytes[i] = segment.get(ValueLayout.JAVA_BYTE, offset + i);
+        }
+        return bytes;
+    }
+
+    private static byte[] reversed(byte[] bytes) {
+        byte[] flipped = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            flipped[i] = bytes[bytes.length - 1 - i];
+        }
+        return flipped;
+    }
+}


### PR DESCRIPTION
## Motivation

Story 311 implements the ASIO `bufferSwitch` streaming loop, copying samples between the driver's I/O buffers and the engine's `AudioBlock`s. But ASIO drivers do **not** all hand the host the same sample format. The Steinberg SDK's `ASIOSampleType` (already surfaced as the `type` field of the 56-byte `ASIOChannelInfo` struct decoded by `asioshim_getChannelInfo` in stories 215 / 223) can be any of a dozen layouts, and a single interface commonly exposes a non-float native format:

- `ASIOSTInt16LSB` / `ASIOSTInt16MSB`
- `ASIOSTInt24LSB` / `ASIOSTInt24MSB` (packed 3-byte samples)
- `ASIOSTInt32LSB` / `ASIOSTInt32MSB` and the right-justified `ASIOSTInt32LSB16/18/20/24` variants
- `ASIOSTFloat32LSB` / `ASIOSTFloat32MSB`
- `ASIOSTFloat64LSB` / `ASIOSTFloat64MSB`

The DAW's mix bus is float32 (and 64-bit internally per story 127). If story 311 copies driver buffers verbatim assuming `Float32LSB`, then on the very common case of an interface delivering `Int24LSB` or `Int32LSB` the audio is reinterpreted as garbage — full-scale noise on input, and on output the driver reinterprets the host's float bytes as integers (loud, potentially speaker-damaging noise). "Full ASIO driver support" must convert each channel from / to its driver-reported `ASIOSampleType`, including correct endianness, 24-bit packing, and right-justified bit-depth handling.

## Goals

- Centralize `ASIOSampleType` conversion at the buffer-switch copy boundary established by story 311, converting **per channel** using the `type` already reported by `asioshim_getChannelInfo` (stories 215 / 223) for that channel:
  - **Input (driver → engine):** decode the driver buffer for the channel's `ASIOSampleType` into normalised float32 in `[-1.0, 1.0]` before publishing the `AudioBlock` via `AudioBackendSupport#publishInput`.
  - **Output (engine → driver):** encode the engine's float32 `sink(...)` block into the channel's `ASIOSampleType`, with saturating clamp to the integer range (no wraparound) for the integer formats.
- Cover the full set of formats a Windows interface realistically uses: `Int16LSB/MSB`, `Int24LSB/MSB` (3-byte packed), `Int32LSB/MSB`, the right-justified `Int32LSB16/18/20/24` variants, `Float32LSB/MSB`, and `Float64LSB/MSB`. Endianness is handled explicitly (byte-swap on the MSB variants); on the only supported target (x64 Windows, little-endian) the LSB variants are the fast no-swap path.
- Decide and document the conversion locus. Preferred: implement the conversion in native code inside the shim's `bufferSwitch` trampoline (story 311) so only normalised float32 ever crosses the FFM boundary, keeping the per-callback Java work allocation-free and format-agnostic. Add a shim export `asioshim_getChannelSampleType(int channelIndex, int isInput, int* outType)` (or reuse the `type` already returned by `asioshim_getChannelInfo`) so the conversion table is driven by the driver's report, not guessed.
- Real-time safety: conversion runs on the driver's `bufferSwitch` callback thread; it must be branch-on-format-once (resolve the per-channel converter at `ASIOCreateBuffers` time, story 311) and then allocation-free and lock-free in the hot path, consistent with the project's `@RealTimeSafe` conventions.
- Round-trip integrity: a float32 buffer encoded to an integer `ASIOSampleType` and decoded back is within that format's quantisation error of the original (bit-exact for `Float32LSB`). 24-bit packing must consume / produce exactly 3 bytes per sample with the correct sign extension.

## Goals — Tests

- Pure-Java (or pure-native) unit tests over each `ASIOSampleType`: a known float pattern (full-scale, −full-scale, zero, ±0.5, a sine) encodes and decodes round-trip within the format's quantisation tolerance; full-scale-plus-epsilon clamps (no wraparound) for integer formats.
- A 24-bit packing test asserts byte-exact little-endian layout for `Int24LSB` and correct sign extension of negative samples.
- An endianness test asserts `Int16MSB` / `Int32MSB` byte order differs from the LSB variant by the expected swap.
- An integration-style test wires a stub driver buffer of a non-float type (e.g. `Int24LSB`) through the story-311 buffer-switch bridge and asserts the published `AudioBlock` is correctly normalised float32 (and the reverse for `sink`).

## Non-Goals

- The buffer-switch loop itself, `ASIOCreateBuffers` / `ASIOStart` / `ASIOStop` — owned by story 311 (prerequisite); this story only fills in the per-sample conversion at that boundary.
- Sample-**rate** conversion — the driver runs at the negotiated rate (stories 213 / 220 / 258); resampling at bus boundaries is story 126's concern, not sample-format conversion.
- Dithering on bit-depth reduction — story 167 (Dithered Bit-Depth Reduction Stage) owns dithering; this story does straight saturating quantisation at the hardware boundary.
- Non-Windows targets; ASIO is Windows-only. (CoreAudio / JACK backends handle their own formats.)
- Exotic / deprecated `ASIOSampleType`s with no realistic Windows hardware (e.g. DSD types) — return a clear `AudioBackendException` for an unsupported reported type rather than mis-decoding it.

## Technical Notes

- Files: `daw-core/native/asio/asioshim.cpp` + `asioshim.h` (per-channel converter selection in the `bufferSwitch` trampoline; optional `asioshim_getChannelSampleType` export), and/or a Java converter alongside `daw-sdk/.../AsioBackend.java` if any conversion remains on the Java side; the `ASIOChannelInfo.type` field is already decoded by the story-215 / 223 channel-info path.
- The `ASIOSampleType` enum values are defined in the Steinberg SDK's `asio.h`; the existing `asioshim_getChannelInfo` already passes the driver's `type` across the FFM boundary as a normalised int32, so the conversion table can key off that value directly.
- Resolve each channel's converter once (at `ASIOCreateBuffers`, story 311) to keep the `bufferSwitch` hot path branch-free; do not switch on `ASIOSampleType` per sample.
- Research backing: `docs/research/audio-development-tools.md` (JAsioHost, relevance High) handles exactly this `ASIOSampleType` → float conversion matrix in its Java ASIO host and is the reference for the format coverage list.
- Reference original stories: **311 — ASIO Real-Time Audio Streaming** (prerequisite), **215 / 223 — Driver-Reported Channel Names / Channel Info** (source of the per-channel `ASIOSampleType`), **127 — 64-bit Internal Mix Bus**, **167 — Dithered Bit-Depth Reduction** (complementary, not overlapping).
