### PR TITLE
313-unbrick-first-time-setup-dismissible-wizard-host-and-outcome-ordering

### DIFF
--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -56,6 +56,7 @@ import com.benesquivelmusic.daw.app.ui.layout.BuiltInLayouts;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.app.ui.settings.BackupSettingsAccess;
 import com.benesquivelmusic.daw.app.ui.settings.FirstRunWizard;
+import com.benesquivelmusic.daw.app.ui.settings.FirstRunWizardHost;
 import com.benesquivelmusic.daw.app.ui.settings.SettingsCatalogue;
 import com.benesquivelmusic.daw.sdk.persistence.BackupRetentionPolicy;
 
@@ -1381,34 +1382,15 @@ public final class MainController {
     void showSetupWizard() {
         FirstRunWizard wizard = new FirstRunWizard(
                 SettingsCatalogue.create(), settingsModel, audioEngineController);
-        var host = new com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog<Void>();
-        host.setTitle(wizard.title());
-        host.setHeaderText(wizard.title());
-        host.getDialogPane().setContent(wizard);
-        host.setResultConverter(_ -> null);
+        FirstRunWizardHost host = new FirstRunWizardHost(
+                wizard, this::applyWizardEdits, this::showWizardRestartNotice);
         if (rootPane != null && rootPane.getScene() != null) {
-            host.initOwner(rootPane.getScene().getWindow());
-        }
-        Runnable closeHost = () -> {
-            // Showing-guarded: the abnormal-close Skip below runs AFTER
-            // the host is already hidden ([X] / the header close glyph).
-            if (host.isShowing()) {
-                host.setResult(null);
-                host.hide();
+            Window owner = rootPane.getScene().getWindow();
+            if (owner != null) {
+                host.initOwner(owner);
             }
-        };
-        wizard.setOnFinished(edits -> {
-            applyWizardEdits(edits);
-            closeHost.run();
-        });
-        wizard.setOnSkipped(closeHost);
+        }
         host.showAndWait();
-        // Story 309 — an abnormal close ([X] or the header close glyph)
-        // triggers neither Finish nor Skip; treat the dismissal as Skip so
-        // the first-run flag is still set and the wizard never auto-nags
-        // on later launches (it stays re-openable from General ▸ Startup).
-        wizard.skipIfNoOutcome();
-        wizard.close(); // idempotent — belt-and-braces teardown
     }
 
     /**
@@ -1418,20 +1400,37 @@ public final class MainController {
      * (persistence + the SettingsApplied publish + engine-reconfigure +
      * {@link LiveSettingsApplier} all ride along; values identical to the
      * persisted ones stay non-pending and write nothing). The dialog is
-     * never shown; detaching its audio controller afterwards tears down
-     * the discovery its wiring started (an in-flight engine-reconfigure
-     * keeps its own captured references and completes normally).
+     * never shown; detaching its backup and audio authorities afterwards
+     * tears down disk-usage and device discovery (an in-flight engine
+     * reconfigure keeps its own captured references and completes normally).
      */
-    private void applyWizardEdits(java.util.Map<String, Object> edits) {
-        SettingsDialog dialog = createSettingsDialog();
+    private Optional<String> applyWizardEdits(java.util.Map<String, Object> edits) {
+        return applyWizardEdits(createSettingsDialog(), edits);
+    }
+
+    static Optional<String> applyWizardEdits(
+            SettingsDialog dialog, java.util.Map<String, Object> edits) {
+        Objects.requireNonNull(dialog, "dialog must not be null");
+        Objects.requireNonNull(edits, "edits must not be null");
         try {
             var shell = dialog.getShell();
             edits.forEach((id, value) ->
                     shell.settingRow(id).ifPresent(row -> row.setValue(value)));
+            Optional<String> restartNotice = shell.isRestartBannerVisible()
+                    ? Optional.of(shell.restartBannerText()) : Optional.empty();
             dialog.applySettings();
+            return restartNotice;
         } finally {
-            dialog.setAudioEngineController(null);
+            try {
+                dialog.setBackupSettingsAccess(null);
+            } finally {
+                dialog.setAudioEngineController(null);
+            }
         }
+    }
+
+    private void showWizardRestartNotice(String message) {
+        notificationBar.show(NotificationLevel.WARNING, message);
     }
 
     /**

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/MainController.java
@@ -81,6 +81,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ResourceBundle;
+import java.util.concurrent.CompletionStage;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
@@ -1400,15 +1401,16 @@ public final class MainController {
      * (persistence + the SettingsApplied publish + engine-reconfigure +
      * {@link LiveSettingsApplier} all ride along; values identical to the
      * persisted ones stay non-pending and write nothing). The dialog is
-     * never shown; detaching its backup and audio authorities afterwards
-     * tears down disk-usage and device discovery (an in-flight engine
-     * reconfigure keeps its own captured references and completes normally).
+     * never shown. Its backup and audio authorities remain attached until the
+     * returned per-apply completion settles, then disk-usage and device
+     * discovery are detached on the same FX-thread continuation.
      */
-    private Optional<String> applyWizardEdits(java.util.Map<String, Object> edits) {
+    private CompletionStage<Optional<String>> applyWizardEdits(
+            java.util.Map<String, Object> edits) {
         return applyWizardEdits(createSettingsDialog(), edits);
     }
 
-    static Optional<String> applyWizardEdits(
+    static CompletionStage<Optional<String>> applyWizardEdits(
             SettingsDialog dialog, java.util.Map<String, Object> edits) {
         Objects.requireNonNull(dialog, "dialog must not be null");
         Objects.requireNonNull(edits, "edits must not be null");
@@ -1418,14 +1420,20 @@ public final class MainController {
                     shell.settingRow(id).ifPresent(row -> row.setValue(value)));
             Optional<String> restartNotice = shell.isRestartBannerVisible()
                     ? Optional.of(shell.restartBannerText()) : Optional.empty();
-            dialog.applySettings();
-            return restartNotice;
+            return dialog.applySettingsAsync()
+                    .thenApply(_ -> restartNotice)
+                    .whenComplete((_, _) -> detachWizardSettingsDialog(dialog));
+        } catch (RuntimeException | Error failure) {
+            detachWizardSettingsDialog(dialog);
+            throw failure;
+        }
+    }
+
+    private static void detachWizardSettingsDialog(SettingsDialog dialog) {
+        try {
+            dialog.setBackupSettingsAccess(null);
         } finally {
-            try {
-                dialog.setBackupSettingsAccess(null);
-            } finally {
-                dialog.setAudioEngineController(null);
-            }
+            dialog.setAudioEngineController(null);
         }
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/SettingsDialog.java
@@ -67,6 +67,8 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Flow;
@@ -1488,6 +1490,32 @@ public final class SettingsDialog extends DawgDialog<Void> {
      * persisted authorities.
      */
     void applySettings() {
+        applySettingsWithCompletion();
+    }
+
+    /**
+     * Applies the pending settings and reports when this apply transaction is
+     * actually complete. A transaction with no live audio work completes
+     * synchronously; a transaction that reconfigures audio completes on the FX
+     * thread only after the associated driver call, deferred persistence, and
+     * post-commit listener have succeeded. Driver or listener failures complete
+     * the stage exceptionally after their contained operation notice is shown.
+     *
+     * <p>The stage is deliberately non-blocking: callers must compose a
+     * continuation instead of waiting on the JavaFX Application Thread.</p>
+     *
+     * @return per-apply completion; never {@code null}
+     */
+    CompletionStage<Void> applySettingsAsync() {
+        try {
+            return applySettingsWithCompletion();
+        } catch (RuntimeException failure) {
+            return CompletableFuture.failedFuture(failure);
+        }
+    }
+
+    private CompletionStage<Void> applySettingsWithCompletion() {
+        CompletableFuture<Void> completion = new CompletableFuture<>();
         shell.clearOperationNotice();
         Map<String, Object> pendingEdits = shell.pendingEdits();
         // A clean Apply/OK after an error is an explicit retry of the close
@@ -1580,19 +1608,25 @@ public final class SettingsDialog extends DawgDialog<Void> {
                     engineReconfigureRequested,
                     deferredAudioEdits,
                     deferredAudioEdits.isEmpty() ? null : listenerAfterApply,
-                    engineReconfigureRequested ? deviceEnumerationTask : null));
+                    engineReconfigureRequested ? deviceEnumerationTask : null,
+                    completion));
+        } else {
+            completion.complete(null);
         }
 
         shell.refreshFromPersisted();
+        return completion;
     }
 
     /** Applies and delays OK-close until asynchronous audio work succeeds. */
     void applyAndCloseWhenReady() {
         applySettings();
         if (outstandingAudioReconfigures.get() == 0) {
-            if (!audioQueueFailed.get()) {
-                FxDispatcher.runOnFx(this::closeShell);
-            }
+            FxDispatcher.runOnFx(() -> {
+                if (!audioQueueFailed.get()) {
+                    closeShell();
+                }
+            });
         } else {
             closeAfterAudioApply = true;
         }
@@ -1667,10 +1701,12 @@ public final class SettingsDialog extends DawgDialog<Void> {
             boolean reconfigureEngine,
             Map<String, Object> deferredEdits,
             SettingsChangeListener listenerAfterCommit,
-            DeviceEnumerationTask enumerationTask) {
+            DeviceEnumerationTask enumerationTask,
+            CompletableFuture<Void> completion) {
 
         private AudioReconfigureSnapshot {
             deferredEdits = Map.copyOf(deferredEdits);
+            Objects.requireNonNull(completion, "completion must not be null");
         }
     }
 
@@ -1702,7 +1738,9 @@ public final class SettingsDialog extends DawgDialog<Void> {
                     return;
                 }
                 try {
-                    applyAudioReconfigure(snapshot);
+                    Throwable failure = applyAudioReconfigure(snapshot);
+                    FxDispatcher.runOnFx(
+                            () -> completeAudioReconfigure(snapshot, failure));
                 } finally {
                     if (outstandingAudioReconfigures.decrementAndGet() == 0) {
                         FxDispatcher.runOnFx(this::updateAudioUtilityDisabledState);
@@ -1719,7 +1757,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
         }
     }
 
-    private void applyAudioReconfigure(AudioReconfigureSnapshot snapshot) {
+    private Throwable applyAudioReconfigure(AudioReconfigureSnapshot snapshot) {
         boolean deferredCommitted = false;
         boolean locked = false;
         boolean sampleRateApplied = false;
@@ -1788,7 +1826,7 @@ public final class SettingsDialog extends DawgDialog<Void> {
             audioRuntimeState = new AudioRuntimeState(effectiveSampleRate,
                     effectiveBufferFrames, effectiveBitDepth, effectiveWorkerPoolSize,
                     effectiveMixPrecision, effectiveSrcQuality);
-            notifySettingsListener(snapshot.listenerAfterCommit());
+            return null;
         } catch (AudioBackendException rejected) {
             audioQueueFailed.set(true);
             restoreAudioRuntime(snapshot, previousState, previousEndpoint,
@@ -1797,16 +1835,19 @@ public final class SettingsDialog extends DawgDialog<Void> {
             if (!deferredCommitted && snapshot.applySampleRate() && !sampleRateApplied) {
                 LOG.log(Level.WARNING,
                         "Sample rate selection rejected by the audio driver", rejected);
-                rejectDeferredAudioEdits(snapshot,
-                        "Sample rate " + (int) snapshot.sampleRate()
-                                + " Hz was rejected by the audio driver.");
+                String notice = "Sample rate " + (int) snapshot.sampleRate()
+                        + " Hz was rejected by the audio driver.";
+                rejectDeferredAudioEdits(snapshot, notice);
+                return new IllegalStateException(notice, rejected);
             } else {
                 LOG.log(Level.WARNING, "Failed to reconfigure the audio engine", rejected);
                 if (!deferredCommitted) {
-                    rejectDeferredAudioEdits(snapshot,
-                            "Could not apply audio configuration: "
-                                    + failureMessage(rejected));
+                    String notice = "Could not apply audio configuration: "
+                            + failureMessage(rejected);
+                    rejectDeferredAudioEdits(snapshot, notice);
+                    return new IllegalStateException(notice, rejected);
                 }
+                return rejected;
             }
         } catch (InterruptedException cancelled) {
             audioQueueFailed.set(true);
@@ -1815,8 +1856,11 @@ public final class SettingsDialog extends DawgDialog<Void> {
                     sampleRateApplied, mixPrecisionApplied, srcQualityApplied,
                     reconfigureAttempted);
             if (!deferredCommitted) {
-                rejectDeferredAudioEdits(snapshot, "Audio configuration was cancelled.");
+                String notice = "Audio configuration was cancelled.";
+                rejectDeferredAudioEdits(snapshot, notice);
+                return new IllegalStateException(notice, cancelled);
             }
+            return cancelled;
         } catch (RuntimeException failure) {
             audioQueueFailed.set(true);
             LOG.log(Level.WARNING, "Failed to reconfigure the audio engine", failure);
@@ -1824,9 +1868,12 @@ public final class SettingsDialog extends DawgDialog<Void> {
                     sampleRateApplied, mixPrecisionApplied, srcQualityApplied,
                     reconfigureAttempted);
             if (!deferredCommitted) {
-                rejectDeferredAudioEdits(snapshot,
-                        "Could not apply audio configuration: " + failureMessage(failure));
+                String notice = "Could not apply audio configuration: "
+                        + failureMessage(failure);
+                rejectDeferredAudioEdits(snapshot, notice);
+                return new IllegalStateException(notice, failure);
             }
+            return failure;
         } finally {
             if (locked) {
                 audioControllerOperationLock.unlock();
@@ -1932,23 +1979,27 @@ public final class SettingsDialog extends DawgDialog<Void> {
         });
     }
 
-    private void notifySettingsListener(SettingsChangeListener listener) {
-        if (listener != null) {
-            FxDispatcher.runOnFx(() -> notifySettingsListenerOnFx(listener));
+    /** FX thread: post-commit notification is part of the per-apply outcome. */
+    private void completeAudioReconfigure(
+            AudioReconfigureSnapshot snapshot, Throwable driverFailure) {
+        Throwable completionFailure = driverFailure;
+        SettingsChangeListener listener = snapshot.listenerAfterCommit();
+        if (completionFailure == null && listener != null) {
+            try {
+                listener.onSettingsChanged(model);
+            } catch (RuntimeException listenerFailure) {
+                LOG.log(Level.WARNING, "Settings change listener failed", listenerFailure);
+                audioQueueFailed.set(true);
+                String notice = "Settings were saved, but a live update failed: "
+                        + failureMessage(listenerFailure);
+                shell.showOperationNotice(notice);
+                completionFailure = new IllegalStateException(notice, listenerFailure);
+            }
         }
-    }
-
-    private void notifySettingsListenerOnFx(SettingsChangeListener listener) {
-        if (listener == null) {
-            return;
-        }
-        try {
-            listener.onSettingsChanged(model);
-        } catch (RuntimeException failure) {
-            LOG.log(Level.WARNING, "Settings change listener failed", failure);
-            audioQueueFailed.set(true);
-            shell.showOperationNotice("Settings were saved, but a live update failed: "
-                    + failureMessage(failure));
+        if (completionFailure == null) {
+            snapshot.completion().complete(null);
+        } else {
+            snapshot.completion().completeExceptionally(completionFailure);
         }
     }
 

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/DialogDismissibility.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/DialogDismissibility.java
@@ -1,0 +1,52 @@
+package com.benesquivelmusic.daw.app.ui.dialogs;
+
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+
+import java.util.Objects;
+
+/**
+ * Construction helpers for content-owned {@link DawgDialog} hosts.
+ *
+ * <p>JavaFX refuses to close a {@code Dialog<Void>} whose result is
+ * {@code null} unless its pane contains a cancel-data button. A host whose
+ * content owns the visible footer therefore carries one hidden
+ * {@link ButtonType#CANCEL}: it is lifecycle plumbing for Esc, the window
+ * close request, the header close glyph, and programmatic {@code close()}.
+ * It is never another visible action.</p>
+ */
+public final class DialogDismissibility {
+
+    private DialogDismissibility() {
+        // utility class
+    }
+
+    /**
+     * Installs one invisible, unmanaged cancel-data button.
+     *
+     * <p>{@link DawgDialog} initially owns a fully wired header close glyph.
+     * Adding a cancel-data button normally retracts it because a visible
+     * footer Cancel makes the glyph redundant. This helper captures and
+     * restores that same node after hiding the plumbing button, preserving
+     * the glyph's existing action, accessibility text, and style without
+     * weakening the visible-footer rule.</p>
+     *
+     * @param dialog the content-owned host; must not be {@code null}
+     * @return the installed hidden button
+     */
+    public static Button installHiddenCancel(DawgDialog<?> dialog) {
+        Objects.requireNonNull(dialog, "dialog must not be null");
+        Node contentOwnedCloseGlyph = dialog.getGraphic();
+
+        dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        Button hiddenCancel = (Button) dialog.getDialogPane().lookupButton(ButtonType.CANCEL);
+        hiddenCancel.setVisible(false);
+        hiddenCancel.setManaged(false);
+
+        if (contentOwnedCloseGlyph != null && dialog.getGraphic() == null) {
+            dialog.setGraphic(contentOwnedCloseGlyph);
+        }
+        return hiddenCancel;
+    }
+}

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/DialogDismissibility.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/dialogs/DialogDismissibility.java
@@ -30,7 +30,8 @@ public final class DialogDismissibility {
      * footer Cancel makes the glyph redundant. This helper captures and
      * restores that same node after hiding the plumbing button, preserving
      * the glyph's existing action, accessibility text, and style without
-     * weakening the visible-footer rule.</p>
+     * weakening the visible-footer rule. Repeated installation reuses the
+     * existing canonical {@link ButtonType#CANCEL} button.</p>
      *
      * @param dialog the content-owned host; must not be {@code null}
      * @return the installed hidden button
@@ -39,7 +40,9 @@ public final class DialogDismissibility {
         Objects.requireNonNull(dialog, "dialog must not be null");
         Node contentOwnedCloseGlyph = dialog.getGraphic();
 
-        dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        if (!dialog.getDialogPane().getButtonTypes().contains(ButtonType.CANCEL)) {
+            dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        }
         Button hiddenCancel = (Button) dialog.getDialogPane().lookupButton(ButtonType.CANCEL);
         hiddenCancel.setVisible(false);
         hiddenCancel.setManaged(false);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginInstallPanel.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/plugin/PluginInstallPanel.java
@@ -1,6 +1,7 @@
 package com.benesquivelmusic.daw.app.ui.plugin;
 
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
+import com.benesquivelmusic.daw.app.ui.dialogs.DialogDismissibility;
 import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
 import com.benesquivelmusic.daw.core.plugin.ExternalPluginEntry;
 import com.benesquivelmusic.daw.core.plugin.PluginLoadException;
@@ -105,6 +106,14 @@ public final class PluginInstallPanel extends VBox {
             DawgDialog.error("Install plugin", rejectionMessage(inspection)).showAndWait();
             return;
         }
+        createDialog(inspection, registry, onInstalled).showAndWait();
+    }
+
+    static DawgDialog<Void> createDialog(
+            JarInspection inspection, PluginRegistry registry, Runnable onInstalled) {
+        Objects.requireNonNull(inspection, "inspection must not be null");
+        Objects.requireNonNull(registry, "registry must not be null");
+        Objects.requireNonNull(onInstalled, "onInstalled must not be null");
         DawgDialog<Void> dialog = new DawgDialog<>();
         dialog.setTitle("Install plugin");
         dialog.setHeaderText("Install plugin");
@@ -112,7 +121,9 @@ public final class PluginInstallPanel extends VBox {
         PluginInstallPanel panel = new PluginInstallPanel(inspection, registry, onInstalled);
         panel.setOnCloseRequest(dialog::close);
         dialog.getDialogPane().setContent(panel);
-        dialog.showAndWait();
+        DialogDismissibility.installHiddenCancel(dialog);
+        dialog.setResultConverter(_ -> null);
+        return dialog;
     }
 
     /** Sets the callback the panel invokes to request its containing dialog close. */
@@ -230,6 +241,7 @@ public final class PluginInstallPanel extends VBox {
 
     private HBox footer(Button primary) {
         Button cancel = new Button("Cancel");
+        cancel.setId("plugin-install-cancel");
         cancel.getStyleClass().addAll("dawg-button", "size-default", "secondary");
         cancel.setOnAction(_ -> requestClose());
         HBox footer = new HBox(ROW_SPACING, cancel, primary);

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizard.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizard.java
@@ -100,7 +100,12 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
 
     private final Label titleLabel = new Label();
     private final Label captionLabel = new Label();
+    private final HBox outcomeError = new HBox();
+    private final Label outcomeErrorText = new Label();
     private final Label enumerationProgress = new Label();
+    private final HBox enumerationError = new HBox();
+    private final Label enumerationErrorText = new Label();
+    private final Button enumerationRetryButton = new Button(msg("wizard.retry"));
     private final VBox contentBox = new VBox();
     private final Button backButton = new Button(msg("wizard.back"));
     private final Button nextButton = new Button(msg("wizard.next"));
@@ -110,9 +115,17 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
 
     private Consumer<Map<String, Object>> onFinished;
     private Runnable onSkipped;
+    private Runnable onOutcomeRecorded;
     private boolean closed;
-    /** {@code true} once {@link #finish()} or {@link #skip()} ran. */
-    private boolean outcomeRecorded;
+    private Outcome outcome;
+
+    /** A successfully recorded terminal choice. */
+    private enum Outcome {
+        /** The collected settings were applied successfully. */
+        FINISHED,
+        /** The user dismissed setup without applying settings. */
+        SKIPPED
+    }
 
     /**
      * The pure auto-show seam: show the wizard iff the first-run flag is
@@ -157,16 +170,10 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
             enumerationTask = new DeviceEnumerationTask(controller,
                     this::applyEnumerationResult,
                     this::showEnumerationProgress,
-                    failure -> LOG.log(Level.WARNING,
-                            "First-run wizard device enumeration failed", failure));
-            enumerationTask.start(
-                    Objects.toString(rowsById.get("audio.backend").getValue(), ""),
-                    Objects.toString(rowsById.get("audio.outputDevice").getValue(), ""));
+                    this::showEnumerationFailure);
+            startDeviceEnumeration();
             rowsById.get("audio.backend").valueProperty().addListener(
-                    (_, _, backend) -> enumerationTask.start(
-                            Objects.toString(backend, ""),
-                            Objects.toString(
-                                    rowsById.get("audio.outputDevice").getValue(), "")));
+                    (_, _, _) -> startDeviceEnumeration());
         }
 
         showStep(0);
@@ -268,11 +275,34 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
     private void buildChrome() {
         titleLabel.getStyleClass().add("first-run-wizard-title");
         captionLabel.getStyleClass().add("first-run-wizard-caption");
+        outcomeError.setId("first-run-wizard-error");
+        outcomeError.getStyleClass().add("first-run-wizard-error");
+        outcomeError.setManaged(false);
+        outcomeError.setVisible(false);
+        outcomeErrorText.getStyleClass().add("first-run-wizard-error-text");
+        outcomeErrorText.setWrapText(true);
+        HBox.setHgrow(outcomeErrorText, Priority.ALWAYS);
+        outcomeError.getChildren().addAll(
+                DawgIcon.of("alert-triangle", DawgIcon.Size.SIZE_16), outcomeErrorText);
         enumerationProgress.setText(msg("settings.group.recomputing"));
         enumerationProgress.getStyleClass().add("first-run-wizard-progress");
         enumerationProgress.setManaged(false);
         enumerationProgress.setVisible(false);
-        VBox header = new VBox(titleLabel, captionLabel);
+        enumerationError.setId("first-run-wizard-enumeration-error");
+        enumerationError.getStyleClass().add("first-run-wizard-enumeration-error");
+        enumerationError.setManaged(false);
+        enumerationError.setVisible(false);
+        enumerationErrorText.getStyleClass().add("first-run-wizard-enumeration-error-text");
+        enumerationErrorText.setWrapText(true);
+        HBox.setHgrow(enumerationErrorText, Priority.ALWAYS);
+        enumerationRetryButton.setId("first-run-wizard-enumeration-retry");
+        enumerationRetryButton.getStyleClass().addAll(
+                "dawg-button", "size-default", "secondary");
+        enumerationRetryButton.setOnAction(_ -> startDeviceEnumeration());
+        enumerationError.getChildren().addAll(
+                DawgIcon.of("alert-triangle", DawgIcon.Size.SIZE_16),
+                enumerationErrorText, enumerationRetryButton);
+        VBox header = new VBox(titleLabel, captionLabel, outcomeError);
         header.getStyleClass().add("first-run-wizard-header");
         setTop(header);
 
@@ -356,6 +386,7 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
             List<Node> children = new ArrayList<>(stepRows.get(step));
             if (step == 0 && enumerationTask != null) {
                 children.add(enumerationProgress);
+                children.add(enumerationError);
             }
             contentBox.getChildren().setAll(children);
         }
@@ -390,32 +421,61 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
     }
 
     /**
-     * Completes the wizard: sets the first-run flag (never auto-shows
-     * again) and hands the collected values to {@code onFinished} — the
-     * caller applies them through the settings dialog's existing Apply
-     * path. Also tears down the audio-step enumeration.
+     * Sets the host-dismiss request that runs only after callback success,
+     * flag persistence, outcome recording, and teardown.
      */
-    public void finish() {
-        outcomeRecorded = true;
-        model.setFirstRunWizardCompleted(true);
-        Map<String, Object> edits = collectedEdits();
-        close();
-        if (onFinished != null) {
-            onFinished.accept(edits);
-        }
+    void setOnOutcomeRecorded(Runnable callback) {
+        this.onOutcomeRecorded = callback;
     }
 
     /**
-     * Skips the wizard: sets the first-run flag (never auto-shows again)
-     * and applies NOTHING. Also tears down the audio-step enumeration.
+     * Completes the wizard by applying the collected values first, then
+     * persisting completion and recording the terminal outcome. A failed
+     * apply leaves every terminal marker unset so Finish remains retryable.
+     */
+    public void finish() {
+        if (closed || outcome != null) {
+            return;
+        }
+        clearOutcomeError();
+        try {
+            Map<String, Object> edits = collectedEdits();
+            if (onFinished != null) {
+                onFinished.accept(edits);
+            }
+            model.setFirstRunWizardCompleted(true);
+        } catch (RuntimeException failure) {
+            LOG.log(Level.WARNING, "First-run wizard settings could not be applied", failure);
+            showOutcomeError("wizard.applyError", failure);
+            return;
+        }
+        outcome = Outcome.FINISHED;
+        close();
+        requestHostDismissal();
+    }
+
+    /**
+     * Skips the wizard by running the Skip callback first, then persisting
+     * completion and recording the terminal outcome. Nothing is applied.
      */
     public void skip() {
-        outcomeRecorded = true;
-        model.setFirstRunWizardCompleted(true);
-        close();
-        if (onSkipped != null) {
-            onSkipped.run();
+        if (closed || outcome != null) {
+            return;
         }
+        clearOutcomeError();
+        try {
+            if (onSkipped != null) {
+                onSkipped.run();
+            }
+            model.setFirstRunWizardCompleted(true);
+        } catch (RuntimeException failure) {
+            LOG.log(Level.WARNING, "First-run wizard could not be skipped", failure);
+            showOutcomeError("wizard.skipError", failure);
+            return;
+        }
+        outcome = Outcome.SKIPPED;
+        close();
+        requestHostDismissal();
     }
 
     /**
@@ -423,7 +483,12 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
      *         this wizard's outcome (the story-309 abnormal-close guard)
      */
     public boolean hasOutcome() {
-        return outcomeRecorded;
+        return outcome != null;
+    }
+
+    /** @return whether Finish, rather than Skip, recorded the outcome */
+    public boolean wasFinished() {
+        return outcome == Outcome.FINISHED;
     }
 
     /**
@@ -437,9 +502,19 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
      * {@code showAndWait()} returns.
      */
     public void skipIfNoOutcome() {
-        if (!outcomeRecorded) {
+        if (!closed && outcome == null) {
             skip();
         }
+    }
+
+    /** @return whether a contained Finish/Skip failure is visible */
+    public boolean isOutcomeErrorVisible() {
+        return outcomeError.isVisible();
+    }
+
+    /** @return the current contained outcome-failure message */
+    public String outcomeErrorText() {
+        return outcomeErrorText.getText();
     }
 
     /** @return the resolved wizard window title (for the host window) */
@@ -451,6 +526,7 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
 
     /** FX thread — the task marshals results through FxDispatcher. */
     private void applyEnumerationResult(DeviceEnumerationTask.Result result) {
+        clearEnumerationFailure();
         rowsById.get("audio.backend").replaceChoiceOptions(result.backendNames());
         rowsById.get("audio.inputDevice")
                 .replaceChoiceOptions(result.inputDeviceNames(), "");
@@ -461,6 +537,65 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
     private void showEnumerationProgress(boolean running) {
         enumerationProgress.setManaged(running);
         enumerationProgress.setVisible(running);
+    }
+
+    private void startDeviceEnumeration() {
+        if (enumerationTask == null || closed) {
+            return;
+        }
+        clearEnumerationFailure();
+        enumerationTask.start(
+                Objects.toString(rowsById.get("audio.backend").getValue(), ""),
+                Objects.toString(rowsById.get("audio.outputDevice").getValue(), ""));
+    }
+
+    private void showEnumerationFailure(Throwable failure) {
+        LOG.log(Level.WARNING, "First-run wizard device enumeration failed", failure);
+        enumerationErrorText.setText(MessageFormat.format(
+                msg("wizard.enumerationError"), failureMessage(failure)));
+        enumerationError.setManaged(true);
+        enumerationError.setVisible(true);
+    }
+
+    private void clearEnumerationFailure() {
+        enumerationError.setManaged(false);
+        enumerationError.setVisible(false);
+        enumerationErrorText.setText("");
+    }
+
+    /** @return whether device discovery failed visibly in the audio step */
+    public boolean isEnumerationErrorVisible() {
+        return enumerationError.isVisible();
+    }
+
+    /** @return the current device-discovery failure text */
+    public String enumerationErrorText() {
+        return enumerationErrorText.getText();
+    }
+
+    private void showOutcomeError(String messageKey, Throwable failure) {
+        outcomeErrorText.setText(MessageFormat.format(
+                msg(messageKey), failureMessage(failure)));
+        outcomeError.setManaged(true);
+        outcomeError.setVisible(true);
+    }
+
+    private void clearOutcomeError() {
+        outcomeError.setManaged(false);
+        outcomeError.setVisible(false);
+        outcomeErrorText.setText("");
+    }
+
+    private void requestHostDismissal() {
+        if (onOutcomeRecorded != null) {
+            onOutcomeRecorded.run();
+        }
+    }
+
+    private static String failureMessage(Throwable failure) {
+        String message = failure.getMessage();
+        return message == null || message.isBlank()
+                ? failure.getClass().getSimpleName() : message;
     }
 
     /** Tears down the audio-step enumeration; idempotent. */

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizard.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizard.java
@@ -5,9 +5,11 @@ import com.benesquivelmusic.daw.app.ui.SettingsModel;
 import com.benesquivelmusic.daw.app.ui.density.DensityManager;
 import com.benesquivelmusic.daw.app.ui.density.DensityMode;
 import com.benesquivelmusic.daw.app.ui.icons.DawgIcon;
+import com.benesquivelmusic.daw.app.ui.marshal.FxDispatcher;
 import com.benesquivelmusic.daw.app.ui.motion.MotionManager;
 import com.benesquivelmusic.daw.app.ui.theme.ThemeManager;
 
+import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.scene.Node;
@@ -29,6 +31,10 @@ import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -113,10 +119,11 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
 
     private final DeviceEnumerationTask enumerationTask;
 
-    private Consumer<Map<String, Object>> onFinished;
+    private Function<Map<String, Object>, CompletionStage<?>> onFinished;
     private Runnable onSkipped;
     private Runnable onOutcomeRecorded;
     private boolean closed;
+    private boolean finishPending;
     private Outcome outcome;
 
     /** A successfully recorded terminal choice. */
@@ -390,7 +397,7 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
             }
             contentBox.getChildren().setAll(children);
         }
-        backButton.setDisable(step == 0);
+        backButton.setDisable(finishPending || step == 0);
         nextButton.setText(done ? msg("wizard.finish") : msg("wizard.next"));
         skipButton.setVisible(!done);
         skipButton.setManaged(!done);
@@ -410,9 +417,29 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
         return edits;
     }
 
-    /** @param callback receives {@link #collectedEdits()} on Finish; may be null */
+    /**
+     * Sets a synchronous Finish callback. This compatibility form is adapted to
+     * an already-completed stage; asynchronous apply paths should use
+     * {@link #setOnFinishedAsync(Function)}.
+     *
+     * @param callback receives {@link #collectedEdits()} on Finish; may be null
+     */
     public void setOnFinished(Consumer<Map<String, Object>> callback) {
-        this.onFinished = callback;
+        onFinished = callback == null ? null : edits -> {
+            callback.accept(edits);
+            return CompletableFuture.completedFuture(null);
+        };
+    }
+
+    /**
+     * Sets the non-blocking Finish contract. The wizard remains open and does
+     * not persist completion until the returned stage succeeds.
+     *
+     * @param callback starts the apply and returns its actual completion; may be null
+     */
+    void setOnFinishedAsync(
+            Function<Map<String, Object>, ? extends CompletionStage<?>> callback) {
+        onFinished = callback == null ? null : edits -> callback.apply(edits);
     }
 
     /** @param callback runs on Skip (nothing is applied); may be null */
@@ -434,24 +461,23 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
      * apply leaves every terminal marker unset so Finish remains retryable.
      */
     public void finish() {
-        if (closed || outcome != null) {
+        if (closed || outcome != null || finishPending) {
             return;
         }
         clearOutcomeError();
+        CompletionStage<?> completion;
         try {
             Map<String, Object> edits = collectedEdits();
-            if (onFinished != null) {
-                onFinished.accept(edits);
-            }
-            model.setFirstRunWizardCompleted(true);
+            completion = onFinished == null
+                    ? CompletableFuture.completedFuture(null)
+                    : Objects.requireNonNull(onFinished.apply(edits),
+                            "Finish callback completion must not be null");
         } catch (RuntimeException failure) {
-            LOG.log(Level.WARNING, "First-run wizard settings could not be applied", failure);
-            showOutcomeError("wizard.applyError", failure);
+            showFinishFailure(failure);
             return;
         }
-        outcome = Outcome.FINISHED;
-        close();
-        requestHostDismissal();
+        setFinishPending(true);
+        completion.whenComplete((_, failure) -> finishCompleted(failure));
     }
 
     /**
@@ -459,7 +485,7 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
      * completion and recording the terminal outcome. Nothing is applied.
      */
     public void skip() {
-        if (closed || outcome != null) {
+        if (closed || outcome != null || finishPending) {
             return;
         }
         clearOutcomeError();
@@ -489,6 +515,11 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
     /** @return whether Finish, rather than Skip, recorded the outcome */
     public boolean wasFinished() {
         return outcome == Outcome.FINISHED;
+    }
+
+    /** @return whether Finish is waiting for its asynchronous apply result */
+    public boolean isFinishPending() {
+        return finishPending;
     }
 
     /**
@@ -598,6 +629,60 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
                 ? failure.getClass().getSimpleName() : message;
     }
 
+    private void finishCompleted(Throwable failure) {
+        Throwable applyFailure = unwrapCompletionFailure(failure);
+        Runnable completion = () -> completeFinishOnFx(applyFailure);
+        if (Platform.isFxApplicationThread()) {
+            completion.run();
+        } else {
+            FxDispatcher.runOnFx(completion);
+        }
+    }
+
+    private void completeFinishOnFx(Throwable applyFailure) {
+        if (!finishPending || closed || outcome != null) {
+            return;
+        }
+        if (applyFailure != null) {
+            setFinishPending(false);
+            showFinishFailure(applyFailure);
+            return;
+        }
+        try {
+            model.setFirstRunWizardCompleted(true);
+        } catch (RuntimeException persistenceFailure) {
+            setFinishPending(false);
+            showFinishFailure(persistenceFailure);
+            return;
+        }
+        outcome = Outcome.FINISHED;
+        setFinishPending(false);
+        close();
+        requestHostDismissal();
+    }
+
+    private void showFinishFailure(Throwable failure) {
+        LOG.log(Level.WARNING, "First-run wizard settings could not be applied", failure);
+        showOutcomeError("wizard.applyError", failure);
+    }
+
+    private void setFinishPending(boolean pending) {
+        finishPending = pending;
+        backButton.setDisable(pending || currentStep.get() == 0);
+        nextButton.setDisable(pending);
+        skipButton.setDisable(pending);
+    }
+
+    private static Throwable unwrapCompletionFailure(Throwable failure) {
+        Throwable current = failure;
+        while ((current instanceof CompletionException
+                || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
     /** Tears down the audio-step enumeration; idempotent. */
     @Override
     public void close() {
@@ -605,6 +690,7 @@ public final class FirstRunWizard extends BorderPane implements AutoCloseable {
             return;
         }
         closed = true;
+        finishPending = false;
         if (enumerationTask != null) {
             enumerationTask.close();
         }

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardHost.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardHost.java
@@ -3,11 +3,18 @@ package com.benesquivelmusic.daw.app.ui.settings;
 import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
 import com.benesquivelmusic.daw.app.ui.dialogs.DialogDismissibility;
 
+import javafx.beans.value.ChangeListener;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
 import javafx.stage.Window;
+import javafx.stage.WindowEvent;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -24,20 +31,27 @@ public final class FirstRunWizardHost {
     private final FirstRunWizard wizard;
     private final DawgDialog<Void> dialog = new DawgDialog<>();
     private final Consumer<String> restartNoticeSink;
+    private final Button hiddenCancel;
+    private final EventHandler<ActionEvent> hiddenCancelGuard;
+    private final EventHandler<WindowEvent> windowCloseGuard;
+    private final ChangeListener<Window> windowListener;
+    private final ChangeListener<Scene> sceneListener;
     private Optional<String> restartNotice = Optional.empty();
+    private Scene observedScene;
+    private Window guardedWindow;
 
     /**
      * Creates a host around an already-constructed wizard.
      *
      * @param wizard the wizard content
-     * @param applyEdits applies the collected values and returns the canonical
-     *                   restart notice when the pending edit set requires one
+     * @param applyEdits applies the collected values and completes with the
+     *                   canonical restart notice only after the apply succeeds
      * @param restartNoticeSink user-visible notice sink invoked after a
      *                          successful Finish has dismissed the host
      */
     public FirstRunWizardHost(
             FirstRunWizard wizard,
-            Function<Map<String, Object>, Optional<String>> applyEdits,
+            Function<Map<String, Object>, CompletionStage<Optional<String>>> applyEdits,
             Consumer<String> restartNoticeSink) {
         this.wizard = Objects.requireNonNull(wizard, "wizard must not be null");
         Objects.requireNonNull(applyEdits, "applyEdits must not be null");
@@ -47,11 +61,33 @@ public final class FirstRunWizardHost {
         dialog.setTitle(wizard.title());
         dialog.setHeaderText(wizard.title());
         dialog.getDialogPane().setContent(wizard);
-        DialogDismissibility.installHiddenCancel(dialog);
+        hiddenCancel = DialogDismissibility.installHiddenCancel(dialog);
+        hiddenCancelGuard = event -> {
+            if (wizard.isFinishPending()) {
+                event.consume();
+            }
+        };
+        hiddenCancel.addEventFilter(ActionEvent.ACTION, hiddenCancelGuard);
+        dialog.setOnCloseRequest(event -> {
+            if (wizard.isFinishPending()) {
+                event.consume();
+            }
+        });
+        windowCloseGuard = event -> {
+            if (wizard.isFinishPending()) {
+                event.consume();
+            }
+        };
+        windowListener = (_, _, window) -> switchGuardedWindow(window);
+        sceneListener = (_, _, scene) -> observeScene(scene);
+        dialog.getDialogPane().sceneProperty().addListener(sceneListener);
+        observeScene(dialog.getDialogPane().getScene());
         dialog.setResultConverter(_ -> null);
 
-        wizard.setOnFinished(edits -> restartNotice = Objects.requireNonNull(
-                applyEdits.apply(edits), "applyEdits result must not be null"));
+        wizard.setOnFinishedAsync(edits -> Objects.requireNonNull(
+                applyEdits.apply(edits), "applyEdits completion must not be null")
+                .thenAccept(notice -> restartNotice = Objects.requireNonNull(
+                        notice, "applyEdits result must not be null")));
         wizard.setOnOutcomeRecorded(this::dismiss);
     }
 
@@ -74,12 +110,50 @@ public final class FirstRunWizardHost {
             }
             return result;
         } finally {
+            removeDismissGuards();
             wizard.close();
         }
     }
 
     DawgDialog<Void> dialogForTest() {
         return dialog;
+    }
+
+    private void observeScene(Scene scene) {
+        if (scene == observedScene) {
+            return;
+        }
+        if (observedScene != null) {
+            observedScene.windowProperty().removeListener(windowListener);
+        }
+        observedScene = scene;
+        if (scene == null) {
+            switchGuardedWindow(null);
+            return;
+        }
+        scene.windowProperty().addListener(windowListener);
+        switchGuardedWindow(scene.getWindow());
+    }
+
+    private void switchGuardedWindow(Window window) {
+        if (window == guardedWindow) {
+            return;
+        }
+        if (guardedWindow != null) {
+            guardedWindow.removeEventFilter(
+                    WindowEvent.WINDOW_CLOSE_REQUEST, windowCloseGuard);
+        }
+        guardedWindow = window;
+        if (window != null) {
+            window.addEventFilter(WindowEvent.WINDOW_CLOSE_REQUEST, windowCloseGuard);
+        }
+    }
+
+    private void removeDismissGuards() {
+        hiddenCancel.removeEventFilter(ActionEvent.ACTION, hiddenCancelGuard);
+        dialog.setOnCloseRequest(null);
+        dialog.getDialogPane().sceneProperty().removeListener(sceneListener);
+        observeScene(null);
     }
 
     private void dismiss() {

--- a/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardHost.java
+++ b/daw-app/src/main/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardHost.java
@@ -1,0 +1,90 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
+import com.benesquivelmusic.daw.app.ui.dialogs.DialogDismissibility;
+
+import javafx.stage.Window;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Modal host lifecycle for {@link FirstRunWizard}.
+ *
+ * <p>The content owns the visible footer, while one hidden cancel-data
+ * button keeps every JavaFX dismissal route live. Finish applies inside the
+ * wizard's retryable error boundary; the host is dismissed only after the
+ * callback, persisted first-run flag, outcome, and teardown succeed.</p>
+ */
+public final class FirstRunWizardHost {
+
+    private final FirstRunWizard wizard;
+    private final DawgDialog<Void> dialog = new DawgDialog<>();
+    private final Consumer<String> restartNoticeSink;
+    private Optional<String> restartNotice = Optional.empty();
+
+    /**
+     * Creates a host around an already-constructed wizard.
+     *
+     * @param wizard the wizard content
+     * @param applyEdits applies the collected values and returns the canonical
+     *                   restart notice when the pending edit set requires one
+     * @param restartNoticeSink user-visible notice sink invoked after a
+     *                          successful Finish has dismissed the host
+     */
+    public FirstRunWizardHost(
+            FirstRunWizard wizard,
+            Function<Map<String, Object>, Optional<String>> applyEdits,
+            Consumer<String> restartNoticeSink) {
+        this.wizard = Objects.requireNonNull(wizard, "wizard must not be null");
+        Objects.requireNonNull(applyEdits, "applyEdits must not be null");
+        this.restartNoticeSink = Objects.requireNonNull(
+                restartNoticeSink, "restartNoticeSink must not be null");
+
+        dialog.setTitle(wizard.title());
+        dialog.setHeaderText(wizard.title());
+        dialog.getDialogPane().setContent(wizard);
+        DialogDismissibility.installHiddenCancel(dialog);
+        dialog.setResultConverter(_ -> null);
+
+        wizard.setOnFinished(edits -> restartNotice = Objects.requireNonNull(
+                applyEdits.apply(edits), "applyEdits result must not be null"));
+        wizard.setOnOutcomeRecorded(this::dismiss);
+    }
+
+    /** Assigns the owner before the host is shown. */
+    public void initOwner(Window owner) {
+        dialog.initOwner(Objects.requireNonNull(owner, "owner must not be null"));
+    }
+
+    /**
+     * Shows the modal host and completes abnormal dismissal as Skip.
+     *
+     * @return the host's empty {@code Void} result
+     */
+    public Optional<Void> showAndWait() {
+        try {
+            Optional<Void> result = dialog.showAndWait();
+            wizard.skipIfNoOutcome();
+            if (wizard.wasFinished()) {
+                restartNotice.ifPresent(restartNoticeSink);
+            }
+            return result;
+        } finally {
+            wizard.close();
+        }
+    }
+
+    DawgDialog<Void> dialogForTest() {
+        return dialog;
+    }
+
+    private void dismiss() {
+        if (dialog.isShowing()) {
+            dialog.close();
+        }
+    }
+}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/i18n/Messages.properties
@@ -397,3 +397,7 @@ wizard.next=Next
 wizard.back=Back
 wizard.skip=Skip
 wizard.finish=Finish
+wizard.retry=Retry
+wizard.applyError=Setup could not be applied: {0}. Review your choices and try Finish again.
+wizard.skipError=Setup could not be skipped: {0}. Try again or close the window.
+wizard.enumerationError=Audio devices could not be discovered: {0}

--- a/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
+++ b/daw-app/src/main/resources/com/benesquivelmusic/daw/app/ui/styles.css
@@ -3028,6 +3028,26 @@
     -fx-text-fill: -text-mute;
     -fx-font-size: 10px;
 }
+.first-run-wizard-error,
+.first-run-wizard-enumeration-error {
+    -fx-padding: 8 12 8 12;
+    -fx-spacing: 8;
+    -fx-alignment: center-left;
+    -fx-background-color: -surface-2;
+    -fx-border-color: -danger;
+    -fx-border-width: 0 0 1 0;
+}
+.first-run-wizard-error .dawg-icon,
+.first-run-wizard-enumeration-error .dawg-icon {
+    -fx-icon-color: -danger;
+}
+.dialog-pane .first-run-wizard-error-text,
+.dialog-pane .first-run-wizard-enumeration-error-text,
+.first-run-wizard-error-text,
+.first-run-wizard-enumeration-error-text {
+    -fx-text-fill: -danger;
+    -fx-font-size: 11px;
+}
 .first-run-wizard-buttons {
     -fx-spacing: 8;
     -fx-alignment: center-right;

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/EngineReconfiguresOnApplyTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/EngineReconfiguresOnApplyTest.java
@@ -601,6 +601,53 @@ class EngineReconfiguresOnApplyTest {
     }
 
     @Test
+    void fastAudioListenerFailureDoesNotRaceOkClose() throws Exception {
+        Story307TestSupport.StubController controller =
+                new Story307TestSupport.StubController();
+        SettingsModel model = Story307TestSupport.model("engineFastListenerFailure");
+        int changedBuffer = model.getBufferSize() == 256 ? 512 : 256;
+        AtomicInteger listenerCalls = new AtomicInteger();
+        AtomicReference<SettingsDialog> dialogRef = new AtomicReference<>();
+
+        Story307TestSupport.onFx(() -> {
+            SettingsDialog dialog = new SettingsDialog(model);
+            dialogRef.set(dialog);
+            dialog.setAudioEngineController(controller);
+            dialog.setSettingsChangeListener(_ -> {
+                if (listenerCalls.incrementAndGet() == 2) {
+                    throw new IllegalStateException("fast listener failed");
+                }
+            });
+            dialog.getShell().settingRow("audio.bufferSize").orElseThrow()
+                    .setValue(changedBuffer);
+            dialog.show();
+            dialog.applySettings();
+
+            assertThat(controller.configurationApplied.await(5, TimeUnit.SECONDS)).isTrue();
+            Thread worker = controller.applyThread.get();
+            worker.join(5_000);
+            assertThat(worker.isAlive()).isFalse();
+
+            dialog.applyAndCloseWhenReady();
+            assertThat(dialog.isShowing()).isTrue();
+            return null;
+        });
+
+        assertThat(Story307TestSupport.awaitFxValue(
+                () -> dialogRef.get().getShell().isOperationNoticeVisible(),
+                true, 5, TimeUnit.SECONDS)).isTrue();
+        Story307TestSupport.onFx(() -> {
+            SettingsDialog dialog = dialogRef.get();
+            assertThat(listenerCalls).hasValue(2);
+            assertThat(dialog.getShell().operationNoticeText())
+                    .contains("fast listener failed");
+            assertThat(dialog.isShowing()).isTrue();
+            dialog.hide();
+            return null;
+        });
+    }
+
+    @Test
     void dirtyCloseApplyKeepsDialogOpenWhenEngineReconfigurationFails() throws Exception {
         Story307TestSupport.StubController controller =
                 new Story307TestSupport.StubController();

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FirstRunWizardApplyEditsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FirstRunWizardApplyEditsTest.java
@@ -3,56 +3,85 @@ package com.benesquivelmusic.daw.app.ui;
 import com.benesquivelmusic.daw.app.ui.settings.BackupSettingsAccess;
 import com.benesquivelmusic.daw.sdk.persistence.BackupRetentionPolicy;
 
+import javafx.application.Platform;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Story 313 coverage for the wizard's canonical SettingsShell restart signal. */
+/** Story 313 coverage for wizard apply completion, failure, and cleanup ordering. */
 @ExtendWith(JavaFxToolkitExtension.class)
 class FirstRunWizardApplyEditsTest {
 
     @Test
     void changedBackendReturnsTheCanonicalRestartBanner() {
-        runOnFxThread(() -> {
+        CompletionStage<Optional<String>> completion = runOnFxThread(() -> {
             SettingsModel model = Story307TestSupport.model("wizardChangedBackend");
             String changedBackend = model.getAudioBackend().equals("ASIO")
                     ? "Java Sound" : "ASIO";
 
-            Optional<String> notice = MainController.applyWizardEdits(
+            CompletionStage<Optional<String>> result = MainController.applyWizardEdits(
                     new SettingsDialog(model), Map.of("audio.backend", changedBackend));
 
-            assertThat(notice).hasValueSatisfying(message -> assertThat(message)
-                    .contains("Restart required")
-                    .contains("Audio backend")
-                    .contains("relaunch"));
             assertThat(model.getAudioBackend()).isEqualTo(changedBackend);
-            return null;
+            return result;
         });
+
+        assertThat(completion.toCompletableFuture())
+                .as("restart-only backend changes have no live audio work")
+                .isDone();
+        Optional<String> notice = completion.toCompletableFuture().join();
+        assertThat(notice).hasValueSatisfying(message -> assertThat(message)
+                .contains("Restart required")
+                .contains("Audio backend")
+                .contains("relaunch"));
     }
 
     @Test
     void unchangedBackendDoesNotInventARestartNotice() {
-        runOnFxThread(() -> {
+        CompletionStage<Optional<String>> completion = runOnFxThread(() -> {
             SettingsModel model = Story307TestSupport.model("wizardUnchangedBackend");
 
-            Optional<String> notice = MainController.applyWizardEdits(
+            return MainController.applyWizardEdits(
                     new SettingsDialog(model),
                     Map.of("audio.backend", model.getAudioBackend()));
-
-            assertThat(notice).isEmpty();
-            return null;
         });
+
+        assertThat(completion.toCompletableFuture().join()).isEmpty();
+    }
+
+    @Test
+    void nonAudioListenerFailureIsReturnedAsAnExceptionalStage() {
+        CompletionStage<Optional<String>> completion = runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(
+                    Story307TestSupport.model("wizardSynchronousListenerFailure"));
+            dialog.setSettingsChangeListener(_ -> {
+                throw new IllegalStateException("non-audio live update failed");
+            });
+
+            return MainController.applyWizardEdits(dialog, Map.of());
+        });
+
+        assertThatThrownBy(() -> completion.toCompletableFuture().join())
+                .hasRootCauseMessage("non-audio live update failed");
     }
 
     @Test
     void hiddenSettingsDialogDetachesBackupWorkAfterApply() {
-        runOnFxThread(() -> {
+        ApplyContext context = runOnFxThread(() -> {
             SettingsModel model = Story307TestSupport.model("wizardBackupCleanup");
             SettingsDialog dialog = new SettingsDialog(model);
             int attachedKeepRecent = BackupRetentionPolicy.DEFAULT.keepRecent() + 7;
@@ -76,8 +105,11 @@ class FirstRunWizardApplyEditsTest {
             assertThat(dialog.getShell().settingRow("backups.keepRecent")
                     .orElseThrow().getValue()).isEqualTo(attachedKeepRecent);
 
-            MainController.applyWizardEdits(dialog, Map.of());
-
+            return new ApplyContext(dialog, MainController.applyWizardEdits(dialog, Map.of()));
+        });
+        context.completion().toCompletableFuture().join();
+        runOnFxThread(() -> {
+            SettingsDialog dialog = context.dialog();
             assertThat(dialog.getShell().settingRow("backups.keepRecent")
                     .orElseThrow().getValue())
                     .as("detaching backup access re-seeds the hidden dialog from defaults")
@@ -85,4 +117,148 @@ class FirstRunWizardApplyEditsTest {
             return null;
         });
     }
+
+    @Test
+    void liveAudioCompletionWaitsForDriverAndFxListener() throws Exception {
+        Story307TestSupport.StubController controller =
+                new Story307TestSupport.StubController();
+        controller.blockFirstConfiguration = true;
+        controller.releaseFirstConfiguration = new CountDownLatch(1);
+        SettingsModel model = Story307TestSupport.model("wizardAsyncAudioSuccess");
+        int originalBuffer = model.getBufferSize();
+        int changedBuffer = originalBuffer == 256 ? 512 : 256;
+        AtomicBoolean listenerRan = new AtomicBoolean();
+        AtomicBoolean listenerRanOnFx = new AtomicBoolean();
+
+        ApplyContext context = runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(model);
+            dialog.setAudioEngineController(controller);
+            dialog.setSettingsChangeListener(_ -> {
+                listenerRan.set(true);
+                listenerRanOnFx.set(Platform.isFxApplicationThread());
+            });
+            return new ApplyContext(dialog, MainController.applyWizardEdits(
+                    dialog, Map.of("audio.bufferSize", changedBuffer)));
+        });
+
+        assertThat(controller.firstConfigurationEntered.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(context.completion().toCompletableFuture()).isNotDone();
+        assertThat(model.getBufferSize())
+                .as("audio persistence is deferred until driver success")
+                .isEqualTo(originalBuffer);
+
+        controller.releaseFirstConfiguration.countDown();
+        assertThat(context.completion().toCompletableFuture().get(5, TimeUnit.SECONDS)).isEmpty();
+        assertThat(listenerRan).isTrue();
+        assertThat(listenerRanOnFx).isTrue();
+        assertThat(model.getBufferSize()).isEqualTo(changedBuffer);
+        assertThat(controller.applyThread.get().isVirtual()).isTrue();
+    }
+
+    @Test
+    void liveAudioDriverFailureCompletesExceptionallyAndRestoresTheEdit() throws Exception {
+        Story307TestSupport.StubController controller =
+                new Story307TestSupport.StubController();
+        controller.failNextConfiguration = true;
+        SettingsModel model = Story307TestSupport.model("wizardAsyncAudioFailure");
+        int originalBuffer = model.getBufferSize();
+        int changedBuffer = originalBuffer == 256 ? 512 : 256;
+
+        ApplyContext context = runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(model);
+            dialog.setAudioEngineController(controller);
+            return new ApplyContext(dialog, MainController.applyWizardEdits(
+                    dialog, Map.of("audio.bufferSize", changedBuffer)));
+        });
+
+        assertThatThrownBy(() -> context.completion().toCompletableFuture()
+                .get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("Could not apply audio configuration")
+                .hasRootCauseMessage("configuration failed");
+        assertThat(model.getBufferSize()).isEqualTo(originalBuffer);
+        runOnFxThread(() -> {
+            assertThat(context.dialog().getShell().isOperationNoticeVisible()).isTrue();
+            assertThat(context.dialog().getShell().operationNoticeText())
+                    .contains("Could not apply audio configuration")
+                    .contains("configuration failed");
+            return null;
+        });
+    }
+
+    @Test
+    void listenerFailureIsPartOfTheApplyCompletion() throws Exception {
+        Story307TestSupport.StubController controller =
+                new Story307TestSupport.StubController();
+        SettingsModel model = Story307TestSupport.model("wizardAsyncListenerFailure");
+        int changedBuffer = model.getBufferSize() == 256 ? 512 : 256;
+
+        ApplyContext context = runOnFxThread(() -> {
+            SettingsDialog dialog = new SettingsDialog(model);
+            dialog.setAudioEngineController(controller);
+            dialog.setSettingsChangeListener(_ -> {
+                assertThat(Platform.isFxApplicationThread()).isTrue();
+                throw new IllegalStateException("live listener rejected the update");
+            });
+            return new ApplyContext(dialog, MainController.applyWizardEdits(
+                    dialog, Map.of("audio.bufferSize", changedBuffer)));
+        });
+
+        assertThatThrownBy(() -> context.completion().toCompletableFuture()
+                .get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("Settings were saved, but a live update failed")
+                .hasRootCauseMessage("live listener rejected the update");
+        assertThat(model.getBufferSize())
+                .as("the listener runs after the successful driver commit")
+                .isEqualTo(changedBuffer);
+    }
+
+    @Test
+    void hiddenDialogStaysAttachedUntilFailureRollbackCapturesLiveEndpoint()
+            throws Exception {
+        Story307TestSupport.StubController controller =
+                new Story307TestSupport.StubController();
+        controller.blockTestTone = true;
+        controller.releaseTestTone = new CountDownLatch(1);
+        controller.failNextConfiguration = true;
+        SettingsModel model = Story307TestSupport.model("wizardDeferredAudioCleanup");
+        model.setAudioBackend(controller.activeBackend);
+        model.setAudioInputDevice("");
+        model.setAudioOutputDevice("");
+
+        SettingsDialog dialog = runOnFxThread(() -> {
+            SettingsDialog created = new SettingsDialog(model);
+            created.setAudioEngineController(controller);
+            created.getTestToneButton().fire();
+            return created;
+        });
+        assertThat(controller.testToneEntered.await(5, TimeUnit.SECONDS)).isTrue();
+
+        ApplyContext context = runOnFxThread(() -> {
+            dialog.getShell().replaceChoiceOptions(
+                    "audio.outputDevice", List.of("", "Rejected output"), "");
+            return new ApplyContext(
+                    dialog,
+                    MainController.applyWizardEdits(
+                            dialog, Map.of("audio.outputDevice", "Rejected output")));
+        });
+        assertThat(context.completion().toCompletableFuture()).isNotDone();
+
+        controller.releaseTestTone.countDown();
+        assertThatThrownBy(() -> context.completion().toCompletableFuture()
+                .get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasRootCauseMessage("configuration failed");
+        assertThat(controller.requests).hasSize(2);
+        assertThat(controller.requests.getFirst().outputDeviceName())
+                .isEqualTo("Rejected output");
+        assertThat(controller.requests.getLast().outputDeviceName())
+                .as("rollback uses the live endpoint captured before hidden-dialog cleanup")
+                .isEmpty();
+    }
+
+    private record ApplyContext(
+            SettingsDialog dialog,
+            CompletionStage<Optional<String>> completion) {}
 }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FirstRunWizardApplyEditsTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FirstRunWizardApplyEditsTest.java
@@ -1,0 +1,88 @@
+package com.benesquivelmusic.daw.app.ui;
+
+import com.benesquivelmusic.daw.app.ui.settings.BackupSettingsAccess;
+import com.benesquivelmusic.daw.sdk.persistence.BackupRetentionPolicy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Story 313 coverage for the wizard's canonical SettingsShell restart signal. */
+@ExtendWith(JavaFxToolkitExtension.class)
+class FirstRunWizardApplyEditsTest {
+
+    @Test
+    void changedBackendReturnsTheCanonicalRestartBanner() {
+        runOnFxThread(() -> {
+            SettingsModel model = Story307TestSupport.model("wizardChangedBackend");
+            String changedBackend = model.getAudioBackend().equals("ASIO")
+                    ? "Java Sound" : "ASIO";
+
+            Optional<String> notice = MainController.applyWizardEdits(
+                    new SettingsDialog(model), Map.of("audio.backend", changedBackend));
+
+            assertThat(notice).hasValueSatisfying(message -> assertThat(message)
+                    .contains("Restart required")
+                    .contains("Audio backend")
+                    .contains("relaunch"));
+            assertThat(model.getAudioBackend()).isEqualTo(changedBackend);
+            return null;
+        });
+    }
+
+    @Test
+    void unchangedBackendDoesNotInventARestartNotice() {
+        runOnFxThread(() -> {
+            SettingsModel model = Story307TestSupport.model("wizardUnchangedBackend");
+
+            Optional<String> notice = MainController.applyWizardEdits(
+                    new SettingsDialog(model),
+                    Map.of("audio.backend", model.getAudioBackend()));
+
+            assertThat(notice).isEmpty();
+            return null;
+        });
+    }
+
+    @Test
+    void hiddenSettingsDialogDetachesBackupWorkAfterApply() {
+        runOnFxThread(() -> {
+            SettingsModel model = Story307TestSupport.model("wizardBackupCleanup");
+            SettingsDialog dialog = new SettingsDialog(model);
+            int attachedKeepRecent = BackupRetentionPolicy.DEFAULT.keepRecent() + 7;
+            dialog.setBackupSettingsAccess(new BackupSettingsAccess() {
+                @Override
+                public BackupRetentionPolicy currentPolicy() {
+                    return BackupRetentionPolicy.DEFAULT
+                            .withKeepRecent(attachedKeepRecent);
+                }
+
+                @Override
+                public Optional<Path> projectDirectory() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public void applyPolicy(BackupRetentionPolicy policy) {
+                    throw new AssertionError("no backup edits should be applied");
+                }
+            });
+            assertThat(dialog.getShell().settingRow("backups.keepRecent")
+                    .orElseThrow().getValue()).isEqualTo(attachedKeepRecent);
+
+            MainController.applyWizardEdits(dialog, Map.of());
+
+            assertThat(dialog.getShell().settingRow("backups.keepRecent")
+                    .orElseThrow().getValue())
+                    .as("detaching backup access re-seeds the hidden dialog from defaults")
+                    .isEqualTo(BackupRetentionPolicy.DEFAULT.keepRecent());
+            return null;
+        });
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FirstRunWizardShowsOnceTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/FirstRunWizardShowsOnceTest.java
@@ -84,9 +84,11 @@ class FirstRunWizardShowsOnceTest {
     }
 
     private static SettingsModel newModel() {
-        Preferences prefs = Preferences.userRoot()
-                .node("firstRunWizardShowsOnceTest_" + System.nanoTime());
-        return new SettingsModel(prefs);
+        return new SettingsModel(newPreferences("firstRunWizardShowsOnceTest"));
+    }
+
+    private static Preferences newPreferences(String prefix) {
+        return Preferences.userRoot().node(prefix + "_" + System.nanoTime());
     }
 
     private static List<String> rowIds(FirstRunWizard wizard) {
@@ -180,6 +182,81 @@ class FirstRunWizardShowsOnceTest {
                     .as("finish hands the EDITED row value to the apply glue "
                             + "— never the descriptor default")
                     .containsEntry("project.defaultTempo", 150.0);
+            return null;
+        });
+    }
+
+    @Test
+    void outcomeIsPersistedOnlyAfterItsCallbackSucceeds() throws Exception {
+        runOnFxThread(() -> {
+            Preferences finishedPreferences = newPreferences("finishedOutcomeOrdering");
+            SettingsModel finishedModel = new SettingsModel(finishedPreferences);
+            FirstRunWizard finishedWizard = new FirstRunWizard(
+                    SettingsCatalogue.create(), finishedModel, null);
+            AtomicBoolean finishSawTerminalState = new AtomicBoolean();
+            finishedWizard.setOnFinished(_ -> finishSawTerminalState.set(
+                    finishedModel.isFirstRunWizardCompleted()
+                            || finishedWizard.hasOutcome()));
+
+            finishedWizard.finish();
+
+            assertThat(finishSawTerminalState)
+                    .as("the apply callback runs before either terminal state")
+                    .isFalse();
+            assertThat(finishedModel.isFirstRunWizardCompleted()).isTrue();
+            assertThat(new SettingsModel(finishedPreferences)
+                    .isFirstRunWizardCompleted()).isTrue();
+            assertThat(finishedWizard.hasOutcome()).isTrue();
+
+            SettingsModel skippedModel = newModel();
+            FirstRunWizard skippedWizard = new FirstRunWizard(
+                    SettingsCatalogue.create(), skippedModel, null);
+            AtomicBoolean skipSawTerminalState = new AtomicBoolean();
+            skippedWizard.setOnSkipped(() -> skipSawTerminalState.set(
+                    skippedModel.isFirstRunWizardCompleted()
+                            || skippedWizard.hasOutcome()));
+
+            skippedWizard.skip();
+
+            assertThat(skipSawTerminalState)
+                    .as("the Skip callback runs before either terminal state")
+                    .isFalse();
+            assertThat(skippedModel.isFirstRunWizardCompleted()).isTrue();
+            assertThat(skippedWizard.hasOutcome()).isTrue();
+            assertThat(skippedWizard.wasFinished()).isFalse();
+
+            Preferences failedPreferences = newPreferences("failedOutcomeOrdering");
+            SettingsModel failedModel = new SettingsModel(failedPreferences);
+            FirstRunWizard failedWizard = new FirstRunWizard(
+                    SettingsCatalogue.create(), failedModel, null);
+            failedWizard.setOnFinished(_ -> {
+                throw new IllegalStateException("ASIO control panel rejected the setup");
+            });
+
+            failedWizard.finish();
+
+            assertThat(failedModel.isFirstRunWizardCompleted())
+                    .as("a throwing apply callback never publishes completion")
+                    .isFalse();
+            assertThat(new SettingsModel(failedPreferences)
+                    .isFirstRunWizardCompleted())
+                    .as("the failed callback does not persist completion either")
+                    .isFalse();
+            assertThat(failedWizard.hasOutcome()).isFalse();
+            assertThat(failedWizard.isOutcomeErrorVisible()).isTrue();
+            assertThat(failedWizard.outcomeErrorText())
+                    .contains("ASIO control panel rejected the setup")
+                    .contains("Finish again");
+
+            SettingsModel abandonedModel = newModel();
+            FirstRunWizard abandonedWizard = new FirstRunWizard(
+                    SettingsCatalogue.create(), abandonedModel, null);
+            abandonedWizard.close();
+            abandonedWizard.skipIfNoOutcome();
+            assertThat(abandonedModel.isFirstRunWizardCompleted())
+                    .as("plain teardown is abandonment, not a host dismissal outcome")
+                    .isFalse();
+            assertThat(abandonedWizard.hasOutcome()).isFalse();
             return null;
         });
     }

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/DialogDismissibilityTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/dialogs/DialogDismissibilityTest.java
@@ -1,0 +1,81 @@
+package com.benesquivelmusic.daw.app.ui.dialogs;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(JavaFxToolkitExtension.class)
+class DialogDismissibilityTest {
+
+    @Test
+    void repeatedInstallationReusesOneHiddenCancelAndPreservesCloseGlyph() {
+        InstallationState state = runOnFxThread(() -> {
+            DawgDialog<Void> dialog = new DawgDialog<>();
+            Node originalCloseGlyph = dialog.getGraphic();
+
+            Button first = DialogDismissibility.installHiddenCancel(dialog);
+            Button second = DialogDismissibility.installHiddenCancel(dialog);
+
+            return new InstallationState(
+                    List.copyOf(dialog.getDialogPane().getButtonTypes()),
+                    first,
+                    second,
+                    originalCloseGlyph,
+                    dialog.getGraphic(),
+                    second.isVisible(),
+                    second.isManaged());
+        });
+
+        assertThat(state.originalCloseGlyph()).isNotNull();
+        assertThat(state.second()).isSameAs(state.first());
+        assertThat(state.buttonTypes()).containsExactly(ButtonType.CANCEL);
+        assertThat(state.visible()).isFalse();
+        assertThat(state.managed()).isFalse();
+        assertThat(state.installedCloseGlyph()).isSameAs(state.originalCloseGlyph());
+    }
+
+    @Test
+    void existingCanonicalCancelIsReusedAndHidden() {
+        InstallationState state = runOnFxThread(() -> {
+            DawgDialog<Void> dialog = new DawgDialog<>();
+            dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+            Button existing = (Button) dialog.getDialogPane().lookupButton(ButtonType.CANCEL);
+
+            Button installed = DialogDismissibility.installHiddenCancel(dialog);
+
+            return new InstallationState(
+                    List.copyOf(dialog.getDialogPane().getButtonTypes()),
+                    existing,
+                    installed,
+                    null,
+                    dialog.getGraphic(),
+                    installed.isVisible(),
+                    installed.isManaged());
+        });
+
+        assertThat(state.second()).isSameAs(state.first());
+        assertThat(state.buttonTypes()).containsExactly(ButtonType.CANCEL);
+        assertThat(state.visible()).isFalse();
+        assertThat(state.managed()).isFalse();
+    }
+
+    private record InstallationState(
+            List<ButtonType> buttonTypes,
+            Button first,
+            Button second,
+            Node originalCloseGlyph,
+            Node installedCloseGlyph,
+            boolean visible,
+            boolean managed) {
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/PluginInstallPanelHostTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/plugin/PluginInstallPanelHostTest.java
@@ -1,0 +1,142 @@
+package com.benesquivelmusic.daw.app.ui.plugin;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
+import com.benesquivelmusic.daw.app.ui.plugin.fixtures.InstallFixturePluginC;
+import com.benesquivelmusic.daw.app.ui.plugin.PluginJarScanner.JarInspection;
+import com.benesquivelmusic.daw.core.plugin.PluginRegistry;
+import com.benesquivelmusic.daw.sdk.editor.PluginManifestReader;
+
+import javafx.animation.PauseTransition;
+import javafx.application.Platform;
+import javafx.event.Event;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.stage.Window;
+import javafx.stage.WindowEvent;
+import javafx.util.Duration;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Story 313 regression coverage for the content-owned install host. */
+@ExtendWith(JavaFxToolkitExtension.class)
+class PluginInstallPanelHostTest {
+
+    private enum Route {
+        CANCEL,
+        ESCAPE,
+        WINDOW_CLOSE
+    }
+
+    @ParameterizedTest
+    @EnumSource(Route.class)
+    void installHostReturnsFromEveryDismissRoute(Route route) {
+        PluginRegistry registry = new PluginRegistry();
+        try {
+            runOnFxThread(() -> {
+                DawgDialog<Void> dialog = PluginInstallPanel.createDialog(
+                        validInspection(), registry, () -> { });
+                Button hiddenCancel = (Button) dialog.getDialogPane()
+                        .lookupButton(ButtonType.CANCEL);
+                AtomicReference<Throwable> routeFailure = new AtomicReference<>();
+                dialog.setOnShown(_ -> Platform.runLater(
+                        () -> driveRoute(route, dialog, routeFailure)));
+
+                Optional<Void> result = showWithWatchdog(dialog, routeFailure);
+
+                rethrow(routeFailure.get());
+                assertThat(result)
+                        .as("Dialog<Void> never leaks its cancel ButtonType as a result")
+                        .isEmpty();
+                assertThat(dialog.isShowing()).isFalse();
+                assertThat(dialog.getDialogPane().getButtonTypes())
+                        .containsExactly(ButtonType.CANCEL);
+                assertThat(hiddenCancel.isVisible()).isFalse();
+                assertThat(hiddenCancel.isManaged()).isFalse();
+                return null;
+            });
+        } finally {
+            registry.disposeAll();
+        }
+    }
+
+    private static void driveRoute(
+            Route route, DawgDialog<Void> dialog, AtomicReference<Throwable> failure) {
+        try {
+            switch (route) {
+                case CANCEL -> {
+                    Node cancel = dialog.getDialogPane().lookup("#plugin-install-cancel");
+                    if (cancel instanceof Button button) {
+                        button.fire();
+                    } else {
+                        throw new AssertionError("plugin install Cancel button was not found");
+                    }
+                }
+                case ESCAPE -> Event.fireEvent(
+                        dialog.getDialogPane().getScene().getWindow(), escapeEvent());
+                case WINDOW_CLOSE -> {
+                    Window window = dialog.getDialogPane().getScene().getWindow();
+                    Event.fireEvent(window,
+                            new WindowEvent(window, WindowEvent.WINDOW_CLOSE_REQUEST));
+                }
+            }
+        } catch (Throwable thrown) {
+            failure.set(thrown);
+            dialog.close();
+        }
+    }
+
+    private static KeyEvent escapeEvent() {
+        return new KeyEvent(KeyEvent.KEY_PRESSED, KeyEvent.CHAR_UNDEFINED, "",
+                KeyCode.ESCAPE, false, false, false, false);
+    }
+
+    private static Optional<Void> showWithWatchdog(
+            DawgDialog<Void> dialog, AtomicReference<Throwable> failure) {
+        PauseTransition watchdog = new PauseTransition(Duration.seconds(2));
+        watchdog.setOnFinished(_ -> {
+            failure.compareAndSet(null,
+                    new AssertionError("plugin install dismissal route timed out"));
+            dialog.close();
+        });
+        watchdog.play();
+        try {
+            return dialog.showAndWait();
+        } finally {
+            watchdog.stop();
+        }
+    }
+
+    private static JarInspection validInspection() {
+        return new JarInspection(
+                Path.of("story-313-plugin.jar"), true, true,
+                new PluginManifestReader.BundleResult.Valid(List.of(
+                        PluginTestJars.manifest(InstallFixturePluginC.class))),
+                1, 1, 0);
+    }
+
+    private static void rethrow(Throwable failure) {
+        if (failure instanceof Error error) {
+            throw error;
+        }
+        if (failure instanceof RuntimeException runtime) {
+            throw runtime;
+        }
+        if (failure != null) {
+            throw new AssertionError(failure);
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardDeviceEnumerationFailureTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardDeviceEnumerationFailureTest.java
@@ -1,0 +1,121 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.AudioEngineController;
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.SettingsModel;
+import com.benesquivelmusic.daw.sdk.audio.AudioDeviceInfo;
+
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.prefs.Preferences;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Story 313: enumeration failures are visible and retryable in step one. */
+@ExtendWith(JavaFxToolkitExtension.class)
+class FirstRunWizardDeviceEnumerationFailureTest {
+
+    @Test
+    void enumerationFailureShowsErrorAndRetryRecoversTheChoices() throws Exception {
+        FailsOnceController controller = new FailsOnceController();
+        FirstRunWizard wizard = runOnFxThread(() -> new FirstRunWizard(
+                SettingsCatalogue.create(), newModel(), controller));
+
+        await(Duration.ofSeconds(5), () -> runOnFxThread(
+                wizard::isEnumerationErrorVisible));
+
+        String errorText = runOnFxThread(wizard::enumerationErrorText);
+        Node retry = runOnFxThread(() -> wizard.lookup(
+                "#first-run-wizard-enumeration-retry"));
+        assertThat(errorText)
+                .contains("Audio devices could not be discovered")
+                .contains("USB driver unavailable");
+        assertThat(retry).isInstanceOf(Button.class);
+        assertThat(retry.isVisible()).isTrue();
+        assertThat(retry.isManaged()).isTrue();
+
+        runOnFxThread(() -> {
+            ((Button) retry).fire();
+            return null;
+        });
+
+        await(Duration.ofSeconds(5), () -> runOnFxThread(() ->
+                !wizard.isEnumerationErrorVisible()
+                        && wizard.currentStepRows().getFirst()
+                                .choiceOptionsProperty().get()
+                                .contains("Recovered Backend")));
+
+        assertThat(controller.attempts.get()).isEqualTo(2);
+        runOnFxThread(() -> {
+            wizard.close();
+            return null;
+        });
+    }
+
+    private static void await(Duration timeout, BooleanSupplier condition)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertThat(condition.getAsBoolean())
+                .as("condition became true within " + timeout)
+                .isTrue();
+    }
+
+    private static SettingsModel newModel() {
+        return new SettingsModel(Preferences.userRoot()
+                .node("firstRunWizardEnumerationFailureTest_" + System.nanoTime()));
+    }
+
+    private static final class FailsOnceController implements AudioEngineController {
+        private final AtomicInteger attempts = new AtomicInteger();
+
+        @Override
+        public String getActiveBackendName() {
+            return "Recovered Backend";
+        }
+
+        @Override
+        public List<String> getAvailableBackendNames() {
+            if (attempts.incrementAndGet() == 1) {
+                throw new IllegalStateException("USB driver unavailable");
+            }
+            return List.of("Recovered Backend");
+        }
+
+        @Override
+        public List<AudioDeviceInfo> listDevices() {
+            return List.of();
+        }
+
+        @Override
+        public List<AudioDeviceInfo> listDevices(String backendName) {
+            return List.of();
+        }
+
+        @Override
+        public double getCpuLoadPercent() {
+            return 0;
+        }
+
+        @Override
+        public void applyConfiguration(Request request) {
+            // not used by enumeration
+        }
+
+        @Override
+        public void playTestTone(String outputDeviceName) {
+            // not used by enumeration
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardHostTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardHostTest.java
@@ -1,0 +1,286 @@
+package com.benesquivelmusic.daw.app.ui.settings;
+
+import com.benesquivelmusic.daw.app.ui.JavaFxToolkitExtension;
+import com.benesquivelmusic.daw.app.ui.SettingsModel;
+import com.benesquivelmusic.daw.app.ui.dialogs.DawgDialog;
+
+import javafx.animation.PauseTransition;
+import javafx.application.Platform;
+import javafx.event.Event;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import javafx.stage.Window;
+import javafx.stage.WindowEvent;
+import javafx.util.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.prefs.Preferences;
+
+import static com.benesquivelmusic.daw.app.ui.snapshot.FxSnapshotTest.runOnFxThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Story 313 host-level dismissal, ordering, and retry regressions. */
+@ExtendWith(JavaFxToolkitExtension.class)
+class FirstRunWizardHostTest {
+
+    private enum Route {
+        FINISH,
+        SKIP,
+        ESCAPE,
+        WINDOW_CLOSE,
+        HEADER_GLYPH
+    }
+
+    @ParameterizedTest
+    @EnumSource(Route.class)
+    void everyHostRouteReturnsFromShowAndWait(Route route) {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            FirstRunWizard wizard = newWizard(model);
+            AtomicInteger applies = new AtomicInteger();
+            FirstRunWizardHost host = new FirstRunWizardHost(
+                    wizard,
+                    _ -> {
+                        applies.incrementAndGet();
+                        return Optional.empty();
+                    },
+                    _ -> { });
+            DawgDialog<Void> dialog = host.dialogForTest();
+            AtomicReference<Throwable> routeFailure = new AtomicReference<>();
+            dialog.setOnShown(_ -> Platform.runLater(
+                    () -> driveRoute(route, dialog, routeFailure)));
+
+            Optional<Void> result = showWithWatchdog(host, routeFailure);
+
+            rethrow(routeFailure.get());
+            assertThat(result).isEmpty();
+            assertThat(dialog.isShowing()).isFalse();
+            assertThat(model.isFirstRunWizardCompleted()).isTrue();
+            assertThat(wizard.hasOutcome()).isTrue();
+            assertThat(wizard.wasFinished()).isEqualTo(route == Route.FINISH);
+            assertThat(applies.get()).isEqualTo(route == Route.FINISH ? 1 : 0);
+            return null;
+        });
+    }
+
+    @Test
+    void hiddenCancelKeepsClosePermissionWithoutRemovingTheHeaderGlyph() {
+        runOnFxThread(() -> {
+            FirstRunWizardHost host = new FirstRunWizardHost(
+                    newWizard(newModel()), _ -> Optional.empty(), _ -> { });
+            DawgDialog<Void> dialog = host.dialogForTest();
+            Button cancel = (Button) dialog.getDialogPane().lookupButton(ButtonType.CANCEL);
+
+            assertThat(dialog.getDialogPane().getButtonTypes())
+                    .containsExactly(ButtonType.CANCEL);
+            assertThat(cancel.isVisible()).isFalse();
+            assertThat(cancel.isManaged()).isFalse();
+            assertThat(dialog.getGraphic()).isNotNull();
+            assertThat(dialog.getGraphic().getStyleClass()).contains("dawg-dialog-close");
+            assertThat(dialog.getGraphic().getOnMouseClicked()).isNotNull();
+            return null;
+        });
+    }
+
+    @Test
+    void failedApplyStaysOpenAndASecondFinishSucceeds() {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            FirstRunWizard wizard = newWizard(model);
+            AtomicInteger attempts = new AtomicInteger();
+            FirstRunWizardHost host = new FirstRunWizardHost(
+                    wizard,
+                    _ -> {
+                        if (attempts.incrementAndGet() == 1) {
+                            throw new IllegalStateException("selected ASIO device is unavailable");
+                        }
+                        return Optional.empty();
+                    },
+                    _ -> { });
+            DawgDialog<Void> dialog = host.dialogForTest();
+            AtomicReference<Throwable> routeFailure = new AtomicReference<>();
+            AtomicBoolean stayedOpen = new AtomicBoolean();
+            AtomicBoolean flagStayedUnset = new AtomicBoolean();
+            AtomicBoolean errorWasVisible = new AtomicBoolean();
+            dialog.setOnShown(_ -> Platform.runLater(() -> {
+                try {
+                    Button next = nextButton(dialog);
+                    advanceToDone(next);
+                    next.fire();
+                    stayedOpen.set(dialog.isShowing());
+                    flagStayedUnset.set(!model.isFirstRunWizardCompleted()
+                            && !wizard.hasOutcome());
+                    errorWasVisible.set(wizard.isOutcomeErrorVisible()
+                            && wizard.outcomeErrorText().contains(
+                                    "selected ASIO device is unavailable"));
+                    next.fire();
+                } catch (Throwable failure) {
+                    routeFailure.set(failure);
+                    dialog.close();
+                }
+            }));
+
+            Optional<Void> result = showWithWatchdog(host, routeFailure);
+
+            rethrow(routeFailure.get());
+            assertThat(result).isEmpty();
+            assertThat(stayedOpen).isTrue();
+            assertThat(flagStayedUnset).isTrue();
+            assertThat(errorWasVisible).isTrue();
+            assertThat(attempts.get()).isEqualTo(2);
+            assertThat(model.isFirstRunWizardCompleted()).isTrue();
+            assertThat(wizard.wasFinished()).isTrue();
+            assertThat(dialog.isShowing()).isFalse();
+            return null;
+        });
+    }
+
+    @Test
+    void restartNoticeIsPublishedOnlyAfterSuccessfulFinish() {
+        runOnFxThread(() -> {
+            AtomicReference<String> notice = new AtomicReference<>();
+            FirstRunWizardHost host = new FirstRunWizardHost(
+                    newWizard(newModel()),
+                    _ -> Optional.of("Restart required for: Audio backend. Changes apply when you relaunch."),
+                    notice::set);
+            DawgDialog<Void> dialog = host.dialogForTest();
+            dialog.setOnShown(_ -> Platform.runLater(() -> {
+                Button next = nextButton(dialog);
+                advanceToDone(next);
+                next.fire();
+            }));
+
+            AtomicReference<Throwable> noticeFailure = new AtomicReference<>();
+            showWithWatchdog(host, noticeFailure);
+            rethrow(noticeFailure.get());
+
+            assertThat(notice.get()).contains("Restart required").contains("relaunch");
+
+            AtomicBoolean cleanNotice = new AtomicBoolean();
+            FirstRunWizardHost cleanHost = new FirstRunWizardHost(
+                    newWizard(newModel()), _ -> Optional.empty(),
+                    _ -> cleanNotice.set(true));
+            DawgDialog<Void> cleanDialog = cleanHost.dialogForTest();
+            cleanDialog.setOnShown(_ -> Platform.runLater(() -> {
+                Button next = nextButton(cleanDialog);
+                advanceToDone(next);
+                next.fire();
+            }));
+            AtomicReference<Throwable> cleanFailure = new AtomicReference<>();
+            showWithWatchdog(cleanHost, cleanFailure);
+            rethrow(cleanFailure.get());
+
+            assertThat(cleanNotice).isFalse();
+            return null;
+        });
+    }
+
+    private static void driveRoute(
+            Route route, DawgDialog<Void> dialog, AtomicReference<Throwable> failure) {
+        try {
+            switch (route) {
+                case FINISH -> {
+                    Button next = nextButton(dialog);
+                    advanceToDone(next);
+                    next.fire();
+                }
+                case SKIP -> ((Button) dialog.getDialogPane()
+                        .lookup("#first-run-wizard-skip")).fire();
+                case ESCAPE -> Event.fireEvent(
+                        dialog.getDialogPane().getScene().getWindow(), escapeEvent());
+                case WINDOW_CLOSE -> {
+                    Window window = dialog.getDialogPane().getScene().getWindow();
+                    Event.fireEvent(window,
+                            new WindowEvent(window, WindowEvent.WINDOW_CLOSE_REQUEST));
+                }
+                case HEADER_GLYPH -> {
+                    Node glyph = dialog.getGraphic();
+                    if (glyph == null) {
+                        throw new AssertionError("shown wizard host has no header close glyph");
+                    }
+                    Event.fireEvent(glyph, mouseClick());
+                }
+            }
+        } catch (Throwable thrown) {
+            failure.set(thrown);
+            dialog.close();
+        }
+    }
+
+    private static Button nextButton(DawgDialog<Void> dialog) {
+        Node button = dialog.getDialogPane().lookup("#first-run-wizard-next");
+        if (button instanceof Button next) {
+            return next;
+        }
+        throw new AssertionError("wizard Next/Finish button was not found");
+    }
+
+    private static void advanceToDone(Button next) {
+        next.fire();
+        next.fire();
+        next.fire();
+    }
+
+    private static KeyEvent escapeEvent() {
+        return new KeyEvent(KeyEvent.KEY_PRESSED, KeyEvent.CHAR_UNDEFINED, "",
+                KeyCode.ESCAPE, false, false, false, false);
+    }
+
+    private static MouseEvent mouseClick() {
+        return new MouseEvent(MouseEvent.MOUSE_CLICKED,
+                0, 0, 0, 0, MouseButton.PRIMARY, 1,
+                false, false, false, false,
+                true, false, false, true, false, true, null);
+    }
+
+    private static Optional<Void> showWithWatchdog(
+            FirstRunWizardHost host, AtomicReference<Throwable> failure) {
+        DawgDialog<Void> dialog = host.dialogForTest();
+        PauseTransition watchdog = new PauseTransition(Duration.seconds(2));
+        watchdog.setOnFinished(_ -> {
+            failure.compareAndSet(null,
+                    new AssertionError("first-run wizard dismissal route timed out"));
+            dialog.close();
+        });
+        watchdog.play();
+        try {
+            return host.showAndWait();
+        } finally {
+            watchdog.stop();
+        }
+    }
+
+    private static FirstRunWizard newWizard(SettingsModel model) {
+        return new FirstRunWizard(SettingsCatalogue.create(), model, null);
+    }
+
+    private static SettingsModel newModel() {
+        return new SettingsModel(Preferences.userRoot()
+                .node("firstRunWizardHostTest_" + System.nanoTime()));
+    }
+
+    private static void rethrow(Throwable failure) {
+        if (failure instanceof Error error) {
+            throw error;
+        }
+        if (failure instanceof RuntimeException runtime) {
+            throw runtime;
+        }
+        if (failure != null) {
+            throw new AssertionError(failure);
+        }
+    }
+}

--- a/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardHostTest.java
+++ b/daw-app/src/test/java/com/benesquivelmusic/daw/app/ui/settings/FirstRunWizardHostTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -55,7 +57,7 @@ class FirstRunWizardHostTest {
                     wizard,
                     _ -> {
                         applies.incrementAndGet();
-                        return Optional.empty();
+                        return CompletableFuture.completedFuture(Optional.empty());
                     },
                     _ -> { });
             DawgDialog<Void> dialog = host.dialogForTest();
@@ -80,7 +82,9 @@ class FirstRunWizardHostTest {
     void hiddenCancelKeepsClosePermissionWithoutRemovingTheHeaderGlyph() {
         runOnFxThread(() -> {
             FirstRunWizardHost host = new FirstRunWizardHost(
-                    newWizard(newModel()), _ -> Optional.empty(), _ -> { });
+                    newWizard(newModel()),
+                    _ -> CompletableFuture.completedFuture(Optional.empty()),
+                    _ -> { });
             DawgDialog<Void> dialog = host.dialogForTest();
             Button cancel = (Button) dialog.getDialogPane().lookupButton(ButtonType.CANCEL);
 
@@ -107,7 +111,7 @@ class FirstRunWizardHostTest {
                         if (attempts.incrementAndGet() == 1) {
                             throw new IllegalStateException("selected ASIO device is unavailable");
                         }
-                        return Optional.empty();
+                        return CompletableFuture.completedFuture(Optional.empty());
                     },
                     _ -> { });
             DawgDialog<Void> dialog = host.dialogForTest();
@@ -149,12 +153,95 @@ class FirstRunWizardHostTest {
     }
 
     @Test
+    void asynchronousFailureKeepsEveryDismissRouteOpenForARetry() {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            FirstRunWizard wizard = newWizard(model);
+            CompletableFuture<Optional<String>> firstApply = new CompletableFuture<>();
+            AtomicInteger attempts = new AtomicInteger();
+            FirstRunWizardHost host = new FirstRunWizardHost(
+                    wizard,
+                    _ -> attempts.incrementAndGet() == 1
+                            ? firstApply
+                            : CompletableFuture.completedFuture(Optional.empty()),
+                    _ -> { });
+            DawgDialog<Void> dialog = host.dialogForTest();
+            AtomicReference<Throwable> routeFailure = new AtomicReference<>();
+            AtomicBoolean pendingStateObserved = new AtomicBoolean();
+            AtomicBoolean dismissalWasBlocked = new AtomicBoolean();
+            AtomicBoolean rootFailureWasVisible = new AtomicBoolean();
+            dialog.setOnShown(_ -> Platform.runLater(() -> {
+                try {
+                    Button next = nextButton(dialog);
+                    advanceToDone(next);
+                    next.fire();
+                    wizard.finish();
+                    pendingStateObserved.set(wizard.isFinishPending()
+                            && next.isDisabled()
+                            && !model.isFirstRunWizardCompleted()
+                            && !wizard.hasOutcome()
+                            && attempts.get() == 1);
+
+                    Window window = dialog.getDialogPane().getScene().getWindow();
+                    Event.fireEvent(window, escapeEvent());
+                    Event.fireEvent(window,
+                            new WindowEvent(window, WindowEvent.WINDOW_CLOSE_REQUEST));
+                    Event.fireEvent(dialog.getGraphic(), mouseClick());
+                    dismissalWasBlocked.set(dialog.isShowing()
+                            && !model.isFirstRunWizardCompleted()
+                            && !wizard.hasOutcome());
+
+                    Thread.ofVirtual().name("wizard-test-driver-failure").start(() -> {
+                        firstApply.completeExceptionally(new CompletionException(
+                                new IllegalStateException(
+                                        "ASIO driver rejected the selected output")));
+                        Platform.runLater(() -> {
+                            try {
+                                rootFailureWasVisible.set(!wizard.isFinishPending()
+                                        && dialog.isShowing()
+                                        && wizard.isOutcomeErrorVisible()
+                                        && wizard.outcomeErrorText().contains(
+                                                "ASIO driver rejected the selected output")
+                                        && !wizard.outcomeErrorText().contains(
+                                                "CompletionException")
+                                        && !model.isFirstRunWizardCompleted()
+                                        && !wizard.hasOutcome());
+                                next.fire();
+                            } catch (Throwable failure) {
+                                routeFailure.set(failure);
+                                dialog.close();
+                            }
+                        });
+                    });
+                } catch (Throwable failure) {
+                    routeFailure.set(failure);
+                    dialog.close();
+                }
+            }));
+
+            Optional<Void> result = showWithWatchdog(host, routeFailure);
+
+            rethrow(routeFailure.get());
+            assertThat(result).isEmpty();
+            assertThat(pendingStateObserved).isTrue();
+            assertThat(dismissalWasBlocked).isTrue();
+            assertThat(rootFailureWasVisible).isTrue();
+            assertThat(attempts).hasValue(2);
+            assertThat(model.isFirstRunWizardCompleted()).isTrue();
+            assertThat(wizard.wasFinished()).isTrue();
+            return null;
+        });
+    }
+
+    @Test
     void restartNoticeIsPublishedOnlyAfterSuccessfulFinish() {
         runOnFxThread(() -> {
             AtomicReference<String> notice = new AtomicReference<>();
             FirstRunWizardHost host = new FirstRunWizardHost(
                     newWizard(newModel()),
-                    _ -> Optional.of("Restart required for: Audio backend. Changes apply when you relaunch."),
+                    _ -> CompletableFuture.completedFuture(Optional.of(
+                            "Restart required for: Audio backend. "
+                                    + "Changes apply when you relaunch.")),
                     notice::set);
             DawgDialog<Void> dialog = host.dialogForTest();
             dialog.setOnShown(_ -> Platform.runLater(() -> {
@@ -171,7 +258,8 @@ class FirstRunWizardHostTest {
 
             AtomicBoolean cleanNotice = new AtomicBoolean();
             FirstRunWizardHost cleanHost = new FirstRunWizardHost(
-                    newWizard(newModel()), _ -> Optional.empty(),
+                    newWizard(newModel()),
+                    _ -> CompletableFuture.completedFuture(Optional.empty()),
                     _ -> cleanNotice.set(true));
             DawgDialog<Void> cleanDialog = cleanHost.dialogForTest();
             cleanDialog.setOnShown(_ -> Platform.runLater(() -> {
@@ -184,6 +272,26 @@ class FirstRunWizardHostTest {
             rethrow(cleanFailure.get());
 
             assertThat(cleanNotice).isFalse();
+            return null;
+        });
+    }
+
+    @Test
+    void lateApplyCompletionAfterWizardTeardownRecordsNoOutcome() {
+        runOnFxThread(() -> {
+            SettingsModel model = newModel();
+            FirstRunWizard wizard = newWizard(model);
+            CompletableFuture<Void> pendingApply = new CompletableFuture<>();
+            wizard.setOnFinishedAsync(_ -> pendingApply);
+
+            wizard.finish();
+            assertThat(wizard.isFinishPending()).isTrue();
+            wizard.close();
+            pendingApply.complete(null);
+
+            assertThat(wizard.isFinishPending()).isFalse();
+            assertThat(wizard.hasOutcome()).isFalse();
+            assertThat(model.isFirstRunWizardCompleted()).isFalse();
             return null;
         });
     }
@@ -253,7 +361,13 @@ class FirstRunWizardHostTest {
         watchdog.setOnFinished(_ -> {
             failure.compareAndSet(null,
                     new AssertionError("first-run wizard dismissal route timed out"));
-            dialog.close();
+            dialog.setOnCloseRequest(null);
+            Window window = dialog.getDialogPane().getScene().getWindow();
+            if (window != null) {
+                window.hide();
+            } else {
+                dialog.close();
+            }
         });
         watchdog.play();
         try {


### PR DESCRIPTION
# Unbrick First-Time Setup: Dismissible Wizard Host, Outcome Ordering, and Apply Error Containment

## Motivation

The reported symptom was "the Finish button visibly does nothing." The root cause is worse: the first-run wizard's host dialog is **structurally unclosable**, and because it is application-modal it bricks the entire application on first launch until the process is killed.

- `MainController.java:1381-1412` (`showSetupWizard`) builds a bare `DawgDialog<Void>` (`:1384`), sets a result converter that always produces `null` (`:1388`), and **never adds a single `ButtonType`** to the dialog pane. The close path (`:1392-1398`) does `setResult(null)` then `hide()`. Verified against the project's actual dependency (`javafx-controls-26` sources): `Dialog.close()` bails when the result is `null` unless `requestPermissionToClose` grants it, `hide()` delegates to `close()`, and the permission check denies unless the pane has exactly one button or a cancel-data button. This pane has **zero** buttons and a `Void` result can never be non-null — every close attempt is permanently denied. `showAndWait()` (`:1405`) never returns. Finish, Skip, Esc, the window [X], and the header ✕ glyph — which `DawgDialog` installs precisely *because* the pane has no cancel button, and which routes to the same denied `close()` (`DawgDialog.java:252-272`, click handler at `:269`) — all dead-end.
- **The one-time flag is recorded before the outcome.** `FirstRunWizard.java:398-405` (`finish`) and `:412-418` (`skip`) set `outcomeRecorded` and `model.setFirstRunWizardCompleted(true)` — persisted immediately (`SettingsModel.java:644-647`) — **before** invoking the callback. A user who kills the stuck process has applied nothing, yet the wizard never auto-shows again (it stays reachable only via Settings ▸ General ▸ Startup, `MainController.java:3894`).
- **The apply chain has no error containment.** `setOnFinished` runs `applyWizardEdits(edits)` before `closeHost.run()` (`MainController.java:1400-1403`) with no try/catch — any throw leaves the dialog open with zero feedback, an independent "Finish does nothing" failure even after the close path is fixed.
- **The tests drive the wrong object.** `FirstRunWizardShowsOnceTest.java:163` exercises `wizard.finish()` directly, never the *host dialog's* close path — which is why the defect shipped untested.

The bug is a **class**, not an instance: the identical zero-button `DawgDialog<Void>` construction recurs in the story-303 plugin install flow — `PluginInstallPanel.java:108-115` builds the host, wires close requests to `dialog::close` (`:113`), and its in-content Cancel button (`:232-245`) routes to the same permanently denied close. Today's tree has exactly **two** such hosts (grep-verified). The contrast is one file away: `SettingsDialog.java:341-352` adds a hidden `ButtonType.CANCEL` with the comment that "ONE hidden CANCEL keeps the Esc/[X] plumbing alive" (`:341-344`). The wizard host omits exactly this.

Two lesser wizard failures complete the picture: device-enumeration failure in the audio step is log-only (`FirstRunWizard.java:160-161` — the first-run user sees inexplicably empty device combos), and a Finish that includes the restart-required backend choice gives zero indication that the chosen ASIO backend is inert until relaunch (`MainController.java:1425-1435` drives apply on a never-shown `SettingsDialog`, so the settings shell's restart banner never appears).

For a studio engineer this is the worst possible first impression: the app locks up on its very first window, and after force-killing it, the setup that never ran is silently marked complete.

## Goals

- The wizard host adopts the hidden-CANCEL idiom of `SettingsDialog.java:341-352`: one `ButtonType.CANCEL`, invisible and unmanaged, whose sole job is to keep the Esc/[X]/`close()` plumbing alive. Finish, Skip, Esc, the window [X], and the header ✕ glyph all actually close the dialog; `showAndWait()` returns on every route (book §5.2).
- Outcome ordering per book §2.5: `outcomeRecorded` and the first-run-completed flag are set **only after** the outcome callback has run successfully — never before, and never on the failure path. `skipIfNoOutcome` continues to catch abnormal closes, which now actually exist; an abnormal close counts as Skip.
- Apply error containment: `applyWizardEdits` runs inside an error boundary. On failure the wizard surfaces a visible error naming what failed, stays open, and is re-armable — the user can fix the input and press Finish again. The dialog closes and the flag persists only on success.
- Device-enumeration failure in the audio step surfaces in the step itself with a retry affordance (`FirstRunWizard.java:160-161`), never as empty combos.
- A Finish whose edits include the restart-required backend id shows the restart notice the never-shown settings shell was supposed to provide — the user learns the chosen ASIO backend engages on next launch.
- Audit every zero-button `DawgDialog<Void>` host in the tree — today exactly two, the wizard host and `PluginInstallPanel.java:108-115` — and apply the same pattern to both; the install panel's Cancel (`:232-245`) genuinely closes its dialog.

## Goals — Tests

- A host-level test drives the **host dialog** (not `wizard.finish()` directly — closing the `FirstRunWizardShowsOnceTest.java:163` gap) through Finish, Skip, Esc, and the header close glyph, and asserts `showAndWait` returns in every case.
- An outcome-ordering test asserts the first-run flag is persisted only after the outcome callback succeeds: an abandoned/abnormally closed wizard leaves the flag unset (auto-shows next launch as Skip semantics dictate), and a throwing callback leaves it unset.
- An apply-failure test: a throwing `applyWizardEdits` leaves the wizard open with a visible error and the flag unset; a subsequent successful Finish applies, closes, and sets the flag.
- An install-panel test: the `PluginInstallPanel` host dialog closes from its Cancel button, from Esc, and from [X].
- A device-enumeration-failure test: an enumeration throw in the audio step renders the visible error state with retry, not silently empty device combos.
- A restart-notice test: Finish carrying the restart-required backend id shows the restart notice; Finish without it shows none.

## Non-Goals

- **The repo-wide dismissibility conformance gate and the no-noop-in-production scan** — story 339 (Stage 4). This story establishes the fix pattern; 339's gate makes the bug class structurally extinct.
- **The exception spine, uncaught handlers, and file log sink** — story 336 (Stage 2). This story's error containment is a local boundary at the one site that bricks first launch.
- **UI-scale defects exposed on wizard step 2** (the clipping root Scale transform, scale never applied at startup) — story 335 (`PERSISTENCE_INTEGRITY_DESIGN_BOOK.md`, Settings Truth).
- **Making the chosen ASIO backend actually stream** — story 316 (`AUDIO_ENGINE_WIRING_DESIGN_BOOK.md`); this story only surfaces the restart notice honestly.
- **The settings shell's restart banner** stays the canonical restart-required surface (`SETTINGS_VIEW_DESIGN_BOOK.md` apply contract); the wizard notice covers the one entry point that bypasses the shell, it does not introduce a second restart framework.
- **Crash-recovery timing on open paths** — story 332 (`PERSISTENCE_INTEGRITY_DESIGN_BOOK.md`).

## Technical Notes

- Implements **Stage 1 — Unbrick First-Time Setup: Dismissible Wizard Host, Outcome Ordering, and Apply Error Containment** of `docs/design/FAILURE_SURFACING_DESIGN_BOOK.md` (§8). The behavioural contracts bound here: §4.6 (the dismissibility pattern), §5.2 (the dismiss-route table — `showAndWait` always eventually returns is the testable invariant), §2.4 (dismissible by construction), §2.5 (record an outcome only after the outcome happened).
- Files to touch: `MainController.java` (`:1381-1412` host construction gains the hidden CANCEL; `:1400-1403` apply moves inside the error boundary; `:1425-1435` restart-notice path), `FirstRunWizard.java` (`:398-418` outcome reordering; `:160-161` enumeration error surface), `PluginInstallPanel.java` (`:108-115` host + `:232-245` Cancel adopt the same idiom). `DawgDialog.java:252-272` (glyph plumbing) is unchanged — it starts working once a cancel-data button exists.
- Why hidden-CANCEL over window-level close mechanics: the hidden button routes *all* dismiss paths (Esc, [X], glyph, programmatic close) through one JavaFX-sanctioned mechanism with a single veto point; window-level closing bypasses the dialog's result/veto lifecycle (book §4.6). The idiom is proven in-tree.
- Outcome ordering follows the established repo rule: publish side effects before terminal state, and terminal state only when true (book §2.5).
- Test seams: the host dialog must be constructible/drivable without FXML-loading the full `MainController` (the repo's established in-process substitute pattern); FX dialog tests follow the repo's headless JavaFX conventions. The new host-driving test is the exact test book §1.1 shows was missing.
- Cross-refs: story **339** (generalising conformance gate — Stage 4), **336** (exception spine the wizard sequencing waits on, book §6.4), **276** (`DawgDialog` chrome and the `EveryDialogConformsTest` idiom the 339 gate extends), **303** (origin of the plugin-install host), **335** (UI-scale), **316** (ASIO production streaming path).
